### PR TITLE
fix(explorer): prevent inline input from blurring on context menu create

### DIFF
--- a/src/modules/explorer/InlineInput.tsx
+++ b/src/modules/explorer/InlineInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 type Props = {
   initial: string;
@@ -23,7 +23,7 @@ export function InlineInput({
   const committedRef = useRef(false);
   const settledRef = useRef(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
     // Two-tick focus to win against parent click handlers and Radix portal
@@ -38,11 +38,15 @@ export function InlineInput({
       else el.select();
     };
     focus();
-    const raf = requestAnimationFrame(() => {
+    const raf = requestAnimationFrame(() => focus());
+    const timer = setTimeout(() => {
       focus();
       settledRef.current = true;
-    });
-    return () => cancelAnimationFrame(raf);
+    }, 170);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+    };
   }, [initial]);
 
   const commit = () => {


### PR DESCRIPTION
Closes #88 

## What
Fix `InlineInput` immediately blurring and disappearing when triggered from the file explorer context menu

## Why
When triggering a new file creation from the context menu, the `InlineInput` would immediately lose focus and disappear, Radix restores focus to the context menu trigger after it closes, which fires after a single `requestAnimationFrame` by then `settledRef` was already `true` so the blur was treated as a user dismiss and `commit()` was called with an empty value

## How
I added a `setTimeout(170)` (tested with 100, it closes, and 150 sometimes work) to delay marking the input as settled, by 170ms Radix has long finished its cleanup, so real user dismissals are handled correctly from that point

## Testing
Right Click root in the file explorer and click New File, input will appear and stay focused


- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`


## Notes for reviewer
I know this might be a cheap solution, but there is no workaround (as far as i know)