### PR TITLE
fix(ai): allow keyless providers (LMStudio) in model picker and chat send

### DIFF
--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -32,6 +32,7 @@ import {
   getModel,
   MODELS,
   PROVIDERS,
+  providerNeedsKey,
   type ModelId,
   type ProviderId,
 } from "../config";
@@ -243,7 +244,7 @@ function ModelDropdown() {
       <DropdownMenuContent align="end" className="min-w-[240px]">
         {PROVIDERS.map((p) => {
           const models = MODELS.filter((m) => m.provider === p.id);
-          const hasKey = !!apiKeys[p.id];
+          const hasKey = providerNeedsKey(p.id) ? !!apiKeys[p.id] : true;
           return (
             <div key={p.id} className="px-1 pt-1.5 first:pt-1">
               <div className="mb-0.5 flex items-center gap-1.5 px-2 text-[9.5px] font-medium tracking-wide text-muted-foreground uppercase">

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -7,6 +7,7 @@ import { create } from "zustand";
 import {
   DEFAULT_MODEL_ID,
   getModel,
+  providerNeedsKey,
   type ModelId,
   type ProviderId,
 } from "../config";
@@ -455,7 +456,8 @@ export function getActiveProviderKey(): string | null {
 
 export function hasKeyForModel(modelId: ModelId): boolean {
   const { apiKeys } = useChatStore.getState();
-  return !!apiKeys[getModel(modelId).provider];
+  const provider = getModel(modelId).provider;
+  return providerNeedsKey(provider) ? !!apiKeys[provider] : true;
 }
 
 export function getOrCreateChat(sessionId: string): Chat<UIMessage> {
@@ -476,7 +478,7 @@ export async function sendMessage(text: string): Promise<boolean> {
   const state = useChatStore.getState();
   const sessionId = state.activeSessionId;
   if (!sessionId) return false;
-  if (!getActiveProviderKey()) return false;
+  if (providerNeedsKey(getModel(state.selectedModelId).provider) && !getActiveProviderKey()) return false;
   const c = getOrCreateChat(sessionId);
   await c.sendMessage({ text });
   return true;


### PR DESCRIPTION
## Summary

- Fixes #69 — LMStudio is a local LLM server that does not require an API key, but Terax showed it greyed out with a "Set key…" prompt and blocked message sending.

- `KEYLESS_PROVIDERS` and `providerNeedsKey()` already existed in `config.ts` but were not used in three locations that gate provider access.

## Changes

- **`src/modules/ai/components/AiStatusBarControls.tsx`** — `hasKey` check now uses `providerNeedsKey(p.id)` so keyless providers (LMStudio) show as available without a key.

- **`src/modules/ai/store/chatStore.ts`** — `hasKeyForModel()` now returns `true` for keyless providers instead of `false` (since `apiKeys["lmstudio"]` is always `null`).

- **`src/modules/ai/store/chatStore.ts`** — `sendMessage()` guard now skips the key check for keyless providers, so messages can actually be sent to LMStudio.

## Testing

- `pnpm exec tsc --noEmit` passes with zero errors
- Verified the fix follows the existing `providerNeedsKey()` pattern already used in `ModelsSection.tsx:193` and `keyring.ts`
- Manual not yet test plan: open Terax, select LMStudio from model dropdown (should no longer be greyed out), verify messages can be sent without setting a key 

## Since I don't have LMStudio, could you please test it? 