### PR TITLE
feat(settings): add sidebar position option

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -165,6 +165,8 @@ export default function App() {
   const initPrefs = usePreferencesStore((s) => s.init);
   const prefDefaultModel = usePreferencesStore((s) => s.defaultModelId);
   const prefsHydrated = usePreferencesStore((s) => s.hydrated);
+  const sidebarPosition = usePreferencesStore((s) => s.sidebarPosition);
+  const sidebarFirst = sidebarPosition === "left";
   useEffect(() => {
     void initPrefs();
   }, [initPrefs]);
@@ -679,6 +681,134 @@ export default function App() {
     });
   }, [setLive, activeId, tabs, explorerRoot, home, openPreviewTab]);
 
+  const sidebarPanel = (
+    <ResizablePanel
+      key="sidebar-panel"
+      id="sidebar"
+      panelRef={sidebarRef}
+      defaultSize="225px"
+      minSize="130px"
+      maxSize="450px"
+      collapsible
+      collapsedSize={0}
+    >
+      <div
+        className={cn(
+          "h-full border-border/60 bg-card",
+          sidebarFirst ? "border-r" : "border-l",
+        )}
+      >
+        <FileExplorer
+          rootPath={explorerRoot}
+          onOpenFile={handleOpenFile}
+          onPathRenamed={handlePathRenamed}
+          onPathDeleted={handlePathDeleted}
+          onRevealInTerminal={cdInNewTab}
+          onAttachToAgent={handleAttachFileToAgent}
+        />
+      </div>
+    </ResizablePanel>
+  );
+
+  const workspacePanel = (
+    <ResizablePanel
+      key="workspace-panel"
+      id="workspace"
+      defaultSize="78%"
+      minSize="30%"
+    >
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="relative min-h-0 flex-1">
+          <div
+            className={cn(
+              "absolute inset-0 px-3 pt-2 pb-2",
+              !isTerminalTab && "invisible pointer-events-none",
+            )}
+            aria-hidden={!isTerminalTab}
+          >
+            <TerminalStack
+              tabs={tabs}
+              activeId={activeId}
+              registerHandle={registerTerminalHandle}
+              onSearchReady={handleSearchReady}
+              onCwd={handleTerminalCwd}
+              onExit={handleLeafExit}
+              onTeraxOpen={handleTeraxOpen}
+              onFocusLeaf={handleFocusLeaf}
+            />
+          </div>
+          <div
+            className={cn(
+              "absolute inset-0 px-3 pt-2 pb-2",
+              !isEditorTab && "invisible pointer-events-none",
+            )}
+            aria-hidden={!isEditorTab}
+          >
+            <EditorStack
+              tabs={tabs}
+              activeId={activeId}
+              registerHandle={registerEditorHandle}
+              onDirtyChange={handleEditorDirty}
+              onCloseTab={disposeTab}
+            />
+          </div>
+          <div
+            className={cn(
+              "absolute inset-0 px-3 pt-2 pb-2",
+              !isPreviewTab && "invisible pointer-events-none",
+            )}
+            aria-hidden={!isPreviewTab}
+          >
+            <PreviewStack
+              tabs={tabs}
+              activeId={activeId}
+              registerHandle={registerPreviewHandle}
+              onUrlChange={handlePreviewUrl}
+            />
+          </div>
+          <div
+            className={cn(
+              "absolute inset-0 px-3 pt-2 pb-2",
+              !isAiDiffTab && "invisible pointer-events-none",
+            )}
+            aria-hidden={!isAiDiffTab}
+          >
+            <AiDiffStack
+              tabs={tabs}
+              activeId={activeId}
+              onAccept={(id) => respondToApproval(id, true)}
+              onReject={(id) => respondToApproval(id, false)}
+            />
+          </div>
+        </div>
+
+        {keysLoaded ? (
+          <motion.div
+            data-ai-input-bar
+            initial={false}
+            animate={{
+              height: panelOpen ? "auto" : 0,
+              opacity: panelOpen ? 1 : 0,
+            }}
+            transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+            className="overflow-hidden"
+            aria-hidden={!panelOpen}
+          >
+            {hasComposer ? (
+              <AiInputBar />
+            ) : (
+              <AiInputBarConnect
+                onAdd={() => void openSettingsWindow("models")}
+              />
+            )}
+          </motion.div>
+        ) : null}
+      </div>
+    </ResizablePanel>
+  );
+
+  const mainHandle = <ResizableHandle key="main-handle" withHandle />;
+
   const shell = (
     <ThemeProvider>
       <TooltipProvider>
@@ -709,116 +839,19 @@ export default function App() {
               orientation="horizontal"
               className="min-h-0 flex-1"
             >
-              <ResizablePanel
-                id="sidebar"
-                panelRef={sidebarRef}
-                defaultSize="225px"
-                minSize="130px"
-                maxSize="450px"
-                collapsible
-                collapsedSize={0}
-              >
-                <div className="h-full border-r border-border/60 bg-card">
-                  <FileExplorer
-                    rootPath={explorerRoot}
-                    onOpenFile={handleOpenFile}
-                    onPathRenamed={handlePathRenamed}
-                    onPathDeleted={handlePathDeleted}
-                    onRevealInTerminal={cdInNewTab}
-                    onAttachToAgent={handleAttachFileToAgent}
-                  />
-                </div>
-              </ResizablePanel>
-              <ResizableHandle withHandle />
-              <ResizablePanel id="workspace" defaultSize="78%" minSize="30%">
-                <div className="flex h-full min-h-0 flex-col">
-                  <div className="relative min-h-0 flex-1">
-                    <div
-                      className={cn(
-                        "absolute inset-0 px-3 pt-2 pb-2",
-                        !isTerminalTab && "invisible pointer-events-none",
-                      )}
-                      aria-hidden={!isTerminalTab}
-                    >
-                      <TerminalStack
-                        tabs={tabs}
-                        activeId={activeId}
-                        registerHandle={registerTerminalHandle}
-                        onSearchReady={handleSearchReady}
-                        onCwd={handleTerminalCwd}
-                        onExit={handleLeafExit}
-                        onTeraxOpen={handleTeraxOpen}
-                        onFocusLeaf={handleFocusLeaf}
-                      />
-                    </div>
-                    <div
-                      className={cn(
-                        "absolute inset-0 px-3 pt-2 pb-2",
-                        !isEditorTab && "invisible pointer-events-none",
-                      )}
-                      aria-hidden={!isEditorTab}
-                    >
-                      <EditorStack
-                        tabs={tabs}
-                        activeId={activeId}
-                        registerHandle={registerEditorHandle}
-                        onDirtyChange={handleEditorDirty}
-                        onCloseTab={disposeTab}
-                      />
-                    </div>
-                    <div
-                      className={cn(
-                        "absolute inset-0 px-3 pt-2 pb-2",
-                        !isPreviewTab && "invisible pointer-events-none",
-                      )}
-                      aria-hidden={!isPreviewTab}
-                    >
-                      <PreviewStack
-                        tabs={tabs}
-                        activeId={activeId}
-                        registerHandle={registerPreviewHandle}
-                        onUrlChange={handlePreviewUrl}
-                      />
-                    </div>
-                    <div
-                      className={cn(
-                        "absolute inset-0 px-3 pt-2 pb-2",
-                        !isAiDiffTab && "invisible pointer-events-none",
-                      )}
-                      aria-hidden={!isAiDiffTab}
-                    >
-                      <AiDiffStack
-                        tabs={tabs}
-                        activeId={activeId}
-                        onAccept={(id) => respondToApproval(id, true)}
-                        onReject={(id) => respondToApproval(id, false)}
-                      />
-                    </div>
-                  </div>
-
-                  {keysLoaded ? (
-                    <motion.div
-                      data-ai-input-bar
-                      initial={false}
-                      animate={{
-                        height: panelOpen ? "auto" : 0,
-                        opacity: panelOpen ? 1 : 0,
-                      }}
-                      transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
-                      className="overflow-hidden"
-                      aria-hidden={!panelOpen}
-                    >
-                      {hasComposer ? (
-                        <AiInputBar />
-                      ) : (
-                        <AiInputBarConnect
-                          onAdd={() => void openSettingsWindow("models")}
-                        />
-                      )}
-                    </motion.div>
-                  ) : null}
-                </div>
-              </ResizablePanel>
+              {sidebarFirst ? (
+                <>
+                  {sidebarPanel}
+                  {mainHandle}
+                  {workspacePanel}
+                </>
+              ) : (
+                <>
+                  {workspacePanel}
+                  {mainHandle}
+                  {sidebarPanel}
+                </>
+              )}
             </ResizablePanelGroup>
           </main>
 

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -1,5 +1,12 @@
 import { Button } from "@/components/ui/button";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -8,6 +15,10 @@ import {
 import { WindowControls } from "@/components/WindowControls";
 import { IS_MAC, KEY_SEP, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  setSidebarPosition,
+  type SidebarPosition,
+} from "@/modules/settings/store";
 import {
   getBindingTokens,
   SHORTCUTS,
@@ -22,6 +33,7 @@ import {
   LayoutTwoRowIcon,
   Settings01Icon,
   SidebarLeftIcon,
+  SidebarRightIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
@@ -73,6 +85,7 @@ export function Header({
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
   const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+  const sidebarPosition = usePreferencesStore((s) => s.sidebarPosition);
 
   const tokensFor = (id: ShortcutId): string => {
     const s = SHORTCUTS.find((s) => s.id === id);
@@ -135,15 +148,40 @@ export function Header({
       }`}
     >
       <div className="flex shrink-0 items-center gap-0.5">
-        <Button
-          onClick={onToggleSidebar}
-          title="Toggle sidebar"
-          variant="ghost"
-          size="icon-sm"
-          className="shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-        >
-          <HugeiconsIcon icon={SidebarLeftIcon} size={18} strokeWidth={1.75} />
-        </Button>
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <Button
+              onClick={onToggleSidebar}
+              title="Toggle sidebar"
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <HugeiconsIcon
+                icon={
+                  sidebarPosition === "left" ? SidebarLeftIcon : SidebarRightIcon
+                }
+                size={18}
+                strokeWidth={1.75}
+              />
+            </Button>
+          </ContextMenuTrigger>
+          <ContextMenuContent className="min-w-40">
+            <ContextMenuRadioGroup
+              value={sidebarPosition}
+              onValueChange={(v) =>
+                void setSidebarPosition(v as SidebarPosition)
+              }
+            >
+              <ContextMenuRadioItem value="left">
+                Sidebar left
+              </ContextMenuRadioItem>
+              <ContextMenuRadioItem value="right">
+                Sidebar right
+              </ContextMenuRadioItem>
+            </ContextMenuRadioGroup>
+          </ContextMenuContent>
+        </ContextMenu>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -12,6 +12,8 @@ import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 
 export type ThemePref = "system" | "light" | "dark";
 
+export type SidebarPosition = "left" | "right";
+
 export const EDITOR_THEMES = [
   "atomone",
   "aura",
@@ -57,6 +59,7 @@ export type Preferences = {
   vimMode: boolean;
   terminalWebglEnabled: boolean;
   terminalFontSize: number;
+  sidebarPosition: SidebarPosition;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
 
@@ -79,6 +82,7 @@ const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
+const KEY_SIDEBAR_POSITION = "sidebarPosition";
 const KEY_SHORTCUTS = "shortcuts";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
@@ -108,6 +112,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   vimMode: false,
   terminalWebglEnabled: true,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
+  sidebarPosition: "left",
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
 
@@ -175,6 +180,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalFontSize:
       get<number>(KEY_TERMINAL_FONT_SIZE) ??
       DEFAULT_PREFERENCES.terminalFontSize,
+    sidebarPosition:
+      get<SidebarPosition>(KEY_SIDEBAR_POSITION) ??
+      DEFAULT_PREFERENCES.sidebarPosition,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -261,6 +269,12 @@ export async function setTerminalFontSize(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_SIZE, clamped);
 }
 
+export async function setSidebarPosition(
+  value: SidebarPosition,
+): Promise<void> {
+  await writePref(KEY_SIDEBAR_POSITION, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {}
 ): Promise<void> {
@@ -298,6 +312,7 @@ export async function onPreferencesChange(
     [KEY_VIM_MODE]: "vimMode",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
+    [KEY_SIDEBAR_POSITION]: "sidebarPosition",
     [KEY_SHORTCUTS]: "shortcuts",
   };
   // Same-process writes still fire onChange immediately; cross-window writes

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import type { ThemePref } from "@/modules/settings/store";
+import type { SidebarPosition, ThemePref } from "@/modules/settings/store";
 import {
   EDITOR_THEME_LABELS,
   EDITOR_THEMES,
@@ -22,6 +22,7 @@ import {
   setAutostart,
   setEditorTheme,
   setRestoreWindowState,
+  setSidebarPosition,
   setTerminalFontSize,
   setTerminalWebglEnabled,
   setVimMode,
@@ -32,6 +33,8 @@ import {
   ArrowDown01Icon,
   ComputerIcon,
   Moon02Icon,
+  SidebarLeftIcon,
+  SidebarRightIcon,
   Sun03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -50,6 +53,15 @@ const APPEARANCE: {
   { id: "dark", label: "Dark", icon: Moon02Icon },
 ];
 
+const SIDEBAR_POSITIONS: {
+  id: SidebarPosition;
+  label: string;
+  icon: typeof SidebarLeftIcon;
+}[] = [
+  { id: "left", label: "Left", icon: SidebarLeftIcon },
+  { id: "right", label: "Right", icon: SidebarRightIcon },
+];
+
 export function GeneralSection() {
   const { theme, setTheme } = useTheme();
   const editorTheme = usePreferencesStore((s) => s.editorTheme);
@@ -60,6 +72,7 @@ export function GeneralSection() {
     (s) => s.terminalWebglEnabled,
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
+  const sidebarPosition = usePreferencesStore((s) => s.sidebarPosition);
 
   // Reconcile autostart pref with the actual OS state on mount — the user may
   // have toggled it from System Settings.
@@ -125,6 +138,34 @@ export function GeneralSection() {
             </button>
           ))}
         </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label>Sidebar</Label>
+        <SettingRow
+          title="Side bar position"
+          description="Show the file explorer on the left or right side of the window."
+        >
+          <div className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-card p-0.5">
+            {SIDEBAR_POSITIONS.map((o) => (
+              <button
+                key={o.id}
+                type="button"
+                aria-pressed={sidebarPosition === o.id}
+                onClick={() => void setSidebarPosition(o.id)}
+                className={cn(
+                  "flex items-center gap-1.5 rounded px-2 py-1 text-[11.5px] transition-colors",
+                  sidebarPosition === o.id
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <HugeiconsIcon icon={o.icon} size={14} strokeWidth={1.75} />
+                {o.label}
+              </button>
+            ))}
+          </div>
+        </SettingRow>
       </div>
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## What

Lets you put the file-explorer sidebar on the left (current behaviour) or the right, VS Code style.

## Why

I keep the terminal/editor on the left and want the file tree on the other side. Right now the sidebar is hard-coded to the left.

## How

- New `sidebarPosition` preference (`"left" | "right"`, default `"left"`) wired through the existing `tauri-plugin-store` + `terax://prefs-changed` plumbing, the same way as `vimMode` and friends.
- Settings -> General gets a small "Side bar position" segmented control.
- Right-clicking the sidebar toggle button in the header opens a Left/Right menu (mirrors VS Code's activity-bar menu); left-click still toggles visibility.
- In `App.tsx` the `ResizablePanelGroup` renders `explorer -> handle -> workspace` or the reverse depending on the pref. Both panels keep stable React keys, so the workspace panel (and every PTY inside it) isn't remounted on a flip — it just reorders. The explorer's divider border flips `border-r` <-> `border-l`, and the toolbar icon swaps to match.

No new dependencies, no `src-tauri/` changes.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean — n/a, no Rust changes
- [x] (If UI) tested in `pnpm tauri dev`

Verified in `pnpm tauri dev` on macOS:
- Toggling the setting in Settings -> General moves the explorer side in the main window live.
- Right-click menu on the header button does the same; left-click still shows/hides the sidebar; `Cmd+B` still works on either side.
- Flipping sides doesn't flash or respawn terminals (no new `pty opened` / `pty closed`).
- Preference persists across restarts; defaults to left on a fresh profile.

## Screenshots / GIFs

Happy to add a short GIF if it helps.

## Notes for reviewer

- I know CONTRIBUTING says open an issue first for non-trivial features — glad to move this to an issue/discussion or close it if it doesn't fit the roadmap. It felt small and self-contained enough to just show the diff.
- `react-resizable-panels` v4 has no `order` prop; panel order there is derived from DOM/flex position, so the conditional render + stable keys is the intended approach. One minor consequence: the panel group has no `autoSaveId`, so a manually-resized explorer width resets to the default after a flip. Adding `autoSaveId` would persist it, but that also changes current behaviour (sizes reset on launch today), so I left it out — easy follow-up if wanted.
