### PR TITLE
feat(terminal): add pane context menu and sync explorer on focus

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -88,6 +88,7 @@ export default function App() {
     focusPane,
     focusNextPaneInTab,
     splitActivePane,
+    splitPaneByLeaf,
     closeActivePane,
     closePaneByLeaf,
   } = useTabs();
@@ -754,6 +755,8 @@ export default function App() {
                         onCwd={handleTerminalCwd}
                         onExit={handleLeafExit}
                         onFocusLeaf={handleFocusLeaf}
+                        onSplitPane={splitPaneByLeaf}
+                        onClosePane={closePaneByLeaf}
                       />
                     </div>
                     <div

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import {
   hasLeaf,
+  findLeafCwd,
   leafIds,
   nextLeafId,
   removeLeaf,
@@ -374,7 +375,8 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         if (t.id !== tabId || t.kind !== "terminal") return t;
         if (!hasLeaf(t.paneTree, leafId)) return t;
         if (t.activeLeafId === leafId) return t;
-        return { ...t, activeLeafId: leafId };
+        const cwd = findLeafCwd(t.paneTree, leafId) ?? t.cwd;
+        return { ...t, activeLeafId: leafId, cwd };
       }),
     );
   }, []);
@@ -413,6 +415,33 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             t.cwd,
           );
           return { ...t, paneTree, activeLeafId: leafId };
