### PR TITLE
fix(terminal): block IME composition keydown events from reaching PTY

### DIFF
--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -131,6 +131,15 @@ function createSlot(): Slot {
   attachWebgl(slot);
 
   term.attachCustomKeyEventHandler((event) => {
+    // During IME composition the browser is assembling a multi-keystroke
+    // character (Chinese pinyin → hanzi, Korean jamo → syllable, etc.).
+    // Raw keydown events — including the Enter that commits a candidate —
+    // must NOT be forwarded to the PTY; xterm will receive the final
+    // composed string through its own compositionend handler instead.
+    // keyCode 229 ("Process") is what Chromium reports for every key
+    // pressed inside an active IME session when isComposing is not yet set.
+    if (event.isComposing || event.keyCode === 229) return false;
+
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;
     const bridge = adapter?.resolveLeaf(leafId);


### PR DESCRIPTION
## What

Guard `attachCustomKeyEventHandler` against IME composition events so that Chinese, Korean, and Japanese input works correctly in the terminal.

```diff
+    if (event.isComposing || event.keyCode === 229) return false;
```

## Why

Closes #158 — Chinese IME: pressing **Enter** to commit a candidate also submitted the current shell command, because the Enter keydown was forwarded raw to the PTY while composition was still active.

Closes #147 — Korean Hangul: inline-composed jamo were duplicated or silently dropped because both the raw keydown events *and* the final `compositionend` string reached the shell.

**Root cause:** xterm's `attachCustomKeyEventHandler` received every keydown event, including those fired during an active IME session (`event.isComposing === true`). There was no guard, so each raw key was written to the PTY in parallel with xterm's own composition handling.

**Fix:** Return `false` from the handler when `event.isComposing` is set, or when `event.keyCode === 229` (the synthetic *Process* code Chromium reports while any key is handled inside an IME session before `isComposing` is available). This tells xterm to skip its keydown pipeline entirely for those events; the fully composed string still arrives via xterm's own `compositionend` handler and is written to the PTY exactly once.

## How it was tested

- TypeScript: `tsc --noEmit` — zero errors
- Manually verified the diff is a strict superset of the existing Ctrl+Backspace guard (that path is unchanged)
- The `isComposing` + keyCode-229 pattern is the standard xterm.js IME fix used by VS Code, Hyper, and other xterm.js embedders