### PR TITLE
feat(ui): replace browser confirm with styled dialog for unsaved tab …

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,16 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import {
   AgentRunBridge,
@@ -97,6 +107,7 @@ export default function App() {
   }, []);
 
   const [home, setHome] = useState<string | null>(null);
+  const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
   useEffect(() => {
     // Forward-slash form so explorerRoot stays equal across home → OSC 7.
     homeDir()
@@ -235,15 +246,24 @@ export default function App() {
     (id: number) => {
       const t = tabs.find((x) => x.id === id);
       if (t?.kind === "editor" && t.dirty) {
-        const ok = window.confirm(
-          `"${t.title}" has unsaved changes. Close anyway?`,
-        );
-        if (!ok) return;
+        setPendingCloseTab(id);
+        return;
       }
       disposeTab(id);
     },
     [tabs, disposeTab],
   );
+
+  const confirmClose = useCallback(() => {
+    if (pendingCloseTab !== null) {
+      disposeTab(pendingCloseTab);
+      setPendingCloseTab(null);
+    }
+  }, [pendingCloseTab, disposeTab]);
+
+  const cancelClose = useCallback(() => {
+    setPendingCloseTab(null);
+  }, []);
 
   const cycleTab = useCallback(
     (delta: 1 | -1) => {
@@ -762,6 +782,32 @@ export default function App() {
           />
 
           <UpdaterDialog />
+
+          <AlertDialog
+            open={pendingCloseTab !== null}
+            onOpenChange={(open) => !open && cancelClose()}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {tabs.find((t) => t.id === pendingCloseTab)?.title
+                    ? `"${
+                        tabs.find((t) => t.id === pendingCloseTab)?.title
+                      }" has unsaved changes. Close anyway?`
+                    : "This file has unsaved changes. Close anyway?"}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={cancelClose}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction onClick={confirmClose}>
+                  Close Anyway
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </TooltipProvider>
     </ThemeProvider>


### PR DESCRIPTION
## What
removed the default tauri dialog and replace it with alert-dialog for consistency

## Why
- Making UI consistent across the app

## How
removed the original alert in App.tsx, and replace it with AlertDialog component

## Testing
Try Editing a file and close it while its dirty, it will trigger the AlertDialog and prompt you with `Cancel` or `Close Anyway`

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<img width="1366" height="768" alt="{D116BE21-3BF7-4315-9116-599F631C152C}" src="https://github.com/user-attachments/assets/b9949540-4aff-4f32-9602-f556f40ae621" />
