### PR TITLE
fix(terminal): support dropping files into terminal

### DIFF
--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,7 +1,22 @@
+import { IS_WINDOWS } from "@/lib/platform";
 import { useTheme } from "@/modules/theme";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import type { DragDropEvent } from "@tauri-apps/api/webview";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { SearchAddon } from "@xterm/addon-search";
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
-import { useTerminalSession, type TeraxOpenInput } from "./lib/useTerminalSession";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { isDropPointInsideRect } from "./lib/drop-hitbox";
+import { buildDroppedPathInput } from "./lib/drop-paths";
+import {
+  useTerminalSession,
+  type TeraxOpenInput,
+} from "./lib/useTerminalSession";
 
 export type TerminalPaneHandle = {
   write: (data: string) => void;
@@ -36,6 +51,11 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
     ref,
   ) {
     const containerRef = useRef<HTMLDivElement>(null);
+    const visibleRef = useRef(visible);
+    const sessionRef = useRef<ReturnType<typeof useTerminalSession> | null>(
+      null,
+    );
+    const [dropActive, setDropActive] = useState(false);
     const { resolvedTheme } = useTheme();
 
     const session = useTerminalSession({
@@ -48,6 +68,12 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       onDetectedLocalUrl: (u) => onDetectedLocalUrl?.(tabId, u),
       onTeraxOpen: (input) => onTeraxOpen?.(tabId, input),
     });
+    sessionRef.current = session;
+
+    useEffect(() => {
+      visibleRef.current = visible;
+      if (!visible) setDropActive(false);
+    }, [visible]);
 
     useEffect(() => {
       // Defer one frame so CSS-variable token resolution sees the new class.
@@ -66,15 +92,86 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       [session],
     );
 
+    useEffect(() => {
+      let disposed = false;
+      let scaleFactor = window.devicePixelRatio || 1;
+
+      try {
+        void getCurrentWindow()
+          .scaleFactor()
+          .then((factor) => {
+            if (!disposed) scaleFactor = factor || 1;
+          })
+          .catch(() => {
+            scaleFactor = 1;
+          });
+
+        const unlisten = getCurrentWebview().onDragDropEvent((event) => {
+          if (disposed) return;
+          const payload = event.payload;
+          if (payload.type === "leave") {
+            setDropActive(false);
+            return;
+          }
+          if (!visibleRef.current) return;
+
+          const container = containerRef.current;
+          if (!container) return;
+          const inside = isDropInside(payload, container, scaleFactor);
+          setDropActive(inside && payload.type !== "drop");
+
+          if (payload.type !== "drop" || !inside) return;
+          const input = buildDroppedPathInput(
+            payload.paths,
+            IS_WINDOWS ? "windows" : "unix",
+          );
+          if (!input) return;
+          sessionRef.current?.focus();
+          sessionRef.current?.write(input);
+        });
+
+        return () => {
+          disposed = true;
+          void unlisten.then((fn) => fn()).catch(console.error);
+        };
+      } catch (error) {
+        console.warn("Terminal file drop unavailable:", error);
+        return () => {
+          disposed = true;
+        };
+      }
+    }, []);
+
     return (
-      <div
-        ref={containerRef}
-        className="h-full w-full"
-        style={{
-          visibility: visible ? "visible" : "hidden",
-          pointerEvents: visible ? "auto" : "none",
-        }}
-      />
+      <div className="relative h-full w-full">
+        <div
+          ref={containerRef}
+          className="h-full w-full"
+          style={{
+            visibility: visible ? "visible" : "hidden",
+            pointerEvents: visible ? "auto" : "none",
+          }}
+        />
+        {dropActive ? (
+          <div className="pointer-events-none absolute inset-2 grid place-items-center rounded-lg border border-primary/45 bg-background/70 text-xs font-medium text-foreground shadow-lg backdrop-blur-sm">
+            Drop file path into terminal
+          </div>
+        ) : null}
+      </div>
     );
   },
 );
+
+function isDropInside(
+  payload: Extract<DragDropEvent, { type: "enter" | "over" | "drop" }>,
+  element: HTMLElement,
+  scaleFactor: number,
+): boolean {
+  const rect = element.getBoundingClientRect();
+  return isDropPointInsideRect(
+    payload.position,
+    rect,
+    { width: window.innerWidth, height: window.innerHeight },
+    scaleFactor,
+  );
+}

