### PR TITLE
Add configurable code font family and ligatures for editor + terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@uiw/codemirror-themes": "^4.25.9",
     "@uiw/react-codemirror": "^4.25.9",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-ligatures": "^0.10.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-ligatures':
+        specifier: ^0.10.0
+        version: 0.10.0
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
@@ -2234,6 +2237,10 @@ packages:
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
+  '@xterm/addon-ligatures@0.10.0':
+    resolution: {integrity: sha512-/Few8ZSHMib7sGjRJoc5l7bCtEB9XJfkNofvPpOcWADxKaUl8og8P172j67OoACSNJAXqeCLIuvj8WFCBkcTxg==}
+    engines: {node: '>8.0.0'}
+
   '@xterm/addon-search@0.16.0':
     resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
 
@@ -2886,6 +2893,14 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  font-finder@1.1.0:
+    resolution: {integrity: sha512-wpCL2uIbi6GurJbU7ZlQ3nGd61Ho+dSU6U83/xJT5UPFfN35EeCW/rOtS+5k+IuEZu2SYmHzDIPL9eA5tSYRAw==}
+    engines: {node: '>8.0.0'}
+
+  font-ligatures@1.4.1:
+    resolution: {integrity: sha512-7W6zlfyhvCqShZ5ReUWqmSd9vBaUudW0Hxis+tqUjtHhsPU+L3Grf8mcZAtCiXHTzorhwdRTId2WeH/88gdFkw==}
+    engines: {node: '>8.0.0'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -2962,6 +2977,10 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
+
+  get-system-fonts@2.0.2:
+    resolution: {integrity: sha512-zzlgaYnHMIEgHRrfC7x0Qp0Ylhw/sHpM6MHXeVBTYIsvGf5GpbnClB+Q6rAPdn+0gd2oZZIo6Tj3EaWrt4VhDQ==}
+    engines: {node: '>8.0.0'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3345,6 +3364,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -3651,6 +3674,10 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  opentype.js@0.8.0:
+    resolution: {integrity: sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg==}
+    hasBin: true
+
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -3745,6 +3772,10 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  promise-stream-reader@1.0.1:
+    resolution: {integrity: sha512-Tnxit5trUjBAqqZCGWwjyxhmgMN4hGrtpW3Oc/tRI4bpm/O2+ej72BB08l6JBnGQgVDGCLvHFGjGgQS6vzhwXg==}
+    engines: {node: '>8.0.0'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -4089,6 +4120,9 @@ packages:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -4360,6 +4394,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -6506,6 +6543,11 @@ snapshots:
 
   '@xterm/addon-fit@0.11.0': {}
 
+  '@xterm/addon-ligatures@0.10.0':
+    dependencies:
+      font-finder: 1.1.0
+      font-ligatures: 1.4.1
+
   '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -7194,6 +7236,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  font-finder@1.1.0:
+    dependencies:
+      get-system-fonts: 2.0.2
+      promise-stream-reader: 1.0.1
+
+  font-ligatures@1.4.1:
+    dependencies:
+      font-finder: 1.1.0
+      lru-cache: 6.0.0
+      opentype.js: 0.8.0
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -7258,6 +7311,8 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  get-system-fonts@2.0.2: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -7633,6 +7688,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   magic-string@0.30.21:
     dependencies:
@@ -8177,6 +8236,10 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
+  opentype.js@0.8.0:
+    dependencies:
+      tiny-inflate: 1.0.3
+
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -8273,6 +8336,8 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  promise-stream-reader@1.0.1: {}
 
   prompts@2.4.2:
     dependencies:
@@ -8795,6 +8860,8 @@ snapshots:
 
   throttleit@2.1.0: {}
 
+  tiny-inflate@1.0.3: {}
+
   tiny-invariant@1.3.3: {}
 
   tinyexec@1.1.1: {}
@@ -9028,6 +9095,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/lib/codeFont.ts
+++ b/src/lib/codeFont.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_CODE_FONT_FAMILY =
+  '"JetBrainsMono Nerd Font", "JetBrainsMono Nerd Font Mono", "JetBrains Mono", SFMono-Regular, Menlo, monospace';
+
+export function getFontLoadFamilies(fontFamily: string): string[] {
+  const families = fontFamily
+    .split(",")
+    .map((part) => part.trim().replace(/^['"]|['"]$/g, ""))
+    .filter(Boolean)
+    .filter((name) => !["monospace", "serif", "sans-serif", "system-ui"].includes(name.toLowerCase()));
+  return [...new Set(families)];
+}

--- a/src/modules/editor/AiDiffPane.tsx
+++ b/src/modules/editor/AiDiffPane.tsx
@@ -90,6 +90,8 @@ export function AiDiffPane({
 }: Props) {
   const cmRef = useRef<ReactCodeMirrorRef>(null);
   const editorThemeId = usePreferencesStore((s) => s.editorTheme);
+  const codeFontFamily = usePreferencesStore((s) => s.codeFontFamily);
+  const codeLigatures = usePreferencesStore((s) => s.codeLigatures);
   const themeExt = EDITOR_THEME_EXT[editorThemeId] ?? EDITOR_THEME_EXT.atomone;
 
   // The merge extension diffs the current document against `original`.
@@ -97,7 +99,7 @@ export function AiDiffPane({
   // updates its proposal, the surrounding bridge re-creates the tab.
   const extensions = useMemo(
     () => [
-      ...buildSharedExtensions(),
+      ...buildSharedExtensions(codeFontFamily, codeLigatures),
       languageCompartment.of([]),
       EditorState.readOnly.of(true),
       EditorView.editable.of(false),
@@ -111,7 +113,7 @@ export function AiDiffPane({
       }),
       DIFF_THEME,
     ],
-    [originalContent],
+    [codeFontFamily, codeLigatures, originalContent],
   );
 
   // Resolve language by path (same approach as EditorPane).

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -18,7 +18,9 @@ import {
 import { Prec } from "@codemirror/state";
 import { vim } from "@replit/codemirror-vim";
 import {
+  buildFontTheme,
   buildSharedExtensions,
+  fontCompartment,
   languageCompartment,
   vimCompartment,
 } from "./lib/extensions";
@@ -63,6 +65,8 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const cmRef = useRef<ReactCodeMirrorRef>(null);
     const editorThemeId = usePreferencesStore((s) => s.editorTheme);
     const vimMode = usePreferencesStore((s) => s.vimMode);
+    const codeFontFamily = usePreferencesStore((s) => s.codeFontFamily);
+    const codeLigatures = usePreferencesStore((s) => s.codeLigatures);
     const languageRef = useRef<string | null>(null);
     const apiKeyRef = useRef<string | null>(null);
 
@@ -124,7 +128,10 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
           },
           close: () => onCloseRef.current?.(),
         })),
-        ...buildSharedExtensions(),
+        ...buildSharedExtensions(
+          usePreferencesStore.getState().codeFontFamily,
+          usePreferencesStore.getState().codeLigatures,
+        ),
         languageCompartment.of([]),
         inlineCompletion({
           getPrefs: () => {
@@ -166,6 +173,16 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
         ),
       });
     }, [vimMode]);
+
+    useEffect(() => {
+      const view = cmRef.current?.view;
+      if (!view) return;
+      view.dispatch({
+        effects: fontCompartment.reconfigure(
+          buildFontTheme(codeFontFamily, codeLigatures),
+        ),
+      });
+    }, [codeFontFamily, codeLigatures]);
 
     useEffect(() => {
       let cancelled = false;

--- a/src/modules/editor/lib/extensions.ts
+++ b/src/modules/editor/lib/extensions.ts
@@ -9,17 +9,34 @@ export const languageCompartment = new Compartment();
 export const readOnlyCompartment = new Compartment();
 export const wrapCompartment = new Compartment();
 export const vimCompartment = new Compartment();
+export const fontCompartment = new Compartment();
 
 // Only what basicSetup doesn't already cover, to avoid duplicate extensions.
 // basicSetup gives us line numbers, fold gutter, history, indentOnInput,
 // bracketMatching, closeBrackets, autocompletion, highlightActiveLine,
 // highlightSelectionMatches and the search keymap.
-export function buildSharedExtensions(): Extension[] {
+export function buildFontTheme(fontFamily: string, ligatures: boolean): Extension {
+  return EditorView.theme({
+    ".cm-scroller": {
+      fontFamily,
+      fontVariantLigatures: ligatures ? "normal" : "none",
+      fontFeatureSettings: ligatures
+        ? '"calt" 1, "liga" 1, "clig" 1'
+        : '"calt" 0, "liga" 0, "clig" 0',
+      fontSize: "13px",
+      lineHeight: "1.55",
+      backgroundColor: "transparent !important",
+    },
+  });
+}
+
+export function buildSharedExtensions(fontFamily: string, ligatures: boolean): Extension[] {
   return [
     indentUnit.of("  "),
     EditorState.tabSize.of(2),
     search({ top: true }),
     lintGutter(),
+    fontCompartment.of(buildFontTheme(fontFamily, ligatures)),
     EditorView.theme({
       "&, &.cm-editor, &.cm-editor.cm-focused": {
         backgroundColor: "transparent !important",
@@ -28,7 +45,6 @@ export function buildSharedExtensions(): Extension[] {
         padding: "8px",
       },
       ".cm-scroller": {
-        fontFamily: '"JetBrains Mono", SFMono-Regular, Menlo, monospace',
         fontSize: "13px",
         lineHeight: "1.55",
         backgroundColor: "transparent !important",

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -1,5 +1,6 @@
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
+import { DEFAULT_CODE_FONT_FAMILY } from "@/lib/codeFont";
 import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   DEFAULT_MODEL_ID,
@@ -40,6 +41,8 @@ export type Preferences = {
   theme: ThemePref;
   defaultModelId: ModelId;
   editorTheme: EditorThemeId;
+  codeFontFamily: string;
+  codeLigatures: boolean;
   customInstructions: string;
   autostart: boolean;
   restoreWindowState: boolean;
@@ -54,6 +57,8 @@ const STORE_PATH = "terax-settings.json";
 const KEY_THEME = "theme";
 const KEY_DEFAULT_MODEL = "defaultModelId";
 const KEY_EDITOR_THEME = "editorTheme";
+const KEY_CODE_FONT_FAMILY = "codeFontFamily";
+const KEY_CODE_LIGATURES = "codeLigatures";
 const KEY_CUSTOM_INSTRUCTIONS = "customInstructions";
 const KEY_AUTOSTART = "autostart";
 const KEY_RESTORE_WINDOW = "restoreWindowState";
@@ -67,6 +72,8 @@ export const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
   defaultModelId: DEFAULT_MODEL_ID,
   editorTheme: "atomone",
+  codeFontFamily: DEFAULT_CODE_FONT_FAMILY,
+  codeLigatures: true,
   customInstructions: "",
   autostart: false,
   restoreWindowState: true,
@@ -91,6 +98,10 @@ export async function loadPreferences(): Promise<Preferences> {
       get<ModelId>(KEY_DEFAULT_MODEL) ?? DEFAULT_PREFERENCES.defaultModelId,
     editorTheme:
       get<EditorThemeId>(KEY_EDITOR_THEME) ?? DEFAULT_PREFERENCES.editorTheme,
+    codeFontFamily:
+      get<string>(KEY_CODE_FONT_FAMILY) ?? DEFAULT_PREFERENCES.codeFontFamily,
+    codeLigatures:
+      get<boolean>(KEY_CODE_LIGATURES) ?? DEFAULT_PREFERENCES.codeLigatures,
     customInstructions:
       get<string>(KEY_CUSTOM_INSTRUCTIONS) ??
       DEFAULT_PREFERENCES.customInstructions,
@@ -126,6 +137,16 @@ export async function setDefaultModel(value: ModelId): Promise<void> {
 
 export async function setEditorTheme(value: EditorThemeId): Promise<void> {
   await store.set(KEY_EDITOR_THEME, value);
+  await store.save();
+}
+
+export async function setCodeFontFamily(value: string): Promise<void> {
+  await store.set(KEY_CODE_FONT_FAMILY, value);
+  await store.save();
+}
+
+export async function setCodeLigatures(value: boolean): Promise<void> {
+  await store.set(KEY_CODE_LIGATURES, value);
   await store.save();
 }
 
@@ -181,6 +202,8 @@ export function onPreferencesChange(
     [KEY_THEME]: "theme",
     [KEY_DEFAULT_MODEL]: "defaultModelId",
     [KEY_EDITOR_THEME]: "editorTheme",
+    [KEY_CODE_FONT_FAMILY]: "codeFontFamily",
+    [KEY_CODE_LIGATURES]: "codeLigatures",
     [KEY_CUSTOM_INSTRUCTIONS]: "customInstructions",
     [KEY_AUTOSTART]: "autostart",
     [KEY_RESTORE_WINDOW]: "restoreWindowState",

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,6 +1,9 @@
+import { getFontLoadFamilies } from "@/lib/codeFont";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
+import { LigaturesAddon } from "@xterm/addon-ligatures";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -9,7 +12,6 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { registerCwdHandler, registerPromptTracker } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
 
-const FONT_FAMILY = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
 const FONT_SIZE = 14;
 
 type Options = {
@@ -50,17 +52,26 @@ export function useTerminalSession({
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const ptyRef = useRef<PtySession | null>(null);
+  const ligaturesRef = useRef<LigaturesAddon | null>(null);
+  const ligaturesEnabledRef = useRef(false);
+  const codeFontFamily = usePreferencesStore((s) => s.codeFontFamily);
+  const codeLigatures = usePreferencesStore((s) => s.codeLigatures);
 
   useEffect(() => {
     let disposed = false;
     const cleanups: Array<() => void> = [];
 
     (async () => {
-      await document.fonts.load(`${FONT_SIZE}px "JetBrains Mono"`);
+      const fontFamily = usePreferencesStore.getState().codeFontFamily;
+      await Promise.all(
+        getFontLoadFamilies(fontFamily).map((family) =>
+          document.fonts.load(`${FONT_SIZE}px "${family}"`).catch(() => []),
+        ),
+      );
       if (disposed || !container.current) return;
 
       const term = new Terminal({
-        fontFamily: FONT_FAMILY,
+        fontFamily,
         fontSize: FONT_SIZE,
         lineHeight: 1.05,
         theme: buildTerminalTheme(),
@@ -81,6 +92,16 @@ export function useTerminalSession({
 
       const search = new SearchAddon();
       term.loadAddon(search);
+      try {
+        const ligatures = new LigaturesAddon();
+        ligaturesRef.current = ligatures;
+        if (usePreferencesStore.getState().codeLigatures) {
+          term.loadAddon(ligatures);
+          ligaturesEnabledRef.current = true;
+        }
+      } catch (e) {
+        console.warn("Ligatures addon unavailable:", e);
+      }
       term.loadAddon(
         new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
       );
@@ -204,6 +225,9 @@ export function useTerminalSession({
       ptyRef.current = null;
       termRef.current?.dispose();
       termRef.current = null;
+      ligaturesRef.current?.dispose();
+      ligaturesRef.current = null;
+      ligaturesEnabledRef.current = false;
       fitRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -248,7 +272,41 @@ export function useTerminalSession({
     term.options.theme = buildTerminalTheme();
   }, []);
 
-  return { write, focus, getBuffer, getSelection, applyTheme };
+  const applyAppearance = useCallback(
+    (fontFamily: string, ligatures: boolean) => {
+      const term = termRef.current;
+      if (!term) return;
+      term.options.fontFamily = fontFamily;
+
+      if (ligatures && !ligaturesEnabledRef.current) {
+        try {
+          const addon = new LigaturesAddon();
+          term.loadAddon(addon);
+          ligaturesRef.current = addon;
+          ligaturesEnabledRef.current = true;
+        } catch (e) {
+          console.warn("Ligatures addon unavailable:", e);
+        }
+      } else if (!ligatures && ligaturesEnabledRef.current) {
+        ligaturesRef.current?.dispose();
+        ligaturesRef.current = null;
+        ligaturesEnabledRef.current = false;
+      }
+
+      fitRef.current?.fit();
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void Promise.all(
+      getFontLoadFamilies(codeFontFamily).map((family) =>
+        document.fonts.load(`${FONT_SIZE}px "${family}"`).catch(() => []),
+      ),
+    ).then(() => applyAppearance(codeFontFamily, codeLigatures));
+  }, [applyAppearance, codeFontFamily, codeLigatures]);
+
+  return { write, focus, getBuffer, getSelection, applyTheme, applyAppearance };
 }
 
 function stripTrailingPunct(url: string): string {

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -13,6 +14,8 @@ import {
   EDITOR_THEME_LABELS,
   EDITOR_THEMES,
   setAutostart,
+  setCodeFontFamily,
+  setCodeLigatures,
   setEditorTheme,
   setRestoreWindowState,
   setVimMode,
@@ -47,6 +50,8 @@ export function GeneralSection() {
   const autostart = usePreferencesStore((s) => s.autostart);
   const restoreWindowState = usePreferencesStore((s) => s.restoreWindowState);
   const vimMode = usePreferencesStore((s) => s.vimMode);
+  const codeFontFamily = usePreferencesStore((s) => s.codeFontFamily);
+  const codeLigatures = usePreferencesStore((s) => s.codeLigatures);
 
   // Reconcile autostart pref with the actual OS state on mount — the user may
   // have toggled it from System Settings.
@@ -107,6 +112,29 @@ export function GeneralSection() {
       </div>
 
       <div className="flex flex-col gap-2">
+        <Label>Editor</Label>
+        <SettingRow
+          title="Code font family"
+          description="CSS font-family stack used by terminal and editor. Example: JetBrainsMono Nerd Font, Fira Code, monospace"
+          className="items-center"
+        >
+          <Input
+            value={codeFontFamily}
+            onChange={(e) => void setCodeFontFamily(e.target.value)}
+            className="h-8 w-[340px] max-w-[52vw] rounded-lg px-2.5 font-mono text-[11.5px]"
+            spellCheck={false}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Ligatures"
+          description="Enable programming ligatures in terminal and editor."
+        >
+          <Switch
+            checked={codeLigatures}
+            onCheckedChange={(v) => void setCodeLigatures(v)}
+          />
+        </SettingRow>
+
         <Label>Editor theme</Label>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
 ## What

 Adds configurable code typography for both editor and terminal: users can now set a custom font-family stack and toggle
 programming ligatures from General Settings.

 ## Why

 Editor and terminal font behavior was hardcoded, which made it difficult for users to use preferred patched fonts (e.g.
 Nerd Fonts) or disable ligatures for readability/performance.

 ## How

 - Added new persisted preferences: codeFontFamily and codeLigatures.
 - Added settings UI controls in General Settings (font-family input + ligatures switch).
 - Refactored CodeMirror shared extensions to accept font/ligature options and reconfigure dynamically via a dedicated
 font compartment.
 - Applied the same settings to EditorPane and AiDiffPane.
 - Integrated @xterm/addon-ligatures in terminal and added runtime appearance updates when preferences change.
 - Added font parsing/loading helpers in src/lib/codeFont.ts and preloaded selected font families before applying terminal
 appearance.

 ## Testing

 - pnpm exec tsc --noEmit clean
 - Manual smoke-test of the affected feature
 - (If you touched src-tauri/) cargo check clean
 - (If UI) tested in pnpm tauri dev

 ## Manual flows exercised:
 - Changed Code font family in Settings and verified updates apply to both editor and terminal.
 - Toggled Ligatures on/off and verified behavior changes in editor and terminal.
 - Opened AI diff view and verified font + ligature preferences are respected there as well.
 - Confirmed terminal still works if ligatures addon cannot be initialized (non-fatal path).

 ## Screenshots / GIFs

<img width="2880" height="1752" alt="2026-05-09-220114_hyprshot" src="https://github.com/user-attachments/assets/fb558a60-7302-4f41-b7b3-e4bc197bc47c" />

 ## Notes for reviewer

 - Terminal ligatures are loaded best-effort; failures are logged and do not break terminal startup.
 - Default behavior remains aligned with previous experience, but now user-overridable.
 - Dependency update includes @xterm/addon-ligatures and related lockfile changes.

 ──────────────────────────────────────────────────────────────────────────────

> Changes were made using pi ai coding agent.