### PR TITLE
feat(ai): add workspace file picker with @ trigger

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
             fs::mutate::fs_rename,
             fs::mutate::fs_delete,
             fs::search::fs_search,
+            fs::search::fs_list_files,
             fs::grep::fs_grep,
             fs::grep::fs_glob,
             shell::shell_run_command,

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -137,6 +137,87 @@ pub fn fs_search(
     })
 }
 
+#[derive(Serialize)]
+pub struct ListFilesResult {
+    pub files: Vec<String>,
+    pub truncated: bool,
+}
+
+#[tauri::command]
+pub fn fs_list_files(
+    root: String,
+    limit: Option<usize>,
+    max_depth: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
+    show_hidden: Option<bool>,
+) -> Result<ListFilesResult, String> {
+    const DEFAULT_LIMIT: usize = 5_000;
+    const HARD_LIMIT: usize = 20_000;
+    const DEFAULT_DEPTH: usize = 8;
+    const HARD_DEPTH: usize = 16;
+
+    let cap = limit.unwrap_or(DEFAULT_LIMIT).clamp(1, HARD_LIMIT);
+    let depth = max_depth.unwrap_or(DEFAULT_DEPTH).clamp(1, HARD_DEPTH);
+    let show_hidden = show_hidden.unwrap_or(false);
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let root_path = resolve_path(&root, &workspace);
+    if !root_path.is_dir() {
+        return Err(format!("not a directory: {root}"));
+    }
+
+    let walker = WalkBuilder::new(&root_path)
+        .hidden(!show_hidden)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .ignore(true)
+        .parents(true)
+        .follow_links(false)
+        .max_depth(Some(depth))
+        .filter_entry(|dent| {
+            if dent.depth() == 0 {
+                return true;
+            }
+            match dent.file_name().to_str() {
+                Some(name) => !PRUNE_DIRS.contains(&name),
+                None => true,
+            }
+        })
+        .build();
+
+    let mut files: Vec<String> = Vec::with_capacity(cap.min(256));
+    let mut scanned: usize = 0;
+    let mut truncated = false;
+
+    for dent in walker.flatten() {
+        scanned += 1;
+        if scanned > MAX_SCANNED {
+            truncated = true;
+            break;
+        }
+        let is_file = dent.file_type().map(|t| t.is_file()).unwrap_or(false);
+        if !is_file {
+            continue;
+        }
+        let path = dent.path();
+        let rel = match path.strip_prefix(&root_path) {
+            Ok(r) => to_canon(r),
+            Err(_) => continue,
+        };
+        if rel.is_empty() {
+            continue;
+        }
+        files.push(rel);
+        if files.len() >= cap {
+            truncated = true;
+            break;
+        }
+    }
+
+    files.sort_by_key(|a| a.to_lowercase());
+    Ok(ListFilesResult { files, truncated })
+}
+
 fn display_path(
     path: &std::path::Path,
     root_path: &std::path::Path,

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -151,8 +151,8 @@ pub fn fs_list_files(
     workspace: Option<WorkspaceEnv>,
     show_hidden: Option<bool>,
 ) -> Result<ListFilesResult, String> {
-    const DEFAULT_LIMIT: usize = 5_000;
-    const HARD_LIMIT: usize = 20_000;
+    const DEFAULT_LIMIT: usize = 2_000;
+    const HARD_LIMIT: usize = 10_000;
     const DEFAULT_DEPTH: usize = 8;
     const HARD_DEPTH: usize = 16;
 

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -19,8 +19,8 @@ import type { Snippet } from "../lib/snippets";
 import { useChatStore } from "../store/chatStore";
 import { useSnippetsStore } from "../store/snippetsStore";
 import { AgentSwitcher } from "./AgentSwitcher";
+import { FilePickerContent } from "./FilePicker";
 import { SnippetPickerContent, type PickerItem } from "./SnippetPicker";
-import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
 
 type SnippetTrigger = {
   start: number;
@@ -80,6 +80,17 @@ export function AiInputBar() {
   const [activeIndex, setActiveIndex] = useState(0);
   const workspaceFiles = useWorkspaceFiles(workspaceRoot);
 
+  const [fileQuery, setFileQuery] = useState("");
+  useEffect(() => {
+    if (!fileTrigger) {
+      setFileQuery("");
+      return;
+    }
+    const q = fileTrigger.query;
+    const t = window.setTimeout(() => setFileQuery(q), 50);
+    return () => window.clearTimeout(t);
+  }, [fileTrigger]);
+
   useEffect(() => {
     autoresize(c.textareaRef.current);
   }, [c.value, c.textareaRef]);
@@ -118,15 +129,26 @@ export function AiInputBar() {
     return [...cmdItems, ...snipItems];
   }, [trigger, snippets]);
 
+  const FILE_PICKER_CAP = 50;
   const filteredFiles = useMemo<string[]>(() => {
     if (!fileTrigger) return [];
-    const q = fileTrigger.query.toLowerCase();
-    return workspaceFiles.filter((f) => f.toLowerCase().includes(q));
-  }, [fileTrigger, workspaceFiles]);
+    const q = fileQuery.toLowerCase();
+    if (!q) return workspaceFiles.files.slice(0, FILE_PICKER_CAP);
+    const out: string[] = [];
+    for (const f of workspaceFiles.files) {
+      if (f.toLowerCase().includes(q)) {
+        out.push(f);
+        if (out.length >= FILE_PICKER_CAP) break;
+      }
+    }
+    return out;
+  }, [fileTrigger, fileQuery, workspaceFiles.files]);
 
+  const fileTriggerOpen = fileTrigger !== null;
+  const snippetTriggerOpen = trigger !== null;
   useEffect(() => {
     setActiveIndex(0);
-  }, [trigger !== null, fileTrigger !== null]);
+  }, [snippetTriggerOpen, fileTriggerOpen, fileQuery]);
 
   const pickerOpen = trigger !== null || fileTrigger !== null;
 
