### PR TITLE
fix(terminal): ensure UTF-8 encoding for PowerShell and shell locale

### DIFF
--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -4,6 +4,12 @@
 if ($global:__TERAX_HOOKS_LOADED) { return }
 $global:__TERAX_HOOKS_LOADED = $true
 
+try {
+    [Console]::InputEncoding  = [System.Text.UTF8Encoding]::new($false)
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $global:OutputEncoding    = [System.Text.UTF8Encoding]::new($false)
+} catch {}
+
 if (Test-Path Function:prompt) {
     Copy-Item Function:prompt Function:__terax_user_prompt -Force -ErrorAction SilentlyContinue
 }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -13,10 +13,31 @@ pub fn build_command(cwd: Option<String>) -> Result<CommandBuilder, String> {
     }
 }
 
+fn ensure_utf8_locale(cmd: &mut CommandBuilder) {
+    let is_utf8 = |v: &str| {
+        let up = v.to_ascii_uppercase();
+        up.contains("UTF-8") || up.contains("UTF8")
+    };
+    let already_utf8 = ["LC_ALL", "LC_CTYPE", "LANG"]
+        .iter()
+        .any(|k| std::env::var(k).ok().as_deref().is_some_and(is_utf8));
+    if already_utf8 {
+        return;
+    }
+    #[cfg(target_os = "macos")]
+    let fallback = "en_US.UTF-8";
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let fallback = "C.UTF-8";
+    #[cfg(windows)]
+    let fallback = "en_US.UTF-8";
+    cmd.env("LANG", fallback);
+}
+
 fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     cmd.env("TERAX_TERMINAL", "1");
+    ensure_utf8_locale(cmd);
 
     let resolved_cwd = cwd
         .map(PathBuf::from)


### PR DESCRIPTION
## What
Ensure UTF-8 encoding is properly configured for PowerShell and shell startup.

## Why
When system locale is not UTF-8, PowerShell may display Chinese characters incorrectly. Explicitly setting encoding ensures consistent output.

## How
- profile.ps1: Set [Console]::InputEncoding and [Console]::OutputEncoding to UTF-8
- shell_init.rs: Add ensure_utf8_locale() function that detects and sets LANG env var at startup

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
From

<img width="1076" height="48" alt="image" src="https://github.com/user-attachments/assets/c9899cd8-43cf-4205-8512-46a0f11ddfeb" />

to

<img width="818" height="44" alt="image" src="https://github.com/user-attachments/assets/5a5c48e6-e366-467a-a723-50b6c4590fc0" />

## Notes for reviewer
Cross-platform: macOS uses en_US.UTF-8, Linux uses C.UTF-8, Windows falls back to en_US.UTF-8.
