### PR TITLE
feat(shortcuts): settings shortcut customization tab 

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -465,6 +465,7 @@ export default function App() {
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
+      "settings.open": () => void openSettingsWindow(),
       "sidebar.toggle": toggleSidebar,
     }),
     [

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { WindowControls } from "@/components/WindowControls";
-import { IS_MAC, MOD_KEY, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { IS_MAC, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
 import type { Tab } from "@/modules/tabs";
 import { TabBar } from "@/modules/tabs";
 import {
@@ -9,7 +11,7 @@ import {
   SidebarLeftIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
   SearchInline,
   type SearchInlineHandle,
@@ -49,6 +51,17 @@ export function Header({
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
+  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+
+  const shortcutLabel = useMemo(() => {
+    const s = SHORTCUTS.find((s) => s.id === "shortcuts.open");
+    if (!s) return "Keyboard shortcuts";
+    const bindings = userShortcuts["shortcuts.open"] || s.defaultBindings;
+    if (!bindings || bindings.length === 0) return "Keyboard shortcuts";
+    const tokens = getBindingTokens(bindings[0]);
+    if (tokens.length === 0) return "Keyboard shortcuts";
+    return `Keyboard shortcuts (${tokens.join("")})`;
+  }, [userShortcuts]);
 
   useEffect(() => {
     const el = rootRef.current;
@@ -68,7 +81,7 @@ export function Header({
         size="icon"
         className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
         onClick={onOpenShortcuts}
-        title={`Keyboard shortcuts (${MOD_KEY}K)`}
+        title={shortcutLabel}
       >
         <HugeiconsIcon icon={KeyboardIcon} size={16} strokeWidth={1.75} />
       </Button>

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { MOD_KEY } from "@/lib/platform";
 import type { EditorPaneHandle } from "@/modules/editor";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
 import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -11,6 +12,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -42,6 +44,25 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     // In normal mode the field is always present.
     const [openInCompact, setOpenInCompact] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+
+    const shortcutText = useMemo(() => {
+      const s = SHORTCUTS.find((s) => s.id === "search.focus");
+      if (!s) return "";
+      const bindings = userShortcuts["search.focus"] || s.defaultBindings;
+      if (!bindings || bindings.length === 0) return "";
+      const tokens = getBindingTokens(bindings[0]);
+      return tokens.join("");
+    }, [userShortcuts]);
+
+    const placeholder = useMemo(() => {
+      const base = target?.kind === "editor" ? "Search in file" : "Search";
+      return shortcutText ? `${base} (${shortcutText})` : base;
+    }, [target?.kind, shortcutText]);
+
+    const tooltipTitle = useMemo(() => {
+      return shortcutText ? `Search (${shortcutText})` : "Search";
+    }, [shortcutText]);
 
     const expanded = !compact || openInCompact;
 
@@ -116,9 +137,7 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
               <Input
                 ref={inputRef}
                 value={q}
-                placeholder={
-                  target?.kind === "editor" ? "Search in file" : "Search"
-                }
+                placeholder={placeholder}
                 className="h-7 w-full bg-muted/80 pr-7 pl-7 text-xs placeholder:text-muted-foreground/70 focus-visible:ring-0"
                 onChange={(e) => {
                   const next = e.target.value;
@@ -177,7 +196,7 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
                 size="icon"
                 className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
                 onClick={focus}
-                title={`Search (${MOD_KEY}F)`}
+                title={tooltipTitle}
               >
                 <HugeiconsIcon
                   icon={Search01Icon}

--- a/src/modules/settings/openSettingsWindow.ts
+++ b/src/modules/settings/openSettingsWindow.ts
@@ -1,6 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 
-export type SettingsTab = "general" | "models" | "agents" | "about";
+export type SettingsTab =
+  | "general"
+  | "shortcuts"
+  | "models"
+  | "agents"
+  | "about";
 
 export async function openSettingsWindow(tab?: SettingsTab): Promise<void> {
   await invoke("open_settings_window", { tab: tab ?? null });

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -7,6 +7,7 @@ import {
   type AutocompleteProviderId,
   type ModelId,
 } from "@/modules/ai/config";
+import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -48,6 +49,7 @@ export type Preferences = {
   autocompleteModelId: string;
   lmstudioBaseURL: string;
   vimMode: boolean;
+  shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
 
 const STORE_PATH = "terax-settings.json";
@@ -62,6 +64,7 @@ const KEY_AUTOCOMPLETE_PROVIDER = "autocompleteProvider";
 const KEY_AUTOCOMPLETE_MODEL = "autocompleteModelId";
 const KEY_LMSTUDIO_BASE_URL = "lmstudioBaseURL";
 const KEY_VIM_MODE = "vimMode";
+const KEY_SHORTCUTS = "shortcuts";
 
 export const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
@@ -75,6 +78,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   autocompleteModelId: DEFAULT_AUTOCOMPLETE_MODEL.cerebras,
   lmstudioBaseURL: LMSTUDIO_DEFAULT_BASE_URL,
   vimMode: false,
+  shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
 
 const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
@@ -120,9 +124,11 @@ export async function loadPreferences(): Promise<Preferences> {
       get<string>(KEY_AUTOCOMPLETE_MODEL) ??
       DEFAULT_PREFERENCES.autocompleteModelId,
     lmstudioBaseURL:
-      get<string>(KEY_LMSTUDIO_BASE_URL) ??
-      DEFAULT_PREFERENCES.lmstudioBaseURL,
+      get<string>(KEY_LMSTUDIO_BASE_URL) ?? DEFAULT_PREFERENCES.lmstudioBaseURL,
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
+    shortcuts:
+      get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
+      DEFAULT_PREFERENCES.shortcuts,
   };
 }
 
@@ -155,7 +161,7 @@ export async function setAutocompleteEnabled(value: boolean): Promise<void> {
 }
 
 export async function setAutocompleteProvider(
-  value: AutocompleteProviderId,
+  value: AutocompleteProviderId
 ): Promise<void> {
   await writePref(KEY_AUTOCOMPLETE_PROVIDER, value);
 }
@@ -170,6 +176,18 @@ export async function setLmstudioBaseURL(value: string): Promise<void> {
 
 export async function setVimMode(value: boolean): Promise<void> {
   await writePref(KEY_VIM_MODE, value);
+}
+
+export async function setShortcuts(
+  value: Record<ShortcutId, KeyBinding[]> | {}
+): Promise<void> {
+  await store.set(KEY_SHORTCUTS, value);
+  await store.save();
+}
+
+export async function resetShortcuts(): Promise<void> {
+  await store.set(KEY_SHORTCUTS, DEFAULT_PREFERENCES.shortcuts);
+  await store.save();
 }
 
 export type PrefKey = keyof Preferences;
@@ -190,6 +208,7 @@ export async function onPreferencesChange(
     [KEY_AUTOCOMPLETE_MODEL]: "autocompleteModelId",
     [KEY_LMSTUDIO_BASE_URL]: "lmstudioBaseURL",
     [KEY_VIM_MODE]: "vimMode",
+    [KEY_SHORTCUTS]: "shortcuts",
   };
   // Same-process writes still fire onChange immediately; cross-window writes
   // arrive via the Tauri event emitted by writePref().

--- a/src/modules/shortcuts/ShortcutsDialog.tsx
+++ b/src/modules/shortcuts/ShortcutsDialog.tsx
@@ -7,7 +7,16 @@ import {
 } from "@/components/ui/dialog";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { SHORTCUTS, SHORTCUT_GROUPS } from "./shortcuts";
+import { Button } from "@/components/ui/button";
+import { Settings01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
+import {
+  getBindingTokens,
+  SHORTCUTS,
+  SHORTCUT_GROUPS,
+} from "./shortcuts";
 
 type Props = {
   open: boolean;
@@ -15,46 +24,82 @@ type Props = {
 };
 
 export function ShortcutsDialog({ open, onOpenChange }: Props) {
+  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+
+  const onOpenSettings = () => {
+    onOpenChange(false);
+    void openSettingsWindow("shortcuts");
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Keyboard shortcuts</DialogTitle>
-          <DialogDescription>
-            Quick reference for Terax controls.
-          </DialogDescription>
+        <DialogHeader className="flex-row items-start justify-between pr-10">
+          <div className="flex flex-col gap-1.5">
+            <DialogTitle>Keyboard shortcuts</DialogTitle>
+            <DialogDescription>
+              Quick reference for Terax controls.
+            </DialogDescription>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 px-2.5 text-[11px] font-medium"
+            onClick={onOpenSettings}
+          >
+            <HugeiconsIcon icon={Settings01Icon} size={12} strokeWidth={2} />
+            <span>Customize</span>
+          </Button>
         </DialogHeader>
 
         <ScrollArea className="max-h-[70vh] min-h-0 pr-2">
           <div className="flex flex-col gap-5">
-          {SHORTCUT_GROUPS.map((group) => {
-            const items = SHORTCUTS.filter((s) => s.group === group);
-            if (items.length === 0) return null;
-            return (
-              <section key={group} className="flex flex-col gap-2">
-                <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                  {group}
-                </h3>
-                <ul className="flex flex-col divide-y divide-border/60">
-                  {items.map((s) => (
-                    <li
-                      key={s.id}
-                      className="flex items-center justify-between py-2"
-                    >
-                      <span className="text-sm text-foreground/90">
-                        {s.label}
-                      </span>
-                      <KbdGroup>
-                        {s.keys.map((k, i) => (
-                          <Kbd key={i}>{k}</Kbd>
-                        ))}
-                      </KbdGroup>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            );
-          })}
+            {SHORTCUT_GROUPS.map((group) => {
+              const items = SHORTCUTS.filter((s) => s.group === group);
+              if (items.length === 0) return null;
+              return (
+                <section key={group} className="flex flex-col gap-2">
+                  <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    {group}
+                  </h3>
+                  <ul className="flex flex-col divide-y divide-border/60">
+                    {items.map((s) => {
+                      const bindings = userShortcuts[s.id] || s.defaultBindings;
+                      const tokens = getBindingTokens(bindings[0]);
+
+                      return (
+                        <li
+                          key={s.id}
+                          className="flex items-center justify-between py-2"
+                        >
+                          <span className="text-sm text-foreground/90">
+                            {s.label}
+                          </span>
+                          {tokens.length > 0 ? (
+                            <KbdGroup>
+                              {tokens.map((token, i) => {
+                                let label = token;
+                                if (
+                                  s.id === "tab.selectByIndex" &&
+                                  i === tokens.length - 1
+                                ) {
+                                  label = "1…9";
+                                }
+                                return <Kbd key={i}>{label}</Kbd>;
+                              })}
+                            </KbdGroup>
+                          ) : (
+                            <span className="text-xs text-muted-foreground italic">
+                              Unassigned
+                            </span>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </section>
+              );
+            })}
           </div>
         </ScrollArea>
       </DialogContent>

--- a/src/modules/shortcuts/lib/useGlobalShortcuts.ts
+++ b/src/modules/shortcuts/lib/useGlobalShortcuts.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef } from "react";
-import { SHORTCUTS, type ShortcutId } from "../shortcuts";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  SHORTCUTS,
+  matchBinding,
+  type ShortcutId,
+} from "../shortcuts";
 
 export type ShortcutHandler = (e: KeyboardEvent) => void;
 export type ShortcutHandlers = Partial<Record<ShortcutId, ShortcutHandler>>;
@@ -15,11 +20,19 @@ export function useGlobalShortcuts(
   const latest = useRef({ handlers, options });
   latest.current = { handlers, options };
 
+  // Access the shortcuts from the store
+  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const { handlers, options } = latest.current;
       for (const s of SHORTCUTS) {
-        if (!s.match(e)) continue;
+        // Use user-defined bindings if they exist, otherwise use default
+        const bindings = userShortcuts[s.id] || s.defaultBindings;
+
+        const isMatch = bindings.some((b) => matchBinding(e, b, s.id));
+        if (!isMatch) continue;
+
         if (options?.isDisabled?.(s.id, e)) return;
         const h = handlers[s.id];
         if (!h) return;
@@ -32,5 +45,5 @@ export function useGlobalShortcuts(
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, []);
+  }, [userShortcuts]);
 }

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -1,4 +1,10 @@
-import { CTRL_KEY, MOD_KEY, SHIFT_KEY, TAB_KEY } from "@/lib/platform";
+import { IS_MAC } from "@/lib/platform";
+
+export const DEFAULT_MODIFIER: keyof KeyBinding = IS_MAC ? "meta" : "ctrl";
+
+/**
+ * Single source of truth for keyboard shortcuts.
+ */
 
 export type ShortcutId =
   | "tab.new"
@@ -12,105 +18,104 @@ export type ShortcutId =
   | "ai.toggle"
   | "ai.askSelection"
   | "shortcuts.open"
+  | "settings.open"
   | "sidebar.toggle";
 
 export type ShortcutGroup = "General" | "Tabs" | "Search" | "AI" | "View";
 
+export type KeyBinding = {
+  key: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  meta?: boolean;
+};
+
 export type Shortcut = {
   id: ShortcutId;
   label: string;
-  keys: string[];
   group: ShortcutGroup;
-  match: (e: KeyboardEvent) => boolean;
+  defaultBindings: KeyBinding[];
 };
-
-const isMod = (e: KeyboardEvent) => e.metaKey || e.ctrlKey;
 
 export const SHORTCUTS: Shortcut[] = [
   {
+    id: "settings.open",
+    label: "Open settings",
+    group: "General",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "," }],
+  },
+  {
     id: "shortcuts.open",
     label: "Show keyboard shortcuts",
-    keys: [MOD_KEY, "K"],
     group: "General",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "k",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "k" }],
   },
   {
     id: "tab.new",
     label: "New tab",
-    keys: [MOD_KEY, "T"],
     group: "Tabs",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "t",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "t" }],
   },
   {
     id: "tab.newPreview",
     label: "New preview tab",
-    keys: [MOD_KEY, "P"],
     group: "Tabs",
-    match: (e) => isMod(e) && !e.shiftKey && e.key.toLowerCase() === "p",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "p" }],
   },
   {
     id: "tab.newEditor",
     label: "New editor tab",
-    keys: [MOD_KEY, "E"],
     group: "Tabs",
-    match: (e) => isMod(e) && !e.shiftKey && e.key.toLowerCase() === "e",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "e" }],
   },
   {
     id: "tab.close",
     label: "Close tab",
-    keys: [MOD_KEY, "W"],
     group: "Tabs",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "w",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "w" }],
   },
   {
     id: "tab.next",
     label: "Next tab",
-    keys: [CTRL_KEY, TAB_KEY],
     group: "Tabs",
-    // Ctrl+Tab is conventionally Ctrl-only on every platform (including macOS).
-    match: (e) => e.ctrlKey && !e.shiftKey && e.key === "Tab",
+    defaultBindings: [{ ctrl: true, key: "Tab" }],
   },
   {
     id: "tab.prev",
     label: "Previous tab",
-    keys: [CTRL_KEY, SHIFT_KEY, TAB_KEY],
     group: "Tabs",
-    match: (e) => e.ctrlKey && e.shiftKey && e.key === "Tab",
+    defaultBindings: [{ ctrl: true, shift: true, key: "Tab" }],
   },
   {
     id: "tab.selectByIndex",
     label: "Jump to tab 1–9",
-    keys: [MOD_KEY, "1…9"],
     group: "Tabs",
-    match: (e) => isMod(e) && /^[1-9]$/.test(e.key),
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "1" }],
   },
   {
     id: "search.focus",
     label: "Find in terminal",
-    keys: [MOD_KEY, "F"],
     group: "Search",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "f",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "f" }],
   },
   {
     id: "ai.toggle",
     label: "Toggle AI agent",
-    keys: [MOD_KEY, "I"],
     group: "AI",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "i",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "i" }],
   },
   {
     id: "ai.askSelection",
     label: "Ask AI about selection",
-    keys: [MOD_KEY, "L"],
     group: "AI",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "l",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "l" }],
   },
   {
     id: "sidebar.toggle",
     label: "Toggle file explorer",
-    keys: [MOD_KEY, "B"],
     group: "View",
-    match: (e) => isMod(e) && e.key.toLowerCase() === "b",
+    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "b" }],
   },
 ];
 
@@ -121,3 +126,55 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   "Search",
   "AI",
 ];
+
+/**
+ * Matching logic: checks if a KeyboardEvent matches a KeyBinding.
+ */
+export function matchBinding(e: KeyboardEvent, binding: KeyBinding, id?: ShortcutId): boolean {
+  const eventKey = e.key.toLowerCase();
+  const bindingKey = binding.key.toLowerCase();
+
+  // Special case for Jump to Tab 1-9
+  if (id === "tab.selectByIndex") {
+    if (!/^[1-9]$/.test(e.key)) return false;
+  } else if (eventKey !== bindingKey) {
+    return false;
+  }
+
+  return (
+    !!e.ctrlKey === !!binding.ctrl &&
+    !!e.shiftKey === !!binding.shift &&
+    !!e.altKey === !!binding.alt &&
+    !!e.metaKey === !!binding.meta
+  );
+}
+
+/**
+ * Display helpers
+ */
+export function getBindingTokens(binding?: KeyBinding): string[] {
+  if (!binding) return [];
+  const tokens: string[] = [];
+  if (IS_MAC) {
+    if (binding.ctrl) tokens.push("⌃");
+    if (binding.alt) tokens.push("⌥");
+    if (binding.shift) tokens.push("⇧");
+    if (binding.meta) tokens.push("⌘");
+  } else {
+    if (binding.ctrl) tokens.push("Ctrl");
+    if (binding.alt) tokens.push("Alt");
+    if (binding.shift) tokens.push("Shift");
+    if (binding.meta) tokens.push("Win");
+  }
+
+  let keyLabel = binding.key;
+  if (keyLabel === " ") keyLabel = "Space";
+  else if (keyLabel === "ArrowUp") keyLabel = "↑";
+  else if (keyLabel === "ArrowDown") keyLabel = "↓";
+  else if (keyLabel === "ArrowLeft") keyLabel = "←";
+  else if (keyLabel === "ArrowRight") keyLabel = "→";
+  else if (keyLabel.length === 1) keyLabel = keyLabel.toUpperCase();
+
+  tokens.push(keyLabel);
+  return tokens;
+}

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -1,6 +1,4 @@
-import { IS_MAC } from "@/lib/platform";
-
-export const DEFAULT_MODIFIER: keyof KeyBinding = IS_MAC ? "meta" : "ctrl";
+import { IS_MAC, MOD_KEY } from "@/lib/platform";
 
 /**
  * Single source of truth for keyboard shortcuts.
@@ -43,37 +41,37 @@ export const SHORTCUTS: Shortcut[] = [
     id: "settings.open",
     label: "Open settings",
     group: "General",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "," }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "," }],
   },
   {
     id: "shortcuts.open",
     label: "Show keyboard shortcuts",
     group: "General",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "k" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "k" }],
   },
   {
     id: "tab.new",
     label: "New tab",
     group: "Tabs",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "t" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "t" }],
   },
   {
     id: "tab.newPreview",
     label: "New preview tab",
     group: "Tabs",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "p" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "p" }],
   },
   {
     id: "tab.newEditor",
     label: "New editor tab",
     group: "Tabs",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "e" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "e" }],
   },
   {
     id: "tab.close",
     label: "Close tab",
     group: "Tabs",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "w" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "w" }],
   },
   {
     id: "tab.next",
@@ -91,31 +89,31 @@ export const SHORTCUTS: Shortcut[] = [
     id: "tab.selectByIndex",
     label: "Jump to tab 1–9",
     group: "Tabs",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "1" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "1" }],
   },
   {
     id: "search.focus",
     label: "Find in terminal",
     group: "Search",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "f" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "f" }],
   },
   {
     id: "ai.toggle",
     label: "Toggle AI agent",
     group: "AI",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "i" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "i" }],
   },
   {
     id: "ai.askSelection",
     label: "Ask AI about selection",
     group: "AI",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "l" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "l" }],
   },
   {
     id: "sidebar.toggle",
     label: "Toggle file explorer",
     group: "View",
-    defaultBindings: [{ [DEFAULT_MODIFIER]: true, key: "b" }],
+    defaultBindings: [{ [MOD_KEY]: true, key: "b" }],
   },
 ];
 

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -9,6 +9,7 @@ import {
   InformationCircleIcon,
   Settings01Icon,
   UserMultiple02Icon,
+  KeyboardIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
@@ -17,16 +18,24 @@ import { AboutSection } from "./sections/AboutSection";
 import { AgentsSection } from "./sections/AgentsSection";
 import { GeneralSection } from "./sections/GeneralSection";
 import { ModelsSection } from "./sections/ModelsSection";
+import { ShortcutsSection } from "./sections/ShortcutsSection";
 
 const TABS: { id: SettingsTab; label: string; icon: typeof Settings01Icon, component: () => JSX.Element }[] =
   [
     { id: "general", label: "General", icon: Settings01Icon, component: GeneralSection },
+    { id: "shortcuts", label: "Shortcuts", icon: KeyboardIcon, component: ShortcutsSection },
     { id: "models", label: "Models", icon: AiScanIcon, component: ModelsSection },
     { id: "agents", label: "Agents", icon: UserMultiple02Icon, component: AgentsSection },
     { id: "about", label: "About", icon: InformationCircleIcon, component: AboutSection },
   ];
 
-const VALID_TABS: SettingsTab[] = ["general", "models", "agents", "about"];
+const VALID_TABS: SettingsTab[] = [
+  "general",
+  "shortcuts",
+  "models",
+  "agents",
+  "about",
+];
 
 function readInitialTab(): SettingsTab {
   if (typeof window === "undefined") return "general";
@@ -70,9 +79,8 @@ export function SettingsApp() {
     <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground select-none">
       <header
         data-tauri-drag-region
-        className={`flex h-11 shrink-0 items-center border-b border-border/60 bg-card/60 ${
-          IS_MAC ? "pr-3 pl-22" : "pr-0 pl-3"
-        }`}
+        className={`flex h-11 shrink-0 items-center border-b border-border/60 bg-card/60 ${IS_MAC ? "pr-3 pl-22" : "pr-0 pl-3"
+          }`}
       >
         <Tabs
           value={active}

--- a/src/settings/sections/ShortcutsSection.tsx
+++ b/src/settings/sections/ShortcutsSection.tsx
@@ -282,6 +282,14 @@ function Recorder({
         return;
       }
 
+      // Require at least one primary modifier (Ctrl, Alt, Meta).
+      // Reject Shift‑only shortcuts that would insert a character.
+      const hasPrimaryModifier = e.ctrlKey || e.altKey || e.metaKey;
+      const isCharacterKey = e.key.length === 1; // anything that types a glyph
+      // this blocks shortcuts such as Shift+2 which would be "@" and Shift+, which would be "<" on many layouts
+      if (!hasPrimaryModifier && (!e.shiftKey || isCharacterKey)) {
+        return;
+      }
       onRecord({
         key: e.key,
         ctrl: e.ctrlKey,

--- a/src/settings/sections/ShortcutsSection.tsx
+++ b/src/settings/sections/ShortcutsSection.tsx
@@ -1,0 +1,320 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setShortcuts } from "@/modules/settings/store";
+import {
+  getBindingTokens,
+  SHORTCUTS,
+  SHORTCUT_GROUPS,
+  type KeyBinding,
+  type Shortcut,
+  type ShortcutId,
+} from "@/modules/shortcuts/shortcuts";
+import {
+  ArrowTurnBackwardIcon,
+  Search01Icon,
+  Delete02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState, useMemo } from "react";
+import { SectionHeader } from "../components/SectionHeader";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export function ShortcutsSection() {
+  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+  const [search, setSearch] = useState("");
+  const [recordingId, setRecordingId] = useState<ShortcutId | null>(null);
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
+
+  const filteredShortcuts = useMemo(() => {
+    // Filter out internal/non-overridable shortcuts like tab.selectByIndex
+    const base = SHORTCUTS.filter((s) => s.id !== "tab.selectByIndex");
+    if (!search) return base;
+    const lower = search.toLowerCase();
+    return base.filter(
+      (s) =>
+        s.label.toLowerCase().includes(lower) ||
+        s.group.toLowerCase().includes(lower)
+    );
+  }, [search]);
+
+  const onRecord = (id: ShortcutId, binding: KeyBinding) => {
+    const next = { ...userShortcuts, [id]: [binding] };
+    void setShortcuts(next);
+    setRecordingId(null);
+  };
+
+  const onClear = (id: ShortcutId) => {
+    const next = { ...userShortcuts, [id]: [] };
+    void setShortcuts(next);
+  };
+
+  const onResetShortcut = (id: ShortcutId) => {
+    const next = { ...userShortcuts };
+    delete next[id];
+    void setShortcuts(next);
+  };
+
+  const onResetAll = () => {
+    void setShortcuts({});
+    setResetDialogOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <SectionHeader
+          title="Shortcuts"
+          description="View and customize keyboard shortcuts."
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 gap-1.5 px-2.5 text-[11px]"
+          onClick={() => setResetDialogOpen(true)}
+        >
+          <HugeiconsIcon
+            icon={ArrowTurnBackwardIcon}
+            size={12}
+            strokeWidth={2}
+          />
+          Reset All
+        </Button>
+      </div>
+
+      <div className="relative">
+        <HugeiconsIcon
+          icon={Search01Icon}
+          size={14}
+          strokeWidth={2}
+          className="absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          placeholder="Search shortcuts..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="h-9 pl-9 text-[12.5px]"
+        />
+      </div>
+
+      <div className="flex flex-col gap-8">
+        {SHORTCUT_GROUPS.map((group) => {
+          const items = filteredShortcuts.filter((s) => s.group === group);
+          if (items.length === 0) return null;
+
+          return (
+            <div key={group} className="flex flex-col gap-3">
+              <h3 className="text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
+                {group}
+              </h3>
+              <div className="flex flex-col divide-y divide-border/40 rounded-lg border border-border/60 bg-card/40 overflow-hidden">
+                {items.map((s) => (
+                  <ShortcutRow
+                    key={s.id}
+                    shortcut={s}
+                    isRecording={recordingId === s.id}
+                    onStartRecording={() => setRecordingId(s.id)}
+                    onStopRecording={() => setRecordingId(null)}
+                    onRecord={(b) => onRecord(s.id, b)}
+                    onClear={() => onClear(s.id)}
+                    onReset={() => onResetShortcut(s.id)}
+                    userBindings={userShortcuts[s.id]}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <AlertDialog open={resetDialogOpen} onOpenChange={setResetDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset all shortcuts?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will revert all your custom keyboard shortcuts to their
+              factory defaults. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={onResetAll}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Reset All
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function ShortcutRow({
+  shortcut,
+  isRecording,
+  onStartRecording,
+  onStopRecording,
+  onRecord,
+  onClear,
+  onReset,
+  userBindings,
+}: {
+  shortcut: Shortcut;
+  isRecording: boolean;
+  onStartRecording: () => void;
+  onStopRecording: () => void;
+  onRecord: (b: KeyBinding) => void;
+  onClear: () => void;
+  onReset: () => void;
+  userBindings?: KeyBinding[];
+}) {
+  const bindings =
+    userBindings !== undefined ? userBindings : shortcut.defaultBindings;
+  const isModified = userBindings !== undefined;
+  const hasBindings = bindings && bindings.length > 0;
+
+  return (
+    <div className="group flex items-center justify-between px-3 py-2.5 transition-colors hover:bg-muted/30">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[12.5px] font-medium">{shortcut.label}</span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {isRecording ? (
+          <Recorder onRecord={onRecord} onCancel={onStopRecording} />
+        ) : (
+          <>
+            <div
+              onClick={onStartRecording}
+              className="flex min-w-[100px] cursor-pointer items-center justify-end gap-1"
+            >
+              {hasBindings ? (
+                <KbdGroup>
+                  {getBindingTokens(bindings[0]).map((t, i) => (
+                    <Kbd
+                      key={i}
+                      className="group-hover:bg-accent group-hover:text-accent-foreground transition-colors"
+                    >
+                      {t}
+                    </Kbd>
+                  ))}
+                </KbdGroup>
+              ) : (
+                <span className="text-[11px] text-muted-foreground italic">
+                  Unassigned
+                </span>
+              )}
+            </div>
+
+            <div className="flex items-center gap-1">
+              {isModified && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7 text-muted-foreground hover:text-foreground"
+                  onClick={onReset}
+                  title="Reset to default"
+                >
+                  <HugeiconsIcon icon={ArrowTurnBackwardIcon} size={12} />
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-muted-foreground hover:text-destructive opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={onClear}
+                title="Clear shortcut"
+              >
+                <HugeiconsIcon icon={Delete02Icon} size={12} />
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Recorder({
+  onRecord,
+  onCancel,
+}: {
+  onRecord: (b: KeyBinding) => void;
+  onCancel: () => void;
+}) {
+  const [_mods, setMods] = useState({
+    ctrl: false,
+    shift: false,
+    alt: false,
+    meta: false,
+  });
+
+  useEffect(() => {
+    const onDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+
+      const isMod = ["Control", "Shift", "Alt", "Meta"].includes(e.key);
+      if (isMod) {
+        setMods({
+          ctrl: e.ctrlKey,
+          shift: e.shiftKey,
+          alt: e.altKey,
+          meta: e.metaKey,
+        });
+        return;
+      }
+
+      onRecord({
+        key: e.key,
+        ctrl: e.ctrlKey,
+        shift: e.shiftKey,
+        alt: e.altKey,
+        meta: e.metaKey,
+      });
+    };
+
+    const onUp = (e: KeyboardEvent) => {
+      const isMod = ["Control", "Shift", "Alt", "Meta"].includes(e.key);
+      if (isMod) {
+        setMods({
+          ctrl: e.ctrlKey,
+          shift: e.shiftKey,
+          alt: e.altKey,
+          meta: e.metaKey,
+        });
+      }
+    };
+
+    window.addEventListener("keydown", onDown, { capture: true });
+    window.addEventListener("keyup", onUp, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onDown, { capture: true });
+      window.removeEventListener("keyup", onUp, { capture: true });
+    };
+  }, [onRecord, onCancel]);
+
+  return (
+    <div className="flex items-center gap-2 rounded bg-accent/50 px-2 py-1 text-[11px] ring-1 ring-accent">
+      <span className="animate-pulse font-medium">Recording...</span>
+      <span className="text-muted-foreground">(Esc to cancel)</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Implements a dynamic, serializable keybinding system for user-customizable shortcuts.

*   **Customization**: New **Shortcuts** settings tab with search, recording, and reset features.
*   **Platform-Aware**: Uses `MOD_KEY` to auto-switch between `Cmd` and `Ctrl`.
*   **Integrated UX**:
    *   `⌘K` menu now supports rebinding and direct settings navigation.
    *   `⌘,` added as a global shortcut for settings.
    *   Dynamic tooltips in the header reflect current bindings.
    *   Handles unassigned shortcuts and edge cases gracefully.

## Testing
*   Validated shortcut recording and persistence.
*   Verified reset/restore factory defaults.
*   Confirmed type safety with `tsc --noEmit`.

## Screenshot
<img width="740" height="537" alt="image" src="https://github.com/user-attachments/assets/3e49391b-e880-40be-be00-399f8610d7a8" />

closes #11 