### PR TITLE
feat(terminal): add saved command shortcuts

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -50,6 +50,7 @@ import {
   type TerminalPaneHandle,
   type TeraxOpenInput,
 } from "@/modules/terminal";
+import { useSavedTerminalCommandsStore } from "@/modules/terminal/store/savedCommandsStore";
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import { homeDir } from "@tauri-apps/api/path";
@@ -143,6 +144,12 @@ export default function App() {
   const setLive = useChatStore((s) => s.setLive);
   const respondToApproval = useChatStore((s) => s.respondToApproval);
   const hasComposer = hasAnyKey(apiKeys);
+  const savedTerminalCommands = useSavedTerminalCommandsStore(
+    (s) => s.commands,
+  );
+  const upsertSavedTerminalCommand = useSavedTerminalCommandsStore(
+    (s) => s.upsert,
+  );
 
   const [keysLoaded, setKeysLoaded] = useState(false);
   useEffect(() => {
@@ -180,6 +187,7 @@ export default function App() {
     void hydrateSessions();
     void useAgentsStore.getState().hydrate();
     void useSnippetsStore.getState().hydrate();
+    void useSavedTerminalCommandsStore.getState().hydrate();
   }, [hydrateSessions]);
 
   const activeTab = tabs.find((t) => t.id === activeId);
@@ -452,6 +460,67 @@ export default function App() {
       }, 80);
     },
     [newTab],
