### PR TITLE
chore(search): refine search focus and keyboard handling for both explorer and file searches

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -536,11 +536,19 @@ export default function App() {
 
   const searchTarget = useMemo<SearchTarget>(() => {
     if (isTerminalTab && activeSearchAddon)
-      return { kind: "terminal", addon: activeSearchAddon };
+      return {
+        kind: "terminal",
+        addon: activeSearchAddon,
+        focus: () => terminalRefs.current.get(activeId)?.focus(),
+      };
     if (isEditorTab && activeEditorHandle)
-      return { kind: "editor", handle: activeEditorHandle };
+      return {
+        kind: "editor",
+        handle: activeEditorHandle,
+        focus: () => activeEditorHandle.focus(),
+      };
     return null;
-  }, [isTerminalTab, isEditorTab, activeSearchAddon, activeEditorHandle]);
+  }, [isTerminalTab, isEditorTab, activeId, activeSearchAddon, activeEditorHandle]);
 
   const activeCwd =
     activeTab?.kind === "terminal" ? (activeTab.cwd ?? null) : null;

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -36,6 +36,7 @@ export type EditorPaneHandle = {
   findNext: () => void;
   findPrevious: () => void;
   clearQuery: () => void;
+  focus: () => void;
   getSelection: () => string | null;
   getPath: () => string;
   /** Re-read the file from disk. Skips silently if the buffer is dirty. */
@@ -211,6 +212,9 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
           view.dispatch({
             effects: setSearchQuery.of(new SearchQuery({ search: "" })),
           });
+        },
+        focus: () => {
+          cmRef.current?.view?.focus();
         },
         getSelection: () => {
           const view = cmRef.current?.view;

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -1,0 +1,195 @@
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Cancel01Icon,
+  Folder01Icon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { invoke } from "@tauri-apps/api/core";
+import { motion } from "motion/react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { fileIconUrl } from "./lib/iconResolver";
+
+type SearchHit = {
+  path: string;
+  rel: string;
+  name: string;
+  is_dir: boolean;
+};
+
+type Props = {
+  rootPath: string;
+  onOpenFile: (path: string) => void;
+  open: boolean;
+  onActiveChange?: (active: boolean) => void;
+};
+
+export type ExplorerSearchHandle = {
+  focus: () => void;
+  isFocused: () => boolean;
+};
+
+export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function ExplorerSearch({
+  rootPath,
+  onOpenFile,
+  open,
+  onActiveChange,
+}: Props,
+  ref,
+) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchHit[]>([]);
+  const [searching, setSearching] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const active = query.trim().length > 0;
+
+  useEffect(() => {
+    onActiveChange?.(active);
+  }, [active, onActiveChange]);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+    } else {
+      setQuery("");
+      setResults([]);
+      setSearching(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    let alive = true;
+    const handle = setTimeout(async () => {
+      try {
+        const hits = await invoke<SearchHit[]>("fs_search", {
+          root: rootPath,
+          query: q,
+          limit: 200,
+        });
+        if (alive) setResults(hits);
+      } catch (e) {
+        if (alive) {
+          console.error("fs_search failed:", e);
+          setResults([]);
+        }
+      } finally {
+        if (alive) setSearching(false);
+      }
+    }, 120);
+
+    return () => {
+      alive = false;
+      clearTimeout(handle);
+    };
+  }, [query, rootPath]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus: () => {
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+        });
+      },
+      isFocused: () => document.activeElement === inputRef.current,
+    }),
+    [],
+  );
+
+  return (
+    <div className="flex flex-col">
+      {open ? (
+        <motion.div
+          className="relative shrink-0 px-2 py-1.5"
+          initial={{ opacity: 0, transform: "translateY(-15px)" }}
+          animate={{ opacity: 1, transform: "translateY(0px)" }}
+        >
+          <HugeiconsIcon
+            icon={Search01Icon}
+            size={13}
+            strokeWidth={2}
+            className="absolute top-1/2 left-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search files…"
+            className="h-7 pr-7 pl-6.5 text-xs"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="absolute top-1/2 right-3.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
+            </button>
+          ) : null}
+        </motion.div>
+      ) : null}
+
+      {active ? (
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="py-1">
+            {searching && results.length === 0 ? (
+              <div className="px-3 py-2 text-[11px] text-muted-foreground">
+                Searching…
+              </div>
+            ) : results.length === 0 ? (
+              <div className="px-3 py-2 text-[11px] text-muted-foreground">
+                No matches
+              </div>
+            ) : (
+              results.map((hit) => {
+                const url = hit.is_dir ? null : fileIconUrl(hit.name);
+                return (
+                  <button
+                    key={hit.path}
+                    type="button"
+                    onClick={() => {
+                      if (!hit.is_dir) onOpenFile(hit.path);
+                    }}
+                    className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs hover:bg-accent"
+                    title={hit.path}
+                  >
+                    {url ? (
+                      <img src={url} alt="" className="size-3.5 shrink-0" />
+                    ) : (
+                      <HugeiconsIcon
+                        icon={Folder01Icon}
+                        size={13}
+                        strokeWidth={1.75}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                    )}
+                    <span className="truncate">{hit.name}</span>
+                    <span className="ml-auto truncate text-[10px] text-muted-foreground">
+                      {hit.rel}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </ScrollArea>
+      ) : null}
+    </div>
+  );
+});

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -28,6 +28,7 @@ type Props = {
   rootPath: string;
   onOpenFile: (path: string) => void;
   open: boolean;
+  onRequestClose: () => void;
   onActiveChange?: (active: boolean) => void;
 };
 
@@ -40,6 +41,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   rootPath,
   onOpenFile,
   open,
+  onRequestClose,
   onActiveChange,
 }: Props,
   ref,
@@ -129,6 +131,19 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                e.stopPropagation();
+                onRequestClose();
+                return;
+              }
+              if (e.key === "Enter") {
+                e.preventDefault();
+                const firstOpenable = results.find((hit) => !hit.is_dir);
+                if (firstOpenable) onOpenFile(firstOpenable.path);
+              }
+            }}
             placeholder="Search files…"
             className="h-7 pr-7 pl-6.5 text-xs"
           />
