### PR TITLE
fix(terminal): clear pendingExit and hold ptyOpening in respawnSession

### DIFF
--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -195,7 +195,18 @@ export async function respawnSession(
   s.lastSentCols = 0;
   s.lastSentRows = 0;
   s.lastDetectedUrl = null;
-  const pty = await openPtyForSession(s, cwd);
+  s.pendingExit = null;
+  // Hold the flag so attachSession can't open a second PTY while we await.
+  s.ptyOpening = true;
+  let pty: PtySession;
+  try {
+    pty = await openPtyForSession(s, cwd);
+  } catch (e) {
+    s.ptyOpening = false;
+    console.error("respawnSession: openPty failed:", e);
+    return;
+  }
+  s.ptyOpening = false;
   if (s.disposed) {
     pty.close();
     return;


### PR DESCRIPTION
What
Two race-condition bugs in 'respawnSession' in 'useTerminalSession.ts'.

Why
1. 's.pendingExit' was not cleared before spawning the new shell. If the old shell exited while the tab was detached, 'attachSession' would fire 'onExit' on the brand-new shell the next time the tab became visible.

2. 's.ptyOpening' was not held during the async 'openPtyForSession' call. A concurrent 'attachSession' (e.g. a tab switch mid-respawn) would see '!s.pty && !s.ptyOpening' and open a second PTY. The respawn result would then overwrite 's.pty', orphaning the first OS process.

Relates to Issue #94

How
- Add 's.pendingExit = null'  before the await.
- Wrap 'openPtyForSession'  in try/catch and hold 's.ptyOpening = true'  for the duration, releasing it on success or failure.

Testing
- 'pnpm exec tsc --noEmit' clean
- UI tested in 'pnpm tauri dev'