### PR TITLE
feat(preview): add rich local file previews

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "opener:default",
+    "opener:allow-open-path",
     "log:default",
     "os:default",
     "store:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod modules;
 
-use modules::{fs, net, pty, secrets, shell, workspace};
+use modules::{fs, net, preview, pty, secrets, shell, workspace};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_window_state::StateFlags;
 
@@ -81,7 +81,9 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .register_uri_scheme_protocol("terax-preview", preview::serve_preview_protocol)
         .manage(pty::PtyState::default())
+        .manage(preview::PreviewState::default())
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())
         .invoke_handler(tauri::generate_handler![
@@ -92,6 +94,7 @@ pub fn run() {
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,
+            fs::file::fs_preview_metadata,
             fs::file::fs_write_file,
             fs::file::fs_stat,
             fs::mutate::fs_create_file,
@@ -113,6 +116,7 @@ pub fn run() {
             workspace::wsl_list_distros,
             workspace::wsl_default_distro,
             workspace::wsl_home,
+            preview::preview_prepare_file,
             open_settings_window,
             secrets::secrets_get,
             secrets::secrets_set,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::path::Path;
 use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
@@ -40,6 +41,79 @@ pub struct FileStat {
     pub kind: StatKind,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreviewKind {
+    Image,
+    Pdf,
+    Audio,
+    Video,
+}
+
+#[derive(Serialize)]
+pub struct PreviewMetadata {
+    pub kind: PreviewKind,
+    pub media_type: &'static str,
+    pub size: u64,
+}
+
+pub fn preview_media_type_for_path(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "svg" => Some("image/svg+xml"),
+        "webp" => Some("image/webp"),
+        "pdf" => Some("application/pdf"),
+        "mp3" => Some("audio/mpeg"),
+        "wav" => Some("audio/wav"),
+        "ogg" | "oga" => Some("audio/ogg"),
+        "flac" => Some("audio/flac"),
+        "m4a" => Some("audio/mp4"),
+        "mp4" => Some("video/mp4"),
+        "webm" => Some("video/webm"),
+        "mov" => Some("video/quicktime"),
+        "mkv" => Some("video/x-matroska"),
+        _ => None,
+    }
+}
+
+pub fn preview_kind_for_media_type(media_type: &str) -> Option<PreviewKind> {
+    if media_type.starts_with("image/") {
+        return Some(PreviewKind::Image);
+    }
+    if media_type == "application/pdf" {
+        return Some(PreviewKind::Pdf);
+    }
+    if media_type.starts_with("audio/") {
+        return Some(PreviewKind::Audio);
+    }
+    if media_type.starts_with("video/") {
+        return Some(PreviewKind::Video);
+    }
+    None
+}
+
+pub fn preview_metadata_for_path(path: &Path) -> Result<PreviewMetadata, String> {
+    let media_type = preview_media_type_for_path(path)
+        .ok_or_else(|| "preview not supported for this file type".to_string())?;
+    let kind = preview_kind_for_media_type(media_type)
+        .ok_or_else(|| "preview not supported for this file type".to_string())?;
+    let meta = std::fs::metadata(path).map_err(|e| {
+        log::debug!("preview metadata stat({}) failed: {e}", path.display());
+        e.to_string()
+    })?;
+    if !meta.is_file() {
+        return Err("path is not a file".to_string());
+    }
+    Ok(PreviewMetadata {
+        kind,
+        media_type,
+        size: meta.len(),
+    })
+}
+
 #[tauri::command]
 pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<ReadResult, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
@@ -73,6 +147,16 @@ pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<Rea
         Ok(content) => Ok(ReadResult::Text { content, size }),
         Err(_) => Ok(ReadResult::Binary { size }),
     }
+}
+
+#[tauri::command]
+pub fn fs_preview_metadata(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+) -> Result<PreviewMetadata, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
+    preview_metadata_for_path(&p)
 }
 
 /// Atomic write: stage into a sibling temp file, then rename over the target.
@@ -144,4 +228,60 @@ pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat
         mtime,
         kind,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{preview_kind_for_media_type, preview_media_type_for_path, PreviewKind};
+    use std::path::Path;
+
+    #[test]
+    fn preview_media_type_recognizes_supported_renderable_files() {
+        let cases = [
+            ("diagram.PNG", Some("image/png")),
+            ("photo.jpeg", Some("image/jpeg")),
+            ("animation.gif", Some("image/gif")),
+            ("vector.svg", Some("image/svg+xml")),
+            ("screen.webp", Some("image/webp")),
+            ("notes.pdf", Some("application/pdf")),
+            ("voice.mp3", Some("audio/mpeg")),
+            ("song.flac", Some("audio/flac")),
+            ("clip.mp4", Some("video/mp4")),
+            ("screen.webm", Some("video/webm")),
+        ];
+
+        for (path, expected) in cases {
+            assert_eq!(preview_media_type_for_path(Path::new(path)), expected);
+        }
+    }
+
+    #[test]
+    fn preview_media_type_rejects_non_renderable_files() {
+        let cases = ["archive.zip", "program.bin", "README.md", "no-extension"];
+
+        for path in cases {
+            assert_eq!(preview_media_type_for_path(Path::new(path)), None);
+        }
+    }
+
+    #[test]
+    fn preview_kind_follows_media_family() {
+        assert_eq!(
+            preview_kind_for_media_type("image/png"),
+            Some(PreviewKind::Image)
+        );
+        assert_eq!(
+            preview_kind_for_media_type("application/pdf"),
+            Some(PreviewKind::Pdf)
+        );
+        assert_eq!(
+            preview_kind_for_media_type("audio/mpeg"),
+            Some(PreviewKind::Audio)
+        );
+        assert_eq!(
+            preview_kind_for_media_type("video/mp4"),
+            Some(PreviewKind::Video)
+        );
+        assert_eq!(preview_kind_for_media_type("application/zip"), None);
+    }
 }

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,5 +1,6 @@
 pub mod fs;
 pub mod net;
