### PR TITLE
feat(tabs): add tab reordering and renaming functionality and a tab context menu

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -88,6 +88,7 @@ export default function App() {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
+    reorderTabs,
   } = useTabs();
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -700,6 +701,7 @@ export default function App() {
             onNewEditor={() => setNewEditorOpen(true)}
             onClose={handleClose}
             onPin={pinTab}
+            onReorder={reorderTabs}
             onToggleSidebar={toggleSidebar}
             onSplit={splitActivePaneInActiveTab}
             canSplit={

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -89,6 +89,7 @@ export default function App() {
     closeActivePane,
     closePaneByLeaf,
     reorderTabs,
+    rename,
   } = useTabs();
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -702,6 +703,7 @@ export default function App() {
             onClose={handleClose}
             onPin={pinTab}
             onReorder={reorderTabs}
+            onRename={rename}
             onToggleSidebar={toggleSidebar}
             onSplit={splitActivePaneInActiveTab}
             canSplit={

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -47,6 +47,7 @@ type Props = {
   canSplit: boolean;
   onOpenShortcuts: () => void;
   onOpenSettings: () => void;
+  onReorder: (tabs: Tab[]) => void;
   searchTarget: SearchTarget;
   searchRef: RefObject<SearchInlineHandle | null>;
 };
@@ -67,6 +68,7 @@ export function Header({
   canSplit,
   onOpenShortcuts,
   onOpenSettings,
+  onReorder,
   searchTarget,
   searchRef,
 }: Props) {
@@ -207,6 +209,7 @@ export function Header({
           onNewEditor={onNewEditor}
           onClose={onClose}
           onPin={onPin}
+          onReorder={onReorder}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -48,6 +48,7 @@ type Props = {
   onOpenShortcuts: () => void;
   onOpenSettings: () => void;
   onReorder: (tabs: Tab[]) => void;
+  onRename: (tabId: number, newName:string) => void;
   searchTarget: SearchTarget;
   searchRef: RefObject<SearchInlineHandle | null>;
 };
@@ -69,6 +70,7 @@ export function Header({
   onOpenShortcuts,
   onOpenSettings,
   onReorder,
+  onRename,
   searchTarget,
   searchRef,
 }: Props) {
@@ -210,6 +212,7 @@ export function Header({
           onClose={onClose}
           onPin={onPin}
           onReorder={onReorder}
+          onRename={onRename}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -18,6 +18,7 @@ import {
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { Reorder } from "motion/react";
 import { useEffect, useRef } from "react";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
@@ -29,8 +30,8 @@ type Props = {
   onNewPreview: () => void;
   onNewEditor: () => void;
   onClose: (id: number) => void;
-  /** Pin (promote) a preview tab to persistent on double-click. */
   onPin: (id: number) => void;
+  onReorder: (tabs: Tab[]) => void;
   compact?: boolean;
 };
 
@@ -43,6 +44,7 @@ export function TabBar({
   onNewEditor,
   onClose,
   onPin,
+  onReorder,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -70,113 +72,126 @@ export function TabBar({
   }, [activeId, tabs.length]);
 
   return (
-    <div
-      ref={scrollRef}
-      data-tauri-drag-region
-      className="min-w-0 shrink overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-    >
-      <div className="flex w-max items-center gap-0.5">
-        <Tabs
-          value={String(activeId)}
-          onValueChange={(v) => onSelect(Number(v))}
-        >
+    <div className="flex w-max items-center gap-0.5">
+      <div
+        ref={scrollRef}
+        data-tauri-drag-region
+        className="min-w-0 shrink overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        <Tabs value={String(activeId)} onValueChange={(v) => onSelect(Number(v))}>
           <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
-            {tabs.map((t) => {
-              const isPreview = t.kind === "editor" && (t as EditorTab).preview;
-              return (
-                <TabsTrigger
-                  key={t.id}
-                  value={String(t.id)}
-                  data-tab-id={t.id}
-                  onDoubleClick={() => isPreview && onPin(t.id)}
-                  className={cn(
-                    "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
-                    compact
-                      ? "px-1.5!"
-                      : tabs.length === 1
-                        ? "px-2!"
-                        : "ps-2! pe-1!",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "flex items-center gap-1.5 truncate",
-                      compact ? "max-w-48" : "max-w-80",
-                    )}
+            <Reorder.Group
+              axis="x"
+              values={tabs}
+              onReorder={onReorder}
+              className="flex w-max items-center gap-0.5"
+            >
+              {tabs.map((t) => {
+                const isPreview = t.kind === "editor" && (t as EditorTab).preview;
+                return (
+                  <Reorder.Item
+                    key={t.id}
+                    value={t}
+                    id={String(t.id)}
                   >
-                    <TabIcon tab={t} />
-                    {/* Preview tabs use italic to signal the transient state,
-                        matching the visual convention from VSCode. */}
-                    <span className={cn("truncate", isPreview && "italic")}>
-                      {labelFor(t)}
-                    </span>
-                    {t.kind === "editor" && t.dirty ? (
-                      <span
-                        aria-label="Unsaved changes"
-                        className="size-1.5 shrink-0 rounded-full bg-foreground/70"
-                      />
-                    ) : null}
-                  </span>
-                  {tabs.length > 1 && (
-                    <span
-                      role="button"
-                      aria-label="Close tab"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onClose(t.id);
-                      }}
-                      className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                    <TabsTrigger
+                      value={String(t.id)}
+                      className={cn(
+                        "group flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md text-xs transition-colors",
+                        "hover:text-foreground/80",
+                        t.id === activeId
+                          ? "bg-accent text-foreground"
+                          : "text-muted-foreground",
+                        compact
+                          ? "px-1.5!"
+                          : tabs.length === 1
+                            ? "px-2!"
+                            : "ps-2! pe-1!",
+                      )}
+                      data-tab-id={t.id}
+                      onDoubleClick={() => isPreview && onPin(t.id)}
                     >
-                      <HugeiconsIcon
-                        icon={Cancel01Icon}
-                        size={11}
-                        strokeWidth={2}
-                      />
-                    </span>
-                  )}
-                </TabsTrigger>
-              );
-            })}
+                      <span
+                        className={cn(
+                          "flex items-center gap-1.5 truncate",
+                          compact ? "max-w-48" : "max-w-80",
+                        )}
+                      >
+                        <TabIcon tab={t} />
+                        {/* Preview tabs use italic to signal the transient state,
+                        matching the visual convention from VSCode. */}
+                        <span className={cn("truncate", isPreview && "italic")}>
+                          {labelFor(t)}
+                        </span>
+                        {t.kind === "editor" && t.dirty ? (
+                          <span
+                            aria-label="Unsaved changes"
+                            className="size-1.5 shrink-0 rounded-full bg-foreground/70"
+                          />
+                        ) : null}
+                      </span>
+                      {tabs.length > 1 && (
+                        <span
+                          role="button"
+                          aria-label="Close tab"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onClose(t.id);
+                          }}
+                          className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                        >
+                          <HugeiconsIcon
+                            icon={Cancel01Icon}
+                            size={11}
+                            strokeWidth={2}
+                          />
+                        </span>
+                      )}
+                    </TabsTrigger>
+                  </Reorder.Item>
+                );
+              })}
+            </Reorder.Group>
           </TabsList>
         </Tabs>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-              title="New tab"
-            >
-              <HugeiconsIcon icon={PlusSignIcon} size={14} strokeWidth={2} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="min-w-44">
-            <DropdownMenuItem onSelect={() => onNew()}>
-              <HugeiconsIcon
-                icon={ComputerTerminal02Icon}
-                size={14}
-                strokeWidth={1.75}
-              />
-              <span className="flex-1">Terminal</span>
-              <span className="text-xs text-muted-foreground">{fmtShortcut(MOD_KEY, "T")}</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onNewEditor()}>
-              <HugeiconsIcon
-                icon={PencilEdit02Icon}
-                size={14}
-                strokeWidth={1.75}
-              />
-              <span className="flex-1">Editor</span>
-              <span className="text-xs text-muted-foreground">{fmtShortcut(MOD_KEY, "E")}</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onNewPreview()}>
-              <HugeiconsIcon icon={Globe02Icon} size={14} strokeWidth={1.75} />
-              <span className="flex-1">Preview</span>
-              <span className="text-xs text-muted-foreground">{fmtShortcut(MOD_KEY, "P")}</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            title="New tab"
+          >
+            <HugeiconsIcon icon={PlusSignIcon} size={14} strokeWidth={2} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-44">
+          <DropdownMenuItem onSelect={() => onNew()}>
+            <HugeiconsIcon
+              icon={ComputerTerminal02Icon}
+              size={14}
+              strokeWidth={1.75}
+            />
+            <span className="flex-1">Terminal</span>
+            <span className="text-xs text-muted-foreground">{fmtShortcut(MOD_KEY, "T")}</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => onNewEditor()}>
+            <HugeiconsIcon
+              icon={PencilEdit02Icon}
+              size={14}
+              strokeWidth={1.75}
+            />
+            <span className="flex-1">Editor</span>
+            <span className="text-xs text-muted-foreground">{fmtShortcut(MOD_KEY, "E")}</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => onNewPreview()}>
+            <HugeiconsIcon icon={Globe02Icon} size={14} strokeWidth={1.75} />
+            <span className="flex-1">Preview</span>
+            <span className="text-xs text-muted-foreground">{fmtShortcut(MOD_KEY, "P")}</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -17,9 +17,17 @@ import {
   PencilEdit02Icon,
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuGroup,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Reorder } from "motion/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
 type Props = {
@@ -31,6 +39,7 @@ type Props = {
   onNewEditor: () => void;
   onClose: (id: number) => void;
   onPin: (id: number) => void;
+  onRename: (id: number, newTitle: string) => void;
   onReorder: (tabs: Tab[]) => void;
   compact?: boolean;
 };
@@ -44,10 +53,12 @@ export function TabBar({
   onNewEditor,
   onClose,
   onPin,
+  onRename,
   onReorder,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [editingTabId, setEditingTabId] = useState<number | null>(null);
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -89,66 +100,109 @@ export function TabBar({
               {tabs.map((t) => {
                 const isPreview = t.kind === "editor" && (t as EditorTab).preview;
                 return (
-                  <Reorder.Item
-                    key={t.id}
-                    value={t}
-                    id={String(t.id)}
-                  >
-                    <TabsTrigger
-                      value={String(t.id)}
-                      className={cn(
-                        "group flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md text-xs transition-colors",
-                        "hover:text-foreground/80",
-                        t.id === activeId
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground",
-                        compact
-                          ? "px-1.5!"
-                          : tabs.length === 1
-                            ? "px-2!"
-                            : "ps-2! pe-1!",
-                      )}
-                      data-tab-id={t.id}
-                      onDoubleClick={() => isPreview && onPin(t.id)}
+                    <Reorder.Item
+                      key={t.id}
+                      value={t}
+                      id={String(t.id)}
                     >
-                      <span
-                        className={cn(
-                          "flex items-center gap-1.5 truncate",
-                          compact ? "max-w-48" : "max-w-80",
-                        )}
-                      >
-                        <TabIcon tab={t} />
-                        {/* Preview tabs use italic to signal the transient state,
-                        matching the visual convention from VSCode. */}
-                        <span className={cn("truncate", isPreview && "italic")}>
-                          {labelFor(t)}
-                        </span>
-                        {t.kind === "editor" && t.dirty ? (
-                          <span
-                            aria-label="Unsaved changes"
-                            className="size-1.5 shrink-0 rounded-full bg-foreground/70"
-                          />
-                        ) : null}
-                      </span>
-                      {tabs.length > 1 && (
-                        <span
-                          role="button"
-                          aria-label="Close tab"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onClose(t.id);
-                          }}
-                          className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
-                        >
-                          <HugeiconsIcon
-                            icon={Cancel01Icon}
-                            size={11}
-                            strokeWidth={2}
-                          />
-                        </span>
-                      )}
-                    </TabsTrigger>
-                  </Reorder.Item>
+                      <ContextMenu>
+                        <ContextMenuTrigger>
+                          <TabsTrigger
+                            value={String(t.id)}
+                            className={cn(
+                              "group flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md text-xs transition-colors",
+                        "hover:text-foreground/80",
+                              t.id === activeId
+                                ? "bg-accent text-foreground"
+                          : "text-muted-foreground",
+                              compact
+                                ? "px-1.5!"
+                                : tabs.length === 1
+                                  ? "px-2!"
+                                  : "ps-2! pe-1!",
+                            )}
+                            data-tab-id={t.id}
+                      onDoubleClick={() => isPreview && onPin(t.id)}
+                          >
+                            <span
+                              className={cn(
+                                "flex items-center gap-1.5 truncate",
+                                compact ? "max-w-48" : "max-w-80",
+                              )}
+                            >
+                              <TabIcon tab={t} />
+                              {/* Preview tabs use italic to signal the transient state, 
+                              matching the visual convention from VSCode. */}
+                              {editingTabId === t.id ? (
+                                <input
+                                  autoFocus
+                                  className="h-5 w-full px-1 text-xs bg-transparent focus:border-none focus-within:outline-none "
+                                  defaultValue={t.title}
+                                  onBlur={(e) => {
+                                    onRename(t.id, e.target.value);
+                                    setEditingTabId(null);
+                                  }}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                      onRename(t.id, (e.target as HTMLInputElement).value);
+                                      setEditingTabId(null);
+                                    }
+                                    if (e.key === "Escape") {
+                                      setEditingTabId(null);
+                                    }
+                                  }}
+                                />
+                              ) : (
+                                <span className={cn("truncate", isPreview && "italic")}>
+                                  {t.title}
+                                </span>
+                              )}
+                              {t.kind === "editor" && t.dirty ? (
+                                <span
+                                  aria-label="Unsaved changes"
+                                  className="size-1.5 shrink-0 rounded-full bg-foreground/70"
+                                />
+                              ) : null}
+                            </span>
+                            {tabs.length > 1 && (
+                              <span
+                                role="button"
+                                aria-label="Close tab"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  onClose(t.id);
+                                }}
+                                className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                              >
+                                <HugeiconsIcon
+                                  icon={Cancel01Icon}
+                                  size={11}
+                                  strokeWidth={2}
+                                />
+                              </span>
+                            )}
+                          </TabsTrigger>
+                        </ContextMenuTrigger>
+                        <ContextMenuContent>
+                          <ContextMenuGroup>
+                            <ContextMenuItem onClick={() => onPin(t.id)}>
+                              <span>Pin</span>
+                            </ContextMenuItem>
+                            {t.kind !== "editor" && (
+                              <ContextMenuItem onClick={() => setEditingTabId(t.id)}>
+                                <span>Rename</span>
+                              </ContextMenuItem>
+                            )}
+                          </ContextMenuGroup>
+                          <ContextMenuSeparator />
+                          <ContextMenuGroup>
+                            <ContextMenuItem variant="destructive" onClick={() => onClose(t.id)}>
+                              <span>Close</span>
+                            </ContextMenuItem>
+                          </ContextMenuGroup>
+                        </ContextMenuContent>
+                      </ContextMenu>
+                    </Reorder.Item>
                 );
               })}
             </Reorder.Group>
@@ -229,13 +283,4 @@ function TabIcon({ tab }: { tab: Tab }) {
       className="shrink-0"
     />
   );
-}
-
-function labelFor(t: Tab): string {
-  if (t.kind === "editor") return t.title;
-  if (t.kind === "preview") return t.title;
-  if (t.kind === "ai-diff") return t.title;
-  if (!t.cwd) return t.title;
-  const parts = t.cwd.split(/[\\/]/).filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : "/";
 }

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -463,6 +463,14 @@ const closeActivePane = useCallback((tabId: number): boolean => {
     setTabs(newOrder);
   }, []);
 
+  const rename = (tabId: number, newTitle: string) => {
+    setTabs((curr) =>
+      curr.map((t) =>
+        t.id === tabId ? { ...t, title: newTitle } : t,
+      ),
+    );
+  }
+
   return {
     tabs,
     activeId,
@@ -483,5 +491,6 @@ const closeActivePane = useCallback((tabId: number): boolean => {
     closeActivePane,
     closePaneByLeaf,
     reorderTabs,
+    rename,
   };
 }

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -429,7 +429,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     });
   }, []);
 
