### PR TITLE
fix(editor): add syntax highlighting for C, C++, Java and C#

### DIFF
--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -42,6 +42,21 @@ const loaders: Record<string, LanguageLoader> = {
 
   php: () => import("@codemirror/lang-php").then((m) => m.php({ plain: true })),
 
+  // C / C++ family
+  c: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.c),
+  h: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.c),
+  cpp: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
+  cc: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
+  cxx: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
+  hpp: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
+  hxx: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
+
+  // Java
+  java: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.java),
+
+  // C#
+  cs: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.csharp),
+
   // Legacy-modes: loaders return the raw StreamParser; wrapped below.
   sh: () => import("@codemirror/legacy-modes/mode/shell").then((m) => m.shell),
   bash: () =>


### PR DESCRIPTION
## What
Adds syntax highlighting for C, C++, Java and C# in the editor by wiring
`@codemirror/legacy-modes/mode/clike` parsers into `languageResolver.ts`.

## Why
Opening any .c (or related) file showed plain text.

## How
Added entries for C/C++/Java/C# extensions using `@codemirror/legacy-modes/mode/clike`,
following the same pattern as `sh`, `toml` and `yaml`. No new dependencies, the package
is already in `package.json`.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
| | Before | After |
|---|---|---|
| `.c` |  <img width="350" alt="after_c" src="https://github.com/user-attachments/assets/9973e72f-9289-435d-a900-58ff32105e7f" /> | <img width="350" alt="before_c" src="https://github.com/user-attachments/assets/e0054f75-4131-4653-b235-973524657683" /> |
| `.java` | <img width="350" alt="before_java" src="https://github.com/user-attachments/assets/6d2965ae-9f01-4fe8-b5b9-7171b0e99a61" /> | <img width="350" alt="after_java" src="https://github.com/user-attachments/assets/f79c2ac8-b8b5-46fd-b2a2-286c1c87383e" /> |
| `.h` | <img width="350" alt="before_h" src="https://github.com/user-attachments/assets/bbf8a10e-2db3-484b-aea6-71c03cd5d608" /> | <img width="350" alt="after_h" src="https://github.com/user-attachments/assets/731d946b-2fb4-4428-9912-c38042bca627" /> |
