### PR TITLE
chore(repo): add contributor docs and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in the fields below — it makes triage much faster.
+
+        For **security issues**, do NOT open an issue. See [SECURITY.md](https://github.com/crynta/Terax-AI/blob/main/SECURITY.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: Terax version
+      description: From Settings → About, or the title bar.
+      placeholder: "0.5.9"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      placeholder: "macOS 15.2 / Ubuntu 24.04 / Windows 11 23H2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of exact steps. The more specific, the faster we can help.
+      placeholder: |
+        1. Open Terax
+        2. Click ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: |
+        If applicable, paste relevant logs (devtools console, terminal output) or attach screenshots.
+        On macOS / Linux: launch from a terminal to see stderr.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true
+        - label: I am running the latest version (or this happens on `main`)
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas
+    url: https://github.com/crynta/Terax-AI/discussions
+    about: For general questions, usage help, and open-ended ideas, please start a Discussion instead of an issue.
+  - name: Security vulnerabilities
+    url: https://github.com/crynta/Terax-AI/blob/main/SECURITY.md
+    about: Do NOT open a public issue for security problems. Please follow the disclosure process in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! A short conversation here saves everyone time before any code is written.
+
+        Terax is intentionally focused — not every idea will make it in. A "no" is not a judgment of the idea.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        The **why**, not the **what**. What were you trying to do when you wished this existed?
+      placeholder: "When I'm working with multiple servers, I want to see them side-by-side without juggling tabs."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you imagine using this? UX sketch, behavior, keyboard shortcut, anything that helps us picture it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds have you tried? What other tools handle this well?
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you willing to contribute the implementation?
+      options:
+        - "Yes, with guidance"
+        - "Yes, I can do it"
+        - "No, just suggesting"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+PR title should follow Conventional Commits — it becomes the squash commit message.
+Examples: feat(terminal): add split panes / fix(explorer): close button alignment
+-->
+
+## What
+<!-- One or two sentences describing the change. -->
+
+## Why
+<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
+
+## How
+<!-- Brief notes on the approach, only if non-obvious. -->
+
+## Testing
+<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
+     describe the actual flows you exercised. -->
+
+- [ ] `pnpm exec tsc --noEmit` clean
+- [ ] Manual smoke-test of the affected feature
+- [ ] (If you touched `src-tauri/`) `cargo check` clean
+- [ ] (If UI) tested in `pnpm tauri dev`
+
+## Screenshots / GIFs
+<!-- Required for any UI change. Before / after if applicable. -->
+
+## Notes for reviewer
+<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of conduct
+
+Terax is a small open-source project and we want it to stay a place people enjoy contributing to.
+
+## The rules, briefly
+
+- **Be respectful.** Disagreement is fine; rudeness, condescension, and personal attacks are not.
+- **Assume good faith.** Most miscommunication isn't malicious — clarify before escalating.
+- **Stay on topic.** Issues, PRs, and discussions are about Terax. Take off-topic conversations elsewhere.
+- **No harassment.** Targeted insults, slurs, sustained disruption, sexualized comments, doxxing, or threats are not tolerated — anywhere, against anyone.
+- **No spam.** That includes promotional links, irrelevant cross-posting, and AI-generated noise that doesn't engage with the actual conversation.
+
+This applies to everything inside the project: issues, PRs, discussions, commits, and any community space we create later (Discord, etc.).
+
+## Enforcement
+
+If you see a violation — or experience one — email **crynta.dev@gmail.com** with subject `[Terax conduct]`. Include links and context.
+
+Maintainers may, at their discretion:
+
+1. Edit or delete the offending content
+2. Issue a private warning
+3. Lock the thread
+4. Block the account from the project
+
+We default to the lightest action that resolves the situation. Severe or repeat violations skip steps.
+
+## Scope
+
+Maintainers act in this project's spaces. We don't police behavior outside the project, but we do consider patterns of behavior elsewhere when deciding on enforcement here.
+
+---
+
+*This document is intentionally short. It is inspired by the [Contributor Covenant](https://www.contributor-covenant.org/) but kept compact for a small project.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,28 @@ Build a release bundle at least once if you touched anything in `src-tauri/`:
 pnpm tauri build
 ```
 
+## Branches
+
+Branch off `main`. Use these prefixes (kebab-case):
+
+| Prefix     | Use for                                  |
+| ---------- | ---------------------------------------- |
+| `feat/`    | New feature                              |
+| `fix/`     | Bug fix                                  |
+| `chore/`   | Refactor, tooling, config, dependencies  |
+| `docs/`    | Docs-only changes                        |
+| `perf/`    | Performance work                         |
+
+Examples: `feat/split-panes`, `fix/explorer-focus`, `chore/windows-bundle-config`.
+
+Don't open PRs from your fork's `main` branch — it makes future syncs painful for you. Always work on a feature branch.
+
+## Issues first for non-trivial work
+
+For anything beyond a typo, a small bug fix, or a clear `good-first-issue` — **open an issue first** and wait for a maintainer to ack the approach. A 10-minute conversation saves a 500-line PR that doesn't fit the roadmap.
+
+If an issue already exists for what you want to do, comment "I'll take this" before starting so we don't duplicate work.
+
 ## What we want
 
 - **Bug fixes** — always.
@@ -52,9 +74,40 @@ pnpm tauri build
 
 ## Commits & PRs
 
-- Commit titles short and contextual: `area: what changed`. Look at `git log` for examples.
-- One logical change per PR. Don't bundle unrelated fixes.
-- Describe what and why in the PR body, plus how you tested it. Screenshots / GIFs for UI changes.
+We squash-merge every PR — the **PR title becomes the squash commit**, so it should follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(terminal): add split panes
+fix(explorer): prevent input from disappearing on create
+chore(deps): bump tauri to 2.x
+docs(readme): clarify Linux install on Arch
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `perf`, `refactor`, `test`, `build`, `ci`.
+Common scopes: `terminal`, `editor`, `explorer`, `pty`, `ai`, `settings`, `tabs`, `shortcuts`, `agents`, `ui`.
+
+Within a PR, individual commit messages can be whatever — they get squashed.
+
+**One logical change per PR.** A PR that adds a feature, fixes an unrelated bug, and reformats `.gitignore` is three PRs. Split them.
+
+**Open a draft PR early** if you want feedback mid-flight; mark "Ready for review" when done. Fill out the PR template — what changed, why, how you tested. Include screenshots / GIFs for any UI change.
+
+### What gets merged faster
+
+- Clear problem statement
+- Small, focused diff
+- Follows existing patterns (read 2-3 nearby files before writing yours)
+- `pnpm exec tsc --noEmit` clean
+- Manual testing notes ("I tested by doing X, Y, Z")
+
+### What gets bounced back
+
+- Mixed-concern PRs ("split this please")
+- Large architectural PRs without prior discussion
+- New dependencies without justification
+- Breaking changes without migration notes
+- Incidental reformatting unrelated to the change (adds noise to review)
+- AI-generated code that obviously wasn't read by the author
 
 ## Project layout
 


### PR DESCRIPTION
## What
Adds contributor-facing docs and structured templates so new contributors have clear conventions to follow.

## Files
- `CONTRIBUTING.md` — extended with branch naming (`feat/`, `fix/`, `chore/`), issues-first guidance for non-trivial work, squash-merge policy, Conventional Commits examples, and what gets merged faster vs bounced back
- `.github/PULL_REQUEST_TEMPLATE.md` — what / why / how / testing / screenshots
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report (OS, version, repro)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem-first feature request
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, routes Q&A to Discussions, security to SECURITY.md
- `CODE_OF_CONDUCT.md` — short, project-appropriate

## Notes
- Did not duplicate or rewrite existing `SECURITY.md` (already in repo and well-written)
- Conventional Commits is recommended, not enforced — can revisit with CI later