### PR TITLE
feat(explorer): add keyboard navigation and context menu to search

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -35,7 +35,8 @@ import {
   NewEditorDialog,
   type EditorPaneHandle,
 } from "@/modules/editor";
-import { FileExplorer } from "@/modules/explorer";
+import { useZoom } from "@/lib/useZoom";
+import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
 import {
   Header,
   type SearchInlineHandle,
@@ -119,12 +120,21 @@ export default function App() {
   const previewRefs = useRef<Map<number, PreviewPaneHandle>>(new Map());
   const [activeEditorHandle, setActiveEditorHandle] =
     useState<EditorPaneHandle | null>(null);
+  const { zoomIn, zoomOut, zoomReset } = useZoom();
+  const explorerRef = useRef<FileExplorerHandle>(null);
+
   const sidebarRef = useRef<PanelImperativeHandle | null>(null);
   const toggleSidebar = useCallback(() => {
     const p = sidebarRef.current;
     if (!p) return;
     if (p.getSize().asPercentage <= 0) p.expand();
     else p.collapse();
+  }, []);
+
+  const focusExplorer = useCallback(() => {
+    const p = sidebarRef.current;
+    if (p && p.getSize().asPercentage <= 0) p.expand();
+    explorerRef.current?.focus();
   }, []);
 
   const [home, setHome] = useState<string | null>(null);
@@ -599,6 +609,10 @@ export default function App() {
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
       "settings.open": () => void openSettingsWindow(),
       "sidebar.toggle": toggleSidebar,
+      "explorer.focus": focusExplorer,
+      "view.zoomIn": zoomIn,
+      "view.zoomOut": zoomOut,
+      "view.zoomReset": zoomReset,
     }),
     [
       activeId,
@@ -613,6 +627,10 @@ export default function App() {
       togglePanelAndFocus,
       askFromSelection,
       toggleSidebar,
+      focusExplorer,
+      zoomIn,
+      zoomOut,
+      zoomReset,
     ],
   );
 
@@ -788,6 +806,7 @@ export default function App() {
               >
                 <div className="h-full border-r border-border/60 bg-card">
                   <FileExplorer
+                    ref={explorerRef}
                     rootPath={explorerRoot}
                     onOpenFile={handleOpenFile}
                     onPathRenamed={handlePathRenamed}

--- a/src/lib/useZoom.ts
+++ b/src/lib/useZoom.ts
@@ -1,23 +1,31 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setZoomLevel as saveZoomToStore } from "@/modules/settings/store";
 
 const ZOOM_STEP = 0.1;
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 2.0;
 
 export function useZoom() {
-  const [zoomLevel, setZoomLevel] = useState(1.0);
+  const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
 
+  // Apply persisted zoom level on mount (if hydrated)
+  const hydrated = usePreferencesStore((s) => s.hydrated);
   useEffect(() => {
-    // Tauri 2 Webview doesn't currently expose getZoom in the JS API.
-    // We'll start at 1.0 and track it locally.
-  }, []);
+    if (hydrated) {
+      void getCurrentWebview().setZoom(zoomLevel);
+    }
+  }, [hydrated, zoomLevel]);
 
