### PR TITLE
fix(terminal): map ctrl-backspace to delete word

### DIFF
--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -13,6 +13,7 @@ import { openPty, type PtySession } from "./pty-bridge";
 export type { TeraxOpenInput };
 
 const FONT_SIZE = 14;
+const BACKWARD_KILL_WORD = "\x17";
 
 type Options = {
   container: React.RefObject<HTMLDivElement | null>;
@@ -87,6 +88,15 @@ export function useTerminalSession({
         allowProposedApi: true,
       });
       termRef.current = term;
+      term.attachCustomKeyEventHandler((event) => {
+        if (!isCtrlBackspace(event)) return true;
+        const pty = ptyRef.current;
+        if (!pty) return true;
+        event.preventDefault();
+        event.stopPropagation();
+        pty.write(BACKWARD_KILL_WORD);
+        return false;
+      });
 
       const fit = new FitAddon();
       fitRef.current = fit;
@@ -264,6 +274,16 @@ export function useTerminalSession({
   }, []);
 
   return { write, focus, getBuffer, getSelection, applyTheme };
+}
+
+function isCtrlBackspace(event: KeyboardEvent): boolean {
+  return (
+    event.type === "keydown" &&
+    event.key === "Backspace" &&
+    event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey
+  );
 }
 
 function stripTrailingPunct(url: string): string {


### PR DESCRIPTION
## What
Maps `Ctrl+Backspace` in terminal panes to the shell-standard backward-word-delete control character (`Ctrl+W`).

## Why
Closes #8. Before this change, `Ctrl+Backspace` behaved like plain Backspace instead of deleting the previous word.

## How
Uses xterm's `attachCustomKeyEventHandler` to intercept only `Ctrl+Backspace` keydown events and write `\x17` to the PTY. Plain Backspace and other modifier combinations continue through xterm unchanged.

## Testing
Manual smoke test in `pnpm tauri dev`:
- Typed `echo alpha beta gamma` without pressing Enter.
- Pressed `Ctrl+Backspace`; `gamma` was deleted.
- Pressed `Ctrl+Backspace` again; `beta` was deleted.
- Held plain Backspace; character-by-character deletion still worked normally.

Automated checks:
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] `git diff --check` clean

## Screenshots / GIFs
Not attached; behavior is keyboard-input only and was manually verified.

## Notes for reviewer
This intentionally avoids changing key-repeat behavior for plain Backspace because the app does not add a repeat delay; this PR fixes the concrete `Ctrl+Backspace` mismatch without touching normal Backspace handling.