### PR TITLE
feat(shortcuts): add command palette

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,10 @@ import { AiComposerProvider } from "@/modules/ai/lib/composer";
 import { useAgentsStore } from "@/modules/ai/store/agentsStore";
 import { useSnippetsStore } from "@/modules/ai/store/snippetsStore";
 import {
+  CommandPalette,
+  createCommandPaletteActions,
+} from "@/modules/command-palette";
+import {
   AiDiffStack,
   EditorStack,
   NewEditorDialog,
@@ -105,6 +109,7 @@ export default function App() {
   }, []);
 
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [newEditorOpen, setNewEditorOpen] = useState(false);
   const miniOpen = useChatStore((s) => s.mini.open);
   const openMini = useChatStore((s) => s.openMini);
@@ -452,20 +457,37 @@ export default function App() {
     [newPreviewTab],
   );
 
+  const openNewEditorDialog = useCallback(() => {
+    setNewEditorOpen(true);
+  }, []);
+
+  const openShortcutsDialog = useCallback(() => {
+    setShortcutsOpen(true);
+  }, []);
+
+  const focusSearch = useCallback(() => {
+    searchInlineRef.current?.focus();
+  }, []);
+
+  const openSettings = useCallback(() => {
+    void openSettingsWindow();
+  }, []);
+
   const shortcutHandlers = useMemo<ShortcutHandlers>(
     () => ({
+      "commandPalette.open": () => setCommandPaletteOpen(true),
       "tab.new": openNewTab,
       "tab.newPreview": () => openPreviewTab(""),
-      "tab.newEditor": () => setNewEditorOpen(true),
+      "tab.newEditor": openNewEditorDialog,
       "tab.close": () => handleClose(activeId),
       "tab.next": () => cycleTab(1),
       "tab.prev": () => cycleTab(-1),
       "tab.selectByIndex": (e) => selectByIndex(parseInt(e.key, 10) - 1),
-      "search.focus": () => searchInlineRef.current?.focus(),
+      "search.focus": focusSearch,
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
-      "settings.open": () => void openSettingsWindow(),
+      "settings.open": openSettings,
       "sidebar.toggle": toggleSidebar,
     }),
     [
@@ -473,8 +495,11 @@ export default function App() {
       cycleTab,
       handleClose,
       openNewTab,
+      openNewEditorDialog,
       openPreviewTab,
       selectByIndex,
+      focusSearch,
+      openSettings,
       togglePanelAndFocus,
       askFromSelection,
       toggleSidebar,
@@ -538,6 +563,45 @@ export default function App() {
       return { kind: "editor", handle: activeEditorHandle };
     return null;
   }, [isTerminalTab, isEditorTab, activeSearchAddon, activeEditorHandle]);
+
+  const commandPaletteActions = useMemo(
+    () =>
+      createCommandPaletteActions({
+        tabs,
+        activeId,
+        searchTarget,
+        explorerRoot,
+        home,
+        openNewTab,
+        openNewEditor: openNewEditorDialog,
+        openNewPreview: () => openPreviewTab(""),
+        closeActiveTab: () => handleClose(activeId),
+        nextTab: () => cycleTab(1),
+        previousTab: () => cycleTab(-1),
+        focusSearch,
+        toggleSidebar,
+        toggleAi: togglePanelAndFocus,
+        openSettings,
+        openShortcuts: openShortcutsDialog,
+      }),
+    [
+      tabs,
+      activeId,
+      searchTarget,
+      explorerRoot,
+      home,
+      openNewTab,
+      openNewEditorDialog,
+      openPreviewTab,
+      handleClose,
+      cycleTab,
+      focusSearch,
+      toggleSidebar,
+      togglePanelAndFocus,
+      openSettings,
+      openShortcutsDialog,
+    ],
+  );
 
   const activeCwd =
     activeTab?.kind === "terminal" ? (activeTab.cwd ?? null) : null;
@@ -753,6 +817,14 @@ export default function App() {
           <ShortcutsDialog
             open={shortcutsOpen}
             onOpenChange={setShortcutsOpen}
+          />
+
+          <CommandPalette
+            open={commandPaletteOpen}
+            onOpenChange={setCommandPaletteOpen}
+            actions={commandPaletteActions}
+            workspaceRoot={explorerRoot}
+            onOpenFile={handleOpenFile}
           />
 
           <NewEditorDialog

--- a/src/modules/command-palette/CommandPalette.tsx
+++ b/src/modules/command-palette/CommandPalette.tsx
@@ -1,0 +1,379 @@
+import {
+  Command,
+  CommandDialog,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  getBindingTokens,
+  SHORTCUTS,
+  type KeyBinding,
+  type ShortcutId,
+} from "@/modules/shortcuts";
+import { AlertCircleIcon, Refresh01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  COMMAND_PALETTE_ACTION_GROUPS,
+  type CommandPaletteAction,
+} from "./actions";
+import {
+  COMMAND_PALETTE_FILE_SEARCH_MIN_QUERY_LENGTH,
+  useWorkspaceFileSearch,
+  type CommandPaletteFileHit,
+} from "./useWorkspaceFileSearch";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  actions: CommandPaletteAction[];
+  workspaceRoot: string | null;
+  onOpenFile: (path: string) => void;
+};
+
+const SHORTCUTS_BY_ID = new Map(SHORTCUTS.map((s) => [s.id, s]));
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  actions,
+  workspaceRoot,
+  onOpenFile,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [selectedValue, setSelectedValue] = useState("");
+  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+  const { results, searching, error, reset, retry } = useWorkspaceFileSearch({
+    root: workspaceRoot,
+    query,
+    enabled: open,
+  });
+
+  const resetPalette = useCallback(() => {
+    setQuery("");
+    setSelectedValue("");
+    reset();
+  }, [reset]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) resetPalette();
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, resetPalette],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = window.setTimeout(() => {
+      document.getElementById("terax-command-palette-input")?.focus();
+    }, 0);
+    return () => window.clearTimeout(handle);
+  }, [open]);
+
+  const trimmedQuery = query.trim();
+  const showFiles =
+    trimmedQuery.length >= COMMAND_PALETTE_FILE_SEARCH_MIN_QUERY_LENGTH;
+
+  const visibleActions = useMemo(
+    () => filterActions(actions, trimmedQuery),
+    [actions, trimmedQuery],
+  );
+
+  const selectableValues = useMemo(() => {
+    const actionValues = visibleActions
+      .filter((action) => !action.disabledReason)
+      .map((action) => actionValue(action));
+
+    if (!showFiles || !workspaceRoot) return actionValues;
+    if (error) return [...actionValues, RETRY_VALUE];
+    return [
+      ...actionValues,
+      ...results.map((hit) => fileValue(hit)),
+    ];
+  }, [error, results, showFiles, visibleActions, workspaceRoot]);
+
+  useEffect(() => {
+    if (selectableValues.length === 0) {
+      setSelectedValue("");
+      return;
+    }
+    if (!selectableValues.includes(selectedValue)) {
+      setSelectedValue(selectableValues[0]);
+    }
+  }, [selectableValues, selectedValue]);
+
+  const runAfterClose = useCallback(
+    (run: () => void) => {
+      handleOpenChange(false);
+      window.setTimeout(run, 0);
+    },
+    [handleOpenChange],
+  );
+
+  const runAction = useCallback(
+    (action: CommandPaletteAction) => {
+      if (action.disabledReason) return;
+      runAfterClose(action.run);
+    },
+    [runAfterClose],
+  );
+
+  const openFile = useCallback(
+    (hit: CommandPaletteFileHit) => {
+      runAfterClose(() => onOpenFile(hit.path));
+    },
+    [onOpenFile, runAfterClose],
+  );
+
+  const runSelectedValue = useCallback(
+    (value: string) => {
+      const action = visibleActions.find((a) => actionValue(a) === value);
+      if (action) {
+        runAction(action);
+        return;
+      }
+      if (value === RETRY_VALUE) {
+        retry();
+        return;
+      }
+      const file = results.find((hit) => fileValue(hit) === value);
+      if (file) openFile(file);
+    },
+    [openFile, results, retry, runAction, visibleActions],
+  );
+
+  const onCommandKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Tab") {
+        if (selectableValues.length === 0) return;
+        e.preventDefault();
+        const currentIndex = selectableValues.indexOf(selectedValue);
+        const baseIndex = currentIndex === -1 ? 0 : currentIndex;
+        const delta = e.shiftKey ? -1 : 1;
+        const nextIndex =
+          (baseIndex + delta + selectableValues.length) %
+          selectableValues.length;
+        setSelectedValue(selectableValues[nextIndex]);
+        return;
+      }
+
+      if (e.key === " " && selectedValue) {
+        e.preventDefault();
+        runSelectedValue(selectedValue);
+      }
+    },
+    [runSelectedValue, selectableValues, selectedValue],
+  );
+
+  const hasVisibleActions = visibleActions.length > 0;
+  const hasAnyVisibleContent = hasVisibleActions || showFiles;
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Command Palette"
+      description="Run a command or open a workspace file."
+      className="top-1/2 w-[min(680px,calc(100vw-32px))] -translate-y-1/2"
+    >
+      <Command
+        shouldFilter={false}
+        loop
+        value={selectedValue}
+        onValueChange={setSelectedValue}
+        onKeyDown={onCommandKeyDown}
+      >
+        <CommandInput
+          id="terax-command-palette-input"
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Run a command or open a file..."
+          autoFocus
+        />
+        <CommandList className="max-h-[420px]">
+          {COMMAND_PALETTE_ACTION_GROUPS.map((group) => {
+            const groupActions = visibleActions.filter((a) => a.group === group);
+            if (groupActions.length === 0) return null;
+            return (
+              <CommandGroup key={group} heading={group}>
+                {groupActions.map((action) => (
+                  <ActionItem
+                    key={action.id}
+                    action={action}
+                    shortcutLabel={formatShortcut(
+                      action.shortcutId,
+                      userShortcuts,
+                    )}
+                    onRun={() => runAction(action)}
+                  />
+                ))}
+              </CommandGroup>
+            );
+          })}
+
+          {showFiles ? (
+            <CommandGroup heading="Files">
+              {!workspaceRoot ? (
+                <StatusItem label="No workspace root" />
+              ) : error ? (
+                <>
+                  <StatusItem label="Could not search workspace" tone="error" />
+                  <CommandItem
+                    value={RETRY_VALUE}
+                    onSelect={retry}
+                    className="text-[12.5px]"
+                  >
+                    <HugeiconsIcon
+                      icon={Refresh01Icon}
+                      size={14}
+                      strokeWidth={1.75}
+                    />
+                    <span>Retry file search</span>
+                  </CommandItem>
+                </>
+              ) : searching && results.length === 0 ? (
+                <StatusItem label="Searching..." />
+              ) : results.length > 0 ? (
+                results.map((hit) => (
+                  <CommandItem
+                    key={hit.path}
+                    value={fileValue(hit)}
+                    onSelect={() => openFile(hit)}
+                    className="text-[12.5px]"
+                  >
+                    <img
+                      src={fileIconUrl(hit.name)}
+                      alt=""
+                      className="size-4 shrink-0"
+                    />
+                    <span className="min-w-0 flex-1 truncate">{hit.name}</span>
+                    <span className="ml-auto max-w-64 truncate text-[11px] font-normal text-muted-foreground">
+                      {hit.rel}
+                    </span>
+                  </CommandItem>
+                ))
+              ) : (
+                <StatusItem label="No files found" />
+              )}
+            </CommandGroup>
+          ) : null}
+
+          {!hasAnyVisibleContent ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No commands found.
+            </div>
+          ) : null}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  );
+}
+
+const RETRY_VALUE = "retry-file-search";
+
+function actionValue(action: CommandPaletteAction): string {
+  return `action:${action.id}`;
+}
+
+function fileValue(hit: CommandPaletteFileHit): string {
+  return `file:${hit.path}`;
+}
+
+function ActionItem({
+  action,
+  shortcutLabel,
+  onRun,
+}: {
+  action: CommandPaletteAction;
+  shortcutLabel: string | null;
+  onRun: () => void;
+}) {
+  const rightLabel = action.disabledReason ?? shortcutLabel;
+  return (
+    <CommandItem
+      value={actionValue(action)}
+      disabled={!!action.disabledReason}
+      onSelect={onRun}
+      className="text-[12.5px]"
+    >
+      <HugeiconsIcon
+        icon={action.icon}
+        size={14}
+        strokeWidth={1.75}
+        className="text-muted-foreground"
+      />
+      <span className="truncate">{action.label}</span>
+      {rightLabel ? (
+        <CommandShortcut
+          className={action.disabledReason ? "normal-case tracking-normal" : ""}
+        >
+          {rightLabel}
+        </CommandShortcut>
+      ) : null}
+    </CommandItem>
+  );
+}
+
+function StatusItem({
+  label,
+  tone = "muted",
+}: {
+  label: string;
+  tone?: "muted" | "error";
+}) {
+  return (
+    <CommandItem
+      value={`status:${label}`}
+      disabled
+      className="text-[12.5px] font-normal"
+    >
+      {tone === "error" ? (
+        <HugeiconsIcon
+          icon={AlertCircleIcon}
+          size={14}
+          strokeWidth={1.75}
+          className="text-destructive"
+        />
+      ) : null}
+      <span
+        className={
+          tone === "error" ? "text-destructive" : "text-muted-foreground"
+        }
+      >
+        {label}
+      </span>
+    </CommandItem>
+  );
+}
+
+function filterActions(
+  actions: CommandPaletteAction[],
+  query: string,
+): CommandPaletteAction[] {
+  const q = query.toLowerCase();
+  if (!q) return actions;
+  return actions.filter((action) => {
+    const haystack = [action.label, action.group, ...action.keywords]
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+function formatShortcut(
+  shortcutId: ShortcutId | undefined,
+  userShortcuts: Record<ShortcutId, KeyBinding[]>,
+): string | null {
+  if (!shortcutId) return null;
+  const shortcut = SHORTCUTS_BY_ID.get(shortcutId);
+  const bindings = userShortcuts[shortcutId] ?? shortcut?.defaultBindings;
+  const tokens = getBindingTokens(bindings?.[0]);
+  if (tokens.length === 0) return null;
+  return tokens.join(" ");
+}

--- a/src/modules/command-palette/actions.ts
+++ b/src/modules/command-palette/actions.ts
@@ -1,0 +1,177 @@
+import type { SearchTarget } from "@/modules/header";
+import type { ShortcutId } from "@/modules/shortcuts";
+import type { Tab } from "@/modules/tabs";
+import {
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+  Cancel01Icon,
+  FileEditIcon,
+  Globe02Icon,
+  KeyboardIcon,
+  Search01Icon,
+  Settings01Icon,
+  SidebarLeftIcon,
+  SparklesIcon,
+  TerminalIcon,
+} from "@hugeicons/core-free-icons";
+
+type CommandIcon = typeof TerminalIcon;
+
+export type CommandPaletteActionGroup =
+  | "General"
+  | "Tabs"
+  | "View"
+  | "Search"
+  | "AI";
+
+export type CommandPaletteAction = {
+  id: string;
+  label: string;
+  group: CommandPaletteActionGroup;
+  keywords: string[];
+  icon: CommandIcon;
+  shortcutId?: ShortcutId;
+  disabledReason?: string;
+  run: () => void;
+  deferRun?: boolean;
+};
+
+export const COMMAND_PALETTE_ACTION_GROUPS: readonly CommandPaletteActionGroup[] =
+  ["General", "Tabs", "View", "Search", "AI"] as const;
+
+export type CommandPaletteActionContext = {
+  tabs: Tab[];
+  activeId: number;
+  searchTarget: SearchTarget;
+  explorerRoot: string | null;
+  home: string | null;
+  openNewTab: () => void;
+  openNewEditor: () => void;
+  openNewPreview: () => void;
+  closeActiveTab: () => void;
+  nextTab: () => void;
+  previousTab: () => void;
+  focusSearch: () => void;
+  toggleSidebar: () => void;
+  toggleAi: () => void;
+  openSettings: () => void;
+  openShortcuts: () => void;
+};
+
+export function createCommandPaletteActions(
+  ctx: CommandPaletteActionContext,
+): CommandPaletteAction[] {
+  const onlyOneTab = ctx.tabs.length < 2;
+  const noWorkspaceRoot = !ctx.explorerRoot && !ctx.home;
+
+  return [
+    {
+      id: "settings.open",
+      label: "Open settings",
+      group: "General",
+      keywords: ["preferences", "config"],
+      icon: Settings01Icon,
+      shortcutId: "settings.open",
+      run: ctx.openSettings,
+      deferRun: true,
+    },
+    {
+      id: "shortcuts.open",
+      label: "Show keyboard shortcuts",
+      group: "General",
+      keywords: ["keys", "keybindings", "help"],
+      icon: KeyboardIcon,
+      shortcutId: "shortcuts.open",
+      run: ctx.openShortcuts,
+      deferRun: true,
+    },
+    {
+      id: "tab.new",
+      label: "New terminal",
+      group: "Tabs",
+      keywords: ["shell", "terminal", "new tab"],
+      icon: TerminalIcon,
+      shortcutId: "tab.new",
+      run: ctx.openNewTab,
+    },
+    {
+      id: "tab.newEditor",
+      label: "New editor tab",
+      group: "Tabs",
+      keywords: ["file", "editor", "create"],
+      icon: FileEditIcon,
+      shortcutId: "tab.newEditor",
+      disabledReason: noWorkspaceRoot ? "No workspace root" : undefined,
+      run: ctx.openNewEditor,
+      deferRun: true,
+    },
+    {
+      id: "tab.newPreview",
+      label: "New preview tab",
+      group: "Tabs",
+      keywords: ["browser", "web", "localhost"],
+      icon: Globe02Icon,
+      shortcutId: "tab.newPreview",
+      run: ctx.openNewPreview,
+    },
+    {
+      id: "tab.close",
+      label: "Close current tab",
+      group: "Tabs",
+      keywords: ["close", "remove"],
+      icon: Cancel01Icon,
+      shortcutId: "tab.close",
+      disabledReason: onlyOneTab ? "Last tab" : undefined,
+      run: ctx.closeActiveTab,
+    },
+    {
+      id: "tab.next",
+      label: "Next tab",
+      group: "Tabs",
+      keywords: ["switch", "right"],
+      icon: ArrowRight01Icon,
+      shortcutId: "tab.next",
+      disabledReason: onlyOneTab ? "Only one tab" : undefined,
+      run: ctx.nextTab,
+    },
+    {
+      id: "tab.prev",
+      label: "Previous tab",
+      group: "Tabs",
+      keywords: ["switch", "left"],
+      icon: ArrowLeft01Icon,
+      shortcutId: "tab.prev",
+      disabledReason: onlyOneTab ? "Only one tab" : undefined,
+      run: ctx.previousTab,
+    },
+    {
+      id: "sidebar.toggle",
+      label: "Toggle file explorer",
+      group: "View",
+      keywords: ["sidebar", "files", "explorer"],
+      icon: SidebarLeftIcon,
+      shortcutId: "sidebar.toggle",
+      run: ctx.toggleSidebar,
+    },
+    {
+      id: "search.focus",
+      label: "Focus search",
+      group: "Search",
+      keywords: ["find", "terminal", "editor"],
+      icon: Search01Icon,
+      shortcutId: "search.focus",
+      disabledReason: ctx.searchTarget ? undefined : "No searchable view",
+      run: ctx.focusSearch,
+      deferRun: true,
+    },
+    {
+      id: "ai.toggle",
+      label: "Toggle AI agent",
+      group: "AI",
+      keywords: ["assistant", "chat", "agent"],
+      icon: SparklesIcon,
+      shortcutId: "ai.toggle",
+      run: ctx.toggleAi,
+    },
+  ];
+}

--- a/src/modules/command-palette/index.ts
+++ b/src/modules/command-palette/index.ts
@@ -1,0 +1,6 @@
+export { CommandPalette } from "./CommandPalette";
+export {
+  createCommandPaletteActions,
+  type CommandPaletteAction,
+  type CommandPaletteActionContext,
+} from "./actions";

--- a/src/modules/command-palette/useWorkspaceFileSearch.ts
+++ b/src/modules/command-palette/useWorkspaceFileSearch.ts
@@ -1,0 +1,111 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const COMMAND_PALETTE_FILE_SEARCH_MIN_QUERY_LENGTH = 2;
+const COMMAND_PALETTE_FILE_SEARCH_LIMIT = 50;
+const COMMAND_PALETTE_FILE_SEARCH_DEBOUNCE_MS = 120;
+
+export type CommandPaletteFileHit = {
+  path: string;
+  rel: string;
+  name: string;
+  is_dir: boolean;
+};
+
+type Params = {
+  root: string | null;
+  query: string;
+  enabled: boolean;
+};
+
+export function useWorkspaceFileSearch({ root, query, enabled }: Params) {
+  const [results, setResults] = useState<CommandPaletteFileHit[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  const applyHits = useCallback((hits: CommandPaletteFileHit[]) => {
+    setResults(
+      hits.filter((hit) => !hit.is_dir).slice(0, COMMAND_PALETTE_FILE_SEARCH_LIMIT),
+    );
+  }, []);
+
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    setResults([]);
+    setSearching(false);
+    setError(null);
+  }, []);
+
+  const retry = useCallback(() => {
+    const rootPath = root;
+    const q = query.trim();
+    if (!enabled || !rootPath || q.length < COMMAND_PALETTE_FILE_SEARCH_MIN_QUERY_LENGTH) {
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setSearching(true);
+    setError(null);
+    void invoke<CommandPaletteFileHit[]>("fs_search", {
+      root: rootPath,
+      query: q,
+      limit: COMMAND_PALETTE_FILE_SEARCH_LIMIT,
+    })
+      .then((hits) => {
+        if (requestId !== requestIdRef.current) return;
+        applyHits(hits);
+      })
+      .catch((e) => {
+        if (requestId !== requestIdRef.current) return;
+        setResults([]);
+        setError(String(e));
+      })
+      .finally(() => {
+        if (requestId === requestIdRef.current) setSearching(false);
+      });
+  }, [applyHits, enabled, query, root]);
+
+  useEffect(() => {
+    const q = query.trim();
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    if (!enabled || !root || q.length < COMMAND_PALETTE_FILE_SEARCH_MIN_QUERY_LENGTH) {
+      setResults([]);
+      setSearching(false);
+      setError(null);
+      return;
+    }
+
+    setSearching(true);
+    setError(null);
+    setResults([]);
+
+    const handle = window.setTimeout(() => {
+      void invoke<CommandPaletteFileHit[]>("fs_search", {
+        root,
+        query: q,
+        limit: COMMAND_PALETTE_FILE_SEARCH_LIMIT,
+      })
+        .then((hits) => {
+          if (requestId !== requestIdRef.current) return;
+          applyHits(hits);
+        })
+        .catch((e) => {
+          if (requestId !== requestIdRef.current) return;
+          setResults([]);
+          setError(String(e));
+        })
+        .finally(() => {
+          if (requestId === requestIdRef.current) setSearching(false);
+        });
+    }, COMMAND_PALETTE_FILE_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [applyHits, enabled, query, root]);
+
+  return { results, searching, error, reset, retry };
+}

--- a/src/modules/shortcuts/index.ts
+++ b/src/modules/shortcuts/index.ts
@@ -2,9 +2,11 @@ export { ShortcutsDialog } from "./ShortcutsDialog";
 export {
   SHORTCUTS,
   SHORTCUT_GROUPS,
+  getBindingTokens,
   type Shortcut,
   type ShortcutGroup,
   type ShortcutId,
+  type KeyBinding,
 } from "./shortcuts";
 export {
   useGlobalShortcuts,

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -5,6 +5,7 @@ import { IS_MAC, MOD_PROP } from "@/lib/platform";
  */
 
 export type ShortcutId =
+  | "commandPalette.open"
   | "tab.new"
   | "tab.newPreview"
   | "tab.newEditor"
@@ -37,6 +38,12 @@ export type Shortcut = {
 };
 
 export const SHORTCUTS: Shortcut[] = [
+  {
+    id: "commandPalette.open",
+    label: "Open command palette",
+    group: "General",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "p" }],
+  },
   {
     id: "settings.open",
     label: "Open settings",


### PR DESCRIPTION
## What
Adds a Command Palette opened with `Cmd/Ctrl+Shift+P` for running common app actions and opening workspace files.

The existing `Cmd/Ctrl+K` keyboard shortcuts dialog stays unchanged.

## Why
Closes #103.

Terax has app-level actions spread across shortcuts and UI controls. A command palette gives users a central, keyboard-first way to discover and run common actions without adding more visible UI chrome.

## How
- Added a `command-palette` module with a factory-based action registry.
- Reused existing `App.tsx` handlers for actions instead of duplicating behavior.
- Reused the existing `fs_search` Tauri command for workspace file search.
- Added direct filtering with `shouldFilter={false}` so actions, files, error states, and retry rows are controlled explicitly.
- Added `Tab` / `Shift+Tab` navigation and `Space` selection in addition to cmdk defaults.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

Verified by running:
- `pnpm exec tsc --noEmit`
- `pnpm build`

Manual test still needed in `pnpm tauri dev`:
- `Cmd/Ctrl+Shift+P` opens the Command Palette.
- `Cmd/Ctrl+K` still opens keyboard shortcuts.
- App actions run from the palette.
- Workspace file search opens files.
- `Tab` / `Shift+Tab`, `Enter`, and `Space` select items.
- Disabled actions show their reason.

## Screenshots / GIFs
TODO: Add a screenshot or GIF of the centered Command Palette.

## Notes for reviewer
- No new dependencies were added.
- No new Rust commands were added.
- Directory opening, recent files, command history, plugin command registry, and Ask AI about selection are intentionally out of scope for v1.
