### PR TITLE
feat(editor): add Go syntax highlighting

### DIFF
--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -30,6 +30,7 @@ const loaders: Record<string, LanguageLoader> = {
     ),
 
   rs: () => import("@codemirror/lang-rust").then((m) => m.rust()),
+  go: () => import("@codemirror/legacy-modes/mode/go").then((m) => m.go),
   py: () => import("@codemirror/lang-python").then((m) => m.python()),
   json: () => import("@codemirror/lang-json").then((m) => m.json()),
 


### PR DESCRIPTION
 ## What changed
  - add Go syntax highlighting support in the editor language resolver
  - map `.go` files to CodeMirror's Go mode via a lazy-loaded legacy parser

  ## Why
  Go files were accepted in the app flow, but the editor did not resolve a language extension for `.go`, so they opened without language-aware syntax highlighting.

  ## Impact
  - `.go` files now get syntax highlighting in the editor
  - the change stays scoped to editor language resolution and does not affect other file types

  ## Validation
  - `pnpm install`
  - `pnpm exec tsc --noEmit`