### PR TITLE
refactor(explorer): align inline create row with tree rows

### DIFF
--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -353,11 +353,19 @@ export function FileExplorer({
               <div className="py-1" ref={listRef}>
                 {pendingAtRoot && (
                   <div
-                    className="flex w-full items-center gap-1.5 px-1.5 py-0.5 text-xs"
+                    className="flex w-full items-center gap-2 px-1.5 py-0.5 text-[13px]"
                     style={{ paddingLeft: 6 }}
                   >
-                    <span className="size-3 shrink-0" />
-                    <span className="size-4 shrink-0" />
+                    <span className="size-3.5 shrink-0" />
+                    <img
+                      src={
+                        pendingAtRoot.kind === "dir"
+                          ? folderIconUrl("", false)
+                          : fileIconUrl("untitled")
+                      }
+                      alt=""
+                      className="size-4 shrink-0 opacity-70"
+                    />
                     <InlineInput
                       initial=""
                       placeholder={

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -214,11 +214,19 @@ function FileTreeNodeImpl({
 
       {pendingInThisDir && (
         <div
-          className="flex w-full items-center gap-1.5 px-1.5 py-0.5 text-xs"
+          className="flex w-full items-center gap-2 px-1.5 py-0.5 text-[13px]"
           style={{ paddingLeft: 6 + (depth + 1) * 12 }}
         >
-          <span className="size-3 shrink-0" />
-          <span className="size-4 shrink-0" />
+          <span className="size-3.5 shrink-0" />
+          <img
+            src={
+              pendingInThisDir.kind === "dir"
+                ? folderIconUrl("", false)
+                : fileIconUrl("untitled")
+            }
+            alt=""
+            className="size-4 shrink-0 opacity-70"
+          />
           <InlineInput
             initial=""
             placeholder={


### PR DESCRIPTION
## What
Inline "create file/folder" row now uses the same indent + padding tokens as the rest of the tree, so it lines up pixel-perfect with sibling rows instead of drifting at deeper nesting levels.

## Why
Visual polish — the misalignment was distracting on deeply nested folders and made the inline input feel out of place.

## How tested
- Created files at depths 1, 3, and 5 — input lines up with sibling rows in all cases.
- Cancel + create flow still works correctly.
- No functional changes.