### PR TITLE
fix(search): refocus terminal after dismissing find

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -621,11 +621,11 @@ export default function App() {
   );
 
   const searchTarget = useMemo<SearchTarget>(() => {
-    if (isTerminalTab && activeSearchAddon)
+    if (isTerminalTab && activeLeafId !== null && activeSearchAddon)
       return {
         kind: "terminal",
         addon: activeSearchAddon,
-        focus: () => terminalRefs.current.get(activeId)?.focus(),
+        focus: () => terminalRefs.current.get(activeLeafId)?.focus(),
       };
     if (isEditorTab && activeEditorHandle)
       return {
@@ -634,7 +634,13 @@ export default function App() {
         focus: () => activeEditorHandle.focus(),
       };
     return null;
-  }, [isTerminalTab, isEditorTab, activeId, activeSearchAddon, activeEditorHandle]);
+  }, [
+    isTerminalTab,
+    isEditorTab,
+    activeLeafId,
+    activeSearchAddon,
+    activeEditorHandle,
+  ]);
 
   const activeCwd =
     activeTab?.kind === "terminal" ? (activeTab.cwd ?? null) : null;


### PR DESCRIPTION
## What
Fix terminal find dismissal so pressing Escape in the search field returns focus to the active terminal pane.

## Why
Closes #195.

The inline search UI already tried to restore focus after Escape, but terminal pane refs are keyed by leaf id while the focus callback looked them up by tab id. That made the focus restore a no-op for terminal tabs.

## How
Use the active terminal leaf id when building the terminal search target focus callback.

## Testing
- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean - n/a, no Rust changes
- [ ] (If UI) tested in `pnpm tauri dev`

Local checks:
- [x] `git diff --check` clean
- [ ] `pnpm exec tsc --noEmit` could not complete locally because `node_modules` is not installed in this checkout

## Screenshots / GIFs
N/A, focus behavior only.

## Notes for reviewer
This is intentionally narrow: it does not add a new shortcut, because Escape already has the intended cancel-and-refocus path. The bug was just that terminal focus restoration used the wrong ref key.
