### PR TITLE
terminal:terax_open command for openning files into a terax tab

### DIFF
--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -59,6 +59,34 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
     PS0='\[\e]133;C\e\\\]'"${PS0:-}"
   fi
 
+  # terax_open: open file in editor tab via OSC 8888.
+  # Usage: terax_open <file>
+  terax_open() {
+    local file="$1"
+
+    if [ -z "$file" ]; then
+      printf "usage: terax_open <file>\n" >&2
+      return 1
+    fi
+
+    # Resolve relative paths relative to PWD.
+    if [[ "$file" != /* ]]; then
+      file="$PWD/$file"
+    fi
+
+    # Check that the path exists and is a regular file.
+    if [ ! -f "$file" ]; then
+      printf "terax_open: not a file: %s\n" "$file" >&2
+      return 1
+    fi
+
+    # Emit OSC 8888 with URL-encoded file path.
+    printf '\e]8888;file=%s\e\\' "$(_terax_urlencode "$file")"
+  }
+
+  # Shorthand alias.
+  alias tp='terax_open'
+
   _terax_precmd
 fi
 :

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -54,6 +54,34 @@ if [[ -z "$__TERAX_HOOKS_LOADED" ]]; then
     add-zsh-hook preexec _terax_preexec
   fi
 
+  # terax_open: open file in editor tab via OSC 8888.
+  # Usage: terax_open <file>
+  terax_open() {
+    local file="$1"
+
+    if [[ -z "$file" ]]; then
+      printf "usage: terax_open <file>\n" >&2
+      return 1
+    fi
+
+    # Resolve relative paths relative to PWD.
+    if [[ "$file" != /* ]]; then
+      file="$PWD/$file"
+    fi
+
+    # Check that the path exists and is a regular file.
+    if [[ ! -f "$file" ]]; then
+      printf "terax_open: not a file: %s\n" "$file" >&2
+      return 1
+    fi
+
+    # Emit OSC 8888 with URL-encoded file path.
+    printf '\e]8888;file=%s\e\\' "$(_terax_urlencode "$file")"
+  }
+
+  # Shorthand alias.
+  alias tp='terax_open'
+
   _terax_precmd
 fi
 :

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/modules/shortcuts";
 import { StatusBar } from "@/modules/statusbar";
 import { useTabs, useWorkspaceCwd } from "@/modules/tabs";
-import { TerminalStack, type TerminalPaneHandle } from "@/modules/terminal";
+import { TerminalStack, type TerminalPaneHandle, type TeraxOpenInput } from "@/modules/terminal";
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import { homeDir } from "@tauri-apps/api/path";
@@ -516,6 +516,14 @@ export default function App() {
     [updateTab],
   );
 
+  const handleTeraxOpen = useCallback(
+    (_tabId: number, input: TeraxOpenInput) => {
+      // Always open in a new tab
+      openFileTab(input.file);
+    },
+    [openFileTab],
+  );
+
   const handleEditorDirty = useCallback(
     (id: number, dirty: boolean) => updateTab(id, { dirty }),
     [updateTab],
@@ -633,6 +641,7 @@ export default function App() {
                         onSearchReady={handleSearchReady}
                         onCwd={handleTerminalCwd}
                         onDetectedLocalUrl={handleDetectedLocalUrl}
+                        onTeraxOpen={handleTeraxOpen}
                       />
                     </div>
                     <div

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,12 +1,7 @@
 import { useTheme } from "@/modules/theme";
 import type { SearchAddon } from "@xterm/addon-search";
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-} from "react";
-import { useTerminalSession } from "./lib/useTerminalSession";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { useTerminalSession, type TeraxOpenInput } from "./lib/useTerminalSession";
 
 export type TerminalPaneHandle = {
   write: (data: string) => void;
@@ -23,6 +18,7 @@ type Props = {
   onExit?: (tabId: number, code: number) => void;
   onCwd?: (tabId: number, cwd: string) => void;
   onDetectedLocalUrl?: (tabId: number, url: string) => void;
+  onTeraxOpen?: (tabId: number, input: TeraxOpenInput) => void;
 };
 
 export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
@@ -35,6 +31,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       onExit,
       onCwd,
       onDetectedLocalUrl,
+      onTeraxOpen,
     },
     ref,
   ) {
@@ -49,6 +46,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       onExit: (c) => onExit?.(tabId, c),
       onCwd: (c) => onCwd?.(tabId, c),
       onDetectedLocalUrl: (u) => onDetectedLocalUrl?.(tabId, u),
+      onTeraxOpen: (input) => onTeraxOpen?.(tabId, input),
     });
 
     useEffect(() => {

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -1,6 +1,7 @@
 import type { Tab } from "@/modules/tabs";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useEffect, useRef } from "react";
+import { type TeraxOpenInput } from "./lib/useTerminalSession";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 
 type Props = {
@@ -10,6 +11,7 @@ type Props = {
   onSearchReady: (id: number, addon: SearchAddon) => void;
   onCwd: (id: number, cwd: string) => void;
   onDetectedLocalUrl: (id: number, url: string) => void;
+  onTeraxOpen?: (id: number, input: TeraxOpenInput) => void;
 };
 
 export function TerminalStack({
@@ -19,6 +21,7 @@ export function TerminalStack({
   onSearchReady,
   onCwd,
   onDetectedLocalUrl,
+  onTeraxOpen,
 }: Props) {
   const terminals = tabs.filter((t) => t.kind === "terminal");
 
@@ -26,6 +29,7 @@ export function TerminalStack({
   const searchReadyRef = useRef(onSearchReady);
   const cwdRef = useRef(onCwd);
   const detectedUrlRef = useRef(onDetectedLocalUrl);
+  const teraxOpenRef = useRef(onTeraxOpen);
   useEffect(() => {
     registerRef.current = registerHandle;
   }, [registerHandle]);
@@ -38,12 +42,16 @@ export function TerminalStack({
   useEffect(() => {
     detectedUrlRef.current = onDetectedLocalUrl;
   }, [onDetectedLocalUrl]);
+  useEffect(() => {
+    teraxOpenRef.current = onTeraxOpen;
+  }, [onTeraxOpen]);
 
   type Bundle = {
     setRef: (h: TerminalPaneHandle | null) => void;
     onSearch: (addon: SearchAddon) => void;
     onCwd: (cwd: string) => void;
     onDetectedUrl: (url: string) => void;
+    onTeraxOpen: (input: TeraxOpenInput) => void;
   };
   const bundles = useRef(new Map<number, Bundle>());
   const getBundle = (id: number): Bundle => {
@@ -54,6 +62,7 @@ export function TerminalStack({
         onSearch: (addon) => searchReadyRef.current(id, addon),
         onCwd: (cwd) => cwdRef.current(id, cwd),
         onDetectedUrl: (url) => detectedUrlRef.current(id, url),
+        onTeraxOpen: (input) => teraxOpenRef.current?.(id, input),
       };
       bundles.current.set(id, b);
     }
@@ -81,6 +90,7 @@ export function TerminalStack({
               onSearchReady={(_id, addon) => b.onSearch(addon)}
               onCwd={(_id, cwd) => b.onCwd(cwd)}
               onDetectedLocalUrl={(_id, url) => b.onDetectedUrl(url)}
+              onTeraxOpen={(_id, input) => b.onTeraxOpen(input)}
             />
           </div>
         );

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -1,2 +1,3 @@
 export { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 export { TerminalStack } from "./TerminalStack";
+export type { TeraxOpenInput } from "./lib/useTerminalSession";

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -36,6 +36,22 @@ export function registerPromptTracker(term: Terminal): PromptTracker {
   };
 }
 
+export type TeraxOpenInput = {
+  file: string;
+};
+
+export function registerTeraxOpenHandler(
+  term: Terminal,
+  onTeraxOpen: (input: TeraxOpenInput) => void,
+): () => void {
+  const d = term.parser.registerOscHandler(8888, (data) => {
+    const input = parseTeraxOpen(data);
+    if (input) onTeraxOpen(input);
+    return true;
+  });
+  return () => d.dispose();
+}
+
 function parseOsc7(data: string): string | null {
   const m = data.match(/^file:\/\/[^/]*(\/.*)$/);
   if (!m) return null;
@@ -43,5 +59,18 @@ function parseOsc7(data: string): string | null {
     return decodeURIComponent(m[1]);
   } catch {
     return m[1];
+  }
+}
+
+function parseTeraxOpen(data: string): TeraxOpenInput | null {
+  // Parse format: "file=/path/to/file"
+  const fileMatch = data.match(/file=([^;]+)/);
+
+  if (!fileMatch) return null;
+
+  try {
+    return { file: decodeURIComponent(fileMatch[1]) };
+  } catch {
+    return { file: fileMatch[1] };
   }
 }

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -6,8 +6,10 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { registerCwdHandler, registerPromptTracker } from "./osc-handlers";
+import { registerCwdHandler, registerPromptTracker, registerTeraxOpenHandler, type TeraxOpenInput } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
+
+export type { TeraxOpenInput };
 
 const FONT_FAMILY = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
 const FONT_SIZE = 14;
@@ -20,6 +22,7 @@ type Options = {
   onExit?: (code: number) => void;
   onCwd?: (cwd: string) => void;
   onDetectedLocalUrl?: (url: string) => void;
+  onTeraxOpen?: (input: TeraxOpenInput) => void;
 };
 
 // Matches dev-server-style local URLs (vite, next dev, webpack, …). Anchors
@@ -35,18 +38,21 @@ export function useTerminalSession({
   onExit,
   onCwd,
   onDetectedLocalUrl,
+  onTeraxOpen,
 }: Options) {
   const detectedRef = useRef<string | null>(null);
   const onDetectedRef = useRef(onDetectedLocalUrl);
   const onCwdRef = useRef(onCwd);
   const onExitRef = useRef(onExit);
   const onSearchReadyRef = useRef(onSearchReady);
+  const onTeraxOpenRef = useRef(onTeraxOpen);
   useEffect(() => {
     onDetectedRef.current = onDetectedLocalUrl;
     onCwdRef.current = onCwd;
     onExitRef.current = onExit;
     onSearchReadyRef.current = onSearchReady;
-  }, [onDetectedLocalUrl, onCwd, onExit, onSearchReady]);
+    onTeraxOpenRef.current = onTeraxOpen;
+  }, [onDetectedLocalUrl, onCwd, onExit, onSearchReady, onTeraxOpen]);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const ptyRef = useRef<PtySession | null>(null);
@@ -99,6 +105,7 @@ export function useTerminalSession({
       const prompt = registerPromptTracker(term);
       cleanups.push(
         registerCwdHandler(term, (cwd) => onCwdRef.current?.(cwd)),
+        registerTeraxOpenHandler(term, (input) => onTeraxOpenRef.current?.(input)),
         prompt.dispose,
       );
       onSearchReadyRef.current?.(search);


### PR DESCRIPTION
## What

Add `terax_open <file>` and `tp` to the integrated shell so users can open files from the terminal directly in a Terax editor tab.

## Why

This improves keyboard-driven navigation by letting users jump from the integrated terminal to an editor tab without reaching for the sidebar or mouse-driven file browsing.

## How

- Bash/zsh shell integration emits OSC 8888 with an encoded file path.
- The terminal frontend handles OSC 8888 and opens the file through the existing editor tab flow.
- The parser defensively handles malformed encoded payloads.

## Testing

- [x] `./node_modules/.bin/tsc --noEmit` clean
- [x] `git diff --check` clean
- [x] Manual smoke-test of `tp <file>` from an integrated bash shell
- [x] Manual smoke-test of `tp <file>` from an integrated zsh shell
- [x] Manual smoke-test with filenames containing spaces, `%`, and `;`
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

No visual layout change.

## Notes for reviewer

Repeated `tp <same-file>` currently follows the existing file-tab behavior and focuses the already-open editor tab.