@@ -157,7 +172,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                 No matches
               </div>
             ) : (
-              results.map((hit) => {
+              results.map((hit, index) => {
                 const url = hit.is_dir ? null : fileIconUrl(hit.name);
                 return (
                   <button
@@ -166,7 +181,9 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                     onClick={() => {
                       if (!hit.is_dir) onOpenFile(hit.path);
                     }}
-                    className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs hover:bg-accent"
+                    className={`flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs ${
+                      index === 0 ? "bg-accent" : "hover:bg-accent"
+                    }`}
                     title={hit.path}
                   >
                     {url ? (

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -6,10 +6,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
-  Cancel01Icon,
   FileAddIcon,
   Folder01Icon,
   FolderAddIcon,
@@ -17,22 +15,18 @@ import {
   Search01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { invoke } from "@tauri-apps/api/core";
-import { motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ExplorerSearch,
+  type ExplorerSearchHandle,
+} from "./ExplorerSearch";
 import { FileTreeNode } from "./FileTreeNode";
 import { InlineInput } from "./InlineInput";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
-import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
+import { folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
-
-type SearchHit = {
-  path: string;
-  rel: string;
-  name: string;
-  is_dir: boolean;
-};
+import { useGlobalShortcuts } from "@/modules/shortcuts";
 
 type Props = {
   rootPath: string | null;
@@ -57,12 +51,11 @@ export function FileExplorer({
   onAttachToAgent,
 }: Props) {
   const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchHit[]>([]);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [searching, setSearching] = useState(false);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isSearchActive, setIsSearchActive] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<ExplorerSearchHandle>(null);
 
   type FlatItem = { path: string; isDir: boolean };
   const flat = useMemo<FlatItem[]>(() => {
@@ -88,38 +81,16 @@ export function FileExplorer({
     }
   }, [flat, selectedPath]);
 
-  useEffect(() => {
-    if (!rootPath) return;
-    const q = query.trim();
-    if (!q) {
-      setResults([]);
-      setSearching(false);
-      return;
-    }
-    setSearching(true);
-    let alive = true;
-    const handle = setTimeout(async () => {
-      try {
-        const hits = await invoke<SearchHit[]>("fs_search", {
-          root: rootPath,
-          query: q,
-          limit: 200,
-        });
-        if (alive) setResults(hits);
-      } catch (e) {
-        if (alive) {
-          console.error("fs_search failed:", e);
-          setResults([]);
-        }
-      } finally {
-        if (alive) setSearching(false);
+  useGlobalShortcuts({
+    "explorer.search": () => {
+      if (searchRef.current?.isFocused()) {
+        setIsSearchOpen(false);
+        return;
       }
-    }, 120);
-    return () => {
-      alive = false;
-      clearTimeout(handle);
-    };
-  }, [query, rootPath]);
+      setIsSearchOpen(true);
+      searchRef.current?.focus();
+    },
+  });
 
   if (!rootPath) {
     return (
@@ -142,7 +113,7 @@ export function FileExplorer({
     tree.pendingCreate?.parentPath === rootPath ? tree.pendingCreate : null;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (tree.renaming || tree.pendingCreate || query.trim()) return;
+    if (tree.renaming || tree.pendingCreate || isSearchOpen) return;
     const target = e.target as HTMLElement;
     if (
       target.tagName === "INPUT" ||
@@ -236,8 +207,9 @@ export function FileExplorer({
           variant="ghost"
           size="icon"
           className="size-6 text-muted-foreground hover:text-foreground"
-          onClick={() => setIsSearchOpen(!isSearchOpen)}
-          title="New file"
+          onClick={() => setIsSearchOpen((v) => !v)}
+          title="Search files"
+          aria-label="Search files"
         >
           <HugeiconsIcon icon={Search01Icon} size={13} strokeWidth={2} />
         </Button>
@@ -271,82 +243,15 @@ export function FileExplorer({
         </Button>
       </div>
 
-      {isSearchOpen && (
-        <motion.div
-          className="relative shrink-0 px-2 py-1.5"
-          initial={{ opacity: 0, transform: "translateY(-15px)" }}
-          animate={{ opacity: 1, transform: "translateY(0px)" }}
-        >
-          <HugeiconsIcon
-            icon={Search01Icon}
-            size={13}
-            strokeWidth={2}
-            className="absolute top-1/2 left-4 -translate-y-1/2 text-muted-foreground"
-          />
-          <Input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search files…"
-            className="h-7 pr-7 pl-6.5 text-xs"
-          />
-          {query ? (
-            <button
-              type="button"
-              onClick={() => setQuery("")}
-              className="absolute top-1/2 right-3.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-              aria-label="Clear search"
-            >
-              <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
-            </button>
-          ) : null}
-        </motion.div>
-      )}
+      <ExplorerSearch
+        ref={searchRef}
+        rootPath={rootPath}
+        onOpenFile={onOpenFile}
+        open={isSearchOpen}
+        onActiveChange={setIsSearchActive}
+      />
 
-      {query.trim() ? (
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="py-1">
-            {searching && results.length === 0 ? (
-              <div className="px-3 py-2 text-[11px] text-muted-foreground">
-                Searching…
-              </div>
-            ) : results.length === 0 ? (
-              <div className="px-3 py-2 text-[11px] text-muted-foreground">
-                No matches
-              </div>
-            ) : (
-              results.map((hit) => {
-                const url = hit.is_dir ? null : fileIconUrl(hit.name);
-                return (
-                  <button
-                    key={hit.path}
-                    type="button"
-                    onClick={() => {
-                      if (!hit.is_dir) onOpenFile(hit.path);
-                    }}
-                    className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs hover:bg-accent"
-                    title={hit.path}
-                  >
-                    {url ? (
-                      <img src={url} alt="" className="size-3.5 shrink-0" />
-                    ) : (
-                      <HugeiconsIcon
-                        icon={Folder01Icon}
-                        size={13}
-                        strokeWidth={1.75}
-                        className="shrink-0 text-muted-foreground"
-                      />
-                    )}
-                    <span className="truncate">{hit.name}</span>
-                    <span className="ml-auto truncate text-[10px] text-muted-foreground">
-                      {hit.rel}
-                    </span>
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </ScrollArea>
-      ) : (
+      {!isSearchActive ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>
             <ScrollArea className="min-h-0 flex-1">
@@ -448,7 +353,7 @@ export function FileExplorer({
             </ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -16,14 +16,11 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  ExplorerSearch,
-  type ExplorerSearchHandle,
-} from "./ExplorerSearch";
+import { ExplorerSearch, type ExplorerSearchHandle } from "./ExplorerSearch";
 import { FileTreeNode } from "./FileTreeNode";
 import { InlineInput } from "./InlineInput";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
-import { folderIconUrl } from "./lib/iconResolver";
+import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
@@ -133,7 +130,7 @@ export function FileExplorer({
       setSelectedPath(path);
       requestAnimationFrame(() => {
         const el = listRef.current?.querySelector<HTMLElement>(
-          `[data-fs-path="${CSS.escape(path)}"]`,
+          `[data-fs-path="${CSS.escape(path)}"]`
         );
         el?.scrollIntoView({ block: "nearest" });
       });

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -248,6 +248,7 @@ export function FileExplorer({
         rootPath={rootPath}
         onOpenFile={onOpenFile}
         open={isSearchOpen}
+        onRequestClose={() => setIsSearchOpen(false)}
         onActiveChange={setIsSearchActive}
       />
 

--- a/src/modules/explorer/index.ts
+++ b/src/modules/explorer/index.ts
@@ -1,1 +1,2 @@
 export { FileExplorer } from "./FileExplorer";
+export { ExplorerSearch } from "./ExplorerSearch";

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -25,8 +25,8 @@ const TERM_DECORATIONS = {
 };
 
 export type SearchTarget =
-  | { kind: "terminal"; addon: SearchAddon }
-  | { kind: "editor"; handle: EditorPaneHandle }
+  | { kind: "terminal"; addon: SearchAddon; focus: () => void }
+  | { kind: "editor"; handle: EditorPaneHandle; focus: () => void }
   | null;
 
 export type SearchInlineHandle = { focus: () => void };
@@ -44,6 +44,14 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     // In normal mode the field is always present.
     const [openInCompact, setOpenInCompact] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const pendingFocusRef = useRef(false);
+    const setInputRef = useCallback((el: HTMLInputElement | null) => {
+      inputRef.current = el;
+      if (!el || !pendingFocusRef.current) return;
+      pendingFocusRef.current = false;
+      el.focus();
+    }, []);
+
     const userShortcuts = usePreferencesStore((s) => s.shortcuts);
 
     const shortcutText = useMemo(() => {
@@ -67,8 +75,10 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     const expanded = !compact || openInCompact;
 
     const focus = useCallback(() => {
+      pendingFocusRef.current = true;
       if (compact) setOpenInCompact(true);
-      requestAnimationFrame(() => inputRef.current?.focus());
+      else inputRef.current?.focus();
+      if (inputRef.current) pendingFocusRef.current = false;
     }, [compact]);
 
     useImperativeHandle(ref, () => ({ focus }), [focus]);
@@ -77,6 +87,11 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
       if (!target) return;
       if (target.kind === "terminal") target.addon.clearDecorations();
       else target.handle.clearQuery();
+    }, [target]);
+
+    const restoreTargetFocus = useCallback(() => {
+      if (!target) return;
+      target.focus();
     }, [target]);
 
     // Target switched (terminal ↔ editor) or removed → drop highlights.
@@ -135,7 +150,7 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
                 className="pointer-events-none absolute top-1/2 left-2 -translate-y-1/2 text-muted-foreground"
               />
               <Input
-                ref={inputRef}
+                ref={setInputRef}
                 value={q}
                 placeholder={placeholder}
                 className="h-7 w-full bg-muted/80 pr-7 pl-7 text-xs placeholder:text-muted-foreground/70 focus-visible:ring-0"
@@ -157,9 +172,8 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
                     setQ("");
                     if (compact) {
                       setOpenInCompact(false);
-                    } else {
-                      inputRef.current?.blur();
                     }
+                    restoreTargetFocus();
                   }
                 }}
               />

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -13,6 +13,7 @@ export type ShortcutId =
   | "tab.prev"
   | "tab.selectByIndex"
   | "search.focus"
+  | "explorer.search"
   | "ai.toggle"
   | "ai.askSelection"
   | "shortcuts.open"
@@ -90,6 +91,13 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Jump to tab 1–9",
     group: "Tabs",
     defaultBindings: [{ [MOD_PROP]: true, key: "1" }],
+  },
+  {
+    id: "explorer.search",
+    label: "Search files",
+    keys: [MOD_KEY, SHIFT_KEY, "F"],
+    group: "Search",
+    match: (e) => isMod(e) && e.shiftKey && e.key.toLowerCase() === "f",
   },
   {
     id: "search.focus",

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -95,9 +95,8 @@ export const SHORTCUTS: Shortcut[] = [
   {
     id: "explorer.search",
     label: "Search files",
-    keys: [MOD_KEY, SHIFT_KEY, "F"],
     group: "Search",
-    match: (e) => isMod(e) && e.shiftKey && e.key.toLowerCase() === "f",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "f" }],
   },
   {
     id: "search.focus",
@@ -136,7 +135,11 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
 /**
  * Matching logic: checks if a KeyboardEvent matches a KeyBinding.
  */
-export function matchBinding(e: KeyboardEvent, binding: KeyBinding, id?: ShortcutId): boolean {
+export function matchBinding(
+  e: KeyboardEvent,
+  binding: KeyBinding,
+  id?: ShortcutId
+): boolean {
   const eventKey = e.key.toLowerCase();
   const bindingKey = binding.key.toLowerCase();
 


### PR DESCRIPTION
## What
Refactors the explorer search UI and fixes its focus/keyboard behavior, while also improving the related global search focus flow.

## Why
The explorer search interaction was losing focus state and needed clearer keyboard handling. The related search UI elsewhere in the app also needed better focus restoration when closing search.

## How
- Extracted explorer search into its own component.
- Fixed search focus state when opening and closing the explorer search input.
- Added `Escape` and `Enter` handling in explorer search.
- Updated the shared search flow so closing search restores focus to the active editor or terminal.
- Exposed editor focus so the header search can return control to the active pane.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ x (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`
- [x] `pnpm build`

## Screenshots / GIFs
No visual changes.

## Notes for reviewer
This is a focused refactor and behavior fix in the explorer search and shared search focus interactions. You can try the new cmd/ctrl+shift+f shortcut globally.