### PR TITLE
fix(pty): unblock Tauri worker on Windows pty_close

### DIFF
--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
+use std::thread;
 
 use portable_pty::PtySize;
 use tauri::ipc::Channel;
@@ -119,6 +120,23 @@ pub fn pty_close(state: tauri::State<PtyState>, id: u32) -> Result<(), String> {
             log::debug!("pty_close: kill id={id} returned {e}");
         }
         log::info!("pty closed id={id}");
+        // Drop the Arc on a detached thread. On Windows `MasterPty`'s Drop
+        // calls `ClosePseudoConsole`, which can block until conhost finishes
+        // draining its output buffer. Doing it here would freeze the Tauri
+        // worker thread that handled this command — and on Windows that
+        // sometimes manifests as the closed pane refusing to disappear from
+        // the React tree because subsequent IPC stalls behind it.
+        thread::Builder::new()
+            .name(format!("terax-pty-drop-{id}"))
+            .spawn(move || {
+                let t0 = std::time::Instant::now();
+                drop(s);
+                log::info!(
+                    "pty session id={id} dropped in {}ms",
+                    t0.elapsed().as_millis()
+                );
+            })
+            .expect("spawn pty drop thread");
     } else {
         log::debug!("pty_close: unknown id={id}");
     }

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -31,11 +31,22 @@ pub enum PtyEvent {
 }
 
 pub struct Session {
-    pub master: Mutex<Box<dyn MasterPty + Send>>,
-    pub writer: Mutex<Box<dyn Write + Send>>,
-    pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    // Field drop order is intentional. Rust drops fields top-to-bottom:
+    //   1. `_job` — on Windows, closing the Job HANDLE fires
+    //      KILL_ON_JOB_CLOSE, terminating the pwsh tree before the master
+    //      pipe drops. Without this, ClosePseudoConsole in `master`'s Drop
+    //      can block waiting for conhost to drain pending output, freezing
+    //      the Tauri worker thread that triggered the close.
+    //   2. `killer` — best-effort kill (redundant on Windows once Job
+    //      closed, but harmless and required on Unix where there is no Job).
+    //   3. `writer` — closes the input side of the master pipe.
+    //   4. `master` — last; ClosePseudoConsole on Windows. By now the child
+    //      is dead and conhost has nothing left to drain.
     #[cfg(windows)]
     _job: Option<super::job::PtyJob>,
+    pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    pub writer: Mutex<Box<dyn Write + Send>>,
+    pub master: Mutex<Box<dyn MasterPty + Send>>,
 }
 
 impl Drop for Session {
@@ -89,11 +100,11 @@ pub fn spawn(
     };
 
     let session = Arc::new(Session {
-        master: Mutex::new(pair.master),
-        writer: Mutex::new(writer),
-        killer: Mutex::new(killer),
         #[cfg(windows)]
         _job: job,
+        killer: Mutex::new(killer),
+        writer: Mutex::new(writer),
+        master: Mutex::new(pair.master),
     });
 
     let pending: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::with_capacity(READ_BUF)));

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -218,6 +218,9 @@ function attachSession(
   s.callbacks = callbacks;
 
   const firstAttach = !s.term.element;
+  console.debug(
+    `[terax:pty] attach leaf=${leafId} firstAttach=${firstAttach}`,
+  );
   if (firstAttach) {
     s.term.open(container);
   } else if (s.term.element && s.term.element.parentNode !== container) {
@@ -337,6 +340,7 @@ function attachSession(
 function detachSession(leafId: number): void {
   const s = sessions.get(leafId);
   if (!s) return;
+  console.debug(`[terax:pty] detach leaf=${leafId}`);
   s.observer?.disconnect();
   s.observer = null;
   if (s.fitTimer) {
@@ -353,6 +357,7 @@ function detachSession(leafId: number): void {
 export function disposeSession(leafId: number): void {
   const s = sessions.get(leafId);
   if (!s) return;
+  console.debug(`[terax:pty] dispose leaf=${leafId} ptyId=${s.pty?.id ?? null}`);
   s.disposed = true;
   s.cleanups.forEach((fn) => fn());
   s.observer?.disconnect();
@@ -361,6 +366,7 @@ export function disposeSession(leafId: number): void {
   s.pty?.close();
   s.term.dispose();
   sessions.delete(leafId);
+  console.debug(`[terax:pty] dispose leaf=${leafId} done`);
 }
 
 type Options = {


### PR DESCRIPTION
## What

Move the `Session` Arc drop in `pty_close` onto a detached thread and reorder `Session` fields so the Windows Job HANDLE drops before `MasterPty`.

## Why

`TERAX.md` already documents that `ClosePseudoConsole` can block. With the previous field order (`master` first, `_job` last) and synchronous drop on the Tauri command thread, a slow ConPTY teardown freezes the worker that handled `pty_close`. Subsequent IPC stalls behind it, and on Windows that can present as the closed pane refusing to disappear from the React tree.

Repro for the original "split close stuck" symptom is fuzzy on my setup (Windows 10 22H2, PS 5.1) — I could not solidly reproduce after the patch, and the symptom did appear intermittently before. Treating this as defensive hardening of the existing risk note rather than a sharply-bisected fix.

## How

`src-tauri/src/modules/pty/session.rs`
- Reorder `Session` fields so `_job` drops first. Closing the Job HANDLE fires `KILL_ON_JOB_CLOSE`, terminating the pwsh tree before `master`'s Drop calls `ClosePseudoConsole`. With the previous order, conhost might still be draining output when the master drop tried to close the pipe.

`src-tauri/src/modules/pty/mod.rs`
- After `killer.kill()` and removing the session from the map, move the Arc into a `terax-pty-drop-<id>` thread. Even if `ClosePseudoConsole` blocks on Windows, the Tauri worker returns immediately. Includes a timing log on the detached thread so future repros tell us if the drop is ever multi-second.

`src/modules/terminal/lib/useTerminalSession.ts`
- `console.debug` markers around `attachSession` / `detachSession` / `disposeSession`. If the symptom resurfaces, DevTools will show whether dispose is reached and where it stops.

Net diff: +41 / -6 across three files.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `cargo check` — clean
- `cargo clippy --all-targets` — clean on changed files (only pre-existing `secrets.rs::manual_ok_err` warning remains, untouched)
- `rustfmt --check` on the two `.rs` files — clean
- `pnpm tauri dev` — built and ran on Windows 10 22H2, PowerShell 5.1 shell. Manually opened 5 panes (`pty opened id=1..5`), closed two (`id=3`, `id=5`). Both closes landed in the log; UI removed the pane DOM and accepted further splits afterward.

I did not exercise `pnpm tauri build` — happy to if a maintainer wants that before merge.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature (split + close in dev)
- [x] (touched `src-tauri/`) `cargo check` clean
- [x] (UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

No visual change; behaviour-only fix.

## Notes for reviewer

- Repro is fuzzy — I'd value a second pair of eyes on whether the Job-drops-first ordering is actually load-bearing on the Windows versions you test against. The `TERAX.md` note about `ClosePseudoConsole` blocking is the strongest justification.
- The JS `console.debug` markers are intentionally cheap. Easy to revert in a follow-up once we have field signal.
- `pre-existing` clippy warning + rustfmt drift in `src/modules/secrets.rs` is untouched; would belong in a separate `chore(fmt)` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)