+        }),
+      );
+      return newLeafId;
+    },
+    [],
+  );
+
+  const splitPaneByLeaf = useCallback(
+    (leafId: number, dir: SplitDir, before: boolean = false): number | null => {
+      let newLeafId: number | null = null;
+      setTabs((curr) =>
+        curr.map((t) => {
+          if (t.kind !== "terminal" || !hasLeaf(t.paneTree, leafId)) return t;
+          if (leafIds(t.paneTree).length >= MAX_PANES_PER_TAB) return t;
+          const splitId = nextIdRef.current++;
+          const lid = nextIdRef.current++;
+          newLeafId = lid;
+          const paneTree = splitLeaf(
+            t.paneTree,
+            leafId,
+            splitId,
+            lid,
+            dir,
+            t.cwd,
+            before,
+          );
+          return { ...t, paneTree, activeLeafId: lid };
         }),
       );
       return newLeafId;
@@ -498,6 +527,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     focusPane,
     focusNextPaneInTab,
     splitActivePane,
+    splitPaneByLeaf,
     closeActivePane,
     closePaneByLeaf,
   };

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -4,9 +4,16 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import type { SearchAddon } from "@xterm/addon-search";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
-import type { PaneNode } from "./lib/panes";
+import type { PaneNode, SplitDir } from "./lib/panes";
 
 type LeafBundle = {
   setRef: (h: TerminalPaneHandle | null) => void;
@@ -20,6 +27,8 @@ type Props = {
   tabVisible: boolean;
   activeLeafId: number;
   onFocusLeaf: (leafId: number) => void;
+  onSplitPane: (leafId: number, dir: SplitDir, before: boolean) => void;
+  onClosePane: (leafId: number) => void;
   getBundle: (leafId: number) => LeafBundle;
 };
 
@@ -28,35 +37,73 @@ export function PaneTreeView({
   tabVisible,
   activeLeafId,
   onFocusLeaf,
+  onSplitPane,
+  onClosePane,
   getBundle,
 }: Props) {
   if (node.kind === "leaf") {
     const focused = node.id === activeLeafId;
     const b = getBundle(node.id);
     return (
-      <div
-        onMouseDownCapture={() => {
-          if (!focused) onFocusLeaf(node.id);
-        }}
-        // Catches focus from Tab, programmatic focus, or any path that
-        // skips mousedown — keeps activeLeafId in sync with DOM focus.
-        onFocus={() => {
-          if (!focused) onFocusLeaf(node.id);
-        }}
-        data-pane-leaf={node.id}
-        className="relative h-full w-full"
-      >
-        <TerminalPane
-          leafId={node.id}
-          visible={tabVisible}
-          focused={focused}
-          initialCwd={node.cwd}
-          ref={b.setRef}
-          onSearchReady={(_id, addon) => b.onSearch(addon)}
-          onCwd={(_id, cwd) => b.onCwd(cwd)}
-          onExit={(_id, code) => b.onExit(code)}
-        />
-      </div>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            onMouseDownCapture={() => {
+              if (!focused) onFocusLeaf(node.id);
+            }}
+            onFocus={() => {
+              if (!focused) onFocusLeaf(node.id);
+            }}
+            data-pane-leaf={node.id}
+            className="relative h-full w-full"
+          >
+            <TerminalPane
+              leafId={node.id}
+              visible={tabVisible}
+              focused={focused}
+              initialCwd={node.cwd}
+              ref={b.setRef}
+              onSearchReady={(_id, addon) => b.onSearch(addon)}
+              onCwd={(_id, cwd) => b.onCwd(cwd)}
+              onExit={(_id, code) => b.onExit(code)}
+            />
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="min-w-44 rounded-2xl p-1">
+          <ContextMenuItem
+            className="rounded-xl px-2.5 py-1.5 text-xs gap-2"
+            onSelect={() => onSplitPane(node.id, "col", true)}
+          >
+            Split Up
+          </ContextMenuItem>
+          <ContextMenuItem
+            className="rounded-xl px-2.5 py-1.5 text-xs gap-2"
+            onSelect={() => onSplitPane(node.id, "col", false)}
+          >
+            Split Down
+          </ContextMenuItem>
+          <ContextMenuItem
+            className="rounded-xl px-2.5 py-1.5 text-xs gap-2"
+            onSelect={() => onSplitPane(node.id, "row", true)}
+          >
+            Split Left
+          </ContextMenuItem>
+          <ContextMenuItem
+            className="rounded-xl px-2.5 py-1.5 text-xs gap-2"
+            onSelect={() => onSplitPane(node.id, "row", false)}
+          >
+            Split Right
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            className="rounded-xl px-2.5 py-1.5 text-xs gap-2"
+            variant="destructive"
+            onSelect={() => onClosePane(node.id)}
+          >
+            Close Pane
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
     );
   }
 
@@ -73,6 +120,8 @@ export function PaneTreeView({
               tabVisible={tabVisible}
               activeLeafId={activeLeafId}
               onFocusLeaf={onFocusLeaf}
+              onSplitPane={onSplitPane}
+              onClosePane={onClosePane}
               getBundle={getBundle}
             />
           </ResizablePanel>

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -3,7 +3,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { useEffect, useRef } from "react";
 import { PaneTreeView } from "./PaneTreeView";
 import type { TerminalPaneHandle } from "./TerminalPane";
-import { leafIds } from "./lib/panes";
+import { leafIds, type SplitDir } from "./lib/panes";
 
 type Props = {
   tabs: Tab[];
@@ -14,6 +14,8 @@ type Props = {
   onCwd: (leafId: number, cwd: string) => void;
   onExit: (leafId: number, code: number) => void;
   onFocusLeaf: (tabId: number, leafId: number) => void;
+  onSplitPane: (leafId: number, dir: SplitDir, before: boolean) => void;
+  onClosePane: (leafId: number) => void;
 };
 
 type Bundle = {
@@ -31,6 +33,8 @@ export function TerminalStack({
   onCwd,
   onExit,
   onFocusLeaf,
+  onSplitPane,
+  onClosePane,
 }: Props) {
   const terminals = tabs.filter((t) => t.kind === "terminal");
 
@@ -85,6 +89,8 @@ export function TerminalStack({
               tabVisible={tabVisible}
               activeLeafId={t.activeLeafId}
               onFocusLeaf={(leafId) => onFocusLeaf(t.id, leafId)}
+              onSplitPane={onSplitPane}
+              onClosePane={onClosePane}
               getBundle={getBundle}
             />
           </div>

--- a/src/modules/terminal/lib/panes.ts
+++ b/src/modules/terminal/lib/panes.ts
@@ -54,6 +54,7 @@ export function splitLeaf(
   newLeafId: PaneId,
   dir: SplitDir,
   newCwd?: string,
+  before: boolean = false,
 ): PaneNode {
   if (tree.kind === "split" && tree.dir === dir) {
     const idx = tree.children.findIndex(
@@ -61,12 +62,13 @@ export function splitLeaf(
     );
     if (idx >= 0) {
       const newLeaf: PaneNode = { kind: "leaf", id: newLeafId, cwd: newCwd };
+      const insertIdx = before ? idx : idx + 1;
       return {
         ...tree,
         children: [
-          ...tree.children.slice(0, idx + 1),
+          ...tree.children.slice(0, insertIdx),
           newLeaf,
-          ...tree.children.slice(idx + 1),
+          ...tree.children.slice(insertIdx),
         ],
       };
     }
@@ -78,13 +80,13 @@ export function splitLeaf(
       kind: "split",
       id: newSplitId,
       dir,
-      children: [tree, newLeaf],
+      children: before ? [newLeaf, tree] : [tree, newLeaf],
     };
   }
   return {
     ...tree,
     children: tree.children.map((c) =>
-      splitLeaf(c, targetId, newSplitId, newLeafId, dir, newCwd),
+      splitLeaf(c, targetId, newSplitId, newLeafId, dir, newCwd, before),
     ),
   };
 }


### PR DESCRIPTION
## Summary

- Add right-click context menu to terminal panes with Split Up/Down/Left/Right and Close Pane options
- Explorer now immediately syncs to the focused pane's working directory (no longer waits for next shell prompt)

## Changes

- `src/modules/terminal/lib/panes.ts` — `splitLeaf` now accepts a `before` param for inserting panes before the target
- `src/modules/tabs/lib/useTabs.ts` — new `splitPaneByLeaf` function; `focusPane` now copies leaf CWD to tab
- `src/modules/terminal/PaneTreeView.tsx` — context menu wrapping each terminal leaf
- `src/modules/terminal/TerminalStack.tsx` — pass split/close callbacks
- `src/app/App.tsx` — wire new callbacks to TerminalStack

## Test plan

- [ ] Right-click terminal pane → context menu appears
- [ ] Each split direction places new pane correctly
- [ ] Close Pane removes the pane and transfers focus
- [ ] Clicking between split panes updates explorer root instantly
- [ ] `pnpm tsc --noEmit` passes with no errors