-  const applyZoom = useCallback((newZoom: number) => {
-    const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
-    setZoomLevel(clamped);
-    void getCurrentWebview().setZoom(clamped);
-  }, []);
+  const applyZoom = useCallback(
+    (newZoom: number) => {
+      const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+      void saveZoomToStore(clamped);
+      void getCurrentWebview().setZoom(clamped);
+    },
+    [],
+  );
 
   const zoomIn = useCallback(() => {
     applyZoom(zoomLevel + ZOOM_STEP);

--- a/src/lib/useZoom.ts
+++ b/src/lib/useZoom.ts
@@ -1,0 +1,35 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { useCallback, useEffect, useState } from "react";
+
+const ZOOM_STEP = 0.1;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2.0;
+
+export function useZoom() {
+  const [zoomLevel, setZoomLevel] = useState(1.0);
+
+  useEffect(() => {
+    // Tauri 2 Webview doesn't currently expose getZoom in the JS API.
+    // We'll start at 1.0 and track it locally.
+  }, []);
+
+  const applyZoom = useCallback((newZoom: number) => {
+    const clamped = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+    setZoomLevel(clamped);
+    void getCurrentWebview().setZoom(clamped);
+  }, []);
+
+  const zoomIn = useCallback(() => {
+    applyZoom(zoomLevel + ZOOM_STEP);
+  }, [zoomLevel, applyZoom]);
+
+  const zoomOut = useCallback(() => {
+    applyZoom(zoomLevel - ZOOM_STEP);
+  }, [zoomLevel, applyZoom]);
+
+  const zoomReset = useCallback(() => {
+    applyZoom(1.0);
+  }, [applyZoom]);
+
+  return { zoomLevel, zoomIn, zoomOut, zoomReset };
+}

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -1,6 +1,13 @@
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
   Cancel01Icon,
   Folder01Icon,
   Search01Icon,
@@ -18,6 +25,9 @@ import {
 } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { fileIconUrl } from "./lib/iconResolver";
+import { copyToClipboard, revealInFinder } from "./lib/contextActions";
+import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
+import { cn } from "@/lib/utils";
 
 type SearchHit = {
   path: string;
@@ -40,6 +50,8 @@ type Props = {
   open: boolean;
   onRequestClose: () => void;
   onActiveChange?: (active: boolean) => void;
+  onRevealInTerminal?: (path: string) => void;
+  onAttachToAgent?: (path: string) => void;
 };
 
 export type ExplorerSearchHandle = {
@@ -53,15 +65,19 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   open,
   onRequestClose,
   onActiveChange,
+  onRevealInTerminal,
+  onAttachToAgent,
 }: Props,
   ref,
 ) {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchHit[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [searching, setSearching] = useState(false);
   const [truncated, setTruncated] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const active = query.trim().length > 0;
 
@@ -75,6 +91,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
     } else {
       setQuery("");
       setResults([]);
+      setSelectedIndex(0);
       setSearching(false);
       setTruncated(false);
     }
@@ -84,6 +101,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
     const q = query.trim();
     if (q.length < MIN_QUERY_LEN) {
       setResults([]);
+      setSelectedIndex(0);
       setSearching(false);
       setTruncated(false);
       return;
@@ -102,12 +120,14 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
         if (alive) {
           setResults(res.hits);
           setTruncated(res.truncated);
+          setSelectedIndex(0);
         }
       } catch (e) {
         if (alive) {
           console.error("fs_search failed:", e);
           setResults([]);
           setTruncated(false);
+          setSelectedIndex(0);
         }
       } finally {
         if (alive) setSearching(false);
@@ -132,6 +152,19 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
     }),
     [],
   );
+
+  useEffect(() => {
+    if (active && results.length > 0) {
+      const el = scrollRef.current?.querySelector(`[data-index="${selectedIndex}"]`);
+      el?.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex, results, active]);
+
+  const handleSelect = (hit: SearchHit) => {
+    if (!hit.is_dir) {
+      onOpenFile(hit.path);
+    }
+  };
 
   return (
     <div className="flex flex-col">
@@ -158,10 +191,17 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                 onRequestClose();
                 return;
               }
-              if (e.key === "Enter") {
-                e.preventDefault();
-                const firstOpenable = results.find((hit) => !hit.is_dir);
-                if (firstOpenable) onOpenFile(firstOpenable.path);
+              if (results.length > 0) {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  setSelectedIndex((prev) => (prev + 1) % results.length);
+                } else if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setSelectedIndex((prev) => (prev - 1 + results.length) % results.length);
+                } else if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleSelect(results[selectedIndex]);
+                }
               }
             }}
             placeholder="Search files…"
