### PR TITLE
fix(explorer): prevent inline input from blurring on context menu rename/create

### DIFF
--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -405,7 +405,12 @@ export function FileExplorer({
               </div>
             </ScrollArea>
           </ContextMenuTrigger>
-          <ContextMenuContent className={COMPACT_CONTENT}>
+          <ContextMenuContent 
+            className={COMPACT_CONTENT}
+            onCloseAutoFocus={(e) => {
+              if (tree.renaming || tree.pendingCreate) e.preventDefault();
+            }}
+          >
             {onRevealInTerminal && (
               <ContextMenuItem
                 className={COMPACT_ITEM}

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -136,7 +136,12 @@ function FileTreeNodeImpl({
             </button>
           )}
         </ContextMenuTrigger>
-        <ContextMenuContent className={COMPACT_CONTENT}>
+        <ContextMenuContent 
+          className={COMPACT_CONTENT}
+          onCloseAutoFocus={(e) => {
+            if (tree.renaming || tree.pendingCreate) e.preventDefault();
+          }}
+        >
           {!isDir && (
             <ContextMenuItem
               className={COMPACT_ITEM}


### PR DESCRIPTION
## What
Fixes the inline input instantly blurring and discarding its value when triggered via the context menu (e.g. Rename, New File).
## Why
When triggering a rename from the context menu, the menu's fade-out animation finishes and Radix UI automatically attempts to restore keyboard focus to the menu trigger. This accessibility feature steals focus away from the newly mounted `InlineInput`, causing it to trigger an `onBlur` event and immediately cancel the operation.
## How
Added `onCloseAutoFocus` to `ContextMenuContent` in `FileTreeNode` and `FileExplorer`. This intercepts the Radix focus restoration specifically when `tree.renaming` or `tree.pendingCreate` is active, allowing the input to retain focus.
## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature (verified context menu rename stays focused perfectly).
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`