### PR TITLE
feat(terminal): open OSC URLs locally

### DIFF
--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -84,8 +84,31 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
     printf '\e]8888;file=%s\e\\' "$(_terax_urlencode "$file")"
   }
 
+  # terax_open_url: open URL on the local machine via OSC 8888.
+  # Usage: terax_open_url <url> [auto|preview|browser]
+  terax_open_url() {
+    local url="$1"
+    local target="${2:-auto}"
+
+    if [ -z "$url" ]; then
+      printf "usage: terax_open_url <url> [auto|preview|browser]\n" >&2
+      return 1
+    fi
+
+    case "$target" in
+      auto|preview|browser) ;;
+      *)
+        printf "terax_open_url: target must be auto, preview, or browser\n" >&2
+        return 1
+        ;;
+    esac
+
+    printf '\e]8888;url=%s;target=%s\e\\' "$(_terax_urlencode "$url")" "$target"
+  }
+
   # Shorthand alias.
   alias tp='terax_open'
+  alias terax-open='terax_open_url'
 
   _terax_precmd
 fi

--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -26,6 +26,25 @@ function global:__terax_urlencode {
     $sb.ToString()
 }
 
+function global:terax_open_url {
+    param(
+        [string]$Url,
+        [ValidateSet('auto', 'preview', 'browser')]
+        [string]$Target = 'auto'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Url)) {
+        Write-Error 'usage: terax_open_url <url> [auto|preview|browser]'
+        return
+    }
+
+    $esc = [char]27
+    $urlEnc = __terax_urlencode $Url
+    Write-Host -NoNewline "$esc]8888;url=$urlEnc;target=$Target$esc\"
+}
+
+Set-Alias -Name terax-open -Value terax_open_url -Scope Global -Force
+
 function global:prompt {
     $lec = $LASTEXITCODE
     if ($null -eq $lec) { $lec = if ($?) { 0 } else { 1 } }

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -79,8 +79,31 @@ if [[ -z "$__TERAX_HOOKS_LOADED" ]]; then
     printf '\e]8888;file=%s\e\\' "$(_terax_urlencode "$file")"
   }
 
+  # terax_open_url: open URL on the local machine via OSC 8888.
+  # Usage: terax_open_url <url> [auto|preview|browser]
+  terax_open_url() {
+    local url="$1"
+    local target="${2:-auto}"
+
+    if [[ -z "$url" ]]; then
+      printf "usage: terax_open_url <url> [auto|preview|browser]\n" >&2
+      return 1
+    fi
+
+    case "$target" in
+      auto|preview|browser) ;;
+      *)
+        printf "terax_open_url: target must be auto, preview, or browser\n" >&2
+        return 1
+        ;;
+    esac
+
+    printf '\e]8888;url=%s;target=%s\e\\' "$(_terax_urlencode "$url")" "$target"
+  }
+
   # Shorthand alias.
   alias tp='terax_open'
+  alias terax-open='terax_open_url'
 
   _terax_precmd
 fi

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,10 +41,15 @@ import {
 } from "@/modules/shortcuts";
 import { StatusBar } from "@/modules/statusbar";
 import { useTabs, useWorkspaceCwd } from "@/modules/tabs";
-import { TerminalStack, type TerminalPaneHandle, type TeraxOpenInput } from "@/modules/terminal";
+import {
+  TerminalStack,
+  type TeraxOpenInput,
+  type TerminalPaneHandle,
+} from "@/modules/terminal";
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import { homeDir } from "@tauri-apps/api/path";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type { SearchAddon } from "@xterm/addon-search";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -57,6 +62,22 @@ function sameOrigin(a: string, b: string): boolean {
     return ua.host === ub.host && ua.protocol === ub.protocol;
   } catch {
     return a === b;
+  }
+}
+
+function isLocalPreviewUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (url.hostname === "localhost" ||
+        url.hostname === "127.0.0.1" ||
+        url.hostname === "0.0.0.0" ||
+        url.hostname === "::1" ||
+        url.hostname === "[::1]")
+    );
+  } catch {
+    return false;
   }
 }
 
