### PR TITLE
fix(shortcuts): prevent tauri default shortcuts

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-prevent-default = "5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 portable-pty = "0.9"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ pub fn run() {
     configure_linux_rendering();
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_prevent_default::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         // Skip restoring VISIBLE — frontend calls window.show() after first


### PR DESCRIPTION
## What
Remove the default **Tauri** Shortcuts like `control + r` that reloads the website

## Why
as i was working on a personal project i was using the preview mode, and **accidentally** pressed `control r` resulting in whole UI reloading 

the dev server was still working but the app refreshed as it was a website (tauri is just a WebView wrapper)

### Are Registered shortcuts still working
yes

## How
added [tauri-plugin-prevent-default](https://github.com/ferreira-tb/tauri-plugin-prevent-default) as a dependency and apply it in `main.rs`


- [ ] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Update
CI Failed as there are --locked for deps 