### PR TITLE
fix(tabs): don't silently drop unsaved edits when file is deleted

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -157,6 +157,9 @@ export default function App() {
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
   const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
+  const [pendingDeleteTabs, setPendingDeleteTabs] = useState<number[] | null>(
+    null,
+  );
   useEffect(() => {
     // Forward-slash form so explorerRoot stays equal across home → OSC 7.
     homeDir()
@@ -561,14 +564,30 @@ export default function App() {
     [tabs, updateTab],
   );
 
+  const confirmDeleteClose = useCallback(() => {
+    if (pendingDeleteTabs !== null) {
+      for (const id of pendingDeleteTabs) disposeTab(id);
+      setPendingDeleteTabs(null);
+    }
+  }, [pendingDeleteTabs, disposeTab]);
+
+  const cancelDeleteClose = useCallback(() => {
+    setPendingDeleteTabs(null);
+  }, []);
+
   const handlePathDeleted = useCallback(
     (path: string) => {
+      const dirty: number[] = [];
       for (const t of tabs) {
         if (t.kind !== "editor") continue;
-        if (t.path === path || t.path.startsWith(`${path}/`)) {
+        if (t.path !== path && !t.path.startsWith(`${path}/`)) continue;
+        if (t.dirty) {
+          dirty.push(t.id);
+        } else {
           disposeTab(t.id);
         }
       }
+      if (dirty.length > 0) setPendingDeleteTabs(dirty);
     },
     [tabs, disposeTab],
   );
@@ -991,6 +1010,37 @@ export default function App() {
                   Cancel
                 </AlertDialogCancel>
                 <AlertDialogAction onClick={confirmClose}>
+                  Close Anyway
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <AlertDialog
+            open={pendingDeleteTabs !== null}
+            onOpenChange={(open) => !open && cancelDeleteClose()}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {pendingDeleteTabs?.length === 1
+                    ? (() => {
+                        const title = tabs.find(
+                          (t) => t.id === pendingDeleteTabs[0],
+                        )?.title;
+                        return title
+                          ? `"${title}" has unsaved changes. The file has been deleted. Close anyway?`
+                          : "This file has unsaved changes. The file has been deleted. Close anyway?";
+                      })()
+                    : `${pendingDeleteTabs?.length ?? 0} files have unsaved changes. They have been deleted. Close all anyway?`}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={cancelDeleteClose}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction onClick={confirmDeleteClose}>
                   Close Anyway
                 </AlertDialogAction>
               </AlertDialogFooter>


### PR DESCRIPTION
## What
Was working on #163 and noticed deleting a file from the explorer silently throws away unsaved edits in the open editor tab. This routes that path through the existing "Unsaved Changes" dialog so you get a prompt first.

## Why
`handleClose` already checks `t.dirty` and pops the dialog. `handlePathDeleted` skips that check and calls `disposeTab` directly — so if you delete the file (or a folder containing dirty editors) from the explorer, the buffer disappears with no warning. Folder delete is worse, can wipe several dirty tabs at once.

Repro on `main`:
1. Open any file in the editor.
2. Type a char so the dirty dot appears on the tab.
3. Right-click that file in the explorer → Delete → confirm.
4. Tab closes, buffer is gone, no warning.

## How
- Added a `pendingDeleteTabs` state next to the existing `pendingCloseTab`.
- `handlePathDeleted` now splits matched tabs into dirty vs clean. Clean ones dispose immediately (unchanged); dirty ones queue into a prompt.
- Reuses the existing `AlertDialog` so it matches the close-button flow. Wording handles single tab vs multiple.
- Cancel keeps the tab open so you can Save As somewhere else. Close Anyway disposes them all.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] dirty editor + delete file → prompt appears, Cancel keeps it, Close Anyway disposes
- [x] clean editor + delete → tab closes as before, no dialog
- [x] delete parent folder with multiple dirty editors → single prompt with the count, Close Anyway disposes all
- [x] cargo check — n/a, no Rust changes

## Screenshot
The new dialog shown after deleting a dirty file from the explorer.

<img width="1011" height="714" alt="Screenshot 2026-05-12 at 04 07 03" src="https://github.com/user-attachments/assets/63a04d79-f230-4671-84d2-c5e8ead26a92" />


## Notes
Diff is one file. Did not touch `handleClose` / `confirmClose` / `cancelClose`. Happy to tweak the dialog wording if you would prefer something different.