@@ -276,31 +298,15 @@ export function AiInputBar() {
             </div>
           </PopoverAnchor>
           {fileTrigger ? (
-            <div className="max-h-60 overflow-y-auto rounded-md border border-border/60 bg-card p-1 shadow-lg">
-              {filteredFiles.length === 0 ? (
-                <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
-                  No matching files in workspace root
-                </div>
-              ) : (
-                filteredFiles.map((fileName, idx) => (
-                  <button
-                    key={fileName}
-                    type="button"
-                    onClick={() => void onPickFile(fileName)}
-                    onMouseEnter={() => setActiveIndex(idx)}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs",
-                      idx === activeIndex
-                        ? "bg-accent text-accent-foreground"
-                        : "hover:bg-muted/50",
-                    )}
-                  >
-                    <img src={fileIconUrl(fileName)} alt="" className="size-4 shrink-0" />
-                    <span className="truncate">{fileName}</span>
-                  </button>
-                ))
-              )}
-            </div>
+            <FilePickerContent
+              files={filteredFiles}
+              activeIndex={activeIndex}
+              indexing={workspaceFiles.indexing}
+              truncated={workspaceFiles.truncated}
+              hasWorkspace={workspaceRoot !== null}
+              onPick={(f) => void onPickFile(f)}
+              onHover={setActiveIndex}
+            />
           ) : (
             <SnippetPickerContent
               items={filteredItems}

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -78,7 +78,7 @@ export function AiInputBar() {
   const [trigger, setTrigger] = useState<SnippetTrigger | null>(null);
   const [fileTrigger, setFileTrigger] = useState<FileTrigger | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
-  const workspaceFiles = useWorkspaceFiles(workspaceRoot);
+  const workspaceFiles = useWorkspaceFiles(workspaceRoot, fileTrigger !== null);
 
   const [fileQuery, setFileQuery] = useState("");
   useEffect(() => {
@@ -129,7 +129,7 @@ export function AiInputBar() {
     return [...cmdItems, ...snipItems];
   }, [trigger, snippets]);
 
-  const FILE_PICKER_CAP = 50;
+  const FILE_PICKER_CAP = 30;
   const filteredFiles = useMemo<string[]>(() => {
     if (!fileTrigger) return [];
     const q = fileQuery.toLowerCase();

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -13,13 +13,22 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useMemo, useState } from "react";
 import { useComposer, type FileAttachment } from "../lib/composer";
+import { useWorkspaceFiles } from "../hooks/useWorkspaceFiles";
 import { SLASH_COMMANDS } from "../lib/slashCommands";
 import type { Snippet } from "../lib/snippets";
+import { useChatStore } from "../store/chatStore";
 import { useSnippetsStore } from "../store/snippetsStore";
 import { AgentSwitcher } from "./AgentSwitcher";
 import { SnippetPickerContent, type PickerItem } from "./SnippetPicker";
+import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
 
 type SnippetTrigger = {
+  start: number;
+  end: number;
+  query: string;
+};
+
+type FileTrigger = {
   start: number;
   end: number;
   query: string;
@@ -44,12 +53,32 @@ function detectSnippetTrigger(
   return null;
 }
 
+function detectFileTrigger(
+  value: string,
+  caret: number,
+): FileTrigger | null {
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = value[i];
+    if (ch === "@") {
+      const prev = i === 0 ? " " : value[i - 1];
+      if (!/\s/.test(prev)) return null;
+      const slice = value.slice(i + 1, caret);
+      return { start: i, end: caret, query: slice };
+    }
+    if (/\s/.test(ch)) return null;
+  }
+  return null;
+}
+
 export function AiInputBar() {
   const c = useComposer();
   const snippets = useSnippetsStore((s) => s.snippets);
+  const workspaceRoot = useChatStore((s) => s.live.getWorkspaceRoot());
 
   const [trigger, setTrigger] = useState<SnippetTrigger | null>(null);
+  const [fileTrigger, setFileTrigger] = useState<FileTrigger | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
+  const workspaceFiles = useWorkspaceFiles(workspaceRoot);
 
   useEffect(() => {
     autoresize(c.textareaRef.current);
@@ -59,9 +88,12 @@ export function AiInputBar() {
     const el = c.textareaRef.current;
     if (!el) {
       setTrigger(null);
+      setFileTrigger(null);
       return;
     }
-    setTrigger(detectSnippetTrigger(c.value, el.selectionStart ?? 0));
+    const caret = el.selectionStart ?? 0;
+    setTrigger(detectSnippetTrigger(c.value, caret));
+    setFileTrigger(detectFileTrigger(c.value, caret));
   };
 
   useEffect(updateTrigger, [c.value, c.textareaRef]);
@@ -86,11 +118,17 @@ export function AiInputBar() {
     return [...cmdItems, ...snipItems];
   }, [trigger, snippets]);
 
-  useEffect(() => {
-    if (activeIndex >= filteredItems.length) setActiveIndex(0);
-  }, [filteredItems.length, activeIndex]);
+  const filteredFiles = useMemo<string[]>(() => {
+    if (!fileTrigger) return [];
+    const q = fileTrigger.query.toLowerCase();
+    return workspaceFiles.filter((f) => f.toLowerCase().includes(q));
+  }, [fileTrigger, workspaceFiles]);
 
-  const pickerOpen = trigger !== null;
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [trigger !== null, fileTrigger !== null]);
+
+  const pickerOpen = trigger !== null || fileTrigger !== null;
 
   const onPickItem = (item: PickerItem) => {
     if (!trigger) return;
@@ -118,7 +156,31 @@ export function AiInputBar() {
     });
   };
 
+  const onPickFile = async (filePath: string) => {
+    if (!fileTrigger || !workspaceRoot) return;
+    const before = c.value.slice(0, fileTrigger.start);
+    const after = c.value.slice(fileTrigger.end);
+    c.setValue(`${before}${after}`);
+    setFileTrigger(null);
+    setActiveIndex(0);
+    const fullPath = workspaceRoot.endsWith("/")
+      ? `${workspaceRoot}${filePath}`
+      : `${workspaceRoot}/${filePath}`;
+    await c.attachFileByPath(fullPath);
+    requestAnimationFrame(() => {
+      const el = c.textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(before.length, before.length);
+    });
+  };
+
   const pickActive = () => {
+    if (fileTrigger) {
+      const file = filteredFiles[activeIndex];
+      if (file) void onPickFile(file);
+      return;
+    }
     const it = filteredItems[activeIndex];
     if (it) onPickItem(it);
   };
@@ -164,10 +226,11 @@ export function AiInputBar() {
                 onSelect={updateTrigger}
                 onKeyDown={(e) => {
                   if (pickerOpen) {
+                    const items = fileTrigger ? filteredFiles : filteredItems;
                     if (e.key === "ArrowDown") {
                       e.preventDefault();
                       setActiveIndex((i) =>
-                        Math.min(i + 1, Math.max(0, filteredItems.length - 1)),
+                        Math.min(i + 1, Math.max(0, items.length - 1)),
                       );
                       return;
                     }
@@ -177,7 +240,7 @@ export function AiInputBar() {
                       return;
                     }
                     if (e.key === "Tab" || e.key === "Enter") {
-                      if (filteredItems.length > 0) {
+                      if (items.length > 0) {
                         e.preventDefault();
                         pickActive();
                         return;
@@ -185,7 +248,14 @@ export function AiInputBar() {
                     }
                     if (e.key === "Escape") {
                       e.preventDefault();
-                      setTrigger(null);
+                      if (fileTrigger) {
+                        const before = c.value.slice(0, fileTrigger.start);
+                        const after = c.value.slice(fileTrigger.end);
+                        c.setValue(`${before}${after}`);
+                        setFileTrigger(null);
+                      } else {
+                        setTrigger(null);
+                      }
                       return;
                     }
                   }
@@ -194,7 +264,7 @@ export function AiInputBar() {
                     c.submit();
                   }
                 }}
-                placeholder="Ask Terax anything   -   # for snippets and commands"
+                placeholder="Ask Terax anything   -   # for snippets and commands, @ for files"
                 rows={1}
                 disabled={c.isBusy}
                 className={cn(
@@ -205,12 +275,40 @@ export function AiInputBar() {
               <AgentSwitcher />
             </div>
           </PopoverAnchor>
-          <SnippetPickerContent
-            items={filteredItems}
-            activeIndex={activeIndex}
-            onPick={onPickItem}
-            onHover={setActiveIndex}
-          />
+          {fileTrigger ? (
+            <div className="max-h-60 overflow-y-auto rounded-md border border-border/60 bg-card p-1 shadow-lg">
+              {filteredFiles.length === 0 ? (
+                <div className="px-3 py-2.5 text-[11px] text-muted-foreground">
+                  No matching files in workspace root
+                </div>
+              ) : (
+                filteredFiles.map((fileName, idx) => (
+                  <button
+                    key={fileName}
+                    type="button"
+                    onClick={() => void onPickFile(fileName)}
+                    onMouseEnter={() => setActiveIndex(idx)}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs",
+                      idx === activeIndex
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-muted/50",
+                    )}
+                  >
+                    <img src={fileIconUrl(fileName)} alt="" className="size-4 shrink-0" />
+                    <span className="truncate">{fileName}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          ) : (
+            <SnippetPickerContent
+              items={filteredItems}
+              activeIndex={activeIndex}
+              onPick={onPickItem}
+              onHover={setActiveIndex}
+            />
+          )}
         </Popover>
 
         <AnimatePresence initial={false}>

--- a/src/modules/ai/components/FilePicker.tsx
+++ b/src/modules/ai/components/FilePicker.tsx
@@ -1,0 +1,108 @@
+import { PopoverContent } from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { useEffect, useRef } from "react";
+
+type Props = {
+  files: readonly string[];
+  activeIndex: number;
+  indexing: boolean;
+  truncated: boolean;
+  hasWorkspace: boolean;
+  onPick: (file: string) => void;
+  onHover: (index: number) => void;
+};
+
+export function FilePickerContent({
+  files,
+  activeIndex,
+  indexing,
+  truncated,
+  hasWorkspace,
+  onPick,
+  onHover,
+}: Props) {
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = itemRefs.current[activeIndex];
+    if (!el) return;
+    el.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  return (
+    <PopoverContent
+      side="top"
+      align="start"
+      sideOffset={6}
+      onOpenAutoFocus={(e) => e.preventDefault()}
+      onCloseAutoFocus={(e) => e.preventDefault()}
+      onMouseDown={(e) => e.preventDefault()}
+      className="w-80 overflow-hidden rounded-lg border border-border/60 bg-popover/95 p-0 shadow-xl backdrop-blur-xl"
+    >
+      <div className="border-b border-border/60 px-2.5 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+        Workspace files
+      </div>
+      {!hasWorkspace ? (
+        <div className="px-3 py-3 text-[11px] text-muted-foreground">
+          No workspace open
+        </div>
+      ) : indexing && files.length === 0 ? (
+        <div className="flex items-center gap-2 px-3 py-3 text-[11px] text-muted-foreground">
+          <Spinner className="size-3" />
+          <span>Indexing workspace…</span>
+        </div>
+      ) : files.length === 0 ? (
+        <div className="px-3 py-3 text-[11px] text-muted-foreground">
+          No matching files
+        </div>
+      ) : (
+        <>
+          <div ref={listRef} className="max-h-64 overflow-y-auto py-1">
+            {files.map((path, idx) => {
+              const slash = path.lastIndexOf("/");
+              const name = slash === -1 ? path : path.slice(slash + 1);
+              const dir = slash === -1 ? "" : path.slice(0, slash);
+              return (
+                <button
+                  key={path}
+                  ref={(el) => {
+                    itemRefs.current[idx] = el;
+                  }}
+                  type="button"
+                  onClick={() => onPick(path)}
+                  onMouseEnter={() => onHover(idx)}
+                  className={cn(
+                    "flex w-full items-center gap-2 px-2 py-1.5 text-left text-[12px]",
+                    idx === activeIndex ? "bg-accent" : "hover:bg-accent/60",
+                  )}
+                >
+                  <img
+                    src={fileIconUrl(name)}
+                    alt=""
+                    className="size-4 shrink-0"
+                  />
+                  <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+                    <span className="truncate font-medium">{name}</span>
+                    {dir && (
+                      <span className="truncate text-[10.5px] text-muted-foreground">
+                        {dir}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          {truncated && (
+            <div className="border-t border-border/60 px-2.5 py-1.5 text-[10px] text-muted-foreground">
+              Workspace is large - refine your query to narrow results.
+            </div>
+          )}
+        </>
+      )}
+    </PopoverContent>
+  );
+}

--- a/src/modules/ai/hooks/useWorkspaceFiles.ts
+++ b/src/modules/ai/hooks/useWorkspaceFiles.ts
@@ -1,80 +1,53 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
-export function useWorkspaceFiles(workspaceRoot: string | null) {
-  const [files, setFiles] = useState<string[]>([]);
+export type WorkspaceFilesState = {
+  files: string[];
+  indexing: boolean;
+  truncated: boolean;
+};
+
+type ListFilesResult = { files: string[]; truncated: boolean };
+
+export function useWorkspaceFiles(
+  workspaceRoot: string | null,
+): WorkspaceFilesState {
+  const [state, setState] = useState<WorkspaceFilesState>({
+    files: [],
+    indexing: false,
+    truncated: false,
+  });
 
   useEffect(() => {
-    if (!workspaceRoot) return setFiles([]);
+    if (!workspaceRoot) {
+      setState({ files: [], indexing: false, truncated: false });
+      return;
+    }
 
     let cancelled = false;
-    const load = async () => {
-      try {
-        const gitignore = await loadGitignore(workspaceRoot);
-        const collected = await collectFiles(workspaceRoot, gitignore);
-        if (!cancelled) setFiles(collected);
-      } catch {
-        if (!cancelled) setFiles([]);
-      }
-    };
+    setState((s) => ({ ...s, indexing: true }));
+    invoke<ListFilesResult>("fs_list_files", {
+      root: workspaceRoot,
+      workspace: currentWorkspaceEnv(),
+    })
+      .then((res) => {
+        if (cancelled) return;
+        setState({
+          files: res.files,
+          truncated: res.truncated,
+          indexing: false,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ files: [], indexing: false, truncated: false });
+      });
 
-    load();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [workspaceRoot]);
 
-  return files;
-}
-
-async function loadGitignore(root: string): Promise<Set<string>> {
-  try {
-    const path = root.endsWith("/") ? `${root}.gitignore` : `${root}/.gitignore`;
-    const result = await invoke<{ kind: string; content: string }>("fs_read_file", { path });
-    if (result.kind !== "text") return new Set();
-    
-    return new Set(
-      result.content
-        .split("\n")
-        .map(l => l.trim())
-        .filter(l => l && !l.startsWith("#"))
-    );
-  } catch {
-    return new Set();
-  }
-}
-
-async function collectFiles(dir: string, gitignore: Set<string>, base = ""): Promise<string[]> {
-  try {
-    const entries = await invoke<{ name: string; kind: string }[]>("fs_read_dir", { path: dir });
-    const files: string[] = [];
-
-    for (const entry of entries) {
-      const fullPath = base ? `${base}/${entry.name}` : entry.name;
-      if (isIgnored(fullPath, gitignore)) continue;
-
-      if (entry.kind === "file") {
-        files.push(fullPath);
-      } else if (entry.kind === "dir") {
-        const childPath = dir.endsWith("/") ? `${dir}${entry.name}` : `${dir}/${entry.name}`;
-        files.push(...await collectFiles(childPath, gitignore, fullPath));
-      }
-    }
-
-    return files;
-  } catch {
-    return [];
-  }
-}
-
-function isIgnored(path: string, patterns: Set<string>): boolean {
-  const normalized = path.replace(/^\//, "");
-  for (const pattern of patterns) {
-    const p = pattern.replace(/^\//, "").replace(/\/$/, "");
-    if (p.includes("*")) {
-      const regex = p.replace(/\./g, "\\.").replace(/\*/g, ".*").replace(/\?\?/g, ".");
-      if (new RegExp(regex).test(normalized)) return true;
-    } else if (normalized === p || normalized.startsWith(`${p}/`) || normalized.endsWith(`/${p}`)) {
-      return true;
-    }
-  }
-  return false;
+  return state;
 }

--- a/src/modules/ai/hooks/useWorkspaceFiles.ts
+++ b/src/modules/ai/hooks/useWorkspaceFiles.ts
@@ -1,0 +1,80 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+
+export function useWorkspaceFiles(workspaceRoot: string | null) {
+  const [files, setFiles] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!workspaceRoot) return setFiles([]);
+
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const gitignore = await loadGitignore(workspaceRoot);
+        const collected = await collectFiles(workspaceRoot, gitignore);
+        if (!cancelled) setFiles(collected);
+      } catch {
+        if (!cancelled) setFiles([]);
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+  }, [workspaceRoot]);
+
+  return files;
+}
+
+async function loadGitignore(root: string): Promise<Set<string>> {
+  try {
+    const path = root.endsWith("/") ? `${root}.gitignore` : `${root}/.gitignore`;
+    const result = await invoke<{ kind: string; content: string }>("fs_read_file", { path });
+    if (result.kind !== "text") return new Set();
+    
+    return new Set(
+      result.content
+        .split("\n")
+        .map(l => l.trim())
+        .filter(l => l && !l.startsWith("#"))
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+async function collectFiles(dir: string, gitignore: Set<string>, base = ""): Promise<string[]> {
+  try {
+    const entries = await invoke<{ name: string; kind: string }[]>("fs_read_dir", { path: dir });
+    const files: string[] = [];
+
+    for (const entry of entries) {
+      const fullPath = base ? `${base}/${entry.name}` : entry.name;
+      if (isIgnored(fullPath, gitignore)) continue;
+
+      if (entry.kind === "file") {
+        files.push(fullPath);
+      } else if (entry.kind === "dir") {
+        const childPath = dir.endsWith("/") ? `${dir}${entry.name}` : `${dir}/${entry.name}`;
+        files.push(...await collectFiles(childPath, gitignore, fullPath));
+      }
+    }
+
+    return files;
+  } catch {
+    return [];
+  }
+}
+
+function isIgnored(path: string, patterns: Set<string>): boolean {
+  const normalized = path.replace(/^\//, "");
+  for (const pattern of patterns) {
+    const p = pattern.replace(/^\//, "").replace(/\/$/, "");
+    if (p.includes("*")) {
+      const regex = p.replace(/\./g, "\\.").replace(/\*/g, ".*").replace(/\?\?/g, ".");
+      if (new RegExp(regex).test(normalized)) return true;
+    } else if (normalized === p || normalized.startsWith(`${p}/`) || normalized.endsWith(`/${p}`)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/modules/ai/hooks/useWorkspaceFiles.ts
+++ b/src/modules/ai/hooks/useWorkspaceFiles.ts
@@ -10,13 +10,55 @@ export type WorkspaceFilesState = {
 
 type ListFilesResult = { files: string[]; truncated: boolean };
 
+type CacheEntry = {
+  files: string[];
+  truncated: boolean;
+  fetchedAt: number;
+};
+
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<CacheEntry>>();
+
+function isFresh(entry: CacheEntry): boolean {
+  return Date.now() - entry.fetchedAt < CACHE_TTL_MS;
+}
+
+function fetchFiles(root: string): Promise<CacheEntry> {
+  const existing = inflight.get(root);
+  if (existing) return existing;
+  const promise = invoke<ListFilesResult>("fs_list_files", {
+    root,
+    workspace: currentWorkspaceEnv(),
+  })
+    .then((res) => {
+      const entry: CacheEntry = {
+        files: res.files,
+        truncated: res.truncated,
+        fetchedAt: Date.now(),
+      };
+      cache.set(root, entry);
+      return entry;
+    })
+    .finally(() => {
+      inflight.delete(root);
+    });
+  inflight.set(root, promise);
+  return promise;
+}
+
 export function useWorkspaceFiles(
   workspaceRoot: string | null,
+  enabled: boolean,
 ): WorkspaceFilesState {
-  const [state, setState] = useState<WorkspaceFilesState>({
-    files: [],
-    indexing: false,
-    truncated: false,
+  const [state, setState] = useState<WorkspaceFilesState>(() => {
+    if (!workspaceRoot) {
+      return { files: [], indexing: false, truncated: false };
+    }
+    const cached = cache.get(workspaceRoot);
+    return cached
+      ? { files: cached.files, truncated: cached.truncated, indexing: false }
+      : { files: [], indexing: false, truncated: false };
   });
 
   useEffect(() => {
@@ -25,29 +67,38 @@ export function useWorkspaceFiles(
       return;
     }
 
+    const cached = cache.get(workspaceRoot);
+    if (cached) {
+      setState({
+        files: cached.files,
+        truncated: cached.truncated,
+        indexing: false,
+      });
+      if (isFresh(cached)) return;
+    }
+
+    if (!enabled) return;
+
     let cancelled = false;
     setState((s) => ({ ...s, indexing: true }));
-    invoke<ListFilesResult>("fs_list_files", {
-      root: workspaceRoot,
-      workspace: currentWorkspaceEnv(),
-    })
-      .then((res) => {
+    fetchFiles(workspaceRoot)
+      .then((entry) => {
         if (cancelled) return;
         setState({
-          files: res.files,
-          truncated: res.truncated,
+          files: entry.files,
+          truncated: entry.truncated,
           indexing: false,
         });
       })
       .catch(() => {
         if (cancelled) return;
-        setState({ files: [], indexing: false, truncated: false });
+        setState((s) => ({ ...s, indexing: false }));
       });
 
     return () => {
       cancelled = true;
     };
-  }, [workspaceRoot]);
+  }, [workspaceRoot, enabled]);
 
   return state;
 }


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Add ability to reference workspace files using "@" in AI input bar.

## Why

Select files to attach directly in chat without leaving keyboard

## How

- Added `useWorkspaceFiles` hook to fetch workspace files
- Added file trigger detection for "@" prefix
- Keyboard navigation (arrows, enter) matches existing snippet picker
- Files are attached to chat when selected

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] ~~(If you touched `src-tauri/`) `cargo check` clean~~
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->
<img width="1116" height="381" alt="Capture d’écran 2026-05-10 à 13 11 38" src="https://github.com/user-attachments/assets/0261ffbc-81ed-4045-944f-bf0f9418397c" />

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
Uses existing file attachment system via `attachFileByPath`