@@ -519,10 +540,22 @@ export default function App() {
 
   const handleTeraxOpen = useCallback(
     (_tabId: number, input: TeraxOpenInput) => {
-      // Always open in a new tab
-      openFileTab(input.file);
+      if (input.kind === "file") {
+        openFileTab(input.file);
+        return;
+      }
+
+      if (
+        input.target === "preview" ||
+        (input.target === "auto" && isLocalPreviewUrl(input.url))
+      ) {
+        openPreviewTab(input.url);
+        return;
+      }
+
+      void openUrl(input.url).catch(console.error);
     },
-    [openFileTab],
+    [openFileTab, openPreviewTab],
   );
 
   const handleEditorDirty = useCallback(

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -36,9 +36,18 @@ export function registerPromptTracker(term: Terminal): PromptTracker {
   };
 }
 
-export type TeraxOpenInput = {
-  file: string;
-};
+export type TeraxOpenTarget = "auto" | "preview" | "browser";
+
+export type TeraxOpenInput =
+  | {
+      kind: "file";
+      file: string;
+    }
+  | {
+      kind: "url";
+      url: string;
+      target: TeraxOpenTarget;
+    };
 
 export function registerTeraxOpenHandler(
   term: Terminal,
@@ -65,14 +74,48 @@ function parseOsc7(data: string): string | null {
 }
 
 function parseTeraxOpen(data: string): TeraxOpenInput | null {
-  // Parse format: "file=/path/to/file"
-  const fileMatch = data.match(/file=([^;]+)/);
+  const params = parseOscParams(data);
+  const file = params.get("file");
+  if (file) return { kind: "file", file };
 
-  if (!fileMatch) return null;
+  const url = params.get("url")?.trim();
+  if (!url || !isSupportedUrl(url)) return null;
 
-  try {
-    return { file: decodeURIComponent(fileMatch[1]) };
-  } catch {
-    return { file: fileMatch[1] };
+  return { kind: "url", url, target: parseTarget(params.get("target")) };
+}
+
+function parseOscParams(data: string): Map<string, string> {
+  const params = new Map<string, string>();
+  for (const part of data.split(";")) {
+    const i = part.indexOf("=");
+    if (i === -1) continue;
+    const key = part.slice(0, i).trim();
+    if (!key) continue;
+    params.set(key, decodeParam(part.slice(i + 1)));
   }
+  return params;
+}
+
+function decodeParam(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function isSupportedUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function parseTarget(value: string | undefined): TeraxOpenTarget {
+  if (value === "preview" || value === "browser" || value === "auto") {
+    return value;
+  }
+  return "auto";
 }


### PR DESCRIPTION
## What
Adds OSC 8888 URL handling so terminal output can request a local URL open from remote/SSH-style sessions.

## Why
Closes #78. Existing shell integration could open files locally, but URL opens from SSH or forwarded dev servers needed a dedicated local browser/preview path.

## How
- Extends `terax_open` OSC parsing from file-only input to file/url input.
- Routes `url=` payloads to Terax preview for local URLs by default, or to the system browser for external URLs.
- Supports explicit `target=auto|preview|browser`.
- Adds `terax_open_url <url> [auto|preview|browser]` and `terax-open` aliases for bash, zsh, and PowerShell.

## Testing
Manual smoke test in `pnpm tauri dev`:
- `terax-open http://localhost:3000` opened a Terax preview tab.
- `terax-open http://localhost:3000 browser` opened the system browser.
- `terax-open https://example.com` opened the system browser.
- `terax-open https://example.com preview` opened a Terax preview tab.
- Raw OSC payload `url=http%3A//localhost%3A3000/from-raw-osc%3Fx%3Dhello%20world;target=preview` opened a Terax preview tab with the decoded URL.
- `terax_open /tmp/terax-open-file.txt` still opened an editor tab.

Automated checks:
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] `cargo check --all-targets --locked` clean
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] `git diff --check` clean

## Screenshots / GIFs
Not attached yet; manual testing confirmed the new preview/browser/file-open flows.

## Notes for reviewer
This keeps the existing OSC 8888 transport and avoids new dependencies or backend IPC.