### PR TITLE
fix(windows): set main window title

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -4,6 +4,7 @@
     "windows": [
       {
         "label": "main",
+        "title": "Terax",
         "decorations": false,
         "transparent": true,
         "visible": false,


### PR DESCRIPTION
## Summary
- Adds an explicit `title` to the Windows-specific main window config so Windows does not fall back to the default `Tauri App` title.
- Keeps the fix scoped to `src-tauri/tauri.windows.conf.json`.

Fixes #136

## Why
Tauri merges platform-specific config files with the main config using JSON Merge Patch. Since `app.windows` is an array, the Windows override replaces the base window entry; repeating the title there keeps the resolved Windows window title aligned with the app name.

## Test Plan
- [x] Asserted `src-tauri/tauri.windows.conf.json` has `app.windows[].title === "Terax"` for the `main` window; verified the assertion failed before the fix and passed after.
- [x] `pnpm build`
- [x] `pnpm tauri build --debug --no-bundle --ci`

## Notes
- I could not directly hover the Windows taskbar from this Linux environment, so the verification is config-level plus Tauri build-path validation.