### PR TITLE
fix(pty): inherit launch cwd for first shell

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,6 +89,8 @@ pub fn run() {
     #[cfg(target_os = "linux")]
     apply_wayland_webkit_workaround();
 
+    pty::shell_init::capture_startup_cwd();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -1,6 +1,27 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use portable_pty::CommandBuilder;
+
+static STARTUP_CWD: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+pub fn capture_startup_cwd() {
+    let _ = STARTUP_CWD.set(detect_startup_cwd());
+}
+
+fn detect_startup_cwd() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    if !cwd.is_dir() || cwd == Path::new("/") {
+        return None;
+    }
+    if dirs::home_dir().as_deref() == Some(&cwd) {
+        return None;
+    }
+    if cwd.to_string_lossy().contains(".app/Contents/") {
+        return None;
+    }
+    Some(cwd)
+}
 
 pub fn build_command(cwd: Option<String>) -> Result<CommandBuilder, String> {
     #[cfg(unix)]
@@ -21,6 +42,7 @@ fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
     let resolved_cwd = cwd
         .map(PathBuf::from)
         .filter(|p| p.is_dir())
+        .or_else(|| STARTUP_CWD.get().and_then(|c| c.clone()))
         .or_else(|| dirs::home_dir().filter(|p| p.is_dir()))
         .or_else(|| std::env::current_dir().ok());
     if let Some(cwd) = resolved_cwd {


### PR DESCRIPTION
## What
First PTY now inherits app's launch cwd instead of always falling to \$HOME.

## Why
Closes #168. Launching \`terax\` from a project dir (Linux/WSL CLI, \`open -a Terax /path\` on macOS) lands shell in \$HOME, ignoring where user invoked from.

Frontend passes \`cwd: null\` on cold start (no OSC 7 yet). Old fallback in \`apply_common\` picked \`home_dir\` before \`current_dir\`, so launch cwd was lost.

## How
- \`capture_startup_cwd()\` snapshots \`current_dir()\` once at app boot before any plugin can chdir.
- New fallback order: explicit cwd → captured startup cwd → home → live current_dir.
- Filters out \`/\`, macOS \`.app/Contents/\` bundle path, and home (no-op) so GUI launches still get home.

## Testing
Verified on macOS:
- \`cd ~/terax-ai && terax\` → \`pty cwd: /Users/amangly/terax-ai\` ✓
- \`cd ~ && terax\` → \`pty cwd: /Users/amangly\` ✓
- \`cd / && terax\` → \`pty cwd: /Users/amangly\` (filtered, falls to home) ✓

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`cargo check --all-targets --locked\` clean
- [x] \`pnpm tauri build\` produces .app + .dmg
- [x] Manual smoke-test of all three launch scenarios

## Screenshots
N/A — backend only.

## Notes for reviewer
0.5.7 changelog says \"default working directory for new sessions is now \$HOME\". This PR keeps \$HOME as default for GUI launches but restores CLI-launch cwd inheritance. If full \$HOME default is intent for CLI too, feel free to close.