### PR TITLE
fix(explorer): resolve rename input focus stealing and overflow

### DIFF
--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -405,7 +405,12 @@ export function FileExplorer({
               </div>
             </ScrollArea>
           </ContextMenuTrigger>
-          <ContextMenuContent className={COMPACT_CONTENT}>
+          <ContextMenuContent 
+            className={COMPACT_CONTENT}
+            onCloseAutoFocus={(e) => {
+              if (tree.renaming || tree.pendingCreate) e.preventDefault();
+            }}
+          >
             {onRevealInTerminal && (
               <ContextMenuItem
                 className={COMPACT_ITEM}

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -136,7 +136,12 @@ function FileTreeNodeImpl({
             </button>
           )}
         </ContextMenuTrigger>
-        <ContextMenuContent className={COMPACT_CONTENT}>
+        <ContextMenuContent 
+          className={COMPACT_CONTENT}
+          onCloseAutoFocus={(e) => {
+            if (tree.renaming || tree.pendingCreate) e.preventDefault();
+          }}
+        >
           {!isDir && (
             <ContextMenuItem
               className={COMPACT_ITEM}

--- a/src/modules/explorer/InlineInput.tsx
+++ b/src/modules/explorer/InlineInput.tsx
@@ -82,7 +82,7 @@ export function InlineInput({
         }
         commit();
       }}
-      className="flex-1 truncate rounded-sm border border-border bg-background px-1.5 py-0.5 text-xs text-foreground outline-none ring-0 focus:border-ring"
+      className="min-w-0 flex-1 truncate rounded-sm border border-border bg-background px-1.5 py-0.5 text-xs text-foreground outline-none ring-0 focus:border-ring"
     />
   );
 }


### PR DESCRIPTION
## What
Fixes the inline rename input instantly blurring/discarding when triggered via context menu, and fixes the input box overflowing the sidebar and cutting off its rounded corners.

## Why
When triggering a rename from the context menu, the menu's fade-out animation finishes and Radix UI automatically attempts to restore keyboard focus to the menu trigger. This steals focus away from the active `InlineInput`, causing it to blur and cancel the rename. 
Additionally, standard HTML `<input>` elements have an intrinsic minimum width that prevents them from shrinking inside flex containers, causing it to push out of the right side of narrow sidebars.

## How
1. Added `onCloseAutoFocus` to `ContextMenuContent` in the file tree and explorer to prevent Radix from stealing focus back if a rename or creation is in progress.
2. Added `min-w-0` to the `InlineInput` class list so it can properly shrink below its intrinsic width in flex layouts.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature (verified context menu rename stays focused, and input doesn't overflow narrow sidebars).
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`