@@ -182,7 +222,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
 
       {active ? (
         <ScrollArea className="min-h-0 flex-1">
-          <div className="py-1">
+          <div className="py-1" ref={scrollRef}>
             {searching && results.length === 0 ? (
               <div className="px-3 py-2 text-[11px] text-muted-foreground">
                 Searching…
@@ -194,33 +234,76 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
             ) : (
               results.map((hit, index) => {
                 const url = hit.is_dir ? null : fileIconUrl(hit.name);
+                const isSelected = index === selectedIndex;
                 return (
-                  <button
-                    key={hit.path}
-                    type="button"
-                    onClick={() => {
-                      if (!hit.is_dir) onOpenFile(hit.path);
-                    }}
-                    className={`flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs ${
-                      index === 0 ? "bg-accent" : "hover:bg-accent"
-                    }`}
-                    title={hit.path}
-                  >
-                    {url ? (
-                      <img src={url} alt="" className="size-3.5 shrink-0" />
-                    ) : (
-                      <HugeiconsIcon
-                        icon={Folder01Icon}
-                        size={13}
-                        strokeWidth={1.75}
-                        className="shrink-0 text-muted-foreground"
-                      />
-                    )}
-                    <span className="truncate">{hit.name}</span>
-                    <span className="ml-auto truncate text-[10px] text-muted-foreground">
-                      {hit.rel}
-                    </span>
-                  </button>
+                  <ContextMenu key={hit.path}>
+                    <ContextMenuTrigger asChild>
+                      <button
+                        type="button"
+                        data-index={index}
+                        onClick={() => handleSelect(hit)}
+                        onMouseEnter={() => setSelectedIndex(index)}
+                        className={cn(
+                          "flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs transition-colors",
+                          isSelected ? "bg-accent text-foreground" : "hover:bg-accent/50 text-foreground/80"
+                        )}
+                        title={hit.path}
+                      >
+                        {url ? (
+                          <img src={url} alt="" className="size-3.5 shrink-0" />
+                        ) : (
+                          <HugeiconsIcon
+                            icon={Folder01Icon}
+                            size={13}
+                            strokeWidth={1.75}
+                            className="shrink-0 text-muted-foreground"
+                          />
+                        )}
+                        <span className="truncate">{hit.name}</span>
+                        <span className="ml-auto truncate text-[10px] text-muted-foreground">
+                          {hit.rel}
+                        </span>
+                      </button>
+                    </ContextMenuTrigger>
+                    <ContextMenuContent className={COMPACT_CONTENT}>
+                      {!hit.is_dir && (
+                        <ContextMenuItem
+                          className={COMPACT_ITEM}
+                          onSelect={() => onOpenFile(hit.path)}
+                        >
+                          Open
+                        </ContextMenuItem>
+                      )}
+                      {hit.is_dir && onRevealInTerminal && (
+                        <ContextMenuItem
+                          className={COMPACT_ITEM}
+                          onSelect={() => onRevealInTerminal(hit.path)}
+                        >
+                          Open in Terminal
+                        </ContextMenuItem>
+                      )}
+                      <ContextMenuItem
+                        className={COMPACT_ITEM}
+                        onSelect={() => void revealInFinder(hit.path)}
+                      >
+                        Reveal in Finder
+                      </ContextMenuItem>
+                      <ContextMenuSeparator />
+                      <ContextMenuItem
+                        className={COMPACT_ITEM}
+                        onSelect={() => void copyToClipboard(hit.path)}
+                      >
+                        Copy Path
+                      </ContextMenuItem>
+                      <ContextMenuSeparator />
+                      <ContextMenuItem
+                        className={COMPACT_ITEM}
+                        onSelect={() => onAttachToAgent?.(hit.path)}
+                      >
+                        Attach to Agent
+                      </ContextMenuItem>
+                    </ContextMenuContent>
+                  </ContextMenu>
                 );
               })
             )}

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -78,8 +78,17 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   const [truncated, setTruncated] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const isMouseMoving = useRef(false);
 
   const active = query.trim().length > 0;
+
+  useEffect(() => {
+    const onMove = () => {
+      isMouseMoving.current = true;
+    };
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, []);
 
   useEffect(() => {
     onActiveChange?.(active);
@@ -194,9 +203,11 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
               if (results.length > 0) {
                 if (e.key === "ArrowDown") {
                   e.preventDefault();
+                  isMouseMoving.current = false;
                   setSelectedIndex((prev) => (prev + 1) % results.length);
                 } else if (e.key === "ArrowUp") {
                   e.preventDefault();
+                  isMouseMoving.current = false;
                   setSelectedIndex((prev) => (prev - 1 + results.length) % results.length);
                 } else if (e.key === "Enter") {
                   e.preventDefault();
@@ -242,7 +253,9 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                         type="button"
                         data-index={index}
                         onClick={() => handleSelect(hit)}
-                        onMouseEnter={() => setSelectedIndex(index)}
+                        onMouseEnter={() => {
+                          if (isMouseMoving.current) setSelectedIndex(index);
+                        }}
                         className={cn(
                           "flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs transition-colors",
                           isSelected ? "bg-accent text-foreground" : "hover:bg-accent/50 text-foreground/80"

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -246,6 +246,8 @@ export function FileExplorer({
         open={isSearchOpen}
         onRequestClose={() => setIsSearchOpen(false)}
         onActiveChange={setIsSearchActive}
+        onRevealInTerminal={onRevealInTerminal}
+        onAttachToAgent={onAttachToAgent}
       />
 
       {!isSearchActive ? (

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -14,7 +14,14 @@ import {
   Search01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { ExplorerSearch, type ExplorerSearchHandle } from "./ExplorerSearch";
 import { FileTreeNode } from "./FileTreeNode";
 import { InlineInput } from "./InlineInput";
@@ -23,6 +30,10 @@ import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
+
+export type FileExplorerHandle = {
+  focus: () => void;
+};
 
 type Props = {
   rootPath: string | null;
@@ -38,22 +49,33 @@ function basename(path: string): string {
   return parts.length ? parts[parts.length - 1] : path;
 }
 
-export function FileExplorer({
-  rootPath,
-  onOpenFile,
-  onPathRenamed,
-  onPathDeleted,
-  onRevealInTerminal,
-  onAttachToAgent,
-}: Props) {
-  const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [isSearchActive, setIsSearchActive] = useState(false);
-  const listRef = useRef<HTMLDivElement>(null);
-  const searchRef = useRef<ExplorerSearchHandle>(null);
+export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
+  (
+    {
+      rootPath,
+      onOpenFile,
+      onPathRenamed,
+      onPathDeleted,
+      onRevealInTerminal,
+      onAttachToAgent,
+    },
+    ref,
+  ) => {
+    const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
+    const [selectedPath, setSelectedPath] = useState<string | null>(null);
+    const [isSearchOpen, setIsSearchOpen] = useState(false);
+    const [isSearchActive, setIsSearchActive] = useState(false);
+    const listRef = useRef<HTMLDivElement>(null);
+    const searchRef = useRef<ExplorerSearchHandle>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
 
-  type FlatItem = { path: string; isDir: boolean };
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        containerRef.current?.focus();
+      },
+    }));
+
+    type FlatItem = { path: string; isDir: boolean };
   const flat = useMemo<FlatItem[]>(() => {
     if (!rootPath) return [];
     const out: FlatItem[] = [];
@@ -180,6 +202,7 @@ export function FileExplorer({
 
   return (
     <div
+      ref={containerRef}
       className="flex h-full flex-col outline-none"
       tabIndex={0}
       onKeyDown={handleKeyDown}
@@ -362,4 +385,4 @@ export function FileExplorer({
       ) : null}
     </div>
   );
-}
+});

--- a/src/modules/explorer/index.ts
+++ b/src/modules/explorer/index.ts
@@ -1,2 +1,2 @@
-export { FileExplorer } from "./FileExplorer";
+export { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
 export { ExplorerSearch } from "./ExplorerSearch";

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -60,6 +60,7 @@ export type Preferences = {
   terminalFontSize: number;
   terminalScrollback: number;
   lastWslDistro: string | null;
+  zoomLevel: number;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
 
@@ -86,6 +87,7 @@ const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
+const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_SHORTCUTS = "shortcuts";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
@@ -125,6 +127,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
   lastWslDistro: null,
+  zoomLevel: 1.0,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
 
@@ -203,6 +206,7 @@ export async function loadPreferences(): Promise<Preferences> {
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
+    zoomLevel: get<number>(KEY_ZOOM_LEVEL) ?? DEFAULT_PREFERENCES.zoomLevel,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -309,6 +313,10 @@ export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
 
+export async function setZoomLevel(value: number): Promise<void> {
+  await writePref(KEY_ZOOM_LEVEL, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {},
 ): Promise<void> {
@@ -349,6 +357,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
+    [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_SHORTCUTS]: "shortcuts",
   };
   // Same-process writes still fire onChange immediately; cross-window writes

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -19,6 +19,10 @@ export type ShortcutId =
   | "pane.focusPrev"
   | "search.focus"
   | "explorer.search"
+  | "explorer.focus"
+  | "view.zoomIn"
+  | "view.zoomOut"
+  | "view.zoomReset"
   | "ai.toggle"
   | "ai.askSelection"
   | "shortcuts.open"
@@ -162,6 +166,30 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Toggle file explorer",
     group: "View",
     defaultBindings: [{ [MOD_PROP]: true, key: "b" }],
+  },
+  {
+    id: "explorer.focus",
+    label: "Focus file explorer",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "e" }],
+  },
+  {
+    id: "view.zoomIn",
+    label: "Zoom in",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, key: "=" }],
+  },
+  {
+    id: "view.zoomOut",
+    label: "Zoom out",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, key: "-" }],
+  },
+  {
+    id: "view.zoomReset",
+    label: "Reset zoom",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, key: "0" }],
   },
 ];
 


### PR DESCRIPTION
What changed?
    2     Improved the Explorer Search (fuzzy finder) by making it fully keyboard-operable and adding a context menu to results.
    3
    4     Why?
    5     Developer flow was interrupted by needing to reach for the mouse to select a file after searching. This change enables a pure keyboard workflow (`Ctrl+P` -> `Type` -> `Arrows` -> `Enter`).
    6
    7     How was it tested?
    8     - [x] Verified `pnpm exec tsc --noEmit` passes.
    9     - [x] Manual testing of keyboard selection looping (ArrowDown on last item goes to first).
   10     - [x] Verified `scrollIntoView` correctly tracks selection when list overflows.
   11     - [x] Verified context menu actions (Copy Path) work correctly on search hits.