### PR TITLE
feat(tabs): add transient preview tabs with pinning behavior

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -67,6 +67,7 @@ export default function App() {
     setActiveId,
     newTab,
     openFileTab,
+    pinTab,
     newPreviewTab,
     openAiDiffTab,
     setAiDiffStatus,
@@ -398,8 +399,10 @@ export default function App() {
   );
 
   const handleOpenFile = useCallback(
-    (path: string) => {
-      openFileTab(path);
+    (path: string, pin?: boolean) => {
+      // Explorer defaults to preview (pin=false); explicit actions like
+      // context-menu "Open" pass pin=true for a persistent tab.
+      openFileTab(path, pin ?? false);
     },
     [openFileTab],
   );
@@ -583,6 +586,7 @@ export default function App() {
             onNewPreview={() => openPreviewTab("")}
             onNewEditor={() => setNewEditorOpen(true)}
             onClose={handleClose}
+            onPin={pinTab}
             onToggleSidebar={toggleSidebar}
             onOpenShortcuts={() => setShortcutsOpen(true)}
             onOpenSettings={() => void openSettingsWindow()}

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -36,7 +36,7 @@ type SearchHit = {
 
 type Props = {
   rootPath: string | null;
-  onOpenFile: (path: string) => void;
+  onOpenFile: (path: string, pin?: boolean) => void;
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
   onRevealInTerminal?: (path: string) => void;

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -27,7 +27,12 @@ type Props = {
   rootPath: string;
   depth: number;
   tree: Tree;
-  onOpenFile: (path: string) => void;
+  /**
+   * Called whenever a file should be opened.
+   * `pin` signals persistent intent (e.g. context-menu "Open");
+   * omitting it means the caller decides the default (preview).
+   */
+  onOpenFile: (path: string, pin?: boolean) => void;
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   selectedPath: string | null;
@@ -135,7 +140,7 @@ function FileTreeNodeImpl({
           {!isDir && (
             <ContextMenuItem
               className={COMPACT_ITEM}
-              onSelect={() => onOpenFile(path)}
+              onSelect={() => onOpenFile(path, true)}
             >
               Open
             </ContextMenuItem>

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -24,6 +24,8 @@ type Props = {
   onNewPreview: () => void;
   onNewEditor: () => void;
   onClose: (id: number) => void;
+  /** Promote a preview (transient) tab to persistent. */
+  onPin: (id: number) => void;
   onToggleSidebar: () => void;
   onOpenShortcuts: () => void;
   onOpenSettings: () => void;
@@ -41,6 +43,7 @@ export function Header({
   onNewPreview,
   onNewEditor,
   onClose,
+  onPin,
   onToggleSidebar,
   onOpenShortcuts,
   onOpenSettings,
@@ -123,6 +126,7 @@ export function Header({
           onNewPreview={onNewPreview}
           onNewEditor={onNewEditor}
           onClose={onClose}
+          onPin={onPin}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -20,7 +20,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef } from "react";
-import type { Tab } from "./lib/useTabs";
+import type { EditorTab, Tab } from "./lib/useTabs";
 
 type Props = {
   tabs: Tab[];
@@ -30,6 +30,8 @@ type Props = {
   onNewPreview: () => void;
   onNewEditor: () => void;
   onClose: (id: number) => void;
+  /** Pin (promote) a preview tab to persistent on double-click. */
+  onPin: (id: number) => void;
   compact?: boolean;
 };
 
@@ -41,6 +43,7 @@ export function TabBar({
   onNewPreview,
   onNewEditor,
   onClose,
+  onPin,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -79,50 +82,58 @@ export function TabBar({
           onValueChange={(v) => onSelect(Number(v))}
         >
           <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
-            {tabs.map((t) => (
-              <TabsTrigger
-                key={t.id}
-                value={String(t.id)}
-                data-tab-id={t.id}
-                className={cn(
-                  "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
-                  compact ? "px-1.5!" : "ps-2! pe-1!"
-                )}
-              >
-                <span
+            {tabs.map((t) => {
+              const isPreview = t.kind === "editor" && (t as EditorTab).preview;
+              return (
+                <TabsTrigger
+                  key={t.id}
+                  value={String(t.id)}
+                  data-tab-id={t.id}
+                  onDoubleClick={() => isPreview && onPin(t.id)}
                   className={cn(
-                    "flex items-center gap-1.5 truncate",
-                    compact ? "max-w-32" : "max-w-56",
+                    "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
+                    compact ? "px-1.5!" : "ps-2! pe-1!",
                   )}
                 >
-                  <TabIcon tab={t} active={t.id === activeId} />
-                  <span className="truncate">{labelFor(t)}</span>
-                  {t.kind === "editor" && t.dirty ? (
-                    <span
-                      aria-label="Unsaved changes"
-                      className="size-1.5 shrink-0 rounded-full bg-foreground/70"
-                    />
-                  ) : null}
-                </span>
-                {tabs.length > 1 && (
                   <span
-                    role="button"
-                    aria-label="Close tab"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onClose(t.id);
-                    }}
-                    className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                    className={cn(
+                      "flex items-center gap-1.5 truncate",
+                      compact ? "max-w-32" : "max-w-56",
+                    )}
                   >
-                    <HugeiconsIcon
-                      icon={Cancel01Icon}
-                      size={11}
-                      strokeWidth={2}
-                    />
+                    <TabIcon tab={t} active={t.id === activeId} />
+                    {/* Preview tabs use italic to signal the transient state,
+                        matching the visual convention from VSCode. */}
+                    <span className={cn("truncate", isPreview && "italic")}>
+                      {labelFor(t)}
+                    </span>
+                    {t.kind === "editor" && t.dirty ? (
+                      <span
+                        aria-label="Unsaved changes"
+                        className="size-1.5 shrink-0 rounded-full bg-foreground/70"
+                      />
+                    ) : null}
                   </span>
-                )}
-              </TabsTrigger>
-            ))}
+                  {tabs.length > 1 && (
+                    <span
+                      role="button"
+                      aria-label="Close tab"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClose(t.id);
+                      }}
+                      className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                    >
+                      <HugeiconsIcon
+                        icon={Cancel01Icon}
+                        size={11}
+                        strokeWidth={2}
+                      />
+                    </span>
+                  )}
+                </TabsTrigger>
+              );
+            })}
           </TabsList>
         </Tabs>
         <DropdownMenu>

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -7,5 +7,6 @@ export {
   type PreviewTab,
   type AiDiffTab,
   type AiDiffStatus,
+  type TabPatch,
 } from "./lib/useTabs";
 export { useWorkspaceCwd } from "./lib/useWorkspaceCwd";

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -13,6 +13,12 @@ export type EditorTab = {
   title: string;
   path: string;
   dirty: boolean;
+  /**
+   * True while the tab is in the transient "preview" state — opened by a
+   * single-click in the explorer and not yet pinned by the user. A preview tab
+   * is replaced by the next single-click rather than accumulating.
+   */
+  preview: boolean;
 };
 
 export type PreviewTab = {
@@ -81,31 +87,97 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return id;
   }, []);
 
-  const openFileTab = useCallback((path: string) => {
+  /**
+   * Opens a file in an editor tab.
+   *
+   * - `pin = true` (default) — opens or activates a **persistent** tab.
+   *   If the path is currently in the preview slot it is promoted in-place.
+   *   Use this for programmatic opens (AI diff, New File dialog, etc.).
+   * - `pin = false` — VSCode-style **preview** tab. A single shared slot is
+   *   reused: if a persistent tab for the path already exists it is activated;
+   *   otherwise the current preview slot is replaced with the new path.
+   */
+  const openFileTab = useCallback((path: string, pin = true) => {
     let targetId: number | null = null;
     setTabs((curr) => {
-      const existing = curr.find(
-        (t) => t.kind === "editor" && t.path === path,
-      );
-      if (existing) {
-        targetId = existing.id;
-        return curr;
-      }
-      const id = nextIdRef.current++;
-      targetId = id;
-      return [
-        ...curr,
-        {
+      if (pin) {
+        // Persistent open: find any existing editor tab, pin it if needed.
+        const existing = curr.find(
+          (t) => t.kind === "editor" && t.path === path,
+        );
+        if (existing) {
+          targetId = existing.id;
+          if ((existing as EditorTab).preview) {
+            return curr.map((t) =>
+              t.id === existing.id ? { ...t, preview: false } : t,
+            );
+          }
+          return curr;
+        }
+        const id = nextIdRef.current++;
+        targetId = id;
+        return [
+          ...curr,
+          {
+            id,
+            kind: "editor",
+            title: basename(path),
+            path,
+            dirty: false,
+            preview: false,
+          } satisfies EditorTab,
+        ];
+      } else {
+        // Preview open: persistent tab for this path takes priority.
+        const persistent = curr.find(
+          (t) => t.kind === "editor" && t.path === path && !(t as EditorTab).preview,
+        );
+        if (persistent) {
+          targetId = persistent.id;
+          return curr;
+        }
+        // Reuse the slot if it already shows the same path.
+        const existingPreview = curr.find(
+          (t) => t.kind === "editor" && t.path === path && (t as EditorTab).preview,
+        );
+        if (existingPreview) {
+          targetId = existingPreview.id;
+          return curr;
+        }
+        // Replace the current preview slot, or append a new one.
+        const previewIdx = curr.findIndex(
+          (t) => t.kind === "editor" && (t as EditorTab).preview,
+        );
+        const id = nextIdRef.current++;
+        targetId = id;
+        const tab: EditorTab = {
           id,
           kind: "editor",
           title: basename(path),
           path,
           dirty: false,
-        },
-      ];
+          preview: true,
+        };
+        if (previewIdx === -1) return [...curr, tab];
+        const next = [...curr];
+        next[previewIdx] = tab;
+        return next;
+      }
     });
     if (targetId !== null) setActiveId(targetId);
     return targetId as number | null;
+  }, []);
+
+  /**
+   * Promotes a preview tab to a persistent one. Called on double-click of the
+   * tab title in the tab bar. Dirty edits also auto-promote (see `updateTab`).
+   */
+  const pinTab = useCallback((id: number) => {
+    setTabs((curr) =>
+      curr.map((t) =>
+        t.id === id && t.kind === "editor" ? { ...t, preview: false } : t,
+      ),
+    );
   }, []);
 
   const openAiDiffTab = useCallback(
@@ -205,8 +277,14 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             }),
           };
         }
+        // editor tab: auto-promote from preview the moment the file becomes dirty.
+        const autoPin =
+          patch.dirty === true && (x as EditorTab).preview
+            ? { preview: false }
+            : {};
         return {
           ...x,
+          ...autoPin,
           ...(patch.title !== undefined && { title: patch.title }),
           ...(patch.dirty !== undefined && { dirty: patch.dirty }),
           ...(patch.path !== undefined && { path: patch.path }),
@@ -229,6 +307,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setActiveId,
     newTab,
     openFileTab,
+    pinTab,
     newPreviewTab,
     openAiDiffTab,
     setAiDiffStatus,


### PR DESCRIPTION
## What

Adds transient preview tabs for explorer-driven file navigation.

* Single-click in explorer opens files in a shared transient slot with italic tab titles
* Double-clicking a tab title or editing the file promotes the tab to a persistent state
* Explorer context-menu "Open" bypasses preview mode and opens a persistent tab directly
* Refactors `onOpenFile` and `openFileTab` around a unified `pin` argument

## Why

Opening files from the explorer previously created persistent tabs for every navigation action, which caused tab accumulation during quick file browsing.

This change introduces a lightweight transient tab flow so users can inspect files without polluting the tab bar, while still allowing tabs to become persistent through explicit interaction or edits.

## How

* Added `preview: boolean` to `EditorTab`
* Reworked `openFileTab(path, pin)` to support both transient and persistent opens
* Added `pinTab(id)` for promoting preview tabs in-place
* Auto-promote preview tabs when they become dirty
* Updated explorer open flows to distinguish between preview and persistent intent
* Added italic styling + double-click pin behavior in `TabBar`

## Testing

Manually verified the following flows:

* Single-clicking different files reuses a shared transient tab

* Reopening the same preview file reuses the existing preview tab

* Existing persistent tabs are reused instead of replaced

* Double-clicking a preview tab promotes it to persistent

* Editing a preview tab auto-promotes it

* Context-menu "Open" creates a persistent tab directly

* Closing preview and persistent tabs behaves correctly

* Active tab switching still works as expected

* [x] `pnpm exec tsc --noEmit` clean

* [x] Manual smoke-test of the affected feature

* [ ] (If you touched `src-tauri/`) `cargo check` clean

* [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

Before — each explorer click creates another persistent tab:
<img width="600" height="297" alt="tabs_before" src="https://github.com/user-attachments/assets/62f7a6a1-be1a-4de3-9072-01489154fab4" />

After — explorer navigation reuses a shared transient preview tab:
<img width="600" height="297" alt="tabs_after" src="https://github.com/user-attachments/assets/a125a37b-7300-4ef4-b3e6-21c9fd17a40e" />

## Notes for reviewer

The preview/persistent behavior is intentionally centralized in `openFileTab(path, pin)` so future open flows (search results, AI actions, command palette, etc.) can opt into either behavior consistently without duplicating tab-management logic.
