### PR TITLE
fix(ai): update Gemini model IDs to use -preview suffix

### DIFF
--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -123,13 +123,13 @@ export const MODELS = [
   },
   // Google
   {
-    id: "gemini-3.1-pro",
+    id: "gemini-3.1-pro-preview",
     provider: "google",
     label: "Gemini 3.1 Pro",
     hint: "Best",
   },
   {
-    id: "gemini-3-flash",
+    id: "gemini-3-flash-preview",
     provider: "google",
     label: "Gemini 3 Flash",
     hint: "Fast",
@@ -190,8 +190,8 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "claude-haiku-4-5": 200_000,
   "claude-sonnet-4-6": 200_000,
   "claude-opus-4-7": 200_000,
-  "gemini-3.1-pro": 1_000_000,
-  "gemini-3-flash": 1_000_000,
+  "gemini-3.1-pro-preview": 1_000_000,
+  "gemini-3-flash-preview": 1_000_000,
   "grok-4.20-reasoning": 2_000_000,
   "grok-4.20-non-reasoning": 2_000_000,
   "gpt-oss-120b": 128_000,


### PR DESCRIPTION
## What
Updates the Gemini model IDs in the configuration to append the `-preview` suffix (`gemini-3.1-pro-preview` and `gemini-3-flash-preview`).
## Why
The previously hardcoded model IDs (`gemini-3.1-pro` and `gemini-3-flash`) were returning "not found" or "not supported" errors from the Google AI API. Updating to the exact current model IDs fixes the integration.
## How
Updated the `MODELS` array and the `MODEL_CONTEXT_LIMITS` keys in `src/modules/ai/config.ts`.
## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature (verified the "not found" error no longer appears when querying the model).
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`