--- a/src/modules/terminal/lib/drop-hitbox.test.ts
+++ b/src/modules/terminal/lib/drop-hitbox.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { isDropPointInsideRect } from "./drop-hitbox.ts";
+
+const rect = { left: 0, top: 0, right: 1_000, bottom: 600 };
+const viewport = { width: 1_200, height: 800 };
+
+test("keeps logical drop coordinates at the terminal right edge", () => {
+  assert.equal(
+    isDropPointInsideRect({ x: 950, y: 300 }, rect, viewport, 2),
+    true,
+  );
+});
+
+test("converts high-DPI physical coordinates that exceed the logical viewport", () => {
+  assert.equal(
+    isDropPointInsideRect({ x: 1_900, y: 600 }, rect, viewport, 2),
+    true,
+  );
+});
+
+test("does not treat logical points outside the terminal as inside after scaling", () => {
+  assert.equal(
+    isDropPointInsideRect({ x: 1_100, y: 300 }, rect, viewport, 2),
+    false,
+  );
+});

--- a/src/modules/terminal/lib/drop-hitbox.ts
+++ b/src/modules/terminal/lib/drop-hitbox.ts
@@ -1,0 +1,33 @@
+export type DropPoint = { x: number; y: number };
+export type DropRect = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+export type DropViewport = { width: number; height: number };
+
+export function isDropPointInsideRect(
+  point: DropPoint,
+  rect: DropRect,
+  viewport: DropViewport,
+  scaleFactor: number,
+): boolean {
+  const logical = normalizeDropPoint(point, viewport, scaleFactor);
+  return (
+    logical.x >= rect.left &&
+    logical.x <= rect.right &&
+    logical.y >= rect.top &&
+    logical.y <= rect.bottom
+  );
+}
+
+function normalizeDropPoint(
+  point: DropPoint,
+  viewport: DropViewport,
+  scaleFactor: number,
+): DropPoint {
+  if (point.x <= viewport.width && point.y <= viewport.height) return point;
+  const scale = scaleFactor > 0 ? scaleFactor : 1;
+  return { x: point.x / scale, y: point.y / scale };
+}

--- a/src/modules/terminal/lib/drop-paths.test.ts
+++ b/src/modules/terminal/lib/drop-paths.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildDroppedPathInput } from "./drop-paths.ts";
+
+test("formats dropped Unix paths as shell-safe terminal input", () => {
+  assert.equal(
+    buildDroppedPathInput(
+      ["/Users/roman/Desktop/my screenshot.png", "/tmp/quote's.png"],
+      "unix",
+    ),
+    "'/Users/roman/Desktop/my screenshot.png' '/tmp/quote'\\''s.png' ",
+  );
+});
+
+test("formats dropped Windows paths as shell-safe terminal input", () => {
+  assert.equal(
+    buildDroppedPathInput(
+      ["C:\\Users\\Roman\\Desktop\\my screenshot.png", 'C:\\tmp\\a"b.png'],
+      "windows",
+    ),
+    '"C:\\Users\\Roman\\Desktop\\my screenshot.png" "C:\\tmp\\a`"b.png" ',
+  );
+});
+
+test("returns null when no paths are dropped", () => {
+  assert.equal(buildDroppedPathInput([], "unix"), null);
+});

--- a/src/modules/terminal/lib/drop-paths.ts
+++ b/src/modules/terminal/lib/drop-paths.ts
@@ -1,0 +1,22 @@
+export type TerminalDropPlatform = "unix" | "windows";
+
+export function buildDroppedPathInput(
+  paths: readonly string[],
+  platform: TerminalDropPlatform,
+): string | null {
+  const quoted = paths
+    .filter((path) => path.length > 0)
+    .map((path) =>
+      platform === "windows" ? quoteWindowsPath(path) : quoteUnixPath(path),
+    );
+  if (quoted.length === 0) return null;
+  return `${quoted.join(" ")} `;
+}
+
+function quoteUnixPath(path: string): string {
+  return `'${path.replace(/'/g, "'\\''")}'`;
+}
+
+function quoteWindowsPath(path: string): string {
+  return `"${path.replace(/"/g, '`"')}"`;
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
I want support files/images drop into the coding agents inside terminal. Currently it's not working in codex.

## Why
I didn't open the issue but it's clear. Previously you can't drop images to your coding agents

## How
added a hitbox area where you can drop files in terminal view

## Testing
Tested drops files when agent opened/closed. When ai agent is not opened it's just write a path into the terminal

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

## Notes for reviewer
