### PR TITLE
Feat/restore terminal layout

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -71,6 +71,7 @@ import type { PanelImperativeHandle } from "react-resizable-panels";
 
 export default function App() {
   const {
+    hydrated: tabsHydrated,
     tabs,
     activeId,
     setActiveId,
@@ -903,5 +904,11 @@ export default function App() {
     </ThemeProvider>
   );
 
-  return <AiComposerProvider>{shell}</AiComposerProvider>;
+  const loading = (
+    <ThemeProvider>
+      <div className="h-screen bg-background" />
+    </ThemeProvider>
+  );
+
+  return <AiComposerProvider>{tabsHydrated ? shell : loading}</AiComposerProvider>;
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -71,7 +71,6 @@ import type { PanelImperativeHandle } from "react-resizable-panels";
 
 export default function App() {
   const {
-    hydrated: tabsHydrated,
     tabs,
     activeId,
     setActiveId,
@@ -904,11 +903,15 @@ export default function App() {
     </ThemeProvider>
   );
 
-  const loading = (
-    <ThemeProvider>
-      <div className="h-screen bg-background" />
-    </ThemeProvider>
+  return (
+    <AiComposerProvider>
+      {tabs.length > 0 ? (
+        shell
+      ) : (
+        <ThemeProvider>
+          <div className="h-screen bg-background" />
+        </ThemeProvider>
+      )}
+    </AiComposerProvider>
   );
-
-  return <AiComposerProvider>{tabsHydrated ? shell : loading}</AiComposerProvider>;
 }

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -3,11 +3,11 @@ export {
   MAX_PANES_PER_TAB,
   useTabs,
   type Tab,
+  type TabPatch,
   type TerminalTab,
   type EditorTab,
   type PreviewTab,
   type AiDiffTab,
   type AiDiffStatus,
-  type TabPatch,
 } from "./lib/useTabs";
 export { useWorkspaceCwd } from "./lib/useWorkspaceCwd";

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -3,11 +3,11 @@ export {
   MAX_PANES_PER_TAB,
   useTabs,
   type Tab,
-  type TabPatch,
   type TerminalTab,
   type EditorTab,
   type PreviewTab,
   type AiDiffTab,
   type AiDiffStatus,
+  type TabPatch,
 } from "./lib/useTabs";
 export { useWorkspaceCwd } from "./lib/useWorkspaceCwd";

--- a/src/modules/tabs/lib/persistedWorkspace.ts
+++ b/src/modules/tabs/lib/persistedWorkspace.ts
@@ -2,7 +2,7 @@ import type { PaneNode } from "@/modules/terminal/lib/panes";
 import { leafIds } from "@/modules/terminal/lib/panes";
 import { LazyStore } from "@tauri-apps/plugin-store";
 
-export type PersistedTerminalTab = {
+type PersistedTerminalTab = {
   id: number;
   kind: "terminal";
   title: string;
@@ -11,132 +11,85 @@ export type PersistedTerminalTab = {
   activeLeafId: number;
 };
 
-export type PersistedWorkspace = {
+type PersistedWorkspace = {
   version: 1;
   activeId: number | null;
   nextId: number;
   tabs: PersistedTerminalTab[];
 };
 
-const STORE_PATH = "terax-workspace.json";
 const KEY_WORKSPACE = "terminalWorkspace";
-const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
+const store = new LazyStore("terax-workspace.json", {
+  defaults: {},
+  autoSave: 200,
+});
 
 export async function loadPersistedWorkspace(): Promise<PersistedWorkspace | null> {
-  return normalizeWorkspace(await store.get<unknown>(KEY_WORKSPACE));
-}
+  const saved = await store.get<unknown>(KEY_WORKSPACE);
+  if (!saved || typeof saved !== "object") return null;
 
-export async function savePersistedWorkspace(
-  workspace: PersistedWorkspace | null,
-): Promise<void> {
-  if (!workspace || workspace.tabs.length === 0) {
-    await store.delete(KEY_WORKSPACE);
-    return;
+  const raw = saved as Partial<PersistedWorkspace>;
+  if (raw.version !== 1 || !Array.isArray(raw.tabs) || raw.tabs.length === 0) {
+    return null;
   }
-  await store.set(KEY_WORKSPACE, workspace);
-}
 
-function normalizeWorkspace(value: unknown): PersistedWorkspace | null {
-  if (!value || typeof value !== "object") return null;
-  const raw = value as Record<string, unknown>;
-  if (raw.version !== 1) return null;
-  const nextId = asInt(raw.nextId);
-  if (nextId === null) return null;
-  if (!Array.isArray(raw.tabs)) return null;
+  const tabs = raw.tabs.flatMap((tab) => {
+    try {
+      if (!tab || typeof tab !== "object" || tab.kind !== "terminal") return [];
+      const leaves = leafIds(tab.paneTree).filter(isPositiveInt);
+      if (!isPositiveInt(tab.id) || leaves.length === 0) return [];
+      const cwd = text(tab.cwd);
+      return [
+        {
+          id: tab.id,
+          kind: "terminal" as const,
+          title: text(tab.title) ?? "shell",
+          ...(cwd ? { cwd } : {}),
+          paneTree: tab.paneTree,
+          activeLeafId:
+            isPositiveInt(tab.activeLeafId) && leaves.includes(tab.activeLeafId)
+              ? tab.activeLeafId
+              : leaves[0],
+        },
+      ];
+    } catch {
+      return [];
+    }
+  });
 
-  const tabs = raw.tabs
-    .map(normalizeTerminalTab)
-    .filter((tab): tab is PersistedTerminalTab => tab !== null);
   if (tabs.length === 0) return null;
 
-  const activeId = asInt(raw.activeId);
-  const resolvedActiveId = tabs.some((tab) => tab.id === activeId)
-    ? activeId
-    : tabs[0].id;
+  const activeId =
+    isPositiveInt(raw.activeId) && tabs.some((tab) => tab.id === raw.activeId)
+      ? raw.activeId
+      : tabs[0].id;
 
   return {
     version: 1,
-    activeId: resolvedActiveId,
-    nextId: Math.max(nextId, maxNodeId(tabs) + 1),
+    activeId,
+    nextId:
+      tabs.reduce(
+        (max, tab) => Math.max(max, tab.id, ...leafIds(tab.paneTree)),
+        0,
+      ) + 1,
     tabs,
   };
 }
 
-function normalizeTerminalTab(value: unknown): PersistedTerminalTab | null {
-  if (!value || typeof value !== "object") return null;
-  const raw = value as Record<string, unknown>;
-  if (raw.kind !== "terminal") return null;
-
-  const id = asInt(raw.id);
-  const paneTree = normalizePaneNode(raw.paneTree);
-  if (id === null || paneTree === null) return null;
-
-  const leaves = leafIds(paneTree);
-  if (leaves.length === 0) return null;
-
-  const activeLeafId = asInt(raw.activeLeafId);
-  return {
-    id,
-    kind: "terminal",
-    title: typeof raw.title === "string" && raw.title.length > 0 ? raw.title : "shell",
-    ...(typeof raw.cwd === "string" && raw.cwd.length > 0 ? { cwd: raw.cwd } : {}),
-    paneTree,
-    activeLeafId:
-      activeLeafId !== null && leaves.includes(activeLeafId)
-        ? activeLeafId
-        : leaves[0],
-  };
+export async function savePersistedWorkspace(
+  workspace: Omit<PersistedWorkspace, "nextId"> | null,
+): Promise<void> {
+  await (
+    workspace?.tabs.length
+      ? store.set(KEY_WORKSPACE, workspace)
+      : store.delete(KEY_WORKSPACE)
+  );
 }
 
-function normalizePaneNode(value: unknown): PaneNode | null {
-  if (!value || typeof value !== "object") return null;
-  const raw = value as Record<string, unknown>;
-  if (raw.kind === "leaf") {
-    const id = asInt(raw.id);
-    if (id === null) return null;
-    return {
-      kind: "leaf",
-      id,
-      ...(typeof raw.cwd === "string" && raw.cwd.length > 0 ? { cwd: raw.cwd } : {}),
-    };
-  }
-  if (raw.kind === "split") {
-    const id = asInt(raw.id);
-    const dir = raw.dir;
-    if (id === null || (dir !== "row" && dir !== "col")) return null;
-    if (!Array.isArray(raw.children)) return null;
-    const children = raw.children
-      .map(normalizePaneNode)
-      .filter((child): child is PaneNode => child !== null);
-    if (children.length < 2) return null;
-    return {
-      kind: "split",
-      id,
-      dir,
-      children,
-    };
-  }
-  return null;
+function isPositiveInt(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
-function asInt(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value > 0
-    ? value
-    : null;
-}
-
-function maxNodeId(tabs: PersistedTerminalTab[]): number {
-  let maxId = 0;
-  for (const tab of tabs) {
-    maxId = Math.max(maxId, tab.id, ...leafIds(tab.paneTree));
-    if (tab.paneTree.kind === "split") {
-      maxId = Math.max(maxId, maxSplitId(tab.paneTree));
-    }
-  }
-  return maxId;
-}
-
-function maxSplitId(node: PaneNode): number {
-  if (node.kind === "leaf") return node.id;
-  return Math.max(node.id, ...node.children.map(maxSplitId));
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }

--- a/src/modules/tabs/lib/persistedWorkspace.ts
+++ b/src/modules/tabs/lib/persistedWorkspace.ts
@@ -1,0 +1,142 @@
+import type { PaneNode } from "@/modules/terminal/lib/panes";
+import { leafIds } from "@/modules/terminal/lib/panes";
+import { LazyStore } from "@tauri-apps/plugin-store";
+
+export type PersistedTerminalTab = {
+  id: number;
+  kind: "terminal";
+  title: string;
+  cwd?: string;
+  paneTree: PaneNode;
+  activeLeafId: number;
+};
+
+export type PersistedWorkspace = {
+  version: 1;
+  activeId: number | null;
+  nextId: number;
+  tabs: PersistedTerminalTab[];
+};
+
+const STORE_PATH = "terax-workspace.json";
+const KEY_WORKSPACE = "terminalWorkspace";
+const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
+
+export async function loadPersistedWorkspace(): Promise<PersistedWorkspace | null> {
+  return normalizeWorkspace(await store.get<unknown>(KEY_WORKSPACE));
+}
+
+export async function savePersistedWorkspace(
+  workspace: PersistedWorkspace | null,
+): Promise<void> {
+  if (!workspace || workspace.tabs.length === 0) {
+    await store.delete(KEY_WORKSPACE);
+    return;
+  }
+  await store.set(KEY_WORKSPACE, workspace);
+}
+
+function normalizeWorkspace(value: unknown): PersistedWorkspace | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.version !== 1) return null;
+  const nextId = asInt(raw.nextId);
+  if (nextId === null) return null;
+  if (!Array.isArray(raw.tabs)) return null;
+
+  const tabs = raw.tabs
+    .map(normalizeTerminalTab)
+    .filter((tab): tab is PersistedTerminalTab => tab !== null);
+  if (tabs.length === 0) return null;
+
+  const activeId = asInt(raw.activeId);
+  const resolvedActiveId = tabs.some((tab) => tab.id === activeId)
+    ? activeId
+    : tabs[0].id;
+
+  return {
+    version: 1,
+    activeId: resolvedActiveId,
+    nextId: Math.max(nextId, maxNodeId(tabs) + 1),
+    tabs,
+  };
+}
+
+function normalizeTerminalTab(value: unknown): PersistedTerminalTab | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.kind !== "terminal") return null;
+
+  const id = asInt(raw.id);
+  const paneTree = normalizePaneNode(raw.paneTree);
+  if (id === null || paneTree === null) return null;
+
+  const leaves = leafIds(paneTree);
+  if (leaves.length === 0) return null;
+
+  const activeLeafId = asInt(raw.activeLeafId);
+  return {
+    id,
+    kind: "terminal",
+    title: typeof raw.title === "string" && raw.title.length > 0 ? raw.title : "shell",
+    ...(typeof raw.cwd === "string" && raw.cwd.length > 0 ? { cwd: raw.cwd } : {}),
+    paneTree,
+    activeLeafId:
+      activeLeafId !== null && leaves.includes(activeLeafId)
+        ? activeLeafId
+        : leaves[0],
+  };
+}
+
+function normalizePaneNode(value: unknown): PaneNode | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.kind === "leaf") {
+    const id = asInt(raw.id);
+    if (id === null) return null;
+    return {
+      kind: "leaf",
+      id,
+      ...(typeof raw.cwd === "string" && raw.cwd.length > 0 ? { cwd: raw.cwd } : {}),
+    };
+  }
+  if (raw.kind === "split") {
+    const id = asInt(raw.id);
+    const dir = raw.dir;
+    if (id === null || (dir !== "row" && dir !== "col")) return null;
+    if (!Array.isArray(raw.children)) return null;
+    const children = raw.children
+      .map(normalizePaneNode)
+      .filter((child): child is PaneNode => child !== null);
+    if (children.length < 2) return null;
+    return {
+      kind: "split",
+      id,
+      dir,
+      children,
+    };
+  }
+  return null;
+}
+
+function asInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : null;
+}
+
+function maxNodeId(tabs: PersistedTerminalTab[]): number {
+  let maxId = 0;
+  for (const tab of tabs) {
+    maxId = Math.max(maxId, tab.id, ...leafIds(tab.paneTree));
+    if (tab.paneTree.kind === "split") {
+      maxId = Math.max(maxId, maxSplitId(tab.paneTree));
+    }
+  }
+  return maxId;
+}
+
+function maxSplitId(node: PaneNode): number {
+  if (node.kind === "leaf") return node.id;
+  return Math.max(node.id, ...node.children.map(maxSplitId));
+}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   hasLeaf,
   leafIds,
@@ -10,6 +10,11 @@ import {
   type PaneNode,
   type SplitDir,
 } from "@/modules/terminal/lib/panes";
+import {
+  loadPersistedWorkspace,
+  savePersistedWorkspace,
+  type PersistedTerminalTab,
+} from "./persistedWorkspace";
 
 // Browsers cap WebGL contexts at ~16; one xterm renderer per leaf.
 export const MAX_PANES_PER_TAB = 8;
@@ -86,11 +91,11 @@ function titleFromUrl(url: string): string {
   }
 }
 
-export function useTabs(initial?: Partial<TerminalTab>) {
-  const [tabs, setTabs] = useState<Tab[]>(() => {
-    const tabId = 1;
-    const leafId = 2;
-    return [
+function createInitialTerminalState(initial?: Partial<TerminalTab>) {
+  const tabId = 1;
+  const leafId = 2;
+  return {
+    tabs: [
       {
         id: tabId,
         kind: "terminal",
@@ -98,11 +103,71 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         cwd: initial?.cwd,
         paneTree: { kind: "leaf", id: leafId, cwd: initial?.cwd },
         activeLeafId: leafId,
-      },
-    ];
-  });
-  const [activeId, setActiveId] = useState(1);
-  const nextIdRef = useRef(3);
+      } satisfies TerminalTab,
+    ] as Tab[],
+    activeId: tabId,
+    nextId: 3,
+  };
+}
+
+export function useTabs(initial?: Partial<TerminalTab>) {
+  const [tabs, setTabs] = useState<Tab[]>([]);
+  const [activeId, setActiveId] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+  const nextIdRef = useRef(1);
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadPersistedWorkspace().then((saved) => {
+      if (cancelled) return;
+      const restored = saved ?? createInitialTerminalState(initial);
+      setTabs(restored.tabs);
+      setActiveId(restored.activeId ?? restored.tabs[0]?.id ?? 0);
+      nextIdRef.current = restored.nextId;
+      setHydrated(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [initial]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    persistTimerRef.current = setTimeout(() => {
+      const terminalTabs = tabs.filter(
+        (tab): tab is PersistedTerminalTab & TerminalTab =>
+          tab.kind === "terminal" && tab.private !== true,
+      );
+      if (terminalTabs.length === 0) {
+        void savePersistedWorkspace(null);
+        return;
+      }
+      const restoredActiveId = terminalTabs.some((tab) => tab.id === activeId)
+        ? activeId
+        : terminalTabs[0].id;
+      void savePersistedWorkspace({
+        version: 1,
+        activeId: restoredActiveId,
+        nextId: nextIdRef.current,
+        tabs: terminalTabs.map((tab) => ({
+          id: tab.id,
+          kind: "terminal",
+          title: tab.title,
+          ...(tab.cwd ? { cwd: tab.cwd } : {}),
+          paneTree: tab.paneTree,
+          activeLeafId: tab.activeLeafId,
+        })),
+      });
+    }, 250);
+    return () => {
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = null;
+      }
+    };
+  }, [tabs, activeId, hydrated]);
 
   const newTab = useCallback((cwd?: string) => {
     const tabId = nextIdRef.current++;
@@ -481,6 +546,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   }, []);
 
   return {
+    hydrated,
     tabs,
     activeId,
     setActiveId,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -10,11 +10,7 @@ import {
   type PaneNode,
   type SplitDir,
 } from "@/modules/terminal/lib/panes";
-import {
-  loadPersistedWorkspace,
-  savePersistedWorkspace,
-  type PersistedTerminalTab,
-} from "./persistedWorkspace";
+import { loadPersistedWorkspace, savePersistedWorkspace } from "./persistedWorkspace";
 
 // Browsers cap WebGL contexts at ~16; one xterm renderer per leaf.
 export const MAX_PANES_PER_TAB = 8;
@@ -113,9 +109,7 @@ function createInitialTerminalState(initial?: Partial<TerminalTab>) {
 export function useTabs(initial?: Partial<TerminalTab>) {
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeId, setActiveId] = useState(0);
-  const [hydrated, setHydrated] = useState(false);
   const nextIdRef = useRef(1);
-  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -125,7 +119,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       setTabs(restored.tabs);
       setActiveId(restored.activeId ?? restored.tabs[0]?.id ?? 0);
       nextIdRef.current = restored.nextId;
-      setHydrated(true);
     });
     return () => {
       cancelled = true;
@@ -133,41 +126,29 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   }, [initial]);
 
   useEffect(() => {
-    if (!hydrated) return;
-    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
-    persistTimerRef.current = setTimeout(() => {
-      const terminalTabs = tabs.filter(
-        (tab): tab is PersistedTerminalTab & TerminalTab =>
-          tab.kind === "terminal" && tab.private !== true,
-      );
-      if (terminalTabs.length === 0) {
-        void savePersistedWorkspace(null);
-        return;
-      }
-      const restoredActiveId = terminalTabs.some((tab) => tab.id === activeId)
-        ? activeId
-        : terminalTabs[0].id;
-      void savePersistedWorkspace({
-        version: 1,
-        activeId: restoredActiveId,
-        nextId: nextIdRef.current,
-        tabs: terminalTabs.map((tab) => ({
-          id: tab.id,
-          kind: "terminal",
-          title: tab.title,
-          ...(tab.cwd ? { cwd: tab.cwd } : {}),
-          paneTree: tab.paneTree,
-          activeLeafId: tab.activeLeafId,
-        })),
-      });
-    }, 250);
-    return () => {
-      if (persistTimerRef.current) {
-        clearTimeout(persistTimerRef.current);
-        persistTimerRef.current = null;
-      }
-    };
-  }, [tabs, activeId, hydrated]);
+    if (tabs.length === 0) return;
+    const terminalTabs = tabs.filter(
+      (tab): tab is TerminalTab => tab.kind === "terminal" && tab.private !== true,
+    );
+    void savePersistedWorkspace(
+      terminalTabs.length
+        ? {
+            version: 1,
+            activeId: terminalTabs.some((tab) => tab.id === activeId)
+              ? activeId
+              : terminalTabs[0].id,
+            tabs: terminalTabs.map(({ id, title, cwd, paneTree, activeLeafId }) => ({
+              id,
+              kind: "terminal" as const,
+              title,
+              ...(cwd ? { cwd } : {}),
+              paneTree,
+              activeLeafId,
+            })),
+          }
+        : null,
+    );
+  }, [tabs, activeId]);
 
   const newTab = useCallback((cwd?: string) => {
     const tabId = nextIdRef.current++;
@@ -546,7 +527,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   }, []);
 
   return {
-    hydrated,
     tabs,
     activeId,
     setActiveId,


### PR DESCRIPTION
## What

Persist and restore the terminal workspace layout across relaunches.

This restores:
- terminal tabs
- split pane trees
- active tab
- active pane
- cwd per pane

This intentionally does not restore:
- running process state
- terminal scrollback
- private tabs
- editor/preview tabs

## Why

Closes #176 
Today, if Terax or the OS crashes, the terminal workspace is rebuilt from scratch and users lose their tabs, pane layout, and working directories.

This adds a small frontend-only persistence layer so the terminal workspace can come back in the same shape on the next launch without trying to resume live PTY state.

## How

- persist terminal workspace state with `@tauri-apps/plugin-store`
- hydrate `useTabs()` from saved workspace on startup
- keep the startup shell hidden until tab state is loaded so Terax does not spawn a throwaway default session first
- derive the next tab/pane id from restored state rather than persisting extra counters

## Validation

- [x] `pnpm exec tsc --noEmit` clean

## Notes

- private terminal tabs are excluded from persistence
- restored terminals reopen in the same working directories, but start fresh shells
- this keeps the implementation compact and avoids trying to fake process/session resume