### PR TITLE
chore(shortcuts): refactor useShortcutLabel hook

### DIFF
--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { WindowControls } from "@/components/WindowControls";
 import { IS_MAC, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
-import { useShortcutLabel } from "@/modules/shortcuts/lib/useShortcutLabel";
+import { useShortcutLabel } from "@/modules/shortcuts";
 import type { Tab } from "@/modules/tabs";
 import { TabBar } from "@/modules/tabs";
 import {
@@ -53,7 +53,10 @@ export function Header({
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
-  const shortcutLabel = useShortcutLabel("shortcuts.open", "Keyboard shortcuts");
+  const shortcutLabel = useShortcutLabel(
+    "shortcuts.open",
+    "Keyboard shortcuts"
+  );
 
   useEffect(() => {
     const el = rootRef.current;

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -1,8 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { WindowControls } from "@/components/WindowControls";
 import { IS_MAC, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
-import { usePreferencesStore } from "@/modules/settings/preferences";
-import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
+import { useShortcutLabel } from "@/modules/shortcuts/lib/useShortcutLabel";
 import type { Tab } from "@/modules/tabs";
 import { TabBar } from "@/modules/tabs";
 import {
@@ -11,7 +10,7 @@ import {
   SidebarLeftIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import {
   SearchInline,
   type SearchInlineHandle,
@@ -54,17 +53,7 @@ export function Header({
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
-  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
-
-  const shortcutLabel = useMemo(() => {
-    const s = SHORTCUTS.find((s) => s.id === "shortcuts.open");
-    if (!s) return "Keyboard shortcuts";
-    const bindings = userShortcuts["shortcuts.open"] || s.defaultBindings;
-    if (!bindings || bindings.length === 0) return "Keyboard shortcuts";
-    const tokens = getBindingTokens(bindings[0]);
-    if (tokens.length === 0) return "Keyboard shortcuts";
-    return `Keyboard shortcuts (${tokens.join("")})`;
-  }, [userShortcuts]);
+  const shortcutLabel = useShortcutLabel("shortcuts.open", "Keyboard shortcuts");
 
   useEffect(() => {
     const el = rootRef.current;

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -1,8 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { EditorPaneHandle } from "@/modules/editor";
-import { usePreferencesStore } from "@/modules/settings/preferences";
-import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
+import { useShortcutLabel } from "@/modules/shortcuts/lib/useShortcutLabel";
 import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -12,7 +11,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -44,25 +42,11 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     // In normal mode the field is always present.
     const [openInCompact, setOpenInCompact] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
-    const userShortcuts = usePreferencesStore((s) => s.shortcuts);
-
-    const shortcutText = useMemo(() => {
-      const s = SHORTCUTS.find((s) => s.id === "search.focus");
-      if (!s) return "";
-      const bindings = userShortcuts["search.focus"] || s.defaultBindings;
-      if (!bindings || bindings.length === 0) return "";
-      const tokens = getBindingTokens(bindings[0]);
-      return tokens.join("");
-    }, [userShortcuts]);
-
-    const placeholder = useMemo(() => {
-      const base = target?.kind === "editor" ? "Search in file" : "Search";
-      return shortcutText ? `${base} (${shortcutText})` : base;
-    }, [target?.kind, shortcutText]);
-
-    const tooltipTitle = useMemo(() => {
-      return shortcutText ? `Search (${shortcutText})` : "Search";
-    }, [shortcutText]);
+    const placeholder = useShortcutLabel(
+      "search.focus",
+      target?.kind === "editor" ? "Search in file" : "Search",
+    );
+    const tooltipTitle = useShortcutLabel("search.focus", "Search");
 
     const expanded = !compact || openInCompact;
 

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { EditorPaneHandle } from "@/modules/editor";
-import { useShortcutLabel } from "@/modules/shortcuts/lib/useShortcutLabel";
+import { useShortcutLabel } from "@/modules/shortcuts";
 import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -44,7 +44,7 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     const inputRef = useRef<HTMLInputElement>(null);
     const placeholder = useShortcutLabel(
       "search.focus",
-      target?.kind === "editor" ? "Search in file" : "Search",
+      target?.kind === "editor" ? "Search in file" : "Search"
     );
     const tooltipTitle = useShortcutLabel("search.focus", "Search");
 
@@ -193,5 +193,5 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
         </AnimatePresence>
       </motion.div>
     );
-  },
+  }
 );

--- a/src/modules/shortcuts/ShortcutsDialog.tsx
+++ b/src/modules/shortcuts/ShortcutsDialog.tsx
@@ -14,8 +14,10 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import {
   getBindingTokens,
+  resolveShortcutBindings,
   SHORTCUTS,
   SHORTCUT_GROUPS,
+  type Shortcut,
 } from "./shortcuts";
 
 type Props = {
@@ -24,8 +26,6 @@ type Props = {
 };
 
 export function ShortcutsDialog({ open, onOpenChange }: Props) {
-  const userShortcuts = usePreferencesStore((s) => s.shortcuts);
-
   const onOpenSettings = () => {
     onOpenChange(false);
     void openSettingsWindow("shortcuts");
@@ -63,39 +63,9 @@ export function ShortcutsDialog({ open, onOpenChange }: Props) {
                     {group}
                   </h3>
                   <ul className="flex flex-col divide-y divide-border/60">
-                    {items.map((s) => {
-                      const bindings = userShortcuts[s.id] || s.defaultBindings;
-                      const tokens = getBindingTokens(bindings[0]);
-
-                      return (
-                        <li
-                          key={s.id}
-                          className="flex items-center justify-between py-2"
-                        >
-                          <span className="text-sm text-foreground/90">
-                            {s.label}
-                          </span>
-                          {tokens.length > 0 ? (
-                            <KbdGroup>
-                              {tokens.map((token, i) => {
-                                let label = token;
-                                if (
-                                  s.id === "tab.selectByIndex" &&
-                                  i === tokens.length - 1
-                                ) {
-                                  label = "1…9";
-                                }
-                                return <Kbd key={i}>{label}</Kbd>;
-                              })}
-                            </KbdGroup>
-                          ) : (
-                            <span className="text-xs text-muted-foreground italic">
-                              Unassigned
-                            </span>
-                          )}
-                        </li>
-                      );
-                    })}
+                    {items.map((s) => (
+                      <ShortcutDialogRow key={s.id} shortcut={s} />
+                    ))}
                   </ul>
                 </section>
               );
@@ -104,5 +74,28 @@ export function ShortcutsDialog({ open, onOpenChange }: Props) {
         </ScrollArea>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ShortcutDialogRow({ shortcut }: { shortcut: Shortcut }) {
+  const userBindings = usePreferencesStore((s) => s.shortcuts[shortcut.id]);
+  const bindings = resolveShortcutBindings(shortcut.id, userBindings);
+  const tokens = getBindingTokens(bindings[0]);
+
+  return (
+    <li className="flex items-center justify-between py-2">
+      <span className="text-sm text-foreground/90">{shortcut.label}</span>
+      {tokens.length > 0 ? (
+        <KbdGroup>
+          {tokens.map((token, i) => {
+            if (shortcut.id === "tab.selectByIndex" && i === 2)
+              return <Kbd>1…9</Kbd>;
+            return <Kbd key={i}>{token}</Kbd>;
+          })}
+        </KbdGroup>
+      ) : (
+        <span className="text-xs text-muted-foreground italic">Unassigned</span>
+      )}
+    </li>
   );
 }

--- a/src/modules/shortcuts/index.ts
+++ b/src/modules/shortcuts/index.ts
@@ -2,6 +2,7 @@ export { ShortcutsDialog } from "./ShortcutsDialog";
 export {
   SHORTCUTS,
   SHORTCUT_GROUPS,
+  resolveShortcutBindings,
   type Shortcut,
   type ShortcutGroup,
   type ShortcutId,
@@ -10,3 +11,4 @@ export {
   useGlobalShortcuts,
   type ShortcutHandlers,
 } from "./lib/useGlobalShortcuts";
+export { useShortcutLabel } from "./lib/useShortcutLabel";

--- a/src/modules/shortcuts/lib/useGlobalShortcuts.ts
+++ b/src/modules/shortcuts/lib/useGlobalShortcuts.ts
@@ -3,6 +3,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   SHORTCUTS,
   matchBinding,
+  resolveShortcutBindings,
   type ShortcutId,
 } from "../shortcuts";
 
@@ -20,15 +21,13 @@ export function useGlobalShortcuts(
   const latest = useRef({ handlers, options });
   latest.current = { handlers, options };
 
-  // Access the shortcuts from the store
   const userShortcuts = usePreferencesStore((s) => s.shortcuts);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const { handlers, options } = latest.current;
       for (const s of SHORTCUTS) {
-        // Use user-defined bindings if they exist, otherwise use default
-        const bindings = userShortcuts[s.id] || s.defaultBindings;
+        const bindings = resolveShortcutBindings(s.id, userShortcuts[s.id]);
 
         const isMatch = bindings.some((b) => matchBinding(e, b, s.id));
         if (!isMatch) continue;

--- a/src/modules/shortcuts/lib/useShortcutLabel.ts
+++ b/src/modules/shortcuts/lib/useShortcutLabel.ts
@@ -1,21 +1,23 @@
-import { useMemo } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import { getBindingTokens, SHORTCUTS, type ShortcutId } from "../shortcuts";
+import { useMemo } from "react";
+import {
+  getBindingTokens,
+  resolveShortcutBindings,
+  type ShortcutId,
+} from "../shortcuts";
 
+/** Shortcut chord as display text; optional `label` becomes `Label (⌘K)` style. */
 export function useShortcutLabel(id: ShortcutId, label?: string): string {
-  // Subscribe only to the one shortcut key we care about.
   const userBindings = usePreferencesStore((s) => s.shortcuts[id]);
 
   return useMemo(() => {
-    const s = SHORTCUTS.find((s) => s.id === id);
-    if (!s) return label ?? "";
-
-    const bindings = userBindings ?? s.defaultBindings;
-    if (!bindings || bindings.length === 0) return label ?? "";
+    const bindings = resolveShortcutBindings(id, userBindings);
+    if (!bindings.length) {
+      return label ?? "";
+    }
 
     const shortcutText = getBindingTokens(bindings[0]).join("");
     if (!label) return shortcutText;
     return shortcutText ? `${label} (${shortcutText})` : label;
   }, [id, label, userBindings]);
 }
-

--- a/src/modules/shortcuts/lib/useShortcutLabel.ts
+++ b/src/modules/shortcuts/lib/useShortcutLabel.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { getBindingTokens, SHORTCUTS, type ShortcutId } from "../shortcuts";
+
+export function useShortcutLabel(id: ShortcutId, label?: string): string {
+  // Subscribe only to the one shortcut key we care about.
+  const userBindings = usePreferencesStore((s) => s.shortcuts[id]);
+
+  return useMemo(() => {
+    const s = SHORTCUTS.find((s) => s.id === id);
+    if (!s) return label ?? "";
+
+    const bindings = userBindings ?? s.defaultBindings;
+    if (!bindings || bindings.length === 0) return label ?? "";
+
+    const shortcutText = getBindingTokens(bindings[0]).join("");
+    if (!label) return shortcutText;
+    return shortcutText ? `${label} (${shortcutText})` : label;
+  }, [id, label, userBindings]);
+}
+

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -1,7 +1,8 @@
 import { IS_MAC, MOD_PROP } from "@/lib/platform";
 
 /**
- * Single source of truth for keyboard shortcuts.
+ * Single source of truth for keyboard shortcuts (registry, matching, display tokens).
+ * React labels: `./lib/shortcutDisplayHooks.ts`. Global dispatcher: `./lib/useGlobalShortcuts.ts`.
  */
 
 export type ShortcutId =
@@ -126,9 +127,24 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
 ];
 
 /**
+ * Effective bindings for an id, fallsback to default if preference not set
+ */
+export function resolveShortcutBindings(
+  id: ShortcutId,
+  fromPrefs: KeyBinding[] | undefined
+): KeyBinding[] {
+  const definition = SHORTCUTS.find((s) => s.id === id);
+  return fromPrefs ?? definition?.defaultBindings ?? [];
+}
+
+/**
  * Matching logic: checks if a KeyboardEvent matches a KeyBinding.
  */
-export function matchBinding(e: KeyboardEvent, binding: KeyBinding, id?: ShortcutId): boolean {
+export function matchBinding(
+  e: KeyboardEvent,
+  binding: KeyBinding,
+  id?: ShortcutId
+): boolean {
   const eventKey = e.key.toLowerCase();
   const bindingKey = binding.key.toLowerCase();
 

--- a/src/settings/sections/ShortcutsSection.tsx
+++ b/src/settings/sections/ShortcutsSection.tsx
@@ -5,6 +5,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import { setShortcuts } from "@/modules/settings/store";
 import {
   getBindingTokens,
+  resolveShortcutBindings,
   SHORTCUTS,
   SHORTCUT_GROUPS,
   type KeyBinding,
@@ -180,8 +181,7 @@ function ShortcutRow({
   onReset: () => void;
   userBindings?: KeyBinding[];
 }) {
-  const bindings =
-    userBindings !== undefined ? userBindings : shortcut.defaultBindings;
+  const bindings = resolveShortcutBindings(shortcut.id, userBindings);
   const isModified = userBindings !== undefined;
   const hasBindings = bindings && bindings.length > 0;
 


### PR DESCRIPTION
## What
Extracted `useShortcutLabel` hook and `resolveShortcutBindings` helpers to eliminate duplicated shortcut label logic across Header, SearchInline, ShortcutsDialog, and ShortcutsSection components.

## Why
Reduce code duplication and improve maintainability by centralizing shortcut binding resolution and label formatting logic.

## How
- Created useShortcutLabel hook in src/modules/shortcuts/lib/useShortcutLabel.ts
- Added resolveShortcutBindings helper in src/modules/shortcuts/shortcuts.ts
- Refactored ShortcutsDialog to use new components and helpers
- Updated Header and SearchInline to use the hook instead of duplicated logic
- Updated imports to export new utilities from shortcuts module index

## Testing
- [x] pnpm exec tsc --noEmit clean
- [x] Manual smoke-test of shortcut labels in header
- [x] Manual smoke-test of shortcuts dialog rendering
- [x] Verified shortcut labels display correctly with user-defined and default bindings

## Screenshots / GIFs
Before
<img width="497" height="279" alt="2026-05-10_20-55-10" src="https://github.com/user-attachments/assets/730c18c6-d1d8-4796-95e2-98eb80bcae99" />

After
<img width="398" height="73" alt="image" src="https://github.com/user-attachments/assets/edd7bfcd-2e24-4505-a857-f6cbf94db503" />


## Notes for reviewer
This is a pure refactor with no functional changes. All shortcut behavior remains identical. I think this kind of change can really stack up