### PR TITLE
fix(security): enable Content Security Policy

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: blob:; font-src 'self' data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:*; frame-src http: https:; worker-src 'self' blob:"
     }
   },
   "bundle": {


### PR DESCRIPTION
## What     
  Enables a strict Content Security Policy (CSP) in the Tauri WebView.
                                                                                                                            
  ## Why
  Closes the CRITICAL finding from a security audit: `"csp": null` disables all script execution restrictions in the        
  WebView. If any XSS vector exists (crafted terminal escape sequence, malicious AI response, etc.), injected JavaScript can
   call all Tauri IPC commands — read/write arbitrary files, execute shell commands, access keychain secrets — with zero
  resistance.                                                                                                               
                                                                                                                          
  ## How
  Single-line change in `src-tauri/tauri.conf.json`:
                                                                                                                            
  - `default-src 'self'` — deny-by-default for all resource types                                                           
  - `script-src 'self'` — only execute JS bundled with the app (Tauri auto-injects its IPC nonce)                           
  - `style-src 'self' 'unsafe-inline'` — allows Tailwind + inline `style=` attributes                                       
  - `img-src 'self' data: asset: blob:` — allows SVG file icons (`data:` URLs), Tauri assets, blob URLs                     
  - `connect-src 'self' https: http://localhost:* http://127.0.0.1:*` — allows AI provider APIs + LM Studio on localhost    
  - `frame-src http: https:` — allows web preview iframe to load arbitrary URLs                                             
  - `worker-src 'self' blob:` — safety valve for web workers                                                                
  - `font-src 'self' data:` — local fonts                                                                                   
                                                                                                                            
  `connect-src` uses `https:` wildcard because users can configure custom AI endpoints — we can't enumerate all possible    
  hosts.                                                                                                                    
                                                                                                                            
  ## Testing                                                                                                              
  Verified on macOS (`pnpm tauri dev`):
                                                                                                                            
  - [x] Terminal — PTY output renders, commands execute normally                                                            
  - [x] File explorer — SVG file icons render (data: URLs)                                                                  
  - [x] AI chat — connects to provider, sends/receives messages                                                             
  - [x] Web preview — iframe loads localhost pages                                                                          
  - [x] Settings window — opens and renders fully                                                                           
  - [x] Conversation download — blob: URL file export works                                                                 
  - [x] DevTools console — zero `Refused to load/execute` CSP violations                                                    
                                                                                                                                                                                                                                                                                                                        
  ## Notes for reviewer
  `'unsafe-inline'` on `style-src` is required for Tailwind and the 17 inline `style=` attributes across components. This is
   a known trade-off — it doesn't weaken `script-src`, which is the critical directive blocking XSS execution.