### PR TITLE
feat(terminal): add WebGL toggle and font-size preferences

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -49,6 +49,8 @@ export type Preferences = {
   autocompleteModelId: string;
   lmstudioBaseURL: string;
   vimMode: boolean;
+  terminalWebglEnabled: boolean;
+  terminalFontSize: number;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
 
@@ -64,7 +66,13 @@ const KEY_AUTOCOMPLETE_PROVIDER = "autocompleteProvider";
 const KEY_AUTOCOMPLETE_MODEL = "autocompleteModelId";
 const KEY_LMSTUDIO_BASE_URL = "lmstudioBaseURL";
 const KEY_VIM_MODE = "vimMode";
+const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
+const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_SHORTCUTS = "shortcuts";
+
+export const TERMINAL_FONT_SIZE_DEFAULT = 14;
+export const TERMINAL_FONT_SIZE_MIN = 8;
+export const TERMINAL_FONT_SIZE_MAX = 32;
 
 export const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
@@ -78,6 +86,8 @@ export const DEFAULT_PREFERENCES: Preferences = {
   autocompleteModelId: DEFAULT_AUTOCOMPLETE_MODEL.cerebras,
   lmstudioBaseURL: LMSTUDIO_DEFAULT_BASE_URL,
   vimMode: false,
+  terminalWebglEnabled: true,
+  terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
 
@@ -126,6 +136,12 @@ export async function loadPreferences(): Promise<Preferences> {
     lmstudioBaseURL:
       get<string>(KEY_LMSTUDIO_BASE_URL) ?? DEFAULT_PREFERENCES.lmstudioBaseURL,
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
+    terminalWebglEnabled:
+      get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
+      DEFAULT_PREFERENCES.terminalWebglEnabled,
+    terminalFontSize:
+      get<number>(KEY_TERMINAL_FONT_SIZE) ??
+      DEFAULT_PREFERENCES.terminalFontSize,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -178,6 +194,20 @@ export async function setVimMode(value: boolean): Promise<void> {
   await writePref(KEY_VIM_MODE, value);
 }
 
+export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
+}
+
+export async function setTerminalFontSize(value: number): Promise<void> {
+  const clamped = Number.isFinite(value)
+    ? Math.min(
+        TERMINAL_FONT_SIZE_MAX,
+        Math.max(TERMINAL_FONT_SIZE_MIN, Math.round(value)),
+      )
+    : TERMINAL_FONT_SIZE_DEFAULT;
+  await writePref(KEY_TERMINAL_FONT_SIZE, clamped);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {}
 ): Promise<void> {
@@ -208,6 +238,8 @@ export async function onPreferencesChange(
     [KEY_AUTOCOMPLETE_MODEL]: "autocompleteModelId",
     [KEY_LMSTUDIO_BASE_URL]: "lmstudioBaseURL",
     [KEY_VIM_MODE]: "vimMode",
+    [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
+    [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_SHORTCUTS]: "shortcuts",
   };
   // Same-process writes still fire onChange immediately; cross-window writes

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -74,6 +74,10 @@ export const TERMINAL_FONT_SIZE_DEFAULT = 14;
 export const TERMINAL_FONT_SIZE_MIN = 8;
 export const TERMINAL_FONT_SIZE_MAX = 32;
 
+export const TERMINAL_FONT_SIZES = [
+  10, 12, 13, 14, 15, 16, 18, 20, 22, 24,
+] as const;
+
 export const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
   defaultModelId: DEFAULT_MODEL_ID,

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -51,7 +51,7 @@ type Session = {
   lastDetectedUrl: string | null;
   pendingExit: number | null;
   webglEnabled: boolean;
-  webglLoaded: boolean;
+  webglAddon: WebglAddon | null;
   ready: Promise<void>;
   disposed: boolean;
   initialCwd: string | undefined;
@@ -109,7 +109,7 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     lastDetectedUrl: null,
     pendingExit: null,
     webglEnabled,
-    webglLoaded: false,
+    webglAddon: null,
     ready: Promise.resolve(),
     disposed: false,
     initialCwd,
@@ -247,12 +247,15 @@ function attachSession(
   s.lastW = container.clientWidth;
   s.lastH = container.clientHeight;
 
-  if (firstAttach && !s.webglLoaded && s.webglEnabled) {
+  if (firstAttach && !s.webglAddon && s.webglEnabled) {
     try {
       const webgl = new WebglAddon();
-      webgl.onContextLoss(() => webgl.dispose());
+      webgl.onContextLoss(() => {
+        webgl.dispose();
+        if (s.webglAddon === webgl) s.webglAddon = null;
+      });
       s.term.loadAddon(webgl);
-      s.webglLoaded = true;
+      s.webglAddon = webgl;
     } catch (e) {
       console.warn("WebGL renderer unavailable:", e);
     }
@@ -440,6 +443,39 @@ export function useTerminalSession({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leafId]);
+
+  const fontSize = usePreferencesStore((p) => p.terminalFontSize);
+  useEffect(() => {
+    const s = sessions.get(leafId);
+    if (!s) return;
+    if (s.term.options.fontSize === fontSize) return;
+    s.term.options.fontSize = fontSize;
+    s.fitAddon.fit();
+  }, [leafId, fontSize]);
+
+  const webglPref = usePreferencesStore((p) => p.terminalWebglEnabled);
+  useEffect(() => {
+    const s = sessions.get(leafId);
+    if (!s) return;
+    s.webglEnabled = webglPref;
+    if (!s.term.element) return;
+    if (webglPref && !s.webglAddon) {
+      try {
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => {
+          webgl.dispose();
+          if (s.webglAddon === webgl) s.webglAddon = null;
+        });
+        s.term.loadAddon(webgl);
+        s.webglAddon = webgl;
+      } catch (e) {
+        console.warn("WebGL renderer unavailable:", e);
+      }
+    } else if (!webglPref && s.webglAddon) {
+      s.webglAddon.dispose();
+      s.webglAddon = null;
+    }
+  }, [leafId, webglPref]);
 
   useLayoutEffect(() => {
     if (!visible) return;

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,4 +1,5 @@
 import { detectMonoFontFamily } from "@/lib/fonts";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
@@ -17,7 +18,6 @@ import { openPty, type PtySession } from "./pty-bridge";
 
 export type { TeraxOpenInput };
 
-const FONT_SIZE = 14;
 const BACKWARD_KILL_WORD = "\x17";
 
 const LOCAL_URL_RE =
@@ -50,6 +50,7 @@ type Session = {
   lastCwd: string | null;
   lastDetectedUrl: string | null;
   pendingExit: number | null;
+  webglEnabled: boolean;
   webglLoaded: boolean;
   ready: Promise<void>;
   disposed: boolean;
@@ -63,9 +64,13 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
   const existing = sessions.get(leafId);
   if (existing) return existing;
 
+  const prefs = usePreferencesStore.getState();
+  const webglEnabled = prefs.terminalWebglEnabled;
+  const fontSize = prefs.terminalFontSize;
+
   const term = new Terminal({
     fontFamily: detectMonoFontFamily(),
-    fontSize: FONT_SIZE,
+    fontSize,
     lineHeight: 1.05,
     theme: buildTerminalTheme(),
     cursorBlink: true,
@@ -103,6 +108,7 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     lastCwd: null,
     lastDetectedUrl: null,
     pendingExit: null,
+    webglEnabled,
     webglLoaded: false,
     ready: Promise.resolve(),
     disposed: false,
@@ -241,7 +247,7 @@ function attachSession(
   s.lastW = container.clientWidth;
   s.lastH = container.clientHeight;
 
-  if (firstAttach && !s.webglLoaded) {
+  if (firstAttach && !s.webglLoaded && s.webglEnabled) {
     try {
       const webgl = new WebglAddon();
       webgl.onContextLoss(() => webgl.dispose());

--- a/src/settings/components/SettingRow.tsx
+++ b/src/settings/components/SettingRow.tsx
@@ -1,7 +1,8 @@
 import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
 
 type Props = {
-  title: string;
+  title: ReactNode;
   description?: string;
   children: React.ReactNode;
   className?: string;

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -6,6 +6,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { ThemePref } from "@/modules/settings/store";
@@ -167,8 +173,27 @@ export function GeneralSection() {
       <div className="flex flex-col gap-2">
         <Label>Terminal</Label>
         <SettingRow
-          title="Use WebGL renderer"
-          description="Accelerate rendering with the GPU. Turn off if the terminal text shows corruption or blank tiles."
+          title={
+            <span className="inline-flex items-center gap-1.5">
+              Use WebGL renderer
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="cursor-help text-[11px] text-muted-foreground/70 leading-none"
+                      aria-label="More info about WebGL renderer"
+                    >
+                      ⓘ
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-[260px] text-[11px]">
+                    xterm's WebGL renderer caches glyphs in a GPU texture atlas. On some macOS setups (especially with Nerd Fonts), the atlas corrupts and terminal text becomes unreadable. Turn this off as a fallback — performance dips slightly, but text renders correctly via the DOM renderer.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </span>
+          }
+          description="Hardware-accelerated rendering. Turn off if text shows corruption or blank tiles."
         >
           <Switch
             checked={terminalWebglEnabled}
@@ -183,7 +208,7 @@ export function GeneralSection() {
             <DropdownMenuTrigger asChild>
               <Button
                 variant="outline"
-                className="h-8 justify-between gap-2 px-2.5 text-[12px]"
+                className="h-8 justify-between gap-2 rounded-none px-2.5 text-[12px]"
               >
                 <span>{terminalFontSize} px</span>
                 <HugeiconsIcon
@@ -194,13 +219,16 @@ export function GeneralSection() {
                 />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-[80px]">
+            <DropdownMenuContent
+              align="end"
+              className="min-w-[80px] rounded-none border border-border bg-popover p-0 shadow-none ring-0"
+            >
               {TERMINAL_FONT_SIZES.map((size) => (
                 <DropdownMenuItem
                   key={size}
                   onSelect={() => onPickTerminalFontSize(size)}
                   className={cn(
-                    "text-[12px]",
+                    "rounded-none px-3 py-1.5 text-[12px]",
                     size === terminalFontSize && "bg-accent/50",
                   )}
                 >

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,8 +12,7 @@ import type { ThemePref } from "@/modules/settings/store";
 import {
   EDITOR_THEME_LABELS,
   EDITOR_THEMES,
-  TERMINAL_FONT_SIZE_MAX,
-  TERMINAL_FONT_SIZE_MIN,
+  TERMINAL_FONT_SIZES,
   setAutostart,
   setEditorTheme,
   setRestoreWindowState,
@@ -32,7 +30,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { SectionHeader } from "../components/SectionHeader";
 import { SettingRow } from "../components/SettingRow";
 
@@ -56,15 +54,6 @@ export function GeneralSection() {
     (s) => s.terminalWebglEnabled,
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
-  const [fontSizeDraft, setFontSizeDraft] = useState(() =>
-    String(terminalFontSize),
-  );
-  const [editingFontSize, setEditingFontSize] = useState(false);
-
-  useEffect(() => {
-    if (editingFontSize) return;
-    setFontSizeDraft(String(terminalFontSize));
-  }, [editingFontSize, terminalFontSize]);
 
   // Reconcile autostart pref with the actual OS state on mount — the user may
   // have toggled it from System Settings.
@@ -101,38 +90,7 @@ export function GeneralSection() {
     );
   };
 
-  const onFontSizeChange = (value: string) => {
-    setFontSizeDraft(value);
-    const n = Number(value);
-    if (
-      !Number.isFinite(n) ||
-      n < TERMINAL_FONT_SIZE_MIN ||
-      n > TERMINAL_FONT_SIZE_MAX
-    )
-      return;
-    void setTerminalFontSize(Math.round(n)).catch((e) =>
-      console.error("terminal font size preference update failed", e),
-    );
-  };
-
-  const commitFontSize = () => {
-    const n = Number(fontSizeDraft);
-    if (
-      !Number.isFinite(n) ||
-      n < TERMINAL_FONT_SIZE_MIN ||
-      n > TERMINAL_FONT_SIZE_MAX
-    ) {
-      setFontSizeDraft(String(terminalFontSize));
-      setEditingFontSize(false);
-      return;
-    }
-    const clamped = Math.round(n);
-    void setTerminalFontSize(clamped).catch((e) =>
-      console.error("terminal font size preference update failed", e),
-    );
-    setFontSizeDraft(String(clamped));
-    setEditingFontSize(false);
-  };
+  const onPickTerminalFontSize = (size: number) => void setTerminalFontSize(size);
 
   return (
     <div className="flex flex-col gap-6">
@@ -210,7 +168,7 @@ export function GeneralSection() {
         <Label>Terminal</Label>
         <SettingRow
           title="Use WebGL renderer"
-          description="Accelerates rendering using the GPU. Turn off if terminal text flickers, looks corrupted, or shows blank tiles. Applies to new terminal sessions."
+          description="Accelerate rendering with the GPU. Turn off if the terminal text shows corruption or blank tiles."
         >
           <Switch
             checked={terminalWebglEnabled}
@@ -219,25 +177,38 @@ export function GeneralSection() {
         </SettingRow>
         <SettingRow
           title="Font size"
-          description="Terminal text size in pixels. Applies to new terminal sessions."
+          description="Terminal text size."
         >
-          <div className="flex items-center gap-2">
-            <Input
-              type="number"
-              min={TERMINAL_FONT_SIZE_MIN}
-              max={TERMINAL_FONT_SIZE_MAX}
-              step={1}
-              value={fontSizeDraft}
-              onFocus={() => setEditingFontSize(true)}
-              onChange={(e) => onFontSizeChange(e.currentTarget.value)}
-              onBlur={commitFontSize}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") commitFontSize();
-              }}
-              className="h-8 w-16 rounded-lg px-2 text-center text-[12px]"
-            />
-            <span className="text-[11px] text-muted-foreground">px</span>
-          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="h-8 justify-between gap-2 px-2.5 text-[12px]"
+              >
+                <span>{terminalFontSize} px</span>
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  size={12}
+                  strokeWidth={2}
+                  className="opacity-70"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-[80px]">
+              {TERMINAL_FONT_SIZES.map((size) => (
+                <DropdownMenuItem
+                  key={size}
+                  onSelect={() => onPickTerminalFontSize(size)}
+                  className={cn(
+                    "text-[12px]",
+                    size === terminalFontSize && "bg-accent/50",
+                  )}
+                >
+                  {size} px
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </SettingRow>
       </div>
 

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,9 +13,13 @@ import type { ThemePref } from "@/modules/settings/store";
 import {
   EDITOR_THEME_LABELS,
   EDITOR_THEMES,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
   setAutostart,
   setEditorTheme,
   setRestoreWindowState,
+  setTerminalFontSize,
+  setTerminalWebglEnabled,
   setVimMode,
   type EditorThemeId,
 } from "@/modules/settings/store";
@@ -27,7 +32,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { SectionHeader } from "../components/SectionHeader";
 import { SettingRow } from "../components/SettingRow";
 
@@ -47,6 +52,19 @@ export function GeneralSection() {
   const autostart = usePreferencesStore((s) => s.autostart);
   const restoreWindowState = usePreferencesStore((s) => s.restoreWindowState);
   const vimMode = usePreferencesStore((s) => s.vimMode);
+  const terminalWebglEnabled = usePreferencesStore(
+    (s) => s.terminalWebglEnabled,
+  );
+  const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
+  const [fontSizeDraft, setFontSizeDraft] = useState(() =>
+    String(terminalFontSize),
+  );
+  const [editingFontSize, setEditingFontSize] = useState(false);
+
+  useEffect(() => {
+    if (editingFontSize) return;
+    setFontSizeDraft(String(terminalFontSize));
+  }, [editingFontSize, terminalFontSize]);
 
   // Reconcile autostart pref with the actual OS state on mount — the user may
   // have toggled it from System Settings.
@@ -76,6 +94,45 @@ export function GeneralSection() {
   };
 
   const onPickEditor = (id: EditorThemeId) => void setEditorTheme(id);
+
+  const onToggleTerminalWebgl = (next: boolean) => {
+    void setTerminalWebglEnabled(next).catch((e) =>
+      console.error("terminal WebGL preference update failed", e),
+    );
+  };
+
+  const onFontSizeChange = (value: string) => {
+    setFontSizeDraft(value);
+    const n = Number(value);
+    if (
+      !Number.isFinite(n) ||
+      n < TERMINAL_FONT_SIZE_MIN ||
+      n > TERMINAL_FONT_SIZE_MAX
+    )
+      return;
+    void setTerminalFontSize(Math.round(n)).catch((e) =>
+      console.error("terminal font size preference update failed", e),
+    );
+  };
+
+  const commitFontSize = () => {
+    const n = Number(fontSizeDraft);
+    if (
+      !Number.isFinite(n) ||
+      n < TERMINAL_FONT_SIZE_MIN ||
+      n > TERMINAL_FONT_SIZE_MAX
+    ) {
+      setFontSizeDraft(String(terminalFontSize));
+      setEditingFontSize(false);
+      return;
+    }
+    const clamped = Math.round(n);
+    void setTerminalFontSize(clamped).catch((e) =>
+      console.error("terminal font size preference update failed", e),
+    );
+    setFontSizeDraft(String(clamped));
+    setEditingFontSize(false);
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -146,6 +203,41 @@ export function GeneralSection() {
             checked={vimMode}
             onCheckedChange={(v) => void setVimMode(v)}
           />
+        </SettingRow>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label>Terminal</Label>
+        <SettingRow
+          title="Use WebGL renderer"
+          description="Accelerates rendering using the GPU. Turn off if terminal text flickers, looks corrupted, or shows blank tiles. Applies to new terminal sessions."
+        >
+          <Switch
+            checked={terminalWebglEnabled}
+            onCheckedChange={onToggleTerminalWebgl}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Font size"
+          description="Terminal text size in pixels. Applies to new terminal sessions."
+        >
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              min={TERMINAL_FONT_SIZE_MIN}
+              max={TERMINAL_FONT_SIZE_MAX}
+              step={1}
+              value={fontSizeDraft}
+              onFocus={() => setEditingFontSize(true)}
+              onChange={(e) => onFontSizeChange(e.currentTarget.value)}
+              onBlur={commitFontSize}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitFontSize();
+              }}
+              className="h-8 w-16 rounded-lg px-2 text-center text-[12px]"
+            />
+            <span className="text-[11px] text-muted-foreground">px</span>
+          </div>
         </SettingRow>
       </div>
 


### PR DESCRIPTION
## What
Adds Terminal preferences under Settings → General → Terminal:

- **Use WebGL renderer** — switch the renderer off when the WebGL glyph atlas corrupts text on your setup (some macOS + Nerd Font combinations).
- **Font size** — dropdown of common sizes (10–24 px).

Both preferences apply **live** to existing terminal sessions as well as new ones.

Closes #30.

## Why
On some macOS setups the xterm WebGL renderer corrupts the glyph atlas with certain Nerd Fonts, leaving the terminal unreadable. Issue #30 confirms toggling WebGL off restores readable text; this PR exposes that toggle to users while keeping WebGL on by default for everyone else.

PR #31 attempted this but didn't land cleanly against the refactored session model. This rebuild respects the #31 review — `detectMonoFontFamily()` and `lineHeight: 1.05` are unchanged.

## How
- `src/modules/settings/store.ts` — adds `terminalWebglEnabled` and `terminalFontSize` prefs plus a `TERMINAL_FONT_SIZES` preset list. Cross-window prefs sync via the existing `writePref` + `PREFS_CHANGED_EVENT` plumbing.
- `src/modules/terminal/lib/useTerminalSession.ts` — reactive effects watch both prefs and apply live: font size via `term.options.fontSize` + refit; WebGL via addon load/dispose (with a `term.element` guard so it skips before first attach).
- `src/settings/sections/GeneralSection.tsx` — Switch for WebGL, DropdownMenu of preset sizes matching the existing Editor theme dropdown style.

## Testing
- [x] `pnpm tauri dev` builds and boots clean on a fresh clone of the branch.
- [x] `tsc --noEmit` clean for all new identifiers.
- [x] WebGL toggle applies live — addon disposes/reloads on toggle.
- [x] Font-size dropdown applies live to existing tabs (no need to reopen).
- [x] Defaults match prior behaviour (WebGL on, 14 px).

Screenshots in a follow-up comment.