### PR TITLE
fix(ai): respect keyless providers in model picker onPick and header

### DIFF
--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -200,10 +200,12 @@ function ModelDropdown() {
   const apiKeys = useChatStore((s) => s.apiKeys);
   const setSelected = useChatStore((s) => s.setSelectedModelId);
   const current = getModel(selected);
-  const currentProviderHasKey = !!apiKeys[current.provider];
+  const currentProviderHasKey = providerNeedsKey(current.provider)
+    ? !!apiKeys[current.provider]
+    : true;
 
   const onPick = (id: ModelId, providerId: ProviderId) => {
-    if (!apiKeys[providerId]) {
+    if (providerNeedsKey(providerId) && !apiKeys[providerId]) {
       void openSettingsWindow("models");
       return;
     }


### PR DESCRIPTION
LM Studio is now actually selectable from the chat model dropdown. Closes #140.

## Why
LM Studio is a keyless local server — it does not need an API key. PR #74 fixed the visibility side (LM Studio no longer shows as greyed-out or asks you to "Set key…"). Two parallel checks in the same dropdown were missed:

- Clicking **"LM Studio (local)"** in the dropdown routed to Settings instead of selecting it, because the click handler did `if (!apiKeys[providerId])` and LM Studio key is always null.
- Whenever LM Studio was the active model, the dropdown header used the amber "no key configured" styling for the same reason.

So users saw LM Studio in the picker but could not actually pick it — which is what #140 reports (multiple people confirmed in comments).

## How
Both checks now use `providerNeedsKey()` — the same helper #74 introduced. Two-line change inside `ModelDropdown`.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual: click "LM Studio (local)" → becomes selected model, header updates, no jump to Settings
- [x] Manual: with LM Studio active, header is no longer amber
- [x] Manual: clicking a real keyed provider with no key still routes to Settings — unchanged behaviour
- [x] cargo check — n/a, no Rust changes

## Relationship to #141
#141 is an open redesign of this same `ModelDropdown` (provider sidebar + search). The rewrite happens to fix the click-routing half of this bug as a side effect, but leaves `currentProviderHasKey` untouched at line 203, so the header amber-styling bug persists in that PR. Either ordering works: if this lands first, #141 needs to rebase (small conflict on the line we both touch); if #141 lands first, I will rebase this down to a one-liner that only fixes `currentProviderHasKey`. Happy either way.

## Screenshot
After: clicking "LM Studio (local)" in the dropdown now actually selects it (header updates, no jump to Settings).

<!-- drop screenshot here -->

## Notes
Scoped to `ModelDropdown` in `AiStatusBarControls.tsx`. Same pattern #74 already uses one block below for the per-provider header label.