+pub mod preview;
 pub mod pty;
 pub mod secrets;
 pub mod shell;

--- a/src-tauri/src/modules/preview.rs
+++ b/src-tauri/src/modules/preview.rs
@@ -1,0 +1,247 @@
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use serde::Serialize;
+use tauri::http::header::{
+    ACCEPT_RANGES, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,
+};
+use tauri::http::{Request, Response, StatusCode};
+use tauri::{Manager, Runtime, State, UriSchemeContext};
+
+use crate::modules::fs::file::{preview_metadata_for_path, PreviewKind};
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+
+const MAX_PREPARED_ASSETS: usize = 256;
+const MAX_FULL_RESPONSE_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Default)]
+pub struct PreviewState {
+    next_token: AtomicU64,
+    assets: Mutex<HashMap<String, PreviewAsset>>,
+}
+
+#[derive(Clone)]
+struct PreviewAsset {
+    path: PathBuf,
+    kind: PreviewKind,
+    media_type: String,
+    size: u64,
+}
+
+#[derive(Serialize)]
+pub struct PreparedPreview {
+    pub token: String,
+    pub kind: PreviewKind,
+    pub media_type: String,
+    pub size: u64,
+}
+
+#[tauri::command]
+pub fn preview_prepare_file(
+    state: State<'_, PreviewState>,
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+) -> Result<PreparedPreview, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let path = resolve_path(&path, &workspace);
+    let metadata = preview_metadata_for_path(&path)?;
+    let token = format!("{:x}", state.next_token.fetch_add(1, Ordering::Relaxed));
+
+    let asset = PreviewAsset {
+        path,
+        kind: metadata.kind,
+        media_type: metadata.media_type.to_string(),
+        size: metadata.size,
+    };
+
+    let mut assets = state
+        .assets
+        .lock()
+        .map_err(|_| "preview state lock poisoned".to_string())?;
+    if assets.len() >= MAX_PREPARED_ASSETS {
+        if let Some(first) = assets.keys().next().cloned() {
+            assets.remove(&first);
+        }
+    }
+    assets.insert(token.clone(), asset);
+
+    Ok(PreparedPreview {
+        token,
+        kind: metadata.kind,
+        media_type: metadata.media_type.to_string(),
+        size: metadata.size,
+    })
+}
+
+pub fn serve_preview_protocol<R: Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: Request<Vec<u8>>,
+) -> Response<Vec<u8>> {
+    let token = request.uri().path().trim_start_matches('/').to_string();
+    let state = ctx.app_handle().state::<PreviewState>();
+    let asset = match state
+        .assets
+        .lock()
+        .ok()
+        .and_then(|m| m.get(&token).cloned())
+    {
+        Some(asset) => asset,
+        None => return text_response(StatusCode::NOT_FOUND, "preview asset not found"),
+    };
+
+    match serve_asset(&asset, &request) {
+        Ok(response) => response,
+        Err(e) => text_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+fn serve_asset(
+    asset: &PreviewAsset,
+    request: &Request<Vec<u8>>,
+) -> std::io::Result<Response<Vec<u8>>> {
+    let size = asset.size;
+    if size == 0 {
+        return Ok(binary_response(
+            StatusCode::OK,
+            &asset.media_type,
+            Vec::new(),
+            None,
+            0,
+        ));
+    }
+
+    if let Some(range_header) = request.headers().get("range").and_then(|v| v.to_str().ok()) {
+        if let Some((start, end)) = parse_single_range(range_header, size) {
+            let body = read_range(&asset.path, start, end)?;
+            return Ok(binary_response(
+                StatusCode::PARTIAL_CONTENT,
+                &asset.media_type,
+                body,
+                Some((start, end, size)),
+                end + 1 - start,
+            ));
+        }
+        return Ok(range_not_satisfiable(size));
+    }
+
+    if asset.kind != PreviewKind::Image && size > MAX_FULL_RESPONSE_BYTES {
+        return Ok(text_response(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "preview requires a ranged request for this large file",
+        ));
+    }
+
+    let body = std::fs::read(&asset.path)?;
+    Ok(binary_response(
+        StatusCode::OK,
+        &asset.media_type,
+        body,
+        None,
+        size,
+    ))
+}
+
+fn read_range(path: &Path, start: u64, end: u64) -> std::io::Result<Vec<u8>> {
+    let mut file = std::fs::File::open(path)?;
+    file.seek(SeekFrom::Start(start))?;
+    let len = end + 1 - start;
+    let mut body = vec![0; len as usize];
+    file.read_exact(&mut body)?;
+    Ok(body)
+}
+
+fn binary_response(
+    status: StatusCode,
+    media_type: &str,
+    body: Vec<u8>,
+    content_range: Option<(u64, u64, u64)>,
+    content_length: u64,
+) -> Response<Vec<u8>> {
+    let mut builder = Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, media_type)
+        .header(ACCEPT_RANGES, "bytes")
+        .header(CONTENT_LENGTH, content_length)
+        .header(CACHE_CONTROL, "no-store");
+    if let Some((start, end, size)) = content_range {
+        builder = builder.header(CONTENT_RANGE, format!("bytes {start}-{end}/{size}"));
+    }
+    builder.body(body).unwrap_or_else(|_| {
+        text_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to build preview response",
+        )
+    })
+}
+
+fn range_not_satisfiable(size: u64) -> Response<Vec<u8>> {
+    Response::builder()
+        .status(StatusCode::RANGE_NOT_SATISFIABLE)
+        .header(CONTENT_RANGE, format!("bytes */{size}"))
+        .body(Vec::new())
+        .unwrap_or_else(|_| text_response(StatusCode::INTERNAL_SERVER_ERROR, "range error"))
+}
+
+fn text_response(status: StatusCode, message: &str) -> Response<Vec<u8>> {
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(CACHE_CONTROL, "no-store")
+        .body(message.as_bytes().to_vec())
+        .unwrap()
+}
+
+fn parse_single_range(header: &str, size: u64) -> Option<(u64, u64)> {
+    if size == 0 {
+        return None;
+    }
+    let spec = header.strip_prefix("bytes=")?.split(',').next()?.trim();
+    let (start_raw, end_raw) = spec.split_once('-')?;
+
+    if start_raw.is_empty() {
+        let suffix_len = end_raw.parse::<u64>().ok()?;
+        if suffix_len == 0 {
+            return None;
+        }
+        let start = size.saturating_sub(suffix_len);
+        return Some((start, size - 1));
+    }
+
+    let start = start_raw.parse::<u64>().ok()?;
+    let end = if end_raw.is_empty() {
+        size - 1
+    } else {
+        end_raw.parse::<u64>().ok()?.min(size - 1)
+    };
+
+    if start > end || start >= size {
+        return None;
+    }
+    Some((start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_single_range;
+
+    #[test]
+    fn parses_open_ended_ranges() {
+        assert_eq!(parse_single_range("bytes=10-", 100), Some((10, 99)));
+    }
+
+    #[test]
+    fn parses_suffix_ranges() {
+        assert_eq!(parse_single_range("bytes=-25", 100), Some((75, 99)));
+        assert_eq!(parse_single_range("bytes=-250", 100), Some((0, 99)));
+    }
+
+    #[test]
+    fn rejects_unsatisfiable_ranges() {
+        assert_eq!(parse_single_range("bytes=100-120", 100), None);
+        assert_eq!(parse_single_range("items=0-1", 100), None);
+        assert_eq!(parse_single_range("bytes=-0", 100), None);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob: terax-preview: http://terax-preview.localhost https://terax-preview.localhost; media-src 'self' terax-preview: http://terax-preview.localhost https://terax-preview.localhost; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https: terax-preview: http://terax-preview.localhost https://terax-preview.localhost; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
     }
   },
   "bundle": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -42,7 +42,11 @@ import {
   type SearchInlineHandle,
   type SearchTarget,
 } from "@/modules/header";
-import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
+import {
+  opensInPreviewByDefault,
+  PreviewStack,
+  type PreviewPaneHandle,
+} from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { onKeysChanged } from "@/modules/settings/store";
@@ -86,6 +90,7 @@ export default function App() {
     openFileTab,
     pinTab,
     newPreviewTab,
+    openFilePreviewTab,
     openAiDiffTab,
     closeAiDiffTab,
     closeTab,
@@ -538,24 +543,48 @@ export default function App() {
     (path: string, pin?: boolean) => {
       // Explorer defaults to preview (pin=false); explicit actions like
       // context-menu "Open" pass pin=true for a persistent tab.
+      if (opensInPreviewByDefault(path)) {
+        openFilePreviewTab(path, pin ?? false);
+        return;
+      }
       openFileTab(path, pin ?? false);
     },
-    [openFileTab],
+    [openFilePreviewTab, openFileTab],
+  );
+
+  const handlePreviewFile = useCallback(
+    (path: string, pin?: boolean) => {
+      openFilePreviewTab(path, pin ?? false);
+    },
+    [openFilePreviewTab],
   );
 
   const handlePathRenamed = useCallback(
     (from: string, to: string) => {
       for (const t of tabs) {
-        if (t.kind !== "editor") continue;
-        if (t.path === from) {
+        if (t.kind === "editor" && t.path === from) {
           const i = to.lastIndexOf("/");
           updateTab(t.id, { path: to, title: i === -1 ? to : to.slice(i + 1) });
-        } else if (t.path.startsWith(`${from}/`)) {
+        } else if (t.kind === "editor" && t.path.startsWith(`${from}/`)) {
           const suffix = t.path.slice(from.length);
           const newPath = `${to}${suffix}`;
           const i = newPath.lastIndexOf("/");
           updateTab(t.id, {
             path: newPath,
+            title: i === -1 ? newPath : newPath.slice(i + 1),
+          });
+        } else if (t.kind === "preview" && t.filePath === from) {
+          const i = to.lastIndexOf("/");
+          updateTab(t.id, {
+            filePath: to,
+            title: i === -1 ? to : to.slice(i + 1),
+          });
+        } else if (t.kind === "preview" && t.filePath?.startsWith(`${from}/`)) {
+          const suffix = t.filePath.slice(from.length);
+          const newPath = `${to}${suffix}`;
+          const i = newPath.lastIndexOf("/");
+          updateTab(t.id, {
+            filePath: newPath,
             title: i === -1 ? newPath : newPath.slice(i + 1),
           });
         }
@@ -579,11 +608,21 @@ export default function App() {
     (path: string) => {
       const dirty: number[] = [];
       for (const t of tabs) {
-        if (t.kind !== "editor") continue;
-        if (t.path !== path && !t.path.startsWith(`${path}/`)) continue;
-        if (t.dirty) {
-          dirty.push(t.id);
-        } else {
+        if (t.kind === "editor") {
+          if (t.path !== path && !t.path.startsWith(`${path}/`)) continue;
+          if (t.dirty) {
+            dirty.push(t.id);
+          } else {
+            disposeTab(t.id);
+          }
+          continue;
+        }
+
+        if (
+          t.kind === "preview" &&
+          t.filePath &&
+          (t.filePath === path || t.filePath.startsWith(`${path}/`))
+        ) {
           disposeTab(t.id);
         }
       }
@@ -592,7 +631,12 @@ export default function App() {
     [tabs, disposeTab],
   );
 
-  const activeFilePath = activeTab?.kind === "editor" ? activeTab.path : null;
+  const activeFilePath =
+    activeTab?.kind === "editor"
+      ? activeTab.path
+      : activeTab?.kind === "preview"
+        ? (activeTab.filePath ?? null)
+        : null;
 
   const openPreviewTab = useCallback(
     (url: string) => {
@@ -844,6 +888,7 @@ export default function App() {
                     ref={explorerRef}
                     rootPath={explorerRoot}
                     onOpenFile={handleOpenFile}
+                    onPreviewFile={handlePreviewFile}
                     onPathRenamed={handlePathRenamed}
                     onPathDeleted={handlePathDeleted}
                     onRevealInTerminal={cdInNewTab}
@@ -899,6 +944,7 @@ export default function App() {
                         activeId={activeId}
                         registerHandle={registerPreviewHandle}
                         onUrlChange={handlePreviewUrl}
+                        onOpenFile={handleOpenFile}
                       />
                     </div>
                     <div

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -4,6 +4,7 @@ import {
   SearchQuery,
   setSearchQuery,
 } from "@codemirror/search";
+import { Button } from "@/components/ui/button";
 import { keymap } from "@codemirror/view";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
@@ -30,6 +31,7 @@ import { useDocument } from "./lib/useDocument";
 import { inlineCompletion } from "./lib/autocomplete/inlineExtension";
 import { getKey } from "@/modules/ai/lib/keyring";
 import { onKeysChanged } from "@/modules/settings/store";
+import { openPath } from "@tauri-apps/plugin-opener";
 
 export type EditorPaneHandle = {
   setQuery: (q: string) => void;
@@ -245,21 +247,37 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     }
     if (doc.status === "binary") {
       return (
-        <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-center">
+        <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
           <div className="text-sm text-foreground">Binary file</div>
           <div className="text-xs text-muted-foreground">
             {formatBytes(doc.size)} · preview not supported
           </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void openPath(path).catch(console.error)}
+          >
+            Open externally
+          </Button>
         </div>
       );
     }
     if (doc.status === "toolarge") {
       return (
-        <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-center">
+        <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
           <div className="text-sm text-foreground">File too large</div>
           <div className="text-xs text-muted-foreground">
             {formatBytes(doc.size)} exceeds the {formatBytes(doc.limit)} limit.
           </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void openPath(path).catch(console.error)}
+          >
+            Open externally
+          </Button>
         </div>
       );
     }

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -39,6 +39,7 @@ export type FileExplorerHandle = {
 type Props = {
   rootPath: string | null;
   onOpenFile: (path: string, pin?: boolean) => void;
+  onPreviewFile?: (path: string, pin?: boolean) => void;
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
   onRevealInTerminal?: (path: string) => void;
@@ -55,6 +56,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
     {
       rootPath,
       onOpenFile,
+      onPreviewFile,
       onPathRenamed,
       onPathDeleted,
       onRevealInTerminal,
@@ -346,6 +348,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
                         depth={0}
                         tree={tree}
                         onOpenFile={onOpenFile}
+                        onPreviewFile={onPreviewFile}
                         onRevealInTerminal={onRevealInTerminal}
                         onAttachToAgent={onAttachToAgent}
                         selectedPath={selectedPath}

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
+import { canPreviewFile } from "@/modules/preview";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useCallback, useState } from "react";
@@ -33,6 +34,7 @@ type Props = {
    * omitting it means the caller decides the default (preview).
    */
   onOpenFile: (path: string, pin?: boolean) => void;
+  onPreviewFile?: (path: string, pin?: boolean) => void;
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   selectedPath: string | null;
@@ -46,6 +48,7 @@ function FileTreeNodeImpl({
   depth,
   tree,
   onOpenFile,
+  onPreviewFile,
   onRevealInTerminal,
   onAttachToAgent,
   selectedPath,
@@ -136,12 +139,20 @@ function FileTreeNodeImpl({
             </button>
           )}
         </ContextMenuTrigger>
-        <ContextMenuContent 
+        <ContextMenuContent
           className={COMPACT_CONTENT}
           onCloseAutoFocus={(e) => {
             if (tree.renaming || tree.pendingCreate) e.preventDefault();
           }}
         >
+          {!isDir && canPreviewFile(path) && onPreviewFile && (
+            <ContextMenuItem
+              className={COMPACT_ITEM}
+              onSelect={() => onPreviewFile(path, true)}
+            >
+              Preview
+            </ContextMenuItem>
+          )}
           {!isDir && (
             <ContextMenuItem
               className={COMPACT_ITEM}
@@ -276,6 +287,7 @@ function FileTreeNodeImpl({
             depth={depth + 1}
             tree={tree}
             onOpenFile={onOpenFile}
+            onPreviewFile={onPreviewFile}
             onRevealInTerminal={onRevealInTerminal}
             onAttachToAgent={onAttachToAgent}
             selectedPath={selectedPath}

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -1,5 +1,17 @@
-import { Alert02Icon, Globe02Icon } from "@hugeicons/core-free-icons";
+import { MarkdownCode } from "@/components/ai-elements/markdown-code";
+import { Button } from "@/components/ui/button";
+import { currentWorkspaceEnv } from "@/modules/workspace/env";
+import {
+  Alert02Icon,
+  ArrowReloadHorizontalIcon,
+  File01Icon,
+  Globe02Icon,
+  LinkSquare02Icon,
+  PencilEdit02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { openPath } from "@tauri-apps/plugin-opener";
 import {
   forwardRef,
   useEffect,
@@ -7,10 +19,12 @@ import {
   useRef,
   useState,
 } from "react";
+import { Streamdown } from "streamdown";
 import {
   PreviewAddressBar,
   type PreviewAddressBarHandle,
 } from "./PreviewAddressBar";
+import { basename, filePreviewKind, type FilePreviewKind } from "./filePreview";
 
 export type PreviewPaneHandle = {
   reload: () => void;
@@ -20,19 +34,20 @@ export type PreviewPaneHandle = {
 
 type Props = {
   url: string;
+  filePath?: string;
   visible: boolean;
   onUrlChange: (url: string) => void;
+  onOpenFile?: (path: string, pin?: boolean) => void;
 };
 
-// Tear the iframe down after this much invisibility — a background dev
-// server page can hold hundreds of MB inside the WebView.
+// Tear the iframe down after this much invisibility. A background dev server
+// page can hold hundreds of MB inside the WebView.
 const SUSPEND_AFTER_MS = 30_000;
 
 export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
-  function PreviewPane({ url, visible, onUrlChange }, ref) {
+  function PreviewPane({ url, filePath, visible, onUrlChange, onOpenFile }, ref) {
     // `nonce` is part of the iframe `key`. Bumping it remounts the iframe,
-    // which is the only reliable cross-origin reload (calling
-    // contentWindow.location.reload() throws on cross-origin frames).
+    // which is the only reliable cross-origin reload.
     const [nonce, setNonce] = useState(0);
     const [loaded, setLoaded] = useState(visible);
     const addressRef = useRef<PreviewAddressBarHandle>(null);
@@ -54,12 +69,12 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
           setNonce((n) => n + 1);
         },
         focusAddressBar: () => addressRef.current?.focus(),
-        getUrl: () => url,
+        getUrl: () => filePath ?? url,
       }),
-      [url],
+      [filePath, url],
     );
 
-    const showXfoHint = url ? !isLocalUrl(url) : false;
+    const showXfoHint = !filePath && url ? !isLocalUrl(url) : false;
 
     return (
       <div
@@ -69,12 +84,17 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
           pointerEvents: visible ? "auto" : "none",
         }}
       >
-        <PreviewAddressBar
-          ref={addressRef}
-          url={url}
-          onSubmit={onUrlChange}
-          onReload={() => setNonce((n) => n + 1)}
-        />
+        {filePath ? null : (
+          <PreviewAddressBar
+            ref={addressRef}
+            url={url}
+            onSubmit={onUrlChange}
+            onReload={() => {
+              setLoaded(true);
+              setNonce((n) => n + 1);
+            }}
+          />
+        )}
         {showXfoHint ? (
           <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border/60 bg-amber-500/8 px-3 text-[11px] text-amber-600 dark:text-amber-400">
             <HugeiconsIcon
@@ -91,12 +111,19 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
         ) : null}
         <div
           className={
-            url
-              ? "relative min-h-0 flex-1 bg-white"
+            filePath || url
+              ? "relative min-h-0 flex-1 bg-white dark:bg-background"
               : "relative min-h-0 flex-1 bg-background"
           }
         >
-          {url ? (
+          {filePath ? (
+            <FilePreviewBody
+              path={filePath}
+              nonce={nonce}
+              onReload={() => setNonce((n) => n + 1)}
+              onOpenFile={onOpenFile}
+            />
+          ) : url ? (
             loaded ? (
               <iframe
                 key={`${url}#${nonce}`}
@@ -121,6 +148,389 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
     );
   },
 );
+
+type ReadResult =
+  | { kind: "text"; content: string; size: number }
+  | { kind: "binary"; size: number }
+  | { kind: "toolarge"; size: number; limit: number };
+
+type PreparedPreview = {
+  token: string;
+  kind: Exclude<FilePreviewKind, "markdown">;
+  media_type: string;
+  size: number;
+};
+
+type FilePreviewState =
+  | { status: "loading" }
+  | {
+      status: "asset";
+      kind: Exclude<FilePreviewKind, "markdown">;
+      src: string;
+      mediaType: string;
+      size: number;
+      width?: number;
+      height?: number;
+    }
+  | { status: "markdown"; content: string; size: number }
+  | { status: "binary"; size: number }
+  | { status: "toolarge"; size: number; limit: number }
+  | { status: "unsupported" }
+  | { status: "error"; message: string };
+
+const streamdownComponents = { code: MarkdownCode };
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function FilePreviewBody({
+  path,
+  nonce,
+  onReload,
+  onOpenFile,
+}: {
+  path: string;
+  nonce: number;
+  onReload: () => void;
+  onOpenFile?: (path: string, pin?: boolean) => void;
+}) {
+  const [state, setState] = useState<FilePreviewState>({ status: "loading" });
+  const kind = filePreviewKind(path);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+
+    const load = async () => {
+      try {
+        if (!kind) {
+          setState({ status: "unsupported" });
+          return;
+        }
+
+        if (kind === "markdown") {
+          const res = await invoke<ReadResult>("fs_read_file", {
+            path,
+            workspace: currentWorkspaceEnv(),
+          });
+          if (cancelled) return;
+          if (res.kind === "text") {
+            setState({
+              status: "markdown",
+              content: res.content,
+              size: res.size,
+            });
+          } else if (res.kind === "toolarge") {
+            setState({ status: "toolarge", size: res.size, limit: res.limit });
+          } else {
+            setState({ status: "binary", size: res.size });
+          }
+          return;
+        }
+
+        const res = await invoke<PreparedPreview>("preview_prepare_file", {
+          path,
+          workspace: currentWorkspaceEnv(),
+        });
+        if (cancelled) return;
+        setState({
+          status: "asset",
+          kind: res.kind,
+          src: convertFileSrc(res.token, "terax-preview"),
+          mediaType: res.media_type,
+          size: res.size,
+        });
+      } catch (e) {
+        if (!cancelled) setState({ status: "error", message: String(e) });
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, nonce, path]);
+
+  if (state.status === "loading") {
+    return <FilePreviewMessage title="Loading preview..." path={path} />;
+  }
+  if (state.status === "error") {
+    return (
+      <FilePreviewMessage
+        title="Preview failed"
+        path={path}
+        detail={state.message}
+        action
+      />
+    );
+  }
+  if (state.status === "unsupported") {
+    return (
+      <FilePreviewMessage
+        title="Preview not supported"
+        path={path}
+        detail="Open this file externally or use a file type Terax can render."
+        action
+      />
+    );
+  }
+  if (state.status === "toolarge") {
+    return (
+      <FilePreviewMessage
+        title="File too large to preview"
+        path={path}
+        detail={`${formatBytes(state.size)} exceeds the ${formatBytes(
+          state.limit,
+        )} preview limit.`}
+        action
+      />
+    );
+  }
+  if (state.status === "binary") {
+    return (
+      <FilePreviewMessage
+        title="Binary file"
+        path={path}
+        detail={`${formatBytes(state.size)} - preview not supported.`}
+        action
+      />
+    );
+  }
+
+  const metadata =
+    state.status === "asset"
+      ? {
+          size: state.size,
+          mediaType: state.mediaType,
+          dimensions:
+            state.width && state.height ? `${state.width} x ${state.height}` : null,
+        }
+      : {
+          size: state.size,
+          mediaType: "text/markdown",
+          dimensions: null,
+        };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <FilePreviewToolbar
+        path={path}
+        kind={kind}
+        onReload={onReload}
+        onEdit={
+          kind === "markdown" && onOpenFile
+            ? () => onOpenFile(path, true)
+            : undefined
+        }
+      />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {state.status === "asset" ? (
+          <AssetPreview
+            state={state}
+            path={path}
+            onImageSize={(width, height) =>
+              setState((current) =>
+                current.status === "asset" ? { ...current, width, height } : current,
+              )
+            }
+          />
+        ) : (
+          <MarkdownPreview content={state.content} />
+        )}
+      </div>
+      <FileMetadataBar {...metadata} />
+    </div>
+  );
+}
+
+function FilePreviewToolbar({
+  path,
+  kind,
+  onReload,
+  onEdit,
+}: {
+  path: string;
+  kind: FilePreviewKind | null;
+  onReload: () => void;
+  onEdit?: () => void;
+}) {
+  return (
+    <div className="flex h-8 shrink-0 items-center gap-1 border-b border-border/60 bg-card/40 px-2">
+      <HugeiconsIcon
+        icon={File01Icon}
+        size={14}
+        strokeWidth={1.75}
+        className="shrink-0 text-muted-foreground"
+      />
+      <span className="min-w-0 flex-1 truncate text-xs font-medium" title={path}>
+        {basename(path)}
+      </span>
+      {kind === "markdown" && onEdit ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onEdit}
+          title="Edit file"
+          className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <HugeiconsIcon icon={PencilEdit02Icon} size={14} strokeWidth={1.75} />
+        </Button>
+      ) : null}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onReload}
+        title="Reload preview"
+        className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        <HugeiconsIcon
+          icon={ArrowReloadHorizontalIcon}
+          size={14}
+          strokeWidth={1.75}
+        />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={() => void openPath(path).catch(console.error)}
+        title="Open externally"
+        className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        <HugeiconsIcon icon={LinkSquare02Icon} size={14} strokeWidth={1.75} />
+      </Button>
+    </div>
+  );
+}
+
+function AssetPreview({
+  state,
+  path,
+  onImageSize,
+}: {
+  state: Extract<FilePreviewState, { status: "asset" }>;
+  path: string;
+  onImageSize: (width: number, height: number) => void;
+}) {
+  if (state.kind === "image") {
+    return (
+      <div className="flex h-full w-full items-center justify-center overflow-auto bg-background p-3">
+        <img
+          src={state.src}
+          alt={basename(path)}
+          className="max-h-full max-w-full object-contain"
+          onLoad={(e) => {
+            const img = e.currentTarget;
+            onImageSize(img.naturalWidth, img.naturalHeight);
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (state.kind === "pdf") {
+    return (
+      <iframe
+        src={state.src}
+        title={basename(path)}
+        className="h-full w-full border-0 bg-white"
+      />
+    );
+  }
+
+  if (state.kind === "audio") {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background p-6">
+        <audio src={state.src} controls className="w-full max-w-xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-black">
+      <video
+        src={state.src}
+        controls
+        className="max-h-full max-w-full"
+        preload="metadata"
+      />
+    </div>
+  );
+}
+
+function MarkdownPreview({ content }: { content: string }) {
+  return (
+    <div className="h-full overflow-auto bg-background px-8 py-6">
+      <div className="mx-auto max-w-4xl text-sm leading-6 text-foreground">
+        <Streamdown
+          className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+          components={streamdownComponents}
+        >
+          {content}
+        </Streamdown>
+      </div>
+    </div>
+  );
+}
+
+function FileMetadataBar({
+  size,
+  mediaType,
+  dimensions,
+}: {
+  size: number;
+  mediaType: string;
+  dimensions: string | null;
+}) {
+  return (
+    <div className="flex h-6 shrink-0 items-center gap-3 border-t border-border/60 bg-card/40 px-2 text-[11px] text-muted-foreground">
+      <span>{formatBytes(size)}</span>
+      <span className="truncate">{mediaType}</span>
+      {dimensions ? <span className="shrink-0">{dimensions}</span> : null}
+    </div>
+  );
+}
+
+function FilePreviewMessage({
+  title,
+  path,
+  detail,
+  action,
+}: {
+  title: string;
+  path: string;
+  detail?: string;
+  action?: boolean;
+}) {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <div className="flex size-12 items-center justify-center rounded-2xl border border-border/60 bg-card text-muted-foreground">
+        <HugeiconsIcon icon={File01Icon} size={20} strokeWidth={1.5} />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <p className="max-w-md text-xs leading-relaxed text-muted-foreground">
+          {detail ?? basename(path)}
+        </p>
+      </div>
+      {action ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void openPath(path).catch(console.error)}
+        >
+          Open externally
+        </Button>
+      ) : null}
+    </div>
+  );
+}
 
 function SuspendedState({ onReload }: { onReload: () => void }) {
   return (
@@ -163,8 +573,8 @@ function EmptyState() {
             Ports
           </span>{" "}
           dropdown to jump straight to your running dev server. Public sites
-          often block embedding — open them in your browser via the link icon
-          if you see a blank page.
+          often block embedding - open them in your browser via the link icon if
+          you see a blank page.
         </p>
       </div>
     </div>

--- a/src/modules/preview/PreviewStack.tsx
+++ b/src/modules/preview/PreviewStack.tsx
@@ -7,6 +7,7 @@ type Props = {
   tabs: Tab[];
   activeId: number;
   onUrlChange: (id: number, url: string) => void;
+  onOpenFile?: (path: string, pin?: boolean) => void;
   registerHandle: (id: number, handle: PreviewPaneHandle | null) => void;
 };
 
@@ -14,6 +15,7 @@ export function PreviewStack({
   tabs,
   activeId,
   onUrlChange,
+  onOpenFile,
   registerHandle,
 }: Props) {
   const previews = tabs.filter((t): t is PreviewTab => t.kind === "preview");
@@ -76,8 +78,10 @@ export function PreviewStack({
             <PreviewPane
               ref={getRefCallback(t.id)}
               url={t.url}
+              filePath={t.filePath}
               visible={visible}
               onUrlChange={getUrlCallback(t.id)}
+              onOpenFile={onOpenFile}
             />
           </div>
         );

--- a/src/modules/preview/filePreview.ts
+++ b/src/modules/preview/filePreview.ts
@@ -1,0 +1,36 @@
+export type FilePreviewKind = "image" | "pdf" | "markdown" | "audio" | "video";
+
+const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "svg", "webp"]);
+const MARKDOWN_EXTENSIONS = new Set(["md", "markdown"]);
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "ogg", "oga", "flac", "m4a"]);
+const VIDEO_EXTENSIONS = new Set(["mp4", "webm", "mov", "mkv"]);
+
+export function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : path;
+}
+
+export function extensionForPath(path: string): string {
+  const name = basename(path);
+  const idx = name.lastIndexOf(".");
+  return idx > 0 ? name.slice(idx + 1).toLowerCase() : "";
+}
+
+export function filePreviewKind(path: string): FilePreviewKind | null {
+  const ext = extensionForPath(path);
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (ext === "pdf") return "pdf";
+  if (MARKDOWN_EXTENSIONS.has(ext)) return "markdown";
+  if (AUDIO_EXTENSIONS.has(ext)) return "audio";
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
+  return null;
+}
+
+export function canPreviewFile(path: string): boolean {
+  return filePreviewKind(path) !== null;
+}
+
+export function opensInPreviewByDefault(path: string): boolean {
+  const kind = filePreviewKind(path);
+  return kind === "image" || kind === "pdf" || kind === "audio" || kind === "video";
+}

--- a/src/modules/preview/index.ts
+++ b/src/modules/preview/index.ts
@@ -1,2 +1,9 @@
 export { PreviewStack } from "./PreviewStack";
 export { type PreviewPaneHandle } from "./PreviewPane";
+export {
+  basename as previewFileBasename,
+  canPreviewFile,
+  filePreviewKind,
+  opensInPreviewByDefault,
+  type FilePreviewKind,
+} from "./filePreview";

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -20,7 +20,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef } from "react";
-import type { EditorTab, Tab } from "./lib/useTabs";
+import type { EditorTab, PreviewTab, Tab } from "./lib/useTabs";
 
 type Props = {
   tabs: Tab[];
@@ -85,7 +85,9 @@ export function TabBar({
         >
           <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
             {tabs.map((t) => {
-              const isPreview = t.kind === "editor" && (t as EditorTab).preview;
+              const isPreview =
+                (t.kind === "editor" && (t as EditorTab).preview) ||
+                (t.kind === "preview" && (t as PreviewTab).preview);
               return (
                 <TabsTrigger
                   key={t.id}
@@ -204,9 +206,17 @@ export function TabBar({
 function TabIcon({ tab }: { tab: Tab }) {
   if (tab.kind === "editor") {
     const url = fileIconUrl(tab.title);
-    return url ? <img src={url} alt="" className="size-3.5 shrink-0" /> : null;
+    return url ? (
+      <img src={url} alt="" className="size-3.5 shrink-0" />
+    ) : null;
   }
   if (tab.kind === "preview") {
+    if (tab.filePath) {
+      const url = fileIconUrl(tab.title);
+      return url ? (
+        <img src={url} alt="" className="size-3.5 shrink-0" />
+      ) : null;
+    }
     return (
       <HugeiconsIcon
         icon={Globe02Icon}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -45,6 +45,12 @@ export type PreviewTab = {
   kind: "preview";
   title: string;
   url: string;
+  filePath?: string;
+  /**
+   * True while a file preview tab is transient from a single-click in the
+   * explorer. Persistent URL preview tabs do not use this slot.
+   */
+  preview?: boolean;
 };
 
 export type AiDiffStatus = "pending" | "approved" | "rejected";
@@ -71,6 +77,7 @@ export type TabPatch = Partial<{
   path: string;
   dirty: boolean;
   url: string;
+  filePath: string;
 }>;
 
 function basename(path: string): string {
@@ -230,7 +237,9 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   const pinTab = useCallback((id: number) => {
     setTabs((curr) =>
       curr.map((t) =>
-        t.id === id && t.kind === "editor" ? { ...t, preview: false } : t,
+        t.id === id && (t.kind === "editor" || t.kind === "preview")
+          ? { ...t, preview: false }
+          : t,
       ),
     );
   }, []);
@@ -321,6 +330,46 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return id;
   }, []);
 
+  const openFilePreviewTab = useCallback((path: string, pin = true) => {
+    let targetId: number | null = null;
+    setTabs((curr) => {
+      const existing = curr.find(
+        (t): t is PreviewTab => t.kind === "preview" && t.filePath === path,
+      );
+      if (existing) {
+        targetId = existing.id;
+        if (pin && existing.preview) {
+          return curr.map((t) =>
+            t.id === existing.id ? { ...t, preview: false } : t,
+          );
+        }
+        return curr;
+      }
+
+      const tab: PreviewTab = {
+        id: nextIdRef.current++,
+        kind: "preview",
+        title: basename(path),
+        url: "",
+        filePath: path,
+        preview: !pin,
+      };
+      targetId = tab.id;
+
+      if (pin) return [...curr, tab];
+
+      const previewIdx = curr.findIndex(
+        (t) => t.kind === "preview" && t.filePath && t.preview,
+      );
+      if (previewIdx === -1) return [...curr, tab];
+      const next = [...curr];
+      next[previewIdx] = tab;
+      return next;
+    });
+    if (targetId !== null) setActiveId(targetId);
+    return targetId as number | null;
+  }, []);
+
   const closeTab = useCallback((id: number) => {
     let toDispose: number[] = [];
     setTabs((curr) => {
@@ -356,7 +405,13 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             ...(patch.title !== undefined && { title: patch.title }),
             ...(patch.url !== undefined && {
               url: patch.url,
+              filePath: undefined,
+              preview: false,
               title: patch.title ?? titleFromUrl(patch.url),
+            }),
+            ...(patch.filePath !== undefined && {
+              filePath: patch.filePath,
+              title: patch.title ?? basename(patch.filePath),
             }),
           };
         }
@@ -557,6 +612,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     openFileTab,
     pinTab,
     newPreviewTab,
+    openFilePreviewTab,
     openAiDiffTab,
     setAiDiffStatus,
     closeAiDiffTab,


### PR DESCRIPTION
## Summary
- add local Preview tabs for image, PDF, audio, and video files opened from the file explorer
- add a Markdown Preview context action that reuses the existing Streamdown renderer and includes an Edit action back to the file editor
- replace the old base64 preview-read path with a tokenized `terax-preview` Tauri protocol, including byte-range support for large media
- add preview metadata for file size, media type, and image dimensions, plus external-open fallbacks for unsupported/binary/error states

Refs #111. This slice focuses on local files; Mermaid rendering and ssh:// remote previews are left for follow-up work.

## Test plan
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check origin/main...HEAD`
- `rustfmt --edition 2021 --check src-tauri/src/modules/fs/file.rs src-tauri/src/modules/preview.rs`

## Manual verification
- Earlier local UI smoke covered PNG/SVG/PDF preview tabs and Markdown preview/edit behavior before this rebase repair.
- This update was rebuilt and retested locally after replacing the base64 path; CI has been restarted for the rebased branch.

## Notes for reviewer
- The preview protocol stores only short-lived opaque tokens in the renderer URL instead of exposing filesystem paths through the webview.
- Large non-image media is expected to load through WebView range requests; full non-range responses are capped to avoid large memory spikes.