### PR TITLE
fix(ai): mini chat window no longer overshadows input bar (#40)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -685,12 +685,15 @@ export default function App() {
                       data-ai-input-bar
                       initial={false}
                       animate={{
-                        height: panelOpen ? "auto" : 0,
-                        opacity: panelOpen ? 1 : 0,
+                        // Collapse the docked input row while the mini chat
+                        // window is open — otherwise the floating mini window
+                        // (fixed bottom-right) overshadows it (#40).
+                        height: panelOpen && !miniOpen ? "auto" : 0,
+                        opacity: panelOpen && !miniOpen ? 1 : 0,
                       }}
                       transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
                       className="overflow-hidden"
-                      aria-hidden={!panelOpen}
+                      aria-hidden={!panelOpen || miniOpen}
                     >
                       {hasComposer ? (
                         <AiInputBar />

--- a/src/modules/ai/components/AiMiniWindow.tsx
+++ b/src/modules/ai/components/AiMiniWindow.tsx
@@ -90,7 +90,10 @@ export function AiMiniWindow() {
       transition={{ type: "spring", stiffness: 320, damping: 32 }}
       data-ai-mini-window
       className={cn(
-        "no-scrollbar-deep fixed right-4 bottom-12 z-40 flex h-[42rem] w-[34rem] flex-col overflow-hidden",
+        // Sized to leave breathing room around the status bar and never grow
+        // past the available viewport height — older fixed h-[42rem] could
+        // overshadow the docked input bar on shorter windows (#40).
+        "no-scrollbar-deep fixed right-4 bottom-12 z-40 flex w-[min(34rem,calc(100vw-2rem))] max-h-[min(42rem,calc(100vh-5rem))] flex-col overflow-hidden",
         "rounded-2xl border border-border/40 bg-card/90 shadow-2xl ring-1 ring-black/5 backdrop-blur-2xl dark:ring-white/5",
         "text-[12px]",
       )}


### PR DESCRIPTION
Closes #40.

## What
- Mini chat window's height is capped to the viewport with breathing room around the status bar (replaces fixed `h-[42rem]`).
- Docked input row collapses while the mini window is open, since the floating bottom-right window otherwise sits on top of it.

## Why
Issue #40 — on shorter viewports the fixed-height mini window covered the input bar, making it untypable.

## How tested
- Resized window down to ~600px tall with mini chat open → input remains visible and reachable.
- Closed mini → docked input row returns to normal layout.
- At full height, mini chat looks identical to before.