### PR TITLE
feat(workspace): add suport WSL (Windows) workspace environment

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod modules;
 
-use modules::{fs, net, pty, secrets, shell};
+use modules::{fs, net, pty, secrets, shell, workspace};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_window_state::StateFlags;
 
@@ -147,6 +147,9 @@ pub fn run() {
             shell::shell_bg_logs,
             shell::shell_bg_kill,
             shell::shell_bg_list,
+            workspace::wsl_list_distros,
+            workspace::wsl_default_distro,
+            workspace::wsl_home,
             open_settings_window,
             secrets::secrets_get,
             secrets::secrets_set,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
-use std::path::PathBuf;
 use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
+
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
@@ -40,8 +41,9 @@ pub struct FileStat {
 }
 
 #[tauri::command]
-pub fn fs_read_file(path: String) -> Result<ReadResult, String> {
-    let p = PathBuf::from(&path);
+pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<ReadResult, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
     let meta = std::fs::metadata(&p).map_err(|e| {
         log::debug!("fs_read_file stat({}) failed: {e}", p.display());
         e.to_string()
@@ -76,8 +78,13 @@ pub fn fs_read_file(path: String) -> Result<ReadResult, String> {
 /// Atomic write: stage into a sibling temp file, then rename over the target.
 /// Prevents partial writes from leaving a half-saved file on crash/power loss.
 #[tauri::command]
-pub fn fs_write_file(path: String, content: String) -> Result<(), String> {
-    let target = PathBuf::from(&path);
+pub fn fs_write_file(
+    path: String,
+    content: String,
+    workspace: Option<WorkspaceEnv>,
+) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let target = resolve_path(&path, &workspace);
     let parent = target
         .parent()
         .ok_or_else(|| "path has no parent".to_string())?;
@@ -115,8 +122,9 @@ pub fn fs_write_file(path: String, content: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn fs_stat(path: String) -> Result<FileStat, String> {
-    let p = PathBuf::from(&path);
+pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
     let meta = std::fs::metadata(&p).map_err(|e| e.to_string())?;
     let kind = if meta.is_dir() {
         StatKind::Dir

--- a/src-tauri/src/modules/fs/grep.rs
+++ b/src-tauri/src/modules/fs/grep.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -10,6 +9,7 @@ use ignore::{WalkBuilder, WalkState};
 use serde::Serialize;
 
 use super::to_canon;
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const FILE_SIZE_CAP: u64 = 5 * 1024 * 1024;
 const DEFAULT_MAX_RESULTS: usize = 200;
@@ -50,11 +50,13 @@ pub fn fs_grep(
     glob: Option<Vec<String>>,
     case_insensitive: Option<bool>,
     max_results: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<GrepResponse, String> {
     if pattern.is_empty() {
         return Err("empty pattern".into());
     }
-    let root_path = PathBuf::from(&root);
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
@@ -91,6 +93,8 @@ pub fn fs_grep(
         let scanned = scanned.clone();
         let truncated = truncated.clone();
         let root_path = root_path.clone();
+        let root_display = root.clone();
+        let workspace = workspace.clone();
 
         Box::new(move |dent_res| {
             if truncated.load(Ordering::Relaxed) {
@@ -121,7 +125,7 @@ pub fn fs_grep(
 
             scanned.fetch_add(1, Ordering::Relaxed);
 
-            let abs = to_canon(path);
+            let abs = display_path(path, &root_path, &root_display, &workspace);
             let rel_clone = rel.clone();
             let mut searcher = SearcherBuilder::new()
                 .binary_detection(BinaryDetection::quit(b'\x00'))
@@ -180,11 +184,13 @@ pub fn fs_glob(
     pattern: String,
     root: String,
     max_results: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<GlobResponse, String> {
     if pattern.is_empty() {
         return Err("empty pattern".into());
     }
-    let root_path = PathBuf::from(&root);
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
@@ -224,10 +230,31 @@ pub fn fs_glob(
             continue;
         }
         hits.push(GlobHit {
-            path: to_canon(path),
+            path: display_path(path, &root_path, &root, &workspace),
             rel,
         });
     }
 
     Ok(GlobResponse { hits, truncated })
+}
+
+fn display_path(
+    path: &std::path::Path,
+    root_path: &std::path::Path,
+    root_display: &str,
+    workspace: &WorkspaceEnv,
+) -> String {
+    if workspace.is_wsl() {
+        if let Ok(rel) = path.strip_prefix(root_path) {
+            let rel = to_canon(rel);
+            return if rel.is_empty() {
+                root_display.to_string()
+            } else if root_display.ends_with('/') {
+                format!("{root_display}{rel}")
+            } else {
+                format!("{root_display}/{rel}")
+            };
+        }
+    }
+    to_canon(path)
 }

--- a/src-tauri/src/modules/fs/mutate.rs
+++ b/src-tauri/src/modules/fs/mutate.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 /// Creates a new empty file. Fails if the file already exists.
 #[tauri::command]
-pub fn fs_create_file(path: String) -> Result<(), String> {
-    let p = PathBuf::from(&path);
+pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
     }
@@ -17,8 +18,9 @@ pub fn fs_create_file(path: String) -> Result<(), String> {
 /// Parents are created as needed — matches the common "new folder" UX
 /// where typing "a/b/c" creates the full chain.
 #[tauri::command]
-pub fn fs_create_dir(path: String) -> Result<(), String> {
-    let p = PathBuf::from(&path);
+pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
     }
@@ -30,9 +32,10 @@ pub fn fs_create_dir(path: String) -> Result<(), String> {
 
 /// Renames (or moves) a path. Refuses to overwrite an existing target.
 #[tauri::command]
-pub fn fs_rename(from: String, to: String) -> Result<(), String> {
-    let from_p = PathBuf::from(&from);
-    let to_p = PathBuf::from(&to);
+pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let from_p = resolve_path(&from, &workspace);
+    let to_p = resolve_path(&to, &workspace);
     if !from_p.exists() {
         return Err(format!("not found: {}", from_p.display()));
     }
@@ -52,8 +55,9 @@ pub fn fs_rename(from: String, to: String) -> Result<(), String> {
 /// Deletes a file or directory (recursively for dirs). Callers are
 /// responsible for confirming destructive operations with the user.
 #[tauri::command]
-pub fn fs_delete(path: String) -> Result<(), String> {
-    let p = PathBuf::from(&path);
+pub fn fs_delete(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
     let meta = std::fs::symlink_metadata(&p).map_err(|e| {
         log::debug!("fs_delete stat({}) failed: {e}", p.display());
         e.to_string()

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -1,9 +1,8 @@
-use std::path::PathBuf;
-
 use ignore::WalkBuilder;
 use serde::Serialize;
 
 use super::to_canon;
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 #[derive(Serialize)]
 pub struct SearchHit {
@@ -25,13 +24,15 @@ pub fn fs_search(
     root: String,
     query: String,
     limit: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<Vec<SearchHit>, String> {
     let q = query.trim().to_lowercase();
     if q.is_empty() {
         return Ok(Vec::new());
     }
     let cap = limit.unwrap_or(200).min(1000);
-    let root_path = PathBuf::from(&root);
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
@@ -69,7 +70,7 @@ pub fn fs_search(
             .unwrap_or_default();
         let is_dir = dent.file_type().map(|t| t.is_dir()).unwrap_or(false);
         out.push(SearchHit {
-            path: to_canon(path),
+            path: display_path(path, &root_path, &root, &workspace),
             rel,
             name,
             is_dir,
@@ -84,4 +85,25 @@ pub fn fs_search(
     });
 
     Ok(out)
+}
+
+fn display_path(
+    path: &std::path::Path,
+    root_path: &std::path::Path,
+    root_display: &str,
+    workspace: &WorkspaceEnv,
+) -> String {
+    if workspace.is_wsl() {
+        if let Ok(rel) = path.strip_prefix(root_path) {
+            let rel = to_canon(rel);
+            return if rel.is_empty() {
+                root_display.to_string()
+            } else if root_display.ends_with('/') {
+                format!("{root_display}{rel}")
+            } else {
+                format!("{root_display}/{rel}")
+            };
+        }
+    }
+    to_canon(path)
 }

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
 use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
+
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 #[derive(Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -24,8 +25,9 @@ pub struct DirEntry {
 /// case-insensitively. Hidden (dot-prefix) entries are filtered — UI may add
 /// a "show hidden" toggle later.
 #[tauri::command]
-pub fn fs_read_dir(path: String) -> Result<Vec<DirEntry>, String> {
-    let root = PathBuf::from(&path);
+pub fn fs_read_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<Vec<DirEntry>, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let root = resolve_path(&path, &workspace);
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("fs_read_dir({}) failed: {e}", root.display());
         e.to_string()
@@ -93,8 +95,9 @@ pub fn fs_read_dir(path: String) -> Result<Vec<DirEntry>, String> {
 /// Symlinks to directories are included (matches shell `cd` semantics).
 /// Hidden entries are filtered by dot-prefix only.
 #[tauri::command]
-pub fn list_subdirs(path: String) -> Result<Vec<String>, String> {
-    let root = PathBuf::from(&path);
+pub fn list_subdirs(path: String, workspace: Option<WorkspaceEnv>) -> Result<Vec<String>, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let root = resolve_path(&path, &workspace);
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("list_subdirs({}) read_dir failed: {e}", root.display());
         e.to_string()

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -3,3 +3,4 @@ pub mod net;
 pub mod pty;
 pub mod secrets;
 pub mod shell;
+pub mod workspace;

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -12,6 +12,7 @@ use std::thread;
 use portable_pty::PtySize;
 use tauri::ipc::{Channel, Response};
 
+use crate::modules::workspace::WorkspaceEnv;
 use session::Session;
 
 pub struct PtyState {
@@ -36,13 +37,16 @@ pub fn pty_open(
     cols: u16,
     rows: u16,
     cwd: Option<String>,
+    workspace: Option<WorkspaceEnv>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
-    let (session, _) = session::spawn(cols, rows, cwd, on_data, on_exit).map_err(|e| {
-        log::error!("pty_open failed: {e}");
-        e
-    })?;
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let (session, _) =
+        session::spawn(cols, rows, cwd, workspace, on_data, on_exit).map_err(|e| {
+            log::error!("pty_open failed: {e}");
+            e
+        })?;
     let id = state.next_id.fetch_add(1, Ordering::Relaxed);
     state.sessions.write().unwrap().insert(id, session);
     log::info!("pty opened id={id} cols={cols} rows={rows}");

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -8,6 +8,7 @@ use portable_pty::{native_pty_system, ChildKiller, MasterPty, PtySize};
 use tauri::ipc::{Channel, Response};
 
 use super::shell_init;
+use crate::modules::workspace::WorkspaceEnv;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(4);
 const BURST_MAX_AGE: Duration = Duration::from_millis(16);
@@ -59,6 +60,7 @@ pub fn spawn(
     cols: u16,
     rows: u16,
     cwd: Option<String>,
+    workspace: WorkspaceEnv,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<(Arc<Session>, PtySize), String> {
@@ -73,7 +75,7 @@ pub fn spawn(
     };
     let pair = pty_system.openpty(size).map_err(|e| e.to_string())?;
 
-    let cmd = shell_init::build_command(cwd)?;
+    let cmd = shell_init::build_command(cwd, workspace)?;
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -2,14 +2,26 @@ use std::path::PathBuf;
 
 use portable_pty::CommandBuilder;
 
-pub fn build_command(cwd: Option<String>) -> Result<CommandBuilder, String> {
+use crate::modules::workspace::WorkspaceEnv;
+
+const BASHRC_SCRIPT: &str = include_str!("scripts/bashrc.bash");
+
+fn bashrc_script() -> &'static str {
+    BASHRC_SCRIPT
+}
+
+pub fn build_command(
+    cwd: Option<String>,
+    workspace: WorkspaceEnv,
+) -> Result<CommandBuilder, String> {
     #[cfg(unix)]
     {
+        let _ = workspace;
         unix::build(cwd)
     }
     #[cfg(windows)]
     {
-        windows::build(cwd)
+        windows::build(cwd, workspace)
     }
 }
 
@@ -210,11 +222,15 @@ mod windows {
     use std::fs;
     use std::path::{Path, PathBuf};
 
+    use crate::modules::workspace::WorkspaceEnv;
     use portable_pty::CommandBuilder;
 
     const PROFILE_PS1: &str = include_str!("scripts/profile.ps1");
 
-    pub fn build(cwd: Option<String>) -> Result<CommandBuilder, String> {
+    pub fn build(cwd: Option<String>, workspace: WorkspaceEnv) -> Result<CommandBuilder, String> {
+        if let WorkspaceEnv::Wsl { distro } = workspace {
+            return build_wsl(cwd, distro);
+        }
         let shell_path = super::windows_shell_path();
         let shell_name = shell_path
             .file_name()
@@ -246,6 +262,47 @@ mod windows {
 
         log::info!("spawning Windows shell: {}", shell_path.display());
         Ok(cmd)
+    }
+
+    fn build_wsl(cwd: Option<String>, distro: String) -> Result<CommandBuilder, String> {
+        let mut cmd = CommandBuilder::new("wsl.exe");
+        cmd.arg("-d");
+        cmd.arg(&distro);
+        cmd.arg("--cd");
+        cmd.arg(cwd.as_deref().filter(|s| !s.is_empty()).unwrap_or("~"));
+        cmd.arg("--exec");
+        cmd.arg("bash");
+        match prepare_wsl_bash_rcfile(&distro) {
+            Ok(rc) => {
+                cmd.arg("--rcfile");
+                cmd.arg(rc);
+            }
+            Err(e) => {
+                log::warn!("WSL bash shell integration disabled for {distro}: {e}");
+            }
+        }
+        cmd.arg("-i");
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
+        cmd.env("TERAX_TERMINAL", "1");
+        super::ensure_utf8_locale(&mut cmd);
+        log::info!("spawning WSL shell: {distro}");
+        Ok(cmd)
+    }
+
+    fn prepare_wsl_bash_rcfile(distro: &str) -> Result<String, String> {
+        let home = crate::modules::workspace::wsl_home(distro.to_string())?;
+        let linux_dir = format!(
+            "{}/.cache/terax/shell-integration/bash",
+            home.trim_end_matches('/')
+        );
+        let linux_rc = format!("{linux_dir}/bashrc");
+        let unc_dir = crate::modules::workspace::wsl_path_to_unc(distro, &linux_dir);
+        fs::create_dir_all(&unc_dir).map_err(|e| format!("create {}: {e}", unc_dir.display()))?;
+        let unc_file = crate::modules::workspace::wsl_path_to_unc(distro, &linux_rc);
+        let content = super::bashrc_script().replace("\r\n", "\n");
+        write_if_changed(&unc_file, &content)?;
+        Ok(linux_rc)
     }
 
     fn integration_root() -> Result<PathBuf, String> {

--- a/src-tauri/src/modules/secrets.rs
+++ b/src-tauri/src/modules/secrets.rs
@@ -45,10 +45,7 @@ fn key(service: &str, account: &str) -> String {
 
 #[cfg(target_os = "linux")]
 fn store_path(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_local_data_dir()
-        .map_err(|e| e.to_string())?;
+    let dir = app.path().app_local_data_dir().map_err(|e| e.to_string())?;
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     Ok(dir.join("secrets.json"))
 }
@@ -87,11 +84,7 @@ fn write_store(app: &AppHandle, map: &HashMap<String, String>) -> Result<(), Str
 }
 
 #[cfg(target_os = "linux")]
-fn with_store<F, R>(
-    app: &AppHandle,
-    state: &SecretsState,
-    f: F,
-) -> Result<R, String>
+fn with_store<F, R>(app: &AppHandle, state: &SecretsState, f: F) -> Result<R, String>
 where
     F: FnOnce(&mut HashMap<String, String>) -> R,
 {

--- a/src-tauri/src/modules/shell/background.rs
+++ b/src-tauri/src/modules/shell/background.rs
@@ -1,5 +1,4 @@
 use std::io::Read;
-use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -10,6 +9,7 @@ use serde::Serialize;
 use shared_child::SharedChild;
 
 use super::ringbuffer::BoundedRingBuffer;
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const RING_CAP: usize = 4 * 1024 * 1024;
 
@@ -89,19 +89,23 @@ impl Drop for BackgroundProc {
     }
 }
 
-pub fn spawn(command: String, cwd: Option<String>) -> Result<Arc<BackgroundProc>, String> {
+pub fn spawn(
+    command: String,
+    cwd: Option<String>,
+    workspace: WorkspaceEnv,
+) -> Result<Arc<BackgroundProc>, String> {
     let trimmed = command.trim().to_string();
     if trimmed.is_empty() {
         return Err("empty command".into());
     }
     if let Some(ref dir) = cwd {
-        if !PathBuf::from(dir).is_dir() {
+        if !resolve_path(dir, &workspace).is_dir() {
             return Err(format!("cwd is not a directory: {dir}"));
         }
     }
 
-    let mut cmd = super::build_oneshot_command(&trimmed);
-    if let Some(ref dir) = cwd {
+    let mut cmd = super::build_oneshot_command(&trimmed, &workspace, cwd.as_deref());
+    if let (WorkspaceEnv::Local, Some(ref dir)) = (&workspace, &cwd) {
         cmd.current_dir(dir);
     }
     cmd.stdin(Stdio::null())

--- a/src-tauri/src/modules/shell/mod.rs
+++ b/src-tauri/src/modules/shell/mod.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+
 use background::{BackgroundLogResponse, BackgroundProc, BackgroundProcInfo};
 use session::{SessionRunOutput, ShellSession};
 
@@ -39,18 +41,20 @@ pub async fn shell_run_command(
     command: String,
     cwd: Option<String>,
     timeout_secs: Option<u64>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<CommandOutput, String> {
     let trimmed = command.trim().to_string();
     if trimmed.is_empty() {
         return Err("empty command".into());
     }
 
+    let workspace = WorkspaceEnv::from_option(workspace);
     let cwd_path = if let Some(dir) = cwd.as_deref().filter(|s| !s.is_empty()) {
-        let p = PathBuf::from(dir);
+        let p = resolve_path(dir, &workspace);
         if !p.is_dir() {
             return Err(format!("cwd is not a directory: {}", p.display()));
         }
-        Some(p)
+        Some(dir.to_string())
     } else {
         None
     };
@@ -65,7 +69,7 @@ pub async fn shell_run_command(
     // runtime stays unblocked.
     let (tx, rx) = mpsc::channel::<Result<CommandOutput, String>>();
     thread::spawn(move || {
-        let _ = tx.send(run_blocking(trimmed, cwd_path, dur));
+        let _ = tx.send(run_blocking(trimmed, cwd_path, workspace, dur));
     });
 
     rx.recv().map_err(|e| e.to_string())?
@@ -73,19 +77,21 @@ pub async fn shell_run_command(
 
 pub(crate) fn run_blocking_inner(
     command: String,
-    cwd: Option<PathBuf>,
+    cwd: Option<String>,
+    workspace: WorkspaceEnv,
     dur: Duration,
 ) -> Result<CommandOutput, String> {
-    run_blocking(command, cwd, dur)
+    run_blocking(command, cwd, workspace, dur)
 }
 
 fn run_blocking(
     command: String,
-    cwd: Option<PathBuf>,
+    cwd: Option<String>,
+    workspace: WorkspaceEnv,
     dur: Duration,
 ) -> Result<CommandOutput, String> {
-    let mut cmd = build_oneshot_command(&command);
-    if let Some(dir) = cwd {
+    let mut cmd = build_oneshot_command(&command, &workspace, cwd.as_deref());
+    if let (WorkspaceEnv::Local, Some(dir)) = (&workspace, cwd) {
         cmd.current_dir(dir);
     }
     cmd.stdin(Stdio::null())
@@ -160,18 +166,26 @@ impl Default for ShellState {
 pub fn shell_session_open(
     state: tauri::State<ShellState>,
     cwd: Option<String>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<u32, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
     let initial = match cwd.as_deref().filter(|s| !s.is_empty()) {
         Some(c) => {
-            let p = PathBuf::from(c);
+            let p = resolve_path(c, &workspace);
             if !p.is_dir() {
                 return Err(format!("cwd is not a directory: {c}"));
             }
-            p
+            c.to_string()
         }
-        None => dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")),
+        None => {
+            if let WorkspaceEnv::Wsl { distro } = &workspace {
+                crate::modules::workspace::wsl_home(distro.clone())?
+            } else {
+                crate::modules::fs::to_canon(dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
+            }
+        }
     };
-    let session = Arc::new(ShellSession::new(initial));
+    let session = Arc::new(ShellSession::new(initial, workspace));
     let id = state.next_session_id.fetch_add(1, Ordering::Relaxed);
     state.sessions.write().unwrap().insert(id, session);
     Ok(id)
@@ -184,6 +198,7 @@ pub async fn shell_session_run(
     command: String,
     cwd: Option<String>,
     timeout_secs: Option<u64>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<SessionRunOutput, String> {
     let session = state
         .sessions
@@ -199,7 +214,7 @@ pub async fn shell_session_run(
     );
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        let _ = tx.send(session.run(command, cwd, dur));
+        let _ = tx.send(session.run(command, cwd, workspace, dur));
     });
     rx.recv().map_err(|e| e.to_string())?
 }
@@ -215,8 +230,9 @@ pub fn shell_bg_spawn(
     state: tauri::State<ShellState>,
     command: String,
     cwd: Option<String>,
+    workspace: Option<WorkspaceEnv>,
 ) -> Result<u32, String> {
-    let proc = background::spawn(command, cwd)?;
+    let proc = background::spawn(command, cwd, WorkspaceEnv::from_option(workspace))?;
     let id = state.next_bg_id.fetch_add(1, Ordering::Relaxed);
     state.bg.write().unwrap().insert(id, proc);
     Ok(id)
@@ -257,7 +273,21 @@ pub fn shell_bg_list(state: tauri::State<ShellState>) -> Result<Vec<BackgroundPr
     Ok(out)
 }
 
-pub(crate) fn build_oneshot_command(command: &str) -> Command {
+pub(crate) fn build_oneshot_command(
+    command: &str,
+    workspace: &WorkspaceEnv,
+    cwd: Option<&str>,
+) -> Command {
+    #[cfg(windows)]
+    if let WorkspaceEnv::Wsl { distro } = workspace {
+        let mut cmd = Command::new("wsl.exe");
+        cmd.arg("-d").arg(distro);
+        if let Some(cwd) = cwd.filter(|s| !s.is_empty()) {
+            cmd.arg("--cd").arg(cwd);
+        }
+        cmd.arg("--exec").arg("sh").arg("-lc").arg(command);
+        return cmd;
+    }
     #[cfg(unix)]
     {
         let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());

--- a/src-tauri/src/modules/shell/session.rs
+++ b/src-tauri/src/modules/shell/session.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Mutex;
@@ -8,6 +7,7 @@ use std::time::Duration;
 use serde::Serialize;
 
 use super::run_blocking_inner;
+use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 /// A persistent agent shell session. Each `run` call executes through the
 /// user's login shell with the session's tracked cwd. Cwd persists across
@@ -15,7 +15,8 @@ use super::run_blocking_inner;
 /// not an interactive REPL — interactive tools must NOT be invoked here, use
 /// the background process API for long-running work).
 pub struct ShellSession {
-    pub cwd: Mutex<PathBuf>,
+    pub cwd: Mutex<String>,
+    pub workspace: WorkspaceEnv,
     /// While pristine (no `run` yet), caller-provided cwd hints reseed `cwd`.
     pub pristine: AtomicBool,
     #[allow(dead_code)]
@@ -38,19 +39,20 @@ pub struct SessionRunOutput {
 const CWD_SENTINEL: &str = "__TERAX_CWD__";
 
 impl ShellSession {
-    pub fn new(initial_cwd: PathBuf) -> Self {
+    pub fn new(initial_cwd: String, workspace: WorkspaceEnv) -> Self {
         let started_at_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
         Self {
             cwd: Mutex::new(initial_cwd),
+            workspace,
             pristine: AtomicBool::new(true),
             started_at_ms,
         }
     }
 
-    pub fn current_cwd(&self) -> PathBuf {
+    pub fn current_cwd(&self) -> String {
         self.cwd.lock().unwrap().clone()
     }
 
@@ -58,6 +60,7 @@ impl ShellSession {
         &self,
         command: String,
         cwd_hint: Option<String>,
+        workspace_hint: Option<WorkspaceEnv>,
         timeout: Duration,
     ) -> Result<SessionRunOutput, String> {
         let trimmed = command.trim().to_string();
@@ -66,31 +69,38 @@ impl ShellSession {
         }
         if self.pristine.load(Ordering::Acquire) {
             if let Some(hint) = cwd_hint.filter(|s| !s.is_empty()) {
-                let p = PathBuf::from(&hint);
+                let effective_workspace = workspace_hint.as_ref().unwrap_or(&self.workspace);
+                let p = resolve_path(&hint, effective_workspace);
                 if p.is_dir() {
-                    *self.cwd.lock().unwrap() = p;
+                    *self.cwd.lock().unwrap() = hint;
                 }
             }
         }
         let cwd = self.current_cwd();
-        let wrapped = wrap_with_sentinel(&trimmed);
+        let effective_workspace = workspace_hint.unwrap_or_else(|| self.workspace.clone());
+        let wrapped = wrap_with_sentinel(&trimmed, &effective_workspace);
 
         let (tx, rx) = mpsc::channel::<Result<super::CommandOutput, String>>();
         let cwd_for_thread = cwd.clone();
         thread::spawn(move || {
-            let _ = tx.send(run_blocking_inner(wrapped, Some(cwd_for_thread), timeout));
+            let _ = tx.send(run_blocking_inner(
+                wrapped,
+                Some(cwd_for_thread),
+                effective_workspace,
+                timeout,
+            ));
         });
         let raw = rx.recv().map_err(|e| e.to_string())??;
         self.pristine.store(false, Ordering::Release);
 
         let (stdout_clean, cwd_after) = strip_cwd_sentinel(&raw.stdout, &cwd);
         if let Some(ref new_cwd) = cwd_after {
-            let p = PathBuf::from(new_cwd);
+            let p = resolve_path(new_cwd, &self.workspace);
             if p.is_dir() {
-                *self.cwd.lock().unwrap() = p;
+                *self.cwd.lock().unwrap() = new_cwd.clone();
             }
         }
-        let resolved_cwd = crate::modules::fs::to_canon(self.current_cwd());
+        let resolved_cwd = self.current_cwd().replace('\\', "/");
 
         Ok(SessionRunOutput {
             stdout: stdout_clean,
@@ -103,21 +113,29 @@ impl ShellSession {
     }
 }
 
-#[cfg(unix)]
-fn wrap_with_sentinel(command: &str) -> String {
+fn wrap_posix_with_sentinel(command: &str) -> String {
     format!(
         "{command}\n__terax_rc=$?\nprintf '\\n%s%s\\n' '{CWD_SENTINEL}' \"$(pwd)\"\nexit $__terax_rc\n",
     )
 }
 
-#[cfg(windows)]
-fn wrap_with_sentinel(command: &str) -> String {
-    format!(
+fn wrap_with_sentinel(command: &str, workspace: &WorkspaceEnv) -> String {
+    if workspace.is_wsl() {
+        return wrap_posix_with_sentinel(command);
+    }
+    #[cfg(unix)]
+    {
+        return wrap_posix_with_sentinel(command);
+    }
+    #[cfg(windows)]
+    {
+        format!(
         "{command}\n$__terax_rc = if ($null -ne $LASTEXITCODE) {{ $LASTEXITCODE }} elseif ($?) {{ 0 }} else {{ 1 }}\n\"`n{CWD_SENTINEL}$($PWD.Path)\"\nexit $__terax_rc\n",
     )
+    }
 }
 
-fn strip_cwd_sentinel(stdout: &str, _fallback: &PathBuf) -> (String, Option<String>) {
+fn strip_cwd_sentinel(stdout: &str, _fallback: &str) -> (String, Option<String>) {
     if let Some(idx) = stdout.rfind(CWD_SENTINEL) {
         let before = &stdout[..idx];
         let after = &stdout[idx + CWD_SENTINEL.len()..];

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -114,12 +114,13 @@ pub fn wsl_list_distros() -> Result<Vec<WslDistro>, String> {
             }
             let default = line.starts_with('*');
             let line = line.trim_start_matches('*').trim();
-            let mut parts = line.split_whitespace();
-            let name = match parts.next() {
-                Some(n) => n.to_string(),
-                None => continue,
-            };
-            let state = parts.next().unwrap_or_default();
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() < 3 {
+                continue;
+            }
+            let state_idx = parts.len() - 2;
+            let name = parts[..state_idx].join(" ");
+            let state = parts[state_idx];
             distros.push(WslDistro {
                 name,
                 default,

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -1,0 +1,160 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum WorkspaceEnv {
+    #[default]
+    Local,
+    Wsl {
+        distro: String,
+    },
+}
+
+impl WorkspaceEnv {
+    pub fn from_option(workspace: Option<Self>) -> Self {
+        workspace.unwrap_or_default()
+    }
+
+    pub fn is_wsl(&self) -> bool {
+        matches!(self, Self::Wsl { .. })
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct WslDistro {
+    pub name: String,
+    pub default: bool,
+    pub running: bool,
+}
+
+#[cfg(windows)]
+pub fn resolve_path(path: &str, workspace: &WorkspaceEnv) -> PathBuf {
+    match workspace {
+        WorkspaceEnv::Local => PathBuf::from(path),
+        WorkspaceEnv::Wsl { distro } => wsl_path_to_unc(distro, path),
+    }
+}
+
+#[cfg(not(windows))]
+pub fn resolve_path(path: &str, _workspace: &WorkspaceEnv) -> PathBuf {
+    PathBuf::from(path)
+}
+
+#[cfg(windows)]
+pub fn wsl_path_to_unc(distro: &str, path: &str) -> PathBuf {
+    let normalized = path.replace('\\', "/");
+    let trimmed = normalized.trim_start_matches('/');
+    let primary = PathBuf::from(format!(
+        r"\\wsl.localhost\{}\{}",
+        distro,
+        trimmed.replace('/', r"\")
+    ));
+    if primary.exists() {
+        return primary;
+    }
+    PathBuf::from(format!(r"\\wsl$\{}\{}", distro, trimmed.replace('/', r"\")))
+}
+
+#[cfg(windows)]
+pub fn decode_command_output(bytes: &[u8]) -> String {
+    if bytes.starts_with(&[0xff, 0xfe]) || looks_utf16le(bytes) {
+        let start = if bytes.starts_with(&[0xff, 0xfe]) {
+            2
+        } else {
+            0
+        };
+        let units: Vec<u16> = bytes[start..]
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16_lossy(&units)
+    } else {
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+}
+
+#[cfg(windows)]
+fn looks_utf16le(bytes: &[u8]) -> bool {
+    if bytes.len() < 4 || !bytes.len().is_multiple_of(2) {
+        return false;
+    }
+    let nul_odd = bytes.iter().skip(1).step_by(2).filter(|b| **b == 0).count();
+    nul_odd * 2 >= bytes.len() / 2
+}
+
+#[cfg(windows)]
+fn run_wsl(args: &[&str]) -> Result<String, String> {
+    let out = std::process::Command::new("wsl.exe")
+        .args(args)
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        let stderr = decode_command_output(&out.stderr);
+        return Err(stderr.trim().to_string());
+    }
+    Ok(decode_command_output(&out.stdout))
+}
+
+#[tauri::command]
+pub fn wsl_list_distros() -> Result<Vec<WslDistro>, String> {
+    #[cfg(not(windows))]
+    {
+        Ok(Vec::new())
+    }
+    #[cfg(windows)]
+    {
+        let out = run_wsl(&["--list", "--verbose"])?;
+        let mut distros = Vec::new();
+        for raw in out.lines().skip(1) {
+            let line = raw.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let default = line.starts_with('*');
+            let line = line.trim_start_matches('*').trim();
+            let mut parts = line.split_whitespace();
+            let name = match parts.next() {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            let state = parts.next().unwrap_or_default();
+            distros.push(WslDistro {
+                name,
+                default,
+                running: state.eq_ignore_ascii_case("Running"),
+            });
+        }
+        Ok(distros)
+    }
+}
+
+#[tauri::command]
+pub fn wsl_default_distro() -> Result<Option<String>, String> {
+    let distros = wsl_list_distros()?;
+    Ok(distros
+        .iter()
+        .find(|d| d.default)
+        .map(|d| d.name.clone())
+        .or_else(|| distros.first().map(|d| d.name.clone())))
+}
+
+#[tauri::command]
+pub fn wsl_home(distro: String) -> Result<String, String> {
+    #[cfg(not(windows))]
+    {
+        let _ = distro;
+        Err("WSL is only available on Windows".into())
+    }
+    #[cfg(windows)]
+    {
+        let out = run_wsl(&["-d", &distro, "--exec", "sh", "-lc", "printf %s \"$HOME\""])?;
+        let home = out.trim().to_string();
+        if home.is_empty() {
+            Err(format!("could not resolve WSL home for {distro}"))
+        } else {
+            Ok(home)
+        }
+    }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,6 +62,12 @@ import {
 } from "@/modules/terminal";
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
+import {
+  getWslHome,
+  LOCAL_WORKSPACE,
+  useWorkspaceEnvStore,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
 import { homeDir } from "@tauri-apps/api/path";
 import type { SearchAddon } from "@xterm/addon-search";
 import { AnimatePresence, motion } from "motion/react";
@@ -89,6 +95,7 @@ export default function App() {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
+    resetWorkspace,
   } = useTabs();
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -121,12 +128,55 @@ export default function App() {
 
   const [home, setHome] = useState<string | null>(null);
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
+  const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
+  const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
   useEffect(() => {
     // Forward-slash form so explorerRoot stays equal across home → OSC 7.
     homeDir()
       .then((p) => setHome(p.replace(/\\/g, "/")))
       .catch(() => setHome(null));
   }, []);
+
+  const switchWorkspace = useCallback(
+    async (env: WorkspaceEnv) => {
+      if (
+        env.kind === workspaceEnv.kind &&
+        (env.kind === "local" ||
+          (workspaceEnv.kind === "wsl" && env.distro === workspaceEnv.distro))
+      ) {
+        return;
+      }
+      const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
+      if (dirty) {
+        window.alert("Save or close unsaved editor tabs before switching workspace.");
+        return;
+      }
+
+      let nextHome: string | null = null;
+      try {
+        if (env.kind === "wsl") {
+          nextHome = await getWslHome(env.distro);
+        } else {
+          nextHome = (await homeDir()).replace(/\\/g, "/");
+        }
+      } catch (e) {
+        window.alert(String(e));
+        return;
+      }
+
+      for (const id of liveLeavesRef.current) disposeSession(id);
+      searchAddons.current.clear();
+      terminalRefs.current.clear();
+      editorRefs.current.clear();
+      previewRefs.current.clear();
+      setActiveSearchAddon(null);
+      setActiveEditorHandle(null);
+      setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
+      setHome(nextHome);
+      resetWorkspace(nextHome ?? undefined);
+    },
+    [workspaceEnv, setWorkspaceEnv, resetWorkspace],
+  );
 
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [newEditorOpen, setNewEditorOpen] = useState(false);
@@ -827,6 +877,7 @@ export default function App() {
             filePath={activeFilePath}
             home={home}
             onCd={sendCd}
+            onWorkspaceChange={switchWorkspace}
             onOpenMini={openMini}
             hasComposer={hasComposer}
           />

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -11,6 +11,7 @@ import { expandSnippetTokens, type Snippet } from "../lib/snippets";
 import { tryRunSlashCommand, type SlashCommandMeta } from "./slashCommands";
 import { getOrCreateChat, useChatStore } from "../store/chatStore";
 import { useSnippetsStore } from "../store/snippetsStore";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 export type FileAttachment = {
   id: string;
@@ -175,7 +176,10 @@ export function AiComposerProvider({ children }: ProviderProps) {
         | { kind: "text"; content: string; size: number }
         | { kind: "binary"; size: number }
         | { kind: "toolarge"; size: number; limit: number };
-      const result = await invoke<ReadResult>("fs_read_file", { path });
+      const result = await invoke<ReadResult>("fs_read_file", {
+        path,
+        workspace: currentWorkspaceEnv(),
+      });
       if (result.kind !== "text") {
         // Binary/oversize files: skip (could surface a toast in future).
         console.warn("attachFileByPath: skipped non-text file", path, result);

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 export type ReadResult =
   | { kind: "text"; content: string; size: number }
@@ -37,12 +38,26 @@ export type GlobHit = { path: string; rel: string };
 export type GlobResponse = { hits: GlobHit[]; truncated: boolean };
 
 export const native = {
-  readFile: (path: string) => invoke<ReadResult>("fs_read_file", { path }),
+  readFile: (path: string) =>
+    invoke<ReadResult>("fs_read_file", {
+      path,
+      workspace: currentWorkspaceEnv(),
+    }),
   writeFile: (path: string, content: string) =>
-    invoke<void>("fs_write_file", { path, content }),
-  createFile: (path: string) => invoke<void>("fs_create_file", { path }),
-  createDir: (path: string) => invoke<void>("fs_create_dir", { path }),
-  readDir: (path: string) => invoke<DirEntry[]>("fs_read_dir", { path }),
+    invoke<void>("fs_write_file", {
+      path,
+      content,
+      workspace: currentWorkspaceEnv(),
+    }),
+  createFile: (path: string) =>
+    invoke<void>("fs_create_file", { path, workspace: currentWorkspaceEnv() }),
+  createDir: (path: string) =>
+    invoke<void>("fs_create_dir", { path, workspace: currentWorkspaceEnv() }),
+  readDir: (path: string) =>
+    invoke<DirEntry[]>("fs_read_dir", {
+      path,
+      workspace: currentWorkspaceEnv(),
+    }),
   grep: (params: {
     pattern: string;
     root: string;
@@ -56,12 +71,14 @@ export const native = {
       glob: params.glob ?? null,
       caseInsensitive: params.caseInsensitive ?? null,
       maxResults: params.maxResults ?? null,
+      workspace: currentWorkspaceEnv(),
     }),
   glob: (params: { pattern: string; root: string; maxResults?: number }) =>
     invoke<GlobResponse>("fs_glob", {
       pattern: params.pattern,
       root: params.root,
       maxResults: params.maxResults ?? null,
+      workspace: currentWorkspaceEnv(),
     }),
   runCommand: (
     command: string,
@@ -72,10 +89,14 @@ export const native = {
       command,
       cwd: cwd ?? null,
       timeoutSecs: timeoutSecs ?? null,
+      workspace: currentWorkspaceEnv(),
     }),
 
   shellSessionOpen: (cwd?: string | null) =>
-    invoke<number>("shell_session_open", { cwd: cwd ?? null }),
+    invoke<number>("shell_session_open", {
+      cwd: cwd ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
   shellSessionRun: (
     id: number,
     command: string,
@@ -94,11 +115,16 @@ export const native = {
       command,
       cwd: cwd ?? null,
       timeoutSecs: timeoutSecs ?? null,
+      workspace: currentWorkspaceEnv(),
     }),
   shellSessionClose: (id: number) =>
     invoke<void>("shell_session_close", { id }),
   shellBgSpawn: (command: string, cwd?: string | null) =>
-    invoke<number>("shell_bg_spawn", { command, cwd: cwd ?? null }),
+    invoke<number>("shell_bg_spawn", {
+      command,
+      cwd: cwd ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
   shellBgLogs: (handle: number, sinceOffset?: number) =>
     invoke<{
       bytes: string;

--- a/src/modules/ai/tools/shell.ts
+++ b/src/modules/ai/tools/shell.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { native } from "../lib/native";
 import { checkShellCommand } from "../lib/security";
 import type { ToolContext } from "./context";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 /**
  * Per-session lazy shell-session id. The agent gets one persistent shell per
@@ -22,6 +23,11 @@ async function getSessionShell(
   return p;
 }
 
+function workspaceSessionKey(sessionId: string): string {
+  const env = currentWorkspaceEnv();
+  return env.kind === "wsl" ? `${sessionId}:wsl:${env.distro}` : `${sessionId}:local`;
+}
+
 export function buildShellTools(ctx: ToolContext) {
   return {
     bash_run: tool({
@@ -39,7 +45,7 @@ export function buildShellTools(ctx: ToolContext) {
         if (!sid) return { error: "no active chat session" };
         try {
           const cwd = ctx.getCwd();
-          const shellId = await getSessionShell(sid, cwd);
+          const shellId = await getSessionShell(workspaceSessionKey(sid), cwd);
           const r = await native.shellSessionRun(
             shellId,
             command,

--- a/src/modules/editor/NewEditorDialog.tsx
+++ b/src/modules/editor/NewEditorDialog.tsx
@@ -12,6 +12,7 @@ import { File02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef, useState } from "react";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 type Props = {
   open: boolean;
@@ -68,7 +69,7 @@ export function NewEditorDialog({
       ? trimmed
       : joinPath(rootPath, trimmed);
     try {
-      await invoke("fs_create_file", { path });
+      await invoke("fs_create_file", { path, workspace: currentWorkspaceEnv() });
       onCreated(path);
       onOpenChange(false);
     } catch (e) {

--- a/src/modules/editor/lib/useDocument.ts
+++ b/src/modules/editor/lib/useDocument.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 type ReadResult =
   | { kind: "text"; content: string; size: number }
@@ -46,7 +47,7 @@ export function useDocument({ path, onDirtyChange }: Options) {
     setDoc({ status: "loading" });
     setDirty(false);
 
-    invoke<ReadResult>("fs_read_file", { path })
+    invoke<ReadResult>("fs_read_file", { path, workspace: currentWorkspaceEnv() })
       .then((res) => {
         if (cancelled) return;
         if (res.kind === "text") {
@@ -92,7 +93,7 @@ export function useDocument({ path, onDirtyChange }: Options) {
   const save = useCallback(async () => {
     if (!dirty) return;
     const content = bufferRef.current;
-    await invoke("fs_write_file", { path, content });
+    await invoke("fs_write_file", { path, content, workspace: currentWorkspaceEnv() });
     savedRef.current = content;
     setDirty(false);
   }, [path, dirty]);

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -7,6 +7,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 import { motion } from "motion/react";
 import {
   forwardRef,
@@ -82,6 +83,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
           root: rootPath,
           query: q,
           limit: 200,
+          workspace: currentWorkspaceEnv(),
         });
         if (alive) setResults(hits);
       } catch (e) {

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 export type DirEntry = {
   name: string;
@@ -48,7 +49,10 @@ export function useFileTree(rootPath: string | null, options?: Options) {
   const fetchChildren = useCallback(async (path: string) => {
     setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
     try {
-      const entries = await invoke<DirEntry[]>("fs_read_dir", { path });
+      const entries = await invoke<DirEntry[]>("fs_read_dir", {
+        path,
+        workspace: currentWorkspaceEnv(),
+      });
       setNodes((s) => ({ ...s, [path]: { status: "loaded", entries } }));
     } catch (e) {
       setNodes((s) => ({
@@ -152,7 +156,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
       const cmd =
         pendingCreate.kind === "dir" ? "fs_create_dir" : "fs_create_file";
       try {
-        await invoke(cmd, { path });
+        await invoke(cmd, { path, workspace: currentWorkspaceEnv() });
         await fetchChildren(pendingCreate.parentPath);
       } catch (e) {
         console.error(`${cmd} failed:`, e);
@@ -182,7 +186,11 @@ export function useFileTree(rootPath: string | null, options?: Options) {
       }
       const to = joinPath(parent, trimmed);
       try {
-        await invoke("fs_rename", { from: renaming, to });
+        await invoke("fs_rename", {
+          from: renaming,
+          to,
+          workspace: currentWorkspaceEnv(),
+        });
         options?.onPathRenamed?.(renaming, to);
         await fetchChildren(parent);
       } catch (e) {
@@ -197,7 +205,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
   const deletePath = useCallback(
     async (path: string) => {
       try {
-        await invoke("fs_delete", { path });
+        await invoke("fs_delete", { path, workspace: currentWorkspaceEnv() });
         options?.onPathDeleted?.(path);
         await fetchChildren(dirname(path));
       } catch (e) {

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -57,6 +57,7 @@ export type Preferences = {
   vimMode: boolean;
   terminalWebglEnabled: boolean;
   terminalFontSize: number;
+  lastWslDistro: string | null;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
 
@@ -79,6 +80,7 @@ const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
+const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_SHORTCUTS = "shortcuts";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
@@ -108,6 +110,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   vimMode: false,
   terminalWebglEnabled: true,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
+  lastWslDistro: null,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
 
@@ -175,6 +178,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalFontSize:
       get<number>(KEY_TERMINAL_FONT_SIZE) ??
       DEFAULT_PREFERENCES.terminalFontSize,
+    lastWslDistro:
+      get<string | null>(KEY_LAST_WSL_DISTRO) ??
+      DEFAULT_PREFERENCES.lastWslDistro,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -261,6 +267,10 @@ export async function setTerminalFontSize(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_SIZE, clamped);
 }
 
+export async function setLastWslDistro(value: string | null): Promise<void> {
+  await writePref(KEY_LAST_WSL_DISTRO, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {}
 ): Promise<void> {
@@ -298,6 +308,7 @@ export async function onPreferencesChange(
     [KEY_VIM_MODE]: "vimMode",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
+    [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_SHORTCUTS]: "shortcuts",
   };
   // Same-process writes still fire onChange immediately; cross-window writes

--- a/src/modules/statusbar/CwdBreadcrumb.tsx
+++ b/src/modules/statusbar/CwdBreadcrumb.tsx
@@ -22,6 +22,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 import { segmentsFromCwd } from "./lib/pathUtils";
 
 type Props = {
@@ -184,7 +185,10 @@ function CurrentSegmentDropdown({
   const load = useCallback(async () => {
     setError(null);
     try {
-      const dirs = await invoke<string[]>("list_subdirs", { path });
+      const dirs = await invoke<string[]>("list_subdirs", {
+        path,
+        workspace: currentWorkspaceEnv(),
+      });
       setChildren(dirs);
     } catch (e) {
       setError(String(e));

--- a/src/modules/statusbar/StatusBar.tsx
+++ b/src/modules/statusbar/StatusBar.tsx
@@ -5,12 +5,15 @@ import {
 } from "@/modules/ai/components/AiStatusBarControls";
 import { useChatStore } from "@/modules/ai";
 import { CwdBreadcrumb } from "./CwdBreadcrumb";
+import { WorkspaceEnvSelector } from "./WorkspaceEnvSelector";
+import type { WorkspaceEnv } from "@/modules/workspace";
 
 type Props = {
   cwd: string | null;
   filePath?: string | null;
   home: string | null;
   onCd: (path: string) => void;
+  onWorkspaceChange: (env: WorkspaceEnv) => void;
   onOpenMini: () => void;
   /** Only rendered when the AI panel is open and a key is loaded. */
   hasComposer: boolean;
@@ -21,6 +24,7 @@ export function StatusBar({
   filePath,
   home,
   onCd,
+  onWorkspaceChange,
   onOpenMini,
   hasComposer,
 }: Props) {
@@ -29,7 +33,8 @@ export function StatusBar({
 
   return (
     <footer className="flex h-8 shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-card/60 px-3 text-[11px]">
-      <div className="min-w-0 flex-1 truncate">
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 truncate">
+        <WorkspaceEnvSelector onSelect={onWorkspaceChange} />
         <CwdBreadcrumb cwd={cwd} filePath={filePath} home={home} onCd={onCd} />
       </div>
       <div className="flex shrink-0 items-center gap-1.5">

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -12,6 +12,7 @@ import {
   useWorkspaceEnvStore,
   type WorkspaceEnv,
 } from "@/modules/workspace";
+import { IS_WINDOWS } from "@/lib/platform";
 import { useEffect } from "react";
 
 type Props = {
@@ -19,6 +20,8 @@ type Props = {
 };
 
 export function WorkspaceEnvSelector({ onSelect }: Props) {
+  if (!IS_WINDOWS) return null;
+
   const env = useWorkspaceEnvStore((s) => s.env);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -1,0 +1,77 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Folder01Icon, Refresh01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  LOCAL_WORKSPACE,
+  useWorkspaceEnvStore,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
+import { useEffect } from "react";
+
+type Props = {
+  onSelect: (env: WorkspaceEnv) => void;
+};
+
+export function WorkspaceEnvSelector({ onSelect }: Props) {
+  const env = useWorkspaceEnvStore((s) => s.env);
+  const distros = useWorkspaceEnvStore((s) => s.distros);
+  const loading = useWorkspaceEnvStore((s) => s.loading);
+  const error = useWorkspaceEnvStore((s) => s.error);
+  const refreshDistros = useWorkspaceEnvStore((s) => s.refreshDistros);
+
+  useEffect(() => {
+    void refreshDistros();
+  }, [refreshDistros]);
+
+  const label = env.kind === "wsl" ? `WSL: ${env.distro}` : "Windows";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex h-6 shrink-0 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:bg-accent data-[state=open]:text-foreground"
+          title="Workspace environment"
+        >
+          <HugeiconsIcon icon={Folder01Icon} size={13} strokeWidth={1.75} />
+          <span className="max-w-28 truncate">{label}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-48">
+        <DropdownMenuItem onSelect={() => onSelect(LOCAL_WORKSPACE)}>
+          Windows Local
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {distros.length === 0 ? (
+          <DropdownMenuItem disabled>
+            {loading
+              ? "Loading WSL distros..."
+              : error
+                ? "WSL unavailable"
+                : "No WSL distros found"}
+          </DropdownMenuItem>
+        ) : (
+          distros.map((distro) => (
+            <DropdownMenuItem
+              key={distro.name}
+              onSelect={() => onSelect({ kind: "wsl", distro: distro.name })}
+            >
+              WSL: {distro.name}
+            </DropdownMenuItem>
+          ))
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => void refreshDistros()}>
+          <HugeiconsIcon icon={Refresh01Icon} size={13} strokeWidth={1.75} />
+          Refresh
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -459,6 +459,22 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return closedTab;
   }, []);
 
+  const resetWorkspace = useCallback((cwd?: string) => {
+    const tabId = nextIdRef.current++;
+    const leafId = nextIdRef.current++;
+    setTabs([
+      {
+        id: tabId,
+        kind: "terminal",
+        title: "shell",
+        cwd,
+        paneTree: { kind: "leaf", id: leafId, cwd },
+        activeLeafId: leafId,
+      },
+    ]);
+    setActiveId(tabId);
+  }, []);
+
   return {
     tabs,
     activeId,
@@ -478,5 +494,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
+    resetWorkspace,
   };
 }

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -1,4 +1,5 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
 
 export type PtyHandlers = {
   onData: (bytes: Uint8Array) => void;
@@ -29,6 +30,7 @@ export async function openPty(
     cols,
     rows,
     cwd: cwd ?? null,
+    workspace: currentWorkspaceEnv(),
     onData,
     onExit,
   });

--- a/src/modules/workspace/env.ts
+++ b/src/modules/workspace/env.ts
@@ -1,0 +1,54 @@
+import { invoke } from "@tauri-apps/api/core";
+import { create } from "zustand";
+import { setLastWslDistro } from "@/modules/settings/store";
+
+export type WorkspaceEnv =
+  | { kind: "local" }
+  | { kind: "wsl"; distro: string };
+
+export type WslDistro = {
+  name: string;
+  default: boolean;
+  running: boolean;
+};
+
+type State = {
+  env: WorkspaceEnv;
+  distros: WslDistro[];
+  loading: boolean;
+  error: string | null;
+  setEnv: (env: WorkspaceEnv) => void;
+  refreshDistros: () => Promise<WslDistro[]>;
+};
+
+export const LOCAL_WORKSPACE: WorkspaceEnv = { kind: "local" };
+
+export const useWorkspaceEnvStore = create<State>((set) => ({
+  env: LOCAL_WORKSPACE,
+  distros: [],
+  loading: false,
+  error: null,
+  setEnv: (env) => {
+    set({ env });
+    if (env.kind === "wsl") void setLastWslDistro(env.distro);
+  },
+  refreshDistros: async () => {
+    set({ loading: true, error: null });
+    try {
+      const distros = await invoke<WslDistro[]>("wsl_list_distros");
+      set({ distros, loading: false });
+      return distros;
+    } catch (e) {
+      set({ distros: [], loading: false, error: String(e) });
+      return [];
+    }
+  },
+}));
+
+export function currentWorkspaceEnv(): WorkspaceEnv {
+  return useWorkspaceEnvStore.getState().env;
+}
+
+export async function getWslHome(distro: string): Promise<string> {
+  return invoke<string>("wsl_home", { distro });
+}

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -1,0 +1,8 @@
+export {
+  currentWorkspaceEnv,
+  getWslHome,
+  LOCAL_WORKSPACE,
+  useWorkspaceEnvStore,
+  type WorkspaceEnv,
+  type WslDistro,
+} from "./env";


### PR DESCRIPTION
## What
Adds a workspace environment selector on Windows so the app can run in either Windows Local or a selected WSL distro. The selected environment is propagated through PTY sessions, filesystem operations, explorer/editor/search, and AI shell/filesystem tools.

## Why
WSL workspaces should behave like a first-class workspace target instead of mixing Windows terminal/process behavior with Linux project paths.

Closes #180
Closes #154

## How
Introduces a shared `WorkspaceEnv` contract, WSL distro discovery/home resolution commands, WSL path resolution to UNC paths for Rust filesystem access, and WSL command spawning through `wsl.exe`. The status bar selector resets incompatible workspace state on environment changes and blocks switching when editor tabs have unsaved changes.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

Manual smoke-test covered WSL distro listing for Ubuntu, resolving `/home/vinicios`, launching the WSL bash integration script without the CRLF startup error, and confirming the status-bar focus ring issue was removed after selection.

## Screenshots / GIFs
<img width="292" height="198" alt="Captura de tela 2026-05-12 214050" src="https://github.com/user-attachments/assets/4e111907-b443-4418-ba39-fd2af39b7f08" />

<img width="478" height="209" alt="Captura de tela 2026-05-12 214818" src="https://github.com/user-attachments/assets/90145242-c1f9-4d8a-a387-388599e5dda1" />

## Notes for reviewer
The app still starts in Windows Local by design; only the last selected WSL distro is persisted. Workspace switching intentionally resets tabs/sessions in v1 instead of mixing Windows and WSL tabs.
