### PR TITLE
fix(pty): sweep orphan shells from prior Terax on startup

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,7 +50,9 @@ keyring = { version = "3.6", default-features = false, features = [
 windows-sys = { version = "0.59", features = [
 	"Win32_Foundation",
 	"Win32_Security",
+	"Win32_System_Diagnostics_ToolHelp",
 	"Win32_System_JobObjects",
+	"Win32_System_ProcessStatus",
 	"Win32_System_Threading",
 ] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,6 +89,11 @@ pub fn run() {
     #[cfg(target_os = "linux")]
     apply_wayland_webkit_workaround();
 
+    // Clean up orphan ConPTY shells from a prior Terax that died ungracefully.
+    // Run before any new PTY can be opened so we don't kill our own children.
+    #[cfg(windows)]
+    pty::sweep_orphan_shells();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src-tauri/src/modules/pty/cleanup.rs
+++ b/src-tauri/src/modules/pty/cleanup.rs
@@ -1,0 +1,145 @@
+//! Sweeps orphan PowerShell / pwsh processes left over by previous Terax
+//! instances. ConPTY + portable-pty has a known intermittent race where the
+//! child shell gets stuck mid-init at a tiny working set, never reaching the
+//! prompt. When Terax dies ungracefully (crash, dev HMR force-kill, Ctrl-C of
+//! `cargo run`) before its `pty_close` path runs, the Job Object's
+//! `KILL_ON_JOB_CLOSE` does fire — but only for clean Drops. Force-killed
+//! parents leave the shells parentless and stuck, and they accumulate across
+//! sessions until they degrade subsequent ConPTY spawns.
+//!
+//! On startup we enumerate processes once and terminate any pwsh/powershell
+//! whose parent PID is no longer alive *and* whose working set is below
+//! [`STUCK_WS_THRESHOLD`]. A healthy interactive PowerShell sits well above
+//! 50 MB once its runtime is loaded — a sub-5-MB process is the stuck-init
+//! signature we observed and not useful to anyone.
+
+#![cfg(windows)]
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+
+use windows_sys::Win32::Foundation::{CloseHandle, FALSE};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+};
+use windows_sys::Win32::System::ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
+use windows_sys::Win32::System::Threading::{
+    OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+};
+
+// 5 MB. Healthy PowerShell is 50+ MB; pwsh 7 is 60+ MB. A shell that has been
+// alive long enough to enumerate here but is still under this threshold is in
+// the stuck-init state and won't recover.
+const STUCK_WS_THRESHOLD: usize = 5 * 1024 * 1024;
+
+struct Entry {
+    pid: u32,
+    parent_pid: u32,
+    name: String,
+}
+
+/// Terminate orphaned ConPTY-spawned shells from prior Terax sessions.
+/// Safe to call at any time; idempotent. Logs each termination.
+pub fn sweep_orphan_shells() {
+    let entries = enumerate_processes();
+    let live: HashSet<u32> = entries.iter().map(|e| e.pid).collect();
+
+    let mut killed = 0u32;
+    for e in &entries {
+        if !is_shell(&e.name) {
+            continue;
+        }
+        // Parent still alive? Not an orphan — leave it alone, it may belong
+        // to the current Terax process or another live instance.
+        if live.contains(&e.parent_pid) {
+            continue;
+        }
+        let Some(ws) = working_set_bytes(e.pid) else {
+            continue;
+        };
+        if ws >= STUCK_WS_THRESHOLD {
+            continue;
+        }
+        if terminate(e.pid) {
+            killed += 1;
+            log::info!(
+                "swept orphan shell pid={} name={} ws={}KB",
+                e.pid,
+                e.name,
+                ws / 1024
+            );
+        }
+    }
+    if killed > 0 {
+        log::info!("sweep_orphan_shells: terminated {killed} orphan(s)");
+    }
+}
+
+fn is_shell(name: &str) -> bool {
+    name.eq_ignore_ascii_case("pwsh.exe") || name.eq_ignore_ascii_case("powershell.exe")
+}
+
+fn enumerate_processes() -> Vec<Entry> {
+    let mut out = Vec::new();
+    unsafe {
+        let snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snap.is_null() {
+            return out;
+        }
+        let mut pe: PROCESSENTRY32W = std::mem::zeroed();
+        pe.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        if Process32FirstW(snap, &mut pe) != 0 {
+            loop {
+                let name = wide_to_string(&pe.szExeFile);
+                out.push(Entry {
+                    pid: pe.th32ProcessID,
+                    parent_pid: pe.th32ParentProcessID,
+                    name,
+                });
+                if Process32NextW(snap, &mut pe) == 0 {
+                    break;
+                }
+            }
+        }
+        CloseHandle(snap);
+    }
+    out
+}
+
+fn working_set_bytes(pid: u32) -> Option<usize> {
+    unsafe {
+        let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+        if h.is_null() {
+            return None;
+        }
+        let mut counters: PROCESS_MEMORY_COUNTERS = std::mem::zeroed();
+        let cb = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        let ok = GetProcessMemoryInfo(h, &mut counters, cb);
+        CloseHandle(h);
+        if ok == 0 {
+            None
+        } else {
+            Some(counters.WorkingSetSize)
+        }
+    }
+}
+
+fn terminate(pid: u32) -> bool {
+    unsafe {
+        let h = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+        if h.is_null() {
+            return false;
+        }
+        let ok = TerminateProcess(h, 1) != 0;
+        CloseHandle(h);
+        ok
+    }
+}
+
+fn wide_to_string(wide: &[u16]) -> String {
+    let len = wide.iter().position(|&c| c == 0).unwrap_or(wide.len());
+    OsString::from_wide(&wide[..len])
+        .into_string()
+        .unwrap_or_default()
+}

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -1,7 +1,12 @@
 #[cfg(windows)]
+mod cleanup;
+#[cfg(windows)]
 mod job;
 mod session;
 pub(crate) mod shell_init;
+
+#[cfg(windows)]
+pub use cleanup::sweep_orphan_shells;
 
 use std::collections::HashMap;
 use std::io::Write;


### PR DESCRIPTION
## What

On Windows startup, terminate any orphaned pwsh/powershell process whose parent PID is gone and whose working set is below 5 MB.

## Why

ConPTY + portable-pty has an intermittent race where the spawned shell gets stuck mid-init at ~2 MB, never reaching the prompt. When a prior Terax died ungracefully (crash, dev HMR force-kill, Ctrl-C of `cargo run`), its Job-Object `KILL_ON_JOB_CLOSE` doesn't fire and those stuck shells survive. They hold ConPTY resources and degrade subsequent spawns until manually killed.

Observed locally: 8+ orphan conhost + multiple 2 MB pwsh.exe accumulated after a few dev restarts; fresh Terax launches then hit the same stuck-init pattern. Manually killing the orphans restores normal behavior.

## How

`src-tauri/src/modules/pty/cleanup.rs` (new, Windows-only)
- Enumerate processes via `CreateToolhelp32Snapshot`.
- For each pwsh.exe / powershell.exe entry, terminate if:
  - parent PID is not in the live PID set, **and**
  - working set is below 5 MB (`GetProcessMemoryInfo`).
- Healthy PowerShell is 50+ MB and pwsh 7 is 60+ MB once initialized, so a sub-5-MB process is the stuck-init signature.
- Live shells (including those owned by other running Terax instances) are left alone — we only touch processes whose parent is gone.

`src-tauri/src/modules/pty/mod.rs`
- Mount the new module and re-export `sweep_orphan_shells`.

`src-tauri/src/lib.rs`
- Call `pty::sweep_orphan_shells()` at the top of `run()` before the Tauri builder, so it executes before any new PTY can be opened.

`src-tauri/Cargo.toml`
- Extend `windows-sys` features with `Win32_System_Diagnostics_ToolHelp` and `Win32_System_ProcessStatus`. No new crate dependency.

Net diff: +157 across 4 files.

## Testing

- `cargo check` clean
- `cargo clippy --all-targets` clean on touched files (only pre-existing `secrets.rs::manual_ok_err` warning remains)
- `rustfmt --check` on touched files clean
- Manually reproduced orphan state on Windows 10 22H2 by force-killing a dev Terax with split panes open; observed multiple 2 MB pwsh.exe + leftover conhost. Built and launched terax with the patch; on startup the sweep log fires (`swept orphan shell pid=... ws=N KB`) and the stuck shells are gone before the new pane spawns.

- [x] `cargo check` clean
- [x] `cargo clippy` clean on touched files
- [x] `rustfmt --check` clean on touched files
- [x] Manual repro + sweep verified on Windows 10 22H2

## Screenshots / GIFs

No visual change; backend-only.

## Notes for reviewer

- Heuristic is conservative — orphans with WS >= 5 MB are left alone, so a legitimately stuck shell that has paged in its runtime survives. That trades coverage for safety against killing third-party processes that happen to be PowerShell.
- The `is_shell` check is name-only; it does not look at command line. Adding a command-line check would tighten the filter but requires `NtQueryInformationProcess` and reading another process's PEB.
- Complements #150 (Drop-path Job-first ordering) — that one prevents producing new orphans; this one cleans up the ones already on disk from prior runs.