-  const closeActivePane = useCallback((tabId: number): boolean => {
+const closeActivePane = useCallback((tabId: number): boolean => {
     let closedTab = false;
     setTabs((curr) => {
       const t = curr.find((x) => x.id === tabId);
@@ -459,6 +459,10 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return closedTab;
   }, []);
 
+  const reorderTabs = useCallback((newOrder: Tab[]) => {
+    setTabs(newOrder);
+  }, []);
+
   return {
     tabs,
     activeId,
@@ -478,5 +482,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
+    reorderTabs,
   };
 }


### PR DESCRIPTION
Closes #186 

## What
- **For Reorder**: modified `TabBar.tsx` to wrap each `TabsTrigger` inside a `Reorder.Item` from Framer Motion, placed within a `Reorder.Group`
- **For Rename**: added function `rename` in `useTabs` and edited corresponding files, and added a context menu for tabs

## Why
tabs lacked drag-and-drop reordering (like VSCode and Warp). Added `reorderTabs` callback to the `useTabs` hook to persist the new order when tabs are dragged, and added renaming for `preview` and `shell` tabs

## How
Added tab drag-and-drop by wrapping Radix Tabs with Framer Motion's Reorder component, enabling horizontal reordering while preserving tab accessibility and styling

- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Notes For Reviewer
- The rename only happen for `preview` and `shell` tabs, changing the name of a file will result in removing the icon
- removed function responsible for getting the path as it dont let the `title` update in shell tabs
- the context menu can be improved a lot like creating an array containg objects of what it can and cant do, for now it hold **Pin Tab**, **Rename Tab** and added **Close**, later you can add **Close All** and **Close All except for Current**
- ISSUE: there is one issue that i couldn't fix and its the focus issue, even though i used the `autoFocus` it does not focus to the input meaning the user must manually click it to start renaming
- please consider adding linting and formating to the project, there is a PR that adds oxlint in #82, when working i have oxlint default config, saving files sometimes changes some non-related code making it appear like i did touch parts that i are not related to features