### PR TITLE
fix(pty): add missing terax_open and tp alias to powershell

### DIFF
--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -32,6 +32,28 @@ function global:__terax_urlencode {
     $sb.ToString()
 }
 
+function global:terax_open {
+    param([string]$File)
+
+    if ([string]::IsNullOrWhiteSpace($File)) {
+        Write-Error 'usage: terax_open <file>'
+        return
+    }
+
+    # Resolve relative paths and ensure it exists.
+    $Path = Resolve-Path $File -ErrorAction SilentlyContinue
+    if ($null -eq $Path -or !(Test-Path $Path.Path -PathType Leaf)) {
+        Write-Error "terax_open: not a file: $File"
+        return
+    }
+
+    $esc = [char]27
+    $pathEnc = __terax_urlencode ($Path.Path -replace '\\','/')
+    Write-Host -NoNewline "$esc]8888;file=$pathEnc$esc\"
+}
+
+Set-Alias -Name tp -Value terax_open -Scope Global -Force
+
 function global:prompt {
     $lec = $LASTEXITCODE
     if ($null -eq $lec) { $lec = if ($?) { 0 } else { 1 } }


### PR DESCRIPTION
## What
Adds the missing `terax_open` function and `tp` alias to the PowerShell shell integration (`profile.ps1`).

## Why
Bash and Zsh implementations of Terax shell integration already have `terax_open` (introduced in #27), but PowerShell was missing it, leading to feature disparity and broken user workflows on Windows.

## How
Implemented `global:terax_open` in `profile.ps1` that:
1. Validates input.
2. Resolves relative paths via `Resolve-Path`.
3. Normalizes backslashes to forward slashes.
4. URL-encodes the path.
5. Emits the `OSC 8888` sequence.

## Testing
- [x] `pnpm exec tsc --noEmit` (Failed due to unrelated existing errors in `main`)
- [x] Manual smoke-test of the affected feature (Simulated OSC emission)
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
N/A (Shell script change)

## Notes for reviewer
This fixes a long-standing omission from PR #27. It does not include URL opening from PR #84 to avoid conflicts and maintain a single logical change.