### PR TITLE
fix(pty): unblock Tauri worker on Windows pty_close

### DIFF
--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
+use std::thread;
 
 use portable_pty::PtySize;
 use tauri::ipc::Channel;
@@ -119,6 +120,23 @@ pub fn pty_close(state: tauri::State<PtyState>, id: u32) -> Result<(), String> {
             log::debug!("pty_close: kill id={id} returned {e}");
         }
         log::info!("pty closed id={id}");
+        // Drop the Arc on a detached thread. On Windows `MasterPty`'s Drop
+        // calls `ClosePseudoConsole`, which can block until conhost finishes
+        // draining its output buffer. Doing it here would freeze the Tauri
+        // worker thread that handled this command — and on Windows that
+        // sometimes manifests as the closed pane refusing to disappear from
+        // the React tree because subsequent IPC stalls behind it.
+        thread::Builder::new()
+            .name(format!("terax-pty-drop-{id}"))
+            .spawn(move || {
+                let t0 = std::time::Instant::now();
+                drop(s);
+                log::info!(
+                    "pty session id={id} dropped in {}ms",
+                    t0.elapsed().as_millis()
+                );
+            })
+            .expect("spawn pty drop thread");
     } else {
         log::debug!("pty_close: unknown id={id}");
     }

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -31,11 +31,22 @@ pub enum PtyEvent {
 }
 
 pub struct Session {
-    pub master: Mutex<Box<dyn MasterPty + Send>>,
-    pub writer: Mutex<Box<dyn Write + Send>>,
-    pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    // Field drop order is intentional. Rust drops fields top-to-bottom:
+    //   1. `_job` — on Windows, closing the Job HANDLE fires
+    //      KILL_ON_JOB_CLOSE, terminating the pwsh tree before the master
+    //      pipe drops. Without this, ClosePseudoConsole in `master`'s Drop
+    //      can block waiting for conhost to drain pending output, freezing
+    //      the Tauri worker thread that triggered the close.
+    //   2. `killer` — best-effort kill (redundant on Windows once Job
+    //      closed, but harmless and required on Unix where there is no Job).
+    //   3. `writer` — closes the input side of the master pipe.
+    //   4. `master` — last; ClosePseudoConsole on Windows. By now the child
+    //      is dead and conhost has nothing left to drain.
     #[cfg(windows)]
     _job: Option<super::job::PtyJob>,
+    pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    pub writer: Mutex<Box<dyn Write + Send>>,
+    pub master: Mutex<Box<dyn MasterPty + Send>>,
 }
 
 impl Drop for Session {
@@ -89,11 +100,11 @@ pub fn spawn(
     };
 
     let session = Arc::new(Session {
-        master: Mutex::new(pair.master),
-        writer: Mutex::new(writer),
-        killer: Mutex::new(killer),
         #[cfg(windows)]
         _job: job,
+        killer: Mutex::new(killer),
+        writer: Mutex::new(writer),
+        master: Mutex::new(pair.master),
     });
 
     let pending: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::with_capacity(READ_BUF)));


### PR DESCRIPTION
## What

Drop the `Session` Arc on a detached thread inside `pty_close`, and reorder `Session` fields so `_job` drops before `master`.

## Why

`TERAX.md` already flags that `ClosePseudoConsole` can block. With the previous synchronous drop on the Tauri worker thread, a slow ConPTY teardown stalls subsequent IPC and a closed pane can appear stuck.

## How

- `session.rs`: `_job` field moved before `master` so the Job HANDLE drops first, firing `KILL_ON_JOB_CLOSE` before `ClosePseudoConsole`.
- `mod.rs`: detached `terax-pty-drop-<id>` thread takes the Arc after `killer.kill()`. Tauri worker returns immediately.

## Testing

- `pnpm exec tsc --noEmit` clean
- `cargo check` / `clippy` / `rustfmt --check` clean on touched files
- `pnpm tauri dev` on Windows 10 22H2 + PowerShell 5.1: opened 5 panes, closed 2; both closes landed and DOM removed cleanly.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test
- [x] `cargo check` clean
- [x] Tested in `pnpm tauri dev`