### PR TITLE
feat(zoom): implement zoom functionality

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -18,6 +18,7 @@
     "core:window:allow-set-focus",
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "core:webview:allow-set-webview-zoom",
     "opener:default",
     "log:default",
     "os:default",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -43,7 +43,7 @@ import {
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import { onKeysChanged } from "@/modules/settings/store";
+import { onKeysChanged, setZoomLevel,DEFAULT_ZOOM_LEVEL } from "@/modules/settings/store";
 import {
   ShortcutsDialog,
   useGlobalShortcuts,
@@ -67,7 +67,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PanelImperativeHandle } from "react-resizable-panels";
-
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 
 export default function App() {
   const {
@@ -109,6 +109,7 @@ export default function App() {
   const terminalRefs = useRef<Map<number, TerminalPaneHandle>>(new Map());
   const editorRefs = useRef<Map<number, EditorPaneHandle>>(new Map());
   const previewRefs = useRef<Map<number, PreviewPaneHandle>>(new Map());
+  const zoomLevelRef = useRef(DEFAULT_ZOOM_LEVEL);
   const [activeEditorHandle, setActiveEditorHandle] =
     useState<EditorPaneHandle | null>(null);
   const sidebarRef = useRef<PanelImperativeHandle | null>(null);
@@ -179,6 +180,13 @@ export default function App() {
     void useAgentsStore.getState().hydrate();
     void useSnippetsStore.getState().hydrate();
   }, [hydrateSessions]);
+
+  const savedZoomLevel = usePreferencesStore((s) => s.zoomLevel);
+  useEffect(() => {
+    if (!prefsHydrated) return;
+    zoomLevelRef.current = savedZoomLevel;
+    void getCurrentWebview().setZoom(savedZoomLevel);
+  }, [prefsHydrated, savedZoomLevel]);
 
   const activeTab = tabs.find((t) => t.id === activeId);
   const isTerminalTab = activeTab?.kind === "terminal";
@@ -512,6 +520,24 @@ export default function App() {
     handleClose(activeId);
   }, [activeId, closeActivePane, handleClose]);
 
+  const handleZoomIn = useCallback(async () => {
+    zoomLevelRef.current = Math.min(zoomLevelRef.current + 0.1, 10);
+    await getCurrentWebview().setZoom(zoomLevelRef.current);
+    await setZoomLevel(zoomLevelRef.current);
+  }, []);
+
+  const handleZoomOut = useCallback(async () => {
+    zoomLevelRef.current = Math.max(zoomLevelRef.current - 0.1, 0.2);
+    await getCurrentWebview().setZoom(zoomLevelRef.current);
+    await setZoomLevel(zoomLevelRef.current);
+  }, []);
+
+  const handleResetZoom = useCallback(async () => {
+    zoomLevelRef.current = 1.0;
+    await getCurrentWebview().setZoom(1.0);
+    await setZoomLevel(1.0);
+  }, []);
+
   const shortcutHandlers = useMemo<ShortcutHandlers>(
     () => ({
       "tab.new": openNewTab,
@@ -531,6 +557,9 @@ export default function App() {
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
       "settings.open": () => void openSettingsWindow(),
       "sidebar.toggle": toggleSidebar,
+      "view.zoomIn": handleZoomIn,
+      "view.zoomOut": handleZoomOut,
+      "view.resetZoom": handleResetZoom
     }),
     [
       activeId,
@@ -544,6 +573,9 @@ export default function App() {
       togglePanelAndFocus,
       askFromSelection,
       toggleSidebar,
+      handleZoomIn,
+      handleZoomOut,
+      handleResetZoom
     ],
   );
 

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -52,6 +52,7 @@ export type Preferences = {
   terminalWebglEnabled: boolean;
   terminalFontSize: number;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
+  zoomLevel: number;
 };
 
 const STORE_PATH = "terax-settings.json";
@@ -68,6 +69,7 @@ const KEY_LMSTUDIO_BASE_URL = "lmstudioBaseURL";
 const KEY_VIM_MODE = "vimMode";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
+const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_SHORTCUTS = "shortcuts";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
@@ -77,6 +79,8 @@ export const TERMINAL_FONT_SIZE_MAX = 32;
 export const TERMINAL_FONT_SIZES = [
   10, 12, 13, 14, 15, 16, 18, 20, 22, 24,
 ] as const;
+
+export const DEFAULT_ZOOM_LEVEL = 1.0;
 
 export const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
@@ -93,6 +97,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalWebglEnabled: true,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
+  zoomLevel: DEFAULT_ZOOM_LEVEL,
 };
 
 const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
@@ -149,6 +154,7 @@ export async function loadPreferences(): Promise<Preferences> {
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
+    zoomLevel: get<number>("zoomLevel") ?? DEFAULT_PREFERENCES.zoomLevel,
   };
 }
 
@@ -219,6 +225,10 @@ export async function setShortcuts(
   await store.save();
 }
 
+export async function setZoomLevel(value: number): Promise<void> {
+  await writePref(KEY_ZOOM_LEVEL, value);
+}
+
 export async function resetShortcuts(): Promise<void> {
   await store.set(KEY_SHORTCUTS, DEFAULT_PREFERENCES.shortcuts);
   await store.save();
@@ -245,6 +255,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_SHORTCUTS]: "shortcuts",
+    [KEY_ZOOM_LEVEL]: "zoomLevel",
   };
   // Same-process writes still fire onChange immediately; cross-window writes
   // arrive via the Tauri event emitted by writePref().

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -22,7 +22,10 @@ export type ShortcutId =
   | "ai.askSelection"
   | "shortcuts.open"
   | "settings.open"
-  | "sidebar.toggle";
+  | "sidebar.toggle"
+  | "view.zoomIn"
+  | "view.zoomOut"
+  | "view.resetZoom";
 
 export type ShortcutGroup =
   | "General"
@@ -155,6 +158,24 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Toggle file explorer",
     group: "View",
     defaultBindings: [{ [MOD_PROP]: true, key: "b" }],
+  },
+  {
+    id: "view.zoomIn",
+    label: "Zoom in",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, key: "=" }],
+  },
+  {
+    id: "view.zoomOut",
+    label: "Zoom out",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, key: "-" }],
+  },
+  {
+    id: "view.resetZoom",
+    label: "Reset zoom",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, key: "0" }],
   },
 ];
 


### PR DESCRIPTION
closes #24 

## What
Adding zoom with shortcuts and preferences

## Why
Quality of life Feature

## How
used the `@tauri-apps/api/webview`, imported `getCurrentWebview` and used `setZoom` method. more in [docs](https://v2.tauri.app/reference/javascript/api/namespacewebview/#setzoom)

- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Notes for reviewer
zoom changes does not effect the width of `ResizablePanel`, i tried set the `defaultSize` to `{225 * zoomLevelRef.current}` but it did not work (used transform and start getting weird UI changes so i discarded the idea)