### PR TITLE
feat(ai): add Gemini 2.5 Flash and Gemma 4 31B models

### DIFF
--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -134,6 +134,18 @@ export const MODELS = [
     label: "Gemini 3 Flash",
     hint: "Fast",
   },
+  {
+    id: "gemini-2.5-flash",
+    provider: "google",
+    label: "Gemini 2.5 Flash",
+    hint: "Most Efficient"
+  },
+  {
+    id: "gemma-4-31b-it",
+    provider: "google",
+    label: "Gemma 4 31B",
+    hint:"Lean & Powerfull"
+  },
   // xAI
   {
     id: "grok-4.20-reasoning",
@@ -192,6 +204,8 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "claude-opus-4-7": 200_000,
   "gemini-3.1-pro-preview": 1_000_000,
   "gemini-3-flash-preview": 1_000_000,
+  "gemini-2.5-flash": 1_000_000,
+  "gemma-4-31b-it": 265_000,
   "grok-4.20-reasoning": 2_000_000,
   "grok-4.20-non-reasoning": 2_000_000,
   "gpt-oss-120b": 128_000,


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Added both Gemini 2.5 Flash and Gemma 4 31B models
## Why
both of those models are still used, specially Gemma 4 31B, used a lot both locally and via the Google AI Studio


## Testing
Grep both models from the Menu and Chat with them

- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<img width="239" height="208" alt="{39CE7604-841B-404E-A013-BB0F740A7A17}" src="https://github.com/user-attachments/assets/2a8e6586-479d-4104-9aeb-ca64b9f58c8b" />

