### PR TITLE
feat(release): add Homebrew tap sync workflow

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,38 @@
+name: Homebrew Tap
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish (for example v0.6.1)
+        required: true
+        type: string
+      tap_repository:
+        description: Target tap repository (for example crynta/homebrew-tap)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync-homebrew-tap:
+    if: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Sync cask into tap repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_REPOSITORY: ${{ inputs.tap_repository || vars.HOMEBREW_TAP_REPOSITORY || format('{0}/homebrew-tap', github.repository_owner) }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+        run: node scripts/sync-homebrew-tap.mjs

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -3,16 +3,6 @@ name: Homebrew Tap
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: Release tag to publish (for example v0.6.1)
-        required: true
-        type: string
-      tap_repository:
-        description: Target tap repository (for example crynta/homebrew-tap)
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -32,7 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          HOMEBREW_TAP_REPOSITORY: ${{ inputs.tap_repository || vars.HOMEBREW_TAP_REPOSITORY || format('{0}/homebrew-tap', github.repository_owner) }}
-          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+          HOMEBREW_TAP_REPOSITORY: ${{ vars.HOMEBREW_TAP_REPOSITORY || format('{0}/homebrew-tap', github.repository_owner) }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           SOURCE_REPOSITORY: ${{ github.repository }}
         run: node scripts/sync-homebrew-tap.mjs

--- a/README.md
+++ b/README.md
@@ -100,13 +100,8 @@ pnpm tauri build        # production bundle
 
 ## Homebrew tap
 
-Terax can be shipped through a custom Homebrew cask tap for macOS installs.
-
-**For maintainers**
-- Create a tap repository named `homebrew-tap` (or another `homebrew-*` repo) under your GitHub org/user.
-- Add a repository variable `HOMEBREW_TAP_REPOSITORY` with the target repo, e.g. `crynta/homebrew-tap`.
-- Add a repository secret `HOMEBREW_TAP_GITHUB_TOKEN` with permission to push to that tap repo.
-- When a GitHub release is **published**, [`.github/workflows/homebrew-tap.yml`](.github/workflows/homebrew-tap.yml) downloads the macOS `.dmg` assets, computes SHA-256 values, and updates `Casks/terax.rb` in the tap.
+Published macOS releases can sync a `terax` cask into a separate Homebrew tap.
+Set `HOMEBREW_TAP_GITHUB_TOKEN` and, if needed, `HOMEBREW_TAP_REPOSITORY` to enable [`.github/workflows/homebrew-tap.yml`](.github/workflows/homebrew-tap.yml).
 
 **For users**
 ```bash

--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ pnpm tauri dev          # development
 pnpm tauri build        # production bundle
 ```
 
+## Homebrew tap
+
+Terax can be shipped through a custom Homebrew cask tap for macOS installs.
+
+**For maintainers**
+- Create a tap repository named `homebrew-tap` (or another `homebrew-*` repo) under your GitHub org/user.
+- Add a repository variable `HOMEBREW_TAP_REPOSITORY` with the target repo, e.g. `crynta/homebrew-tap`.
+- Add a repository secret `HOMEBREW_TAP_GITHUB_TOKEN` with permission to push to that tap repo.
+- When a GitHub release is **published**, [`.github/workflows/homebrew-tap.yml`](.github/workflows/homebrew-tap.yml) downloads the macOS `.dmg` assets, computes SHA-256 values, and updates `Casks/terax.rb` in the tap.
+
+**For users**
+```bash
+brew tap <owner>/tap
+brew install --cask terax
+```
+
 **Checks**
 ```bash
 pnpm exec tsc --noEmit          # frontend type-check

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "homebrew:sync": "node scripts/sync-homebrew-tap.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
-    "homebrew:sync": "node scripts/sync-homebrew-tap.mjs"
+    "tauri": "tauri"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",

--- a/scripts/sync-homebrew-tap.mjs
+++ b/scripts/sync-homebrew-tap.mjs
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { execFile as execFileCb } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -10,9 +10,8 @@ const execFile = promisify(execFileCb);
 async function main() {
   const sourceRepository =
     process.env.SOURCE_REPOSITORY ?? process.env.GITHUB_REPOSITORY;
-  const releaseTag = process.env.RELEASE_TAG ?? process.argv[2];
-  const tapRepository = process.env.HOMEBREW_TAP_REPOSITORY ?? "";
-  const tapPath = process.env.HOMEBREW_TAP_PATH ?? "";
+  const releaseTag = process.env.RELEASE_TAG;
+  const tapRepository = process.env.HOMEBREW_TAP_REPOSITORY;
   const githubToken =
     process.env.HOMEBREW_TAP_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
 
@@ -22,9 +21,12 @@ async function main() {
   if (!releaseTag) {
     throw new Error("RELEASE_TAG is required.");
   }
-  if (!tapRepository && !tapPath) {
+  if (!tapRepository) {
+    throw new Error("HOMEBREW_TAP_REPOSITORY is required.");
+  }
+  if (!githubToken) {
     throw new Error(
-      "Set HOMEBREW_TAP_REPOSITORY or HOMEBREW_TAP_PATH before running sync.",
+      "HOMEBREW_TAP_GITHUB_TOKEN or GITHUB_TOKEN is required to push to a tap repository.",
     );
   }
 
@@ -34,49 +36,20 @@ async function main() {
   );
   const version = String(release.tag_name).replace(/^v/, "");
   const assets = Array.isArray(release.assets) ? release.assets : [];
-  const armAsset = findMacAsset(assets, "arm");
-  const intelAsset = findMacAsset(assets, "intel");
-
-  const [armSha, intelSha] = await Promise.all([
-    downloadSha256(armAsset.browser_download_url, githubToken),
-    downloadSha256(intelAsset.browser_download_url, githubToken),
+  const [arm, intel] = await Promise.all([
+    loadMacArtifact(assets, "arm", githubToken),
+    loadMacArtifact(assets, "intel", githubToken),
   ]);
 
-  const cask = renderCask({
-    version,
-    sourceRepository,
-    arm: {
-      sha256: armSha,
-      url: armAsset.browser_download_url,
-    },
-    intel: {
-      sha256: intelSha,
-      url: intelAsset.browser_download_url,
-    },
-  });
-
-  if (tapPath) {
-    await writeCaskFile(tapPath, cask);
-    console.log(
-      `Wrote Homebrew cask to ${path.join(tapPath, "Casks", "terax.rb")}`,
-    );
-    return;
-  }
-
-  if (!githubToken) {
-    throw new Error(
-      "HOMEBREW_TAP_GITHUB_TOKEN or GITHUB_TOKEN is required to push to a tap repository.",
-    );
-  }
-
   const tempRoot = await mkdtemp(path.join(tmpdir(), "terax-homebrew-tap-"));
-  const cloneUrl =
-    process.env.HOMEBREW_TAP_REMOTE_URL ??
-    `https://x-access-token:${githubToken}@github.com/${tapRepository}.git`;
+  const cloneUrl = `https://x-access-token:${githubToken}@github.com/${tapRepository}.git`;
 
   try {
     await execFile("git", ["clone", cloneUrl, tempRoot]);
-    await writeCaskFile(tempRoot, cask);
+    await writeCaskFile(
+      tempRoot,
+      renderCask({ version, sourceRepository, arm, intel }),
+    );
     await execFile("git", ["config", "user.name", "github-actions[bot]"], {
       cwd: tempRoot,
     });
@@ -111,7 +84,7 @@ async function main() {
   }
 }
 
-function findMacAsset(assets, arch) {
+async function loadMacArtifact(assets, arch, token) {
   const dmgAssets = assets.filter((asset) => /\.dmg$/i.test(asset.name ?? ""));
   const patterns =
     arch === "arm"
@@ -127,7 +100,10 @@ function findMacAsset(assets, arch) {
         .join(", ")}`,
     );
   }
-  return match;
+  return {
+    url: match.browser_download_url,
+    sha256: await downloadSha256(match.browser_download_url, token),
+  };
 }
 
 async function downloadSha256(url, token) {
@@ -197,14 +173,6 @@ async function writeCaskFile(root, cask) {
   const caskDir = path.join(root, "Casks");
   const caskPath = path.join(caskDir, "terax.rb");
   await mkdir(caskDir, { recursive: true });
-
-  let existing = null;
-  try {
-    existing = await readFile(caskPath, "utf8");
-  } catch {
-    existing = null;
-  }
-  if (existing === cask) return;
   await writeFile(caskPath, cask, "utf8");
 }
 

--- a/scripts/sync-homebrew-tap.mjs
+++ b/scripts/sync-homebrew-tap.mjs
@@ -1,0 +1,214 @@
+import { createHash } from "node:crypto";
+import { execFile as execFileCb } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+async function main() {
+  const sourceRepository =
+    process.env.SOURCE_REPOSITORY ?? process.env.GITHUB_REPOSITORY;
+  const releaseTag = process.env.RELEASE_TAG ?? process.argv[2];
+  const tapRepository = process.env.HOMEBREW_TAP_REPOSITORY ?? "";
+  const tapPath = process.env.HOMEBREW_TAP_PATH ?? "";
+  const githubToken =
+    process.env.HOMEBREW_TAP_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN ?? "";
+
+  if (!sourceRepository) {
+    throw new Error("SOURCE_REPOSITORY or GITHUB_REPOSITORY is required.");
+  }
+  if (!releaseTag) {
+    throw new Error("RELEASE_TAG is required.");
+  }
+  if (!tapRepository && !tapPath) {
+    throw new Error(
+      "Set HOMEBREW_TAP_REPOSITORY or HOMEBREW_TAP_PATH before running sync.",
+    );
+  }
+
+  const release = await fetchJson(
+    `https://api.github.com/repos/${sourceRepository}/releases/tags/${releaseTag}`,
+    githubToken,
+  );
+  const version = String(release.tag_name).replace(/^v/, "");
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const armAsset = findMacAsset(assets, "arm");
+  const intelAsset = findMacAsset(assets, "intel");
+
+  const [armSha, intelSha] = await Promise.all([
+    downloadSha256(armAsset.browser_download_url, githubToken),
+    downloadSha256(intelAsset.browser_download_url, githubToken),
+  ]);
+
+  const cask = renderCask({
+    version,
+    sourceRepository,
+    arm: {
+      sha256: armSha,
+      url: armAsset.browser_download_url,
+    },
+    intel: {
+      sha256: intelSha,
+      url: intelAsset.browser_download_url,
+    },
+  });
+
+  if (tapPath) {
+    await writeCaskFile(tapPath, cask);
+    console.log(
+      `Wrote Homebrew cask to ${path.join(tapPath, "Casks", "terax.rb")}`,
+    );
+    return;
+  }
+
+  if (!githubToken) {
+    throw new Error(
+      "HOMEBREW_TAP_GITHUB_TOKEN or GITHUB_TOKEN is required to push to a tap repository.",
+    );
+  }
+
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "terax-homebrew-tap-"));
+  const cloneUrl =
+    process.env.HOMEBREW_TAP_REMOTE_URL ??
+    `https://x-access-token:${githubToken}@github.com/${tapRepository}.git`;
+
+  try {
+    await execFile("git", ["clone", cloneUrl, tempRoot]);
+    await writeCaskFile(tempRoot, cask);
+    await execFile("git", ["config", "user.name", "github-actions[bot]"], {
+      cwd: tempRoot,
+    });
+    await execFile(
+      "git",
+      [
+        "config",
+        "user.email",
+        "41898282+github-actions[bot]@users.noreply.github.com",
+      ],
+      { cwd: tempRoot },
+    );
+    await execFile("git", ["add", "Casks/terax.rb"], { cwd: tempRoot });
+
+    const { stdout: status } = await execFile("git", ["status", "--short"], {
+      cwd: tempRoot,
+    });
+    if (!status.trim()) {
+      console.log("Homebrew tap already up to date.");
+      return;
+    }
+
+    await execFile(
+      "git",
+      ["commit", "-m", `chore(homebrew): update terax cask for ${releaseTag}`],
+      { cwd: tempRoot },
+    );
+    await execFile("git", ["push", "origin", "HEAD"], { cwd: tempRoot });
+    console.log(`Updated ${tapRepository} for ${releaseTag}.`);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function findMacAsset(assets, arch) {
+  const dmgAssets = assets.filter((asset) => /\.dmg$/i.test(asset.name ?? ""));
+  const patterns =
+    arch === "arm"
+      ? [/aarch64/i, /arm64/i]
+      : [/x86_64/i, /x64/i, /amd64/i];
+  const match = dmgAssets.find((asset) =>
+    patterns.some((pattern) => pattern.test(asset.name ?? "")),
+  );
+  if (!match) {
+    throw new Error(
+      `Could not find ${arch} macOS .dmg asset in release assets: ${assets
+        .map((asset) => asset.name)
+        .join(", ")}`,
+    );
+  }
+  return match;
+}
+
+async function downloadSha256(url, token) {
+  const response = await fetch(url, {
+    headers: githubHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to download asset: ${url} (${response.status})`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function fetchJson(url, token) {
+  const response = await fetch(url, {
+    headers: githubHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${url} (${response.status})`);
+  }
+  return response.json();
+}
+
+function githubHeaders(token) {
+  return {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "terax-homebrew-sync",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+function renderCask({ version, sourceRepository, arm, intel }) {
+  return `cask "terax" do
+  version "${version}"
+  depends_on macos: ">= :catalina"
+  auto_updates true
+
+  on_arm do
+    sha256 "${arm.sha256}"
+    url "${arm.url}"
+  end
+
+  on_intel do
+    sha256 "${intel.sha256}"
+    url "${intel.url}"
+  end
+
+  name "Terax"
+  desc "Open-source lightweight AI-native terminal"
+  homepage "https://github.com/${sourceRepository}"
+
+  app "Terax.app"
+
+  zap trash: [
+    "~/Library/Application Support/app.crynta.terax",
+    "~/Library/Caches/app.crynta.terax",
+    "~/Library/HTTPStorages/app.crynta.terax",
+    "~/Library/Logs/app.crynta.terax",
+    "~/Library/Preferences/app.crynta.terax.plist",
+    "~/Library/Saved Application State/app.crynta.terax.savedState",
+  ]
+end
+`;
+}
+
+async function writeCaskFile(root, cask) {
+  const caskDir = path.join(root, "Casks");
+  const caskPath = path.join(caskDir, "terax.rb");
+  await mkdir(caskDir, { recursive: true });
+
+  let existing = null;
+  try {
+    existing = await readFile(caskPath, "utf8");
+  } catch {
+    existing = null;
+  }
+  if (existing === cask) return;
+  await writeFile(caskPath, cask, "utf8");
+}
+
+await main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Add Homebrew tap publishing support for macOS releases.

This adds a GitHub Actions workflow plus a small sync script that can take the published macOS release assets, compute SHA-256 values, and update a `terax` cask in a separate Homebrew tap repository.

## Why
Closes #177  

There is an open request for a Homebrew tap so Terax can be installed via `brew install --cask terax`.

Right now the repo publishes release assets, but there is no built-in path to keep a Homebrew tap updated from those releases.

## How

- add `.github/workflows/homebrew-tap.yml`
- add `scripts/sync-homebrew-tap.mjs`
- add `homebrew:sync` helper script in `package.json`
- document maintainer setup and user install commands in `README.md`

The workflow only runs on `release.published` or manual dispatch, and it is inert unless `HOMEBREW_TAP_GITHUB_TOKEN` is configured.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

Manual testing:
- ran `node --check scripts/sync-homebrew-tap.mjs`
- ran a dry run against the current public `v0.6.1` release with `HOMEBREW_TAP_PATH` set to a local temp directory
- confirmed it generated a valid `Casks/terax.rb` using the real macOS `.dmg` assets and computed SHA-256 hashes

N/A, no UI changes.

## Notes for reviewer

- This PR only adds the tap sync plumbing inside this repo. It does not create the external tap repository automatically.
- To fully enable it, maintainers would still need to create a tap repo such as `<owner>/homebrew-tap`, add `HOMEBREW_TAP_GITHUB_TOKEN`, and optionally set `HOMEBREW_TAP_REPOSITORY`.
- The new workflow does not affect existing releases unless those secrets/variables are configured.