+  );
+
+  const writeCommandWhenPromptIsReady = useCallback(
+    (getLeafId: () => number | null, text: string) => {
+      let tries = 0;
+      const maxTries = 60;
+
+      const attempt = () => {
+        const leafId = getLeafId();
+        const term = leafId === null ? null : terminalRefs.current.get(leafId);
+        if (!term) {
+          tries += 1;
+          if (tries < maxTries) window.setTimeout(attempt, 50);
+          return;
+        }
+
+        tries += 1;
+        if (!term.isAtPrompt() && tries < maxTries) {
+          window.setTimeout(attempt, 50);
+          return;
+        }
+
+        term.focus();
+        term.write(text);
+      };
+
+      window.setTimeout(attempt, 0);
+    },
+    [],
+  );
+
+  const insertSavedTerminalCommand = useCallback(
+    (command: string) => {
+      const text = command.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+      if (!text) return;
+
+      const active = tabs.find((x) => x.id === activeId);
+      if (active?.kind === "terminal") {
+        const term = terminalRefs.current.get(active.activeLeafId);
+        if (term?.isAtPrompt()) {
+          window.setTimeout(() => {
+            term.focus();
+            term.write(text);
+          }, 20);
+          return;
+        }
+      }
+
+      const tabId = newTab(inheritedCwdForNewTab());
+      writeCommandWhenPromptIsReady(() => {
+        const tab = tabsRef.current.find((x) => x.id === tabId);
+        return tab?.kind === "terminal" ? tab.activeLeafId : null;
+      }, text);
+    },
+    [
+      activeId,
+      inheritedCwdForNewTab,
+      newTab,
+      tabs,
+      writeCommandWhenPromptIsReady,
+    ],
   );
 
   const handleOpenFile = useCallback(
@@ -842,6 +911,17 @@ export default function App() {
             onOpenPreview={() => {
               if (detectedPreviewUrl) openPreviewTab(detectedPreviewUrl);
             }}
+            savedCommands={savedTerminalCommands}
+            onPickSavedCommand={(command) =>
+              insertSavedTerminalCommand(command.command)
+            }
+            onToggleSavedCommandPin={(command) =>
+              upsertSavedTerminalCommand({
+                ...command,
+                pinned: !command.pinned,
+              })
+            }
+            onManageSavedCommands={() => void openSettingsWindow("commands")}
           />
 
           {hasComposer ? (

--- a/src/modules/settings/openSettingsWindow.ts
+++ b/src/modules/settings/openSettingsWindow.ts
@@ -5,6 +5,7 @@ export type SettingsTab =
   | "shortcuts"
   | "models"
   | "agents"
+  | "commands"
   | "about";
 
 export async function openSettingsWindow(tab?: SettingsTab): Promise<void> {

--- a/src/modules/statusbar/SavedCommandsMenu.tsx
+++ b/src/modules/statusbar/SavedCommandsMenu.tsx
@@ -1,0 +1,630 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { SavedTerminalCommand } from "@/modules/terminal/lib/savedCommands";
+import {
+  ArrowDown01Icon,
+  ComputerTerminal01Icon,
+  PinIcon,
+  PinOffIcon,
+  Search01Icon,
+  Settings01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { flushSync } from "react-dom";
+import {
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  useMemo,
+  useState,
+} from "react";
+
+const SCROLLBAR_CLASS =
+  "[scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border/80";
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MAX_WIDTH = 640;
+const PANEL_MIN_HEIGHT = 320;
+const PANEL_MAX_HEIGHT = 720;
+const PINNED_MIN_HEIGHT = 72;
+const PINNED_MAX_HEIGHT = 520;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function maxPanelWidth() {
+  return Math.max(
+    PANEL_MIN_WIDTH,
+    Math.min(PANEL_MAX_WIDTH, window.innerWidth - 24),
+  );
+}
+
+function maxPanelHeight() {
+  return Math.max(
+    PANEL_MIN_HEIGHT,
+    Math.min(PANEL_MAX_HEIGHT, window.innerHeight - 72),
+  );
+}
+
+function maxPinnedHeight(panelHeight: number) {
+  return Math.min(
+    PINNED_MAX_HEIGHT,
+    Math.max(PINNED_MIN_HEIGHT, panelHeight - 190),
+  );
+}
+
+function resolvedMaxPx(
+  element: HTMLElement,
+  property: "maxHeight" | "maxWidth",
+  fallback: number,
+) {
+  const value = Number.parseFloat(getComputedStyle(element)[property]);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+type Props = {
+  commands: SavedTerminalCommand[];
+  onPick: (command: SavedTerminalCommand) => void;
+  onTogglePin: (command: SavedTerminalCommand) => void;
+  onManage: () => void;
+};
+
+export function SavedCommandsMenu({
+  commands,
+  onPick,
+  onTogglePin,
+  onManage,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [pinnedOpen, setPinnedOpen] = useState(true);
+  const [allOpen, setAllOpen] = useState(true);
+  const [panelSize, setPanelSize] = useState({
+    width: PANEL_MIN_WIDTH,
+    height: 560,
+  });
+  const [pinnedBodyHeight, setPinnedBodyHeight] = useState(128);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const list = [...commands].sort((a, b) => {
+      const pinnedDelta = Number(!!b.pinned) - Number(!!a.pinned);
+      if (pinnedDelta !== 0) return pinnedDelta;
+      return a.name.localeCompare(b.name);
+    });
+    if (!q) return list;
+    return list.filter((command) =>
+      [command.name, command.command, command.description]
+        .join("\n")
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [commands, query]);
+
+  const pinned = filtered.filter((command) => command.pinned);
+  const unpinned = filtered.filter((command) => !command.pinned);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setQuery("");
+  };
+
+  const pickCommand = (command: SavedTerminalCommand) => {
+    setOpen(false);
+    window.setTimeout(() => onPick(command), 20);
+  };
+
+  const pinnedBodyMaxHeight = clamp(
+    pinnedBodyHeight,
+    PINNED_MIN_HEIGHT,
+    maxPinnedHeight(panelSize.height),
+  );
+
+  const startPanelResize = (
+    event: ReactPointerEvent<HTMLDivElement>,
+    axis: "width" | "height" | "both",
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = event.currentTarget;
+    const content = target.closest<HTMLElement>(
+      "[data-slot='dropdown-menu-content']",
+    );
+    if (!content) return;
+
+    const rect = content.getBoundingClientRect();
+    const pointerId = event.pointerId;
+    try {
+      target.setPointerCapture(pointerId);
+    } catch {
+      // Pointer capture can fail if the pointer already ended.
+    }
+
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startWidth = rect.width;
+    const startHeight = rect.height;
+    const maxWidth = Math.min(
+      maxPanelWidth(),
+      resolvedMaxPx(content, "maxWidth", maxPanelWidth()),
+    );
+    const maxHeight = Math.min(
+      maxPanelHeight(),
+      resolvedMaxPx(content, "maxHeight", maxPanelHeight()),
+    );
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    let nextWidth = startWidth;
+    let nextHeight = startHeight;
+    let frame = 0;
+
+    document.body.style.cursor =
+      axis === "both"
+        ? "nwse-resize"
+        : axis === "width"
+          ? "col-resize"
+          : "row-resize";
+    document.body.style.userSelect = "none";
+
+    const applySize = () => {
+      frame = 0;
+      if (axis !== "height") content.style.width = `${nextWidth}px`;
+      if (axis !== "width") content.style.height = `${nextHeight}px`;
+    };
+
+    const onMove = (moveEvent: PointerEvent) => {
+      if (axis !== "height") {
+        nextWidth = clamp(
+          startWidth + startX - moveEvent.clientX,
+          PANEL_MIN_WIDTH,
+          maxWidth,
+        );
+      }
+      if (axis !== "width") {
+        nextHeight = clamp(
+          startHeight + startY - moveEvent.clientY,
+          PANEL_MIN_HEIGHT,
+          maxHeight,
+        );
+      }
+      if (!frame) frame = window.requestAnimationFrame(applySize);
+    };
+
+    const stopResize = () => {
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+        applySize();
+      }
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", stopResize);
+      document.removeEventListener("pointercancel", stopResize);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      setPanelSize({ width: nextWidth, height: nextHeight });
+      setPinnedBodyHeight((current) =>
+        clamp(current, PINNED_MIN_HEIGHT, maxPinnedHeight(nextHeight)),
+      );
+      try {
+        target.releasePointerCapture(pointerId);
+      } catch {
+        // The browser releases capture automatically on pointerup.
+      }
+    };
+
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", stopResize);
+    document.addEventListener("pointercancel", stopResize);
+  };
+
+  const startSectionResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!pinnedOpen || !allOpen) {
+      flushSync(() => {
+        if (!pinnedOpen) setPinnedOpen(true);
+        if (!allOpen) setAllOpen(true);
+      });
+    }
+
+    const target = event.currentTarget;
+    const content = target.closest<HTMLElement>(
+      "[data-slot='dropdown-menu-content']",
+    );
+    const body = content?.querySelector<HTMLElement>(
+      "[data-command-group-body='pinned']",
+    );
+    if (!content || !body) return;
+
+    const contentRect = content.getBoundingClientRect();
+    const bodyRect = body.getBoundingClientRect();
+    const pointerId = event.pointerId;
+    try {
+      target.setPointerCapture(pointerId);
+    } catch {
+      // Pointer capture can fail if the pointer already ended.
+    }
+
+    const startY = event.clientY;
+    const startHeight = bodyRect.height;
+    const maxHeight = maxPinnedHeight(contentRect.height);
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    let nextHeight = startHeight;
+    let frame = 0;
+
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+
+    const applySize = () => {
+      frame = 0;
+      body.style.height = `${nextHeight}px`;
+    };
+
+    const onMove = (moveEvent: PointerEvent) => {
+      nextHeight = clamp(
+        startHeight + moveEvent.clientY - startY,
+        PINNED_MIN_HEIGHT,
+        maxHeight,
+      );
+      if (!frame) frame = window.requestAnimationFrame(applySize);
+    };
+
+    const stopResize = () => {
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+        applySize();
+      }
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", stopResize);
+      document.removeEventListener("pointercancel", stopResize);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      setPinnedBodyHeight(nextHeight);
+      try {
+        target.releasePointerCapture(pointerId);
+      } catch {
+        // The browser releases capture automatically on pointerup.
+      }
+    };
+
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", stopResize);
+    document.addEventListener("pointercancel", stopResize);
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          title="Saved terminal commands"
+          className="flex h-6 max-w-36 items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 text-[11px] text-muted-foreground transition-colors hover:border-border hover:bg-accent hover:text-foreground"
+        >
+          <HugeiconsIcon
+            icon={ComputerTerminal01Icon}
+            size={12}
+            strokeWidth={1.75}
+            className="shrink-0"
+          />
+          <span className="truncate">Commands</span>
+          <HugeiconsIcon
+            icon={ArrowDown01Icon}
+            size={11}
+            strokeWidth={2}
+            className="shrink-0 opacity-70"
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={6}
+        className="relative flex min-w-80 flex-col overflow-hidden"
+        style={{
+          width: panelSize.width,
+          height: panelSize.height,
+          maxWidth: `min(${PANEL_MAX_WIDTH}px, calc(100vw - 24px))`,
+          maxHeight: `min(${PANEL_MAX_HEIGHT}px, calc(100vh - 72px), var(--radix-dropdown-menu-content-available-height))`,
+        }}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <PanelResizeHandle
+          title="Resize command panel height"
+          className="top-0 left-8 right-8 h-3 cursor-row-resize"
+          grip="horizontal"
+          onPointerDown={(e) => startPanelResize(e, "height")}
+        />
+        <PanelResizeHandle
+          title="Resize command panel width"
+          className="top-8 bottom-12 left-0 w-3 cursor-col-resize"
+          grip="vertical"
+          onPointerDown={(e) => startPanelResize(e, "width")}
+        />
+        <PanelResizeHandle
+          title="Resize command panel"
+          className="top-0 left-0 size-5 cursor-nwse-resize rounded-tl-3xl"
+          onPointerDown={(e) => startPanelResize(e, "both")}
+        />
+        <div className="shrink-0">
+          <DropdownMenuLabel className="py-1.5 text-[10px]">
+            Terminal commands
+          </DropdownMenuLabel>
+          <div className="relative mb-1 px-1">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              size={12}
+              strokeWidth={1.75}
+              className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.stopPropagation()}
+              placeholder="Search commands"
+              className="h-7 rounded-lg bg-card/60 pl-7 text-[11px]"
+            />
+          </div>
+        </div>
+
+        {commands.length === 0 ? (
+          <DropdownMenuItem
+            className="text-[12px] text-muted-foreground"
+            onSelect={onManage}
+          >
+            No saved commands
+          </DropdownMenuItem>
+        ) : filtered.length === 0 ? (
+          <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+            No commands match.
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <CommandGroup
+              label="Pinned"
+              emptyLabel={
+                query.trim()
+                  ? "No pinned commands match."
+                  : "No pinned commands yet."
+              }
+              commands={pinned}
+              open={pinnedOpen}
+              onOpenChange={setPinnedOpen}
+              onPick={pickCommand}
+              onTogglePin={onTogglePin}
+              sectionClassName="shrink-0"
+              bodyClassName={cn("overflow-y-auto pr-0.5", SCROLLBAR_CLASS)}
+              bodyKey="pinned"
+              bodyStyle={{ height: pinnedBodyMaxHeight }}
+            />
+            <SectionResizeHandle onPointerDown={startSectionResize} />
+            <CommandGroup
+              label="All commands"
+              emptyLabel={
+                query.trim()
+                  ? "No other commands match."
+                  : "No other saved commands."
+              }
+              commands={unpinned}
+              open={allOpen}
+              onOpenChange={setAllOpen}
+              onPick={pickCommand}
+              onTogglePin={onTogglePin}
+              sectionClassName="min-h-0 flex-1"
+              bodyClassName={cn(
+                "min-h-0 flex-1 overflow-y-scroll pr-0.5",
+                SCROLLBAR_CLASS,
+              )}
+            />
+          </div>
+        )}
+
+        <div className="shrink-0">
+          <div className="-mx-1.5 my-1.5 h-px bg-border/50" />
+          <DropdownMenuItem
+            className="text-[12px]"
+            onSelect={() => {
+              setOpen(false);
+              onManage();
+            }}
+          >
+            <HugeiconsIcon icon={Settings01Icon} size={13} strokeWidth={1.75} />
+            Manage commands
+          </DropdownMenuItem>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function PanelResizeHandle({
+  title,
+  className,
+  grip,
+  onPointerDown,
+}: {
+  title: string;
+  className: string;
+  grip?: "vertical" | "horizontal";
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+}) {
+  return (
+    <div
+      role="separator"
+      title={title}
+      className={cn(
+        "group absolute z-10 touch-none transition-colors hover:bg-border/25",
+        className,
+      )}
+      onPointerDown={onPointerDown}
+    >
+      {grip === "vertical" ? (
+        <span className="pointer-events-none absolute top-1/2 left-1/2 h-7 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/80 transition-colors group-hover:bg-foreground/35" />
+      ) : null}
+      {grip === "horizontal" ? (
+        <span className="pointer-events-none absolute top-1/2 left-1/2 h-1 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/70 transition-colors group-hover:bg-foreground/35" />
+      ) : null}
+    </div>
+  );
+}
+
+function SectionResizeHandle({
+  onPointerDown,
+}: {
+  onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+}) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      title="Resize command sections"
+      className="group relative -mx-1.5 my-1 flex h-3 shrink-0 cursor-row-resize touch-none items-center px-1.5"
+      onPointerDown={onPointerDown}
+    >
+      <span className="h-px flex-1 bg-border/50 transition-colors group-hover:bg-border" />
+      <span
+        className="pointer-events-none absolute top-1/2 left-1/2 h-1 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/70 transition-colors group-hover:bg-foreground/35"
+      />
+    </div>
+  );
+}
+
+function CommandGroup({
+  label,
+  emptyLabel,
+  commands,
+  open,
+  onOpenChange,
+  onPick,
+  onTogglePin,
+  sectionClassName,
+  bodyClassName,
+  bodyKey,
+  bodyStyle,
+}: {
+  label: string;
+  emptyLabel: string;
+  commands: SavedTerminalCommand[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPick: (command: SavedTerminalCommand) => void;
+  onTogglePin: (command: SavedTerminalCommand) => void;
+  sectionClassName?: string;
+  bodyClassName?: string;
+  bodyKey?: string;
+  bodyStyle?: CSSProperties;
+}) {
+  return (
+    <section className={cn("flex flex-col gap-0.5", sectionClassName)}>
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        className="flex h-7 items-center gap-1.5 rounded-lg px-2 text-[9.5px] font-medium tracking-wide text-muted-foreground uppercase transition-colors hover:bg-accent/60 hover:text-foreground"
+      >
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          size={11}
+          strokeWidth={2}
+          className={cn("transition-transform", !open && "-rotate-90")}
+        />
+        <span>{label}</span>
+        <span className="ml-auto rounded bg-muted/50 px-1.5 py-0.5 text-[9px] tabular-nums">
+          {commands.length}
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          className={cn("flex flex-col gap-0.5", bodyClassName)}
+          data-command-group-body={bodyKey}
+          style={bodyStyle}
+        >
+          {commands.length > 0 ? (
+            commands.map((command) => (
+              <CommandRow
+                key={command.id}
+                command={command}
+                onPick={onPick}
+                onTogglePin={onTogglePin}
+              />
+            ))
+          ) : (
+            <div className="px-3 py-2 text-[11px] text-muted-foreground">
+              {emptyLabel}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function CommandRow({
+  command,
+  onPick,
+  onTogglePin,
+}: {
+  command: SavedTerminalCommand;
+  onPick: (command: SavedTerminalCommand) => void;
+  onTogglePin: (command: SavedTerminalCommand) => void;
+}) {
+  return (
+    <div className="group flex items-start gap-1 rounded-xl px-2 py-2 transition-colors hover:bg-accent focus-within:bg-accent">
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 flex-col items-start gap-1 text-left outline-none"
+        onClick={() => onPick(command)}
+      >
+        <span className="flex w-full min-w-0 items-center gap-1.5 truncate text-[12px] font-medium">
+          {command.pinned ? (
+            <HugeiconsIcon
+              icon={PinIcon}
+              size={11}
+              strokeWidth={1.75}
+              className="shrink-0 text-muted-foreground"
+            />
+          ) : null}
+          <span className="truncate">{command.name}</span>
+        </span>
+        <code className="w-full max-w-full truncate font-mono text-[10.5px] text-muted-foreground">
+          {command.command}
+        </code>
+        {command.description ? (
+          <span className="w-full max-w-full truncate text-[10.5px] text-muted-foreground">
+            {command.description}
+          </span>
+        ) : null}
+      </button>
+      <button
+        type="button"
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onTogglePin(command);
+        }}
+        title={command.pinned ? "Unpin command" : "Pin command"}
+        aria-label={command.pinned ? "Unpin command" : "Pin command"}
+        className={cn(
+          "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-60 transition hover:bg-background/60 hover:text-foreground hover:opacity-100 focus:opacity-100 focus:outline-none",
+          command.pinned && "opacity-100 text-foreground",
+        )}
+      >
+        <HugeiconsIcon
+          icon={command.pinned ? PinOffIcon : PinIcon}
+          size={12}
+          strokeWidth={1.75}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/modules/statusbar/StatusBar.tsx
+++ b/src/modules/statusbar/StatusBar.tsx
@@ -4,9 +4,11 @@ import {
   AiStatusBarControls,
 } from "@/modules/ai/components/AiStatusBarControls";
 import { useChatStore } from "@/modules/ai";
+import type { SavedTerminalCommand } from "@/modules/terminal";
 import { Globe02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CwdBreadcrumb } from "./CwdBreadcrumb";
+import { SavedCommandsMenu } from "./SavedCommandsMenu";
 
 type Props = {
   cwd: string | null;
@@ -19,6 +21,10 @@ type Props = {
   /** When set, render a one-click "Open preview" chip pointing at this URL. */
   detectedPreviewUrl?: string | null;
   onOpenPreview?: () => void;
+  savedCommands: SavedTerminalCommand[];
+  onPickSavedCommand: (command: SavedTerminalCommand) => void;
+  onToggleSavedCommandPin: (command: SavedTerminalCommand) => void;
+  onManageSavedCommands: () => void;
 };
 
 export function StatusBar({
@@ -30,6 +36,10 @@ export function StatusBar({
   hasComposer,
   detectedPreviewUrl,
   onOpenPreview,
+  savedCommands,
+  onPickSavedCommand,
+  onToggleSavedCommandPin,
+  onManageSavedCommands,
 }: Props) {
   const panelOpen = useChatStore((s) => s.panelOpen);
   const openPanel = useChatStore((s) => s.openPanel);
@@ -59,6 +69,12 @@ export function StatusBar({
             </span>
           </button>
         ) : null}
+        <SavedCommandsMenu
+          commands={savedCommands}
+          onPick={onPickSavedCommand}
+          onTogglePin={onToggleSavedCommandPin}
+          onManage={onManageSavedCommands}
+        />
         <AgentStatusPill onClick={onOpenMini} />
         {panelOpen && hasComposer ? (
           <AiStatusBarControls />

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -8,6 +8,7 @@ export type TerminalPaneHandle = {
   focus: () => void;
   getBuffer: (maxLines?: number) => string | null;
   getSelection: () => string | null;
+  isAtPrompt: () => boolean;
 };
 
 type Props = {
@@ -69,6 +70,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
         focus: () => session.focus(),
         getBuffer: (max?: number) => session.getBuffer(max),
         getSelection: () => session.getSelection(),
+        isAtPrompt: () => session.isAtPrompt(),
       }),
       [session],
     );

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -5,6 +5,7 @@ export {
   respawnSession,
   type TeraxOpenInput,
 } from "./lib/useTerminalSession";
+export type { SavedTerminalCommand } from "./lib/savedCommands";
 export {
   hasLeaf,
   isLeaf,

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -14,24 +14,38 @@ export function registerCwdHandler(
 
 export type PromptTracker = {
   getMarker: () => IMarker | null;
+  isAtPrompt: () => boolean;
+  markInput: (data: string) => void;
   dispose: () => void;
 };
 
 export function registerPromptTracker(term: Terminal): PromptTracker {
   let marker: IMarker | null = null;
+  let state: "unknown" | "prompt" | "busy" = "unknown";
   const d = term.parser.registerOscHandler(133, (data) => {
-    if (data.startsWith("A")) {
+    const code = data[0];
+    if (code === "A") {
       marker?.dispose();
       marker = term.registerMarker(0);
+      state = "unknown";
+    } else if (code === "B") {
+      state = "prompt";
+    } else if (code === "C" || code === "D") {
+      state = "busy";
     }
     return true;
   });
   return {
     getMarker: () => (marker && !marker.isDisposed ? marker : null),
+    isAtPrompt: () => state === "prompt",
+    markInput: (data) => {
+      if (state === "prompt" && /[\r\n]/.test(data)) state = "busy";
+    },
     dispose: () => {
       d.dispose();
       marker?.dispose();
       marker = null;
+      state = "unknown";
     },
   };
 }

--- a/src/modules/terminal/lib/savedCommands.ts
+++ b/src/modules/terminal/lib/savedCommands.ts
@@ -1,0 +1,31 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+
+export type SavedTerminalCommand = {
+  id: string;
+  name: string;
+  description: string;
+  command: string;
+  pinned?: boolean;
+};
+
+const STORE_PATH = "terax-terminal-commands.json";
+const KEY_LIST = "commands";
+
+const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
+
+export async function loadSavedTerminalCommands(): Promise<
+  SavedTerminalCommand[]
+> {
+  return (await store.get<SavedTerminalCommand[]>(KEY_LIST)) ?? [];
+}
+
+export async function saveSavedTerminalCommands(
+  list: SavedTerminalCommand[],
+): Promise<void> {
+  await store.set(KEY_LIST, list);
+  await store.save();
+}
+
+export function newSavedTerminalCommandId(): string {
+  return `tc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -11,6 +11,7 @@ import {
   registerCwdHandler,
   registerPromptTracker,
   registerTeraxOpenHandler,
+  type PromptTracker,
   type TeraxOpenInput,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
@@ -37,6 +38,7 @@ type Session = {
   term: Terminal;
   fitAddon: FitAddon;
   searchAddon: SearchAddon;
+  prompt: PromptTracker | null;
   pty: PtySession | null;
   cleanups: (() => void)[];
   callbacks: Callbacks;
@@ -90,6 +92,7 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     term,
     fitAddon,
     searchAddon,
+    prompt: null,
     pty: null,
     cleanups: [],
     callbacks: {},
@@ -122,7 +125,10 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
   });
 
   // Routes through session.pty so respawn doesn't need to rebind.
-  term.onData((data) => session.pty?.write(data));
+  term.onData((data) => {
+    session.prompt?.markInput(data);
+    session.pty?.write(data);
+  });
 
   // PTY is opened lazily in attachSession after the first fit, so the shell
   // starts with the real terminal size and never flushes a 80x24-sized
@@ -132,7 +138,11 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     if (session.disposed) return;
 
     const prompt = registerPromptTracker(term);
-    session.cleanups.push(prompt.dispose);
+    session.prompt = prompt;
+    session.cleanups.push(() => {
+      prompt.dispose();
+      session.prompt = null;
+    });
     session.cleanups.push(
       registerCwdHandler(term, (cwd) => {
         session.lastCwd = cwd;
@@ -463,13 +473,17 @@ export function useTerminalSession({
     return sel.length > 0 ? sel : null;
   }, [leafId]);
 
+  const isAtPrompt = useCallback((): boolean => {
+    return sessions.get(leafId)?.prompt?.isAtPrompt() ?? false;
+  }, [leafId]);
+
   const applyTheme = useCallback(() => {
     const s = sessions.get(leafId);
     if (!s) return;
     s.term.options.theme = buildTerminalTheme();
   }, [leafId]);
 
-  return { write, focus, getBuffer, getSelection, applyTheme };
+  return { write, focus, getBuffer, getSelection, isAtPrompt, applyTheme };
 }
 
 function isCtrlBackspace(event: KeyboardEvent): boolean {

--- a/src/modules/terminal/store/savedCommandsStore.ts
+++ b/src/modules/terminal/store/savedCommandsStore.ts
@@ -1,0 +1,50 @@
+import { emit, listen } from "@tauri-apps/api/event";
+import { create } from "zustand";
+import {
+  loadSavedTerminalCommands,
+  newSavedTerminalCommandId,
+  saveSavedTerminalCommands,
+  type SavedTerminalCommand,
+} from "../lib/savedCommands";
+
+const CHANGED_EVENT = "terax://saved-terminal-commands-changed";
+
+type State = {
+  hydrated: boolean;
+  commands: SavedTerminalCommand[];
+  hydrate: () => Promise<void>;
+  upsert: (command: SavedTerminalCommand) => void;
+  remove: (id: string) => void;
+};
+
+let initialized = false;
+
+export const useSavedTerminalCommandsStore = create<State>((set, get) => ({
+  hydrated: false,
+  commands: [],
+  hydrate: async () => {
+    if (initialized) return;
+    initialized = true;
+    set({ commands: await loadSavedTerminalCommands(), hydrated: true });
+    void listen(CHANGED_EVENT, async () => {
+      set({ commands: await loadSavedTerminalCommands() });
+    });
+  },
+  upsert: (command) => {
+    const list = get().commands;
+    const idx = list.findIndex((c) => c.id === command.id);
+    const next =
+      idx === -1
+        ? [...list, command]
+        : list.map((c) => (c.id === command.id ? command : c));
+    set({ commands: next });
+    void saveSavedTerminalCommands(next).then(() => emit(CHANGED_EVENT));
+  },
+  remove: (id) => {
+    const next = get().commands.filter((c) => c.id !== id);
+    set({ commands: next });
+    void saveSavedTerminalCommands(next).then(() => emit(CHANGED_EVENT));
+  },
+}));
+
+export { newSavedTerminalCommandId };

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -6,34 +6,67 @@ import type { SettingsTab } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   AiScanIcon,
+  ComputerTerminal01Icon,
   InformationCircleIcon,
+  KeyboardIcon,
   Settings01Icon,
   UserMultiple02Icon,
-  KeyboardIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { JSX, useEffect, useState } from "react";
 import { AboutSection } from "./sections/AboutSection";
 import { AgentsSection } from "./sections/AgentsSection";
+import { CommandsSection } from "./sections/CommandsSection";
 import { GeneralSection } from "./sections/GeneralSection";
 import { ModelsSection } from "./sections/ModelsSection";
 import { ShortcutsSection } from "./sections/ShortcutsSection";
 
-const TABS: { id: SettingsTab; label: string; icon: typeof Settings01Icon, component: () => JSX.Element }[] =
-  [
-    { id: "general", label: "General", icon: Settings01Icon, component: GeneralSection },
-    { id: "shortcuts", label: "Shortcuts", icon: KeyboardIcon, component: ShortcutsSection },
-    { id: "models", label: "Models", icon: AiScanIcon, component: ModelsSection },
-    { id: "agents", label: "Agents", icon: UserMultiple02Icon, component: AgentsSection },
-    { id: "about", label: "About", icon: InformationCircleIcon, component: AboutSection },
-  ];
+const TABS: {
+  id: SettingsTab;
+  label: string;
+  icon: typeof Settings01Icon;
+  component: () => JSX.Element;
+}[] = [
+  {
+    id: "general",
+    label: "General",
+    icon: Settings01Icon,
+    component: GeneralSection,
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: KeyboardIcon,
+    component: ShortcutsSection,
+  },
+  { id: "models", label: "Models", icon: AiScanIcon, component: ModelsSection },
+  {
+    id: "agents",
+    label: "Agents",
+    icon: UserMultiple02Icon,
+    component: AgentsSection,
+  },
+  {
+    id: "commands",
+    label: "Commands",
+    icon: ComputerTerminal01Icon,
+    component: CommandsSection,
+  },
+  {
+    id: "about",
+    label: "About",
+    icon: InformationCircleIcon,
+    component: AboutSection,
+  },
+];
 
 const VALID_TABS: SettingsTab[] = [
   "general",
   "shortcuts",
   "models",
   "agents",
+  "commands",
   "about",
 ];
 

--- a/src/settings/sections/CommandsSection.tsx
+++ b/src/settings/sections/CommandsSection.tsx
@@ -1,0 +1,266 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  type SavedTerminalCommand,
+  newSavedTerminalCommandId,
+} from "@/modules/terminal/lib/savedCommands";
+import { useSavedTerminalCommandsStore } from "@/modules/terminal/store/savedCommandsStore";
+import {
+  Add01Icon,
+  ComputerTerminal01Icon,
+  Delete02Icon,
+  Edit02Icon,
+  PinIcon,
+  PinOffIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+import { SectionHeader } from "../components/SectionHeader";
+
+export function CommandsSection() {
+  const commands = useSavedTerminalCommandsStore((s) => s.commands);
+  const hydrate = useSavedTerminalCommandsStore((s) => s.hydrate);
+  const upsert = useSavedTerminalCommandsStore((s) => s.upsert);
+  const remove = useSavedTerminalCommandsStore((s) => s.remove);
+  const [editing, setEditing] = useState<SavedTerminalCommand | null>(null);
+
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
+
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        title="Commands"
+        description="Reusable terminal commands for quick access from the status bar."
+      />
+
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <Label>Terminal commands</Label>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1.5 px-2 text-[11px]"
+            onClick={() =>
+              setEditing({
+                id: newSavedTerminalCommandId(),
+                name: "",
+                description: "",
+                command: "",
+              })
+            }
+          >
+            <HugeiconsIcon icon={Add01Icon} size={12} strokeWidth={1.75} />
+            New command
+          </Button>
+        </div>
+
+        {commands.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-6 text-center text-[11px] text-muted-foreground">
+            No saved commands yet.
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {commands.map((command) => (
+              <li
+                key={command.id}
+                className="flex items-center gap-2 rounded-lg border border-border/60 bg-card/60 px-3 py-2"
+              >
+                <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted/40">
+                  <HugeiconsIcon
+                    icon={ComputerTerminal01Icon}
+                    size={14}
+                    strokeWidth={1.5}
+                  />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="truncate text-[12px] font-medium">
+                    {command.name}
+                  </span>
+                  <code className="truncate rounded bg-muted/40 px-1.5 py-0.5 font-mono text-[10.5px] text-muted-foreground">
+                    {command.command}
+                  </code>
+                  {command.description ? (
+                    <span className="truncate text-[10.5px] text-muted-foreground">
+                      {command.description}
+                    </span>
+                  ) : null}
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className={cn(
+                    "size-7",
+                    command.pinned
+                      ? "text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                  onClick={() =>
+                    upsert({ ...command, pinned: !command.pinned })
+                  }
+                  title={command.pinned ? "Unpin" : "Pin"}
+                >
+                  <HugeiconsIcon
+                    icon={command.pinned ? PinOffIcon : PinIcon}
+                    size={12}
+                    strokeWidth={1.75}
+                  />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7"
+                  onClick={() => setEditing(command)}
+                  title="Edit"
+                >
+                  <HugeiconsIcon
+                    icon={Edit02Icon}
+                    size={12}
+                    strokeWidth={1.75}
+                  />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-7 text-muted-foreground hover:text-destructive"
+                  onClick={() => remove(command.id)}
+                  title="Delete"
+                >
+                  <HugeiconsIcon
+                    icon={Delete02Icon}
+                    size={12}
+                    strokeWidth={1.75}
+                  />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <CommandEditorDialog
+        command={editing}
+        existing={commands}
+        onClose={() => setEditing(null)}
+        onSave={(command) => {
+          upsert(command);
+          setEditing(null);
+        }}
+      />
+    </div>
+  );
+}
+
+function CommandEditorDialog({
+  command,
+  existing,
+  onClose,
+  onSave,
+}: {
+  command: SavedTerminalCommand | null;
+  existing: SavedTerminalCommand[];
+  onClose: () => void;
+  onSave: (command: SavedTerminalCommand) => void;
+}) {
+  const [draft, setDraft] = useState<SavedTerminalCommand | null>(command);
+  useEffect(() => setDraft(command), [command]);
+  if (!draft) return null;
+
+  const isNew = !existing.some((c) => c.id === draft.id);
+  const canSave =
+    draft.name.trim().length > 0 && draft.command.trim().length > 0;
+
+  const save = () => {
+    onSave({
+      id: draft.id,
+      name: draft.name.trim(),
+      description: draft.description.trim(),
+      command: draft.command.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim(),
+    });
+  };
+
+  return (
+    <Dialog open={!!command} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-[14px]">
+            {isNew ? "New command" : "Edit command"}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <Label>Name</Label>
+            <Input
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              placeholder="e.g. Run app"
+              className="h-8 text-[12px]"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label>Command</Label>
+            <Input
+              value={draft.command}
+              onChange={(e) => setDraft({ ...draft, command: e.target.value })}
+              placeholder="pnpm tauri dev"
+              className="h-8 font-mono text-[11.5px]"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label>Description</Label>
+            <Input
+              value={draft.description}
+              onChange={(e) =>
+                setDraft({ ...draft, description: e.target.value })
+              }
+              placeholder="Optional note"
+              className="h-8 text-[12px]"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => setDraft({ ...draft, pinned: !draft.pinned })}
+            className={cn(
+              "flex h-8 items-center gap-2 rounded-md border px-2 text-left text-[11.5px] transition-colors",
+              draft.pinned
+                ? "border-foreground/30 bg-accent text-foreground"
+                : "border-border/60 bg-card/60 text-muted-foreground hover:bg-accent/40",
+            )}
+          >
+            <HugeiconsIcon
+              icon={draft.pinned ? PinOffIcon : PinIcon}
+              size={13}
+              strokeWidth={1.75}
+            />
+            {draft.pinned ? "Pinned in quick access" : "Pin in quick access"}
+          </button>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" disabled={!canSave} onClick={save}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-[11px] font-medium tracking-tight text-muted-foreground">
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
## What
Adds saved terminal commands that can be managed in Settings and launched from a status bar menu.

## Why
Closes #70.

## How
- Persists saved terminal commands with the Tauri store plugin.
- Adds a Commands settings section for creating, editing, deleting, and pinning commands.
- Adds a status bar dropdown with search, pinned/all sections, pin toggles, collapsible sections, scrollable lists, and resizable panel/section handles.
- Tracks terminal prompt state via OSC 133 so command insertion targets an idle prompt, or opens a new terminal when the active terminal is busy.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] `cd src-tauri && cargo clippy` clean
- [x] Manual smoke-test of the affected feature: created commands, pinned/unpinned, searched, collapsed/expanded sections, resized the panel and section splitter, inserted commands into a prompt, and verified busy terminals open a new tab before insertion.
- [x] (If UI) tested in `pnpm tauri dev`
- [x] `cd src-tauri && cargo fmt -- --check` clean

## Screenshots / GIFs
UI change was exercised locally in `pnpm tauri dev`; no static screenshot attached from the CLI.

## Notes for reviewer
`cargo fmt -- --check` reports existing formatting drift in `src-tauri/src/modules/secrets.rs`, which this PR does not touch. I left that unrelated Rust formatting change out to keep this PR focused.