### PR TITLE
fix(ui): add `decorations: false` to Tauri window in windows options

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,8 @@
         "minHeight": 280,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "visible": false
+        "visible": false,
+        "decorations": false
       }
     ],
     "security": {
@@ -44,10 +45,16 @@
     "linux": {
       "deb": {
         "section": "utils",
-        "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]
+        "depends": [
+          "libwebkit2gtk-4.1-0",
+          "libgtk-3-0"
+        ]
       },
       "rpm": {
-        "depends": ["webkit2gtk4.1", "gtk3"]
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3"
+        ]
       },
       "appimage": {
         "bundleMediaFramework": true


### PR DESCRIPTION
## What
Removed Default windows appbar and leave the original created one.

## Why
there exist a programable close button in the application's bar, so the native one is just a secondary one on top of the created bar.


- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
### Before
<img width="951" height="152" alt="before" src="https://github.com/user-attachments/assets/c0218e35-de41-4782-b3e7-6eec9a68d7fb" />

### After
<img width="908" height="146" alt="after" src="https://github.com/user-attachments/assets/ee83f8bf-cb4c-4f57-8537-6ae41a4c1739" />


## Notes for reviewer
- since appbar is removed that is no native way to resize the windows, considering adding the feature for mac/windows and linux(not window managers)
- there is a white borders showing on the corner in the app, that is for windows managers only, but it needs to be removed, i tried looking for the code (border radius if exists) and couldn't find any relative matches.