### PR TITLE
TabBar: padding and alignment fix

### DIFF
--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -85,8 +85,8 @@ export function TabBar({
                 value={String(t.id)}
                 data-tab-id={t.id}
                 className={cn(
-                  "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80",
-                  compact ? "px-2" : "px-2.5",
+                  "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
+                  compact ? "px-1.5!" : "ps-2! pe-1!"
                 )}
               >
                 <span

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -79,7 +79,7 @@ export function SettingsApp() {
           className="flex-1 items-center"
           data-tauri-drag-region
         >
-          <TabsList className="mx-auto h-7 bg-muted/40">
+          <TabsList className="mx-auto h-7 bg-muted/40 px-2">
             {TABS.map((t) => (
               <TabsTrigger
                 key={t.id}


### PR DESCRIPTION
## Issue
tab bar had an alignment issue that caused me to accidentally close a tab instead of navigating to it more than once

and settings tab bar had uneven padding

## solution
just changed some tailwind classes to override the base components paddings

### Before
<img width="168" height="56" alt="image" src="https://github.com/user-attachments/assets/5862811d-933f-4d55-94cb-4994143787e2" />

<img width="133" height="48" alt="image" src="https://github.com/user-attachments/assets/36b781f2-75b7-40fd-a744-e16df1d275ce" />



### After
<img width="159" height="69" alt="image" src="https://github.com/user-attachments/assets/df6fae3c-4588-411c-ae41-a1608c8f6cb8" />

<img width="147" height="57" alt="image" src="https://github.com/user-attachments/assets/0246bd0f-059b-4309-a106-a63324f18c51" />
