### PR TITLE
feat(ai): add MiniMax provider with M3 as default

### DIFF
--- a/src/modules/ai/__tests__/minimax-e2e.test.ts
+++ b/src/modules/ai/__tests__/minimax-e2e.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+const API_KEY = process.env.MINIMAX_API_KEY;
+const BASE_URL = "https://api.minimax.io/v1";
+
+describe.skipIf(!API_KEY)("MiniMax E2E", () => {
+  it(
+    "completes basic chat via OpenAI-compatible endpoint",
+    async () => {
+      const response = await fetch(`${BASE_URL}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: "MiniMax-M2.7",
+          messages: [{ role: "user", content: 'Say "test passed"' }],
+          max_tokens: 20,
+          temperature: 1.0,
+        }),
+      });
+      expect(response.ok).toBe(true);
+      const data = await response.json();
+      expect(data.choices[0].message.content).toBeTruthy();
+    },
+    30000,
+  );
+});

--- a/src/modules/ai/__tests__/minimax-e2e.test.ts
+++ b/src/modules/ai/__tests__/minimax-e2e.test.ts
@@ -14,7 +14,7 @@ describe.skipIf(!API_KEY)("MiniMax E2E", () => {
           Authorization: `Bearer ${API_KEY}`,
         },
         body: JSON.stringify({
-          model: "MiniMax-M2.7",
+          model: "MiniMax-M3",
           messages: [{ role: "user", content: 'Say "test passed"' }],
           max_tokens: 20,
           temperature: 1.0,

--- a/src/modules/ai/__tests__/minimax-provider.test.ts
+++ b/src/modules/ai/__tests__/minimax-provider.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROVIDERS,
+  MODELS,
+  MODEL_CONTEXT_LIMITS,
+  MODEL_PRICING,
+  getProvider,
+  getModel,
+  DEFAULT_AUTOCOMPLETE_MODEL,
+  type ProviderId,
+  type ModelId,
+} from "../config";
+
+describe("MiniMax provider registration", () => {
+  it("is listed in PROVIDERS", () => {
+    const minimax = PROVIDERS.find((p) => p.id === "minimax");
+    expect(minimax).toBeDefined();
+    expect(minimax!.label).toBe("MiniMax");
+    expect(minimax!.keyringAccount).toBe("minimax-api-key");
+  });
+
+  it("is retrievable via getProvider", () => {
+    const p = getProvider("minimax" as ProviderId);
+    expect(p.id).toBe("minimax");
+    expect(p.consoleUrl).toContain("minimax.io");
+  });
+});
+
+describe("MiniMax model registration", () => {
+  it("registers MiniMax-M2.7", () => {
+    const m = MODELS.find((m) => m.id === "MiniMax-M2.7");
+    expect(m).toBeDefined();
+    expect(m!.provider).toBe("minimax");
+  });
+
+  it("registers MiniMax-M2.7-highspeed", () => {
+    const m = MODELS.find((m) => m.id === "MiniMax-M2.7-highspeed");
+    expect(m).toBeDefined();
+    expect(m!.provider).toBe("minimax");
+  });
+
+  it("is retrievable via getModel", () => {
+    const m = getModel("MiniMax-M2.7" as ModelId);
+    expect(m.provider).toBe("minimax");
+    expect(m.label).toContain("MiniMax");
+  });
+
+  it("has context limits defined", () => {
+    expect(MODEL_CONTEXT_LIMITS["MiniMax-M2.7"]).toBe(204_800);
+    expect(MODEL_CONTEXT_LIMITS["MiniMax-M2.7-highspeed"]).toBe(204_800);
+  });
+
+  it("has pricing defined", () => {
+    const pricing = MODEL_PRICING["MiniMax-M2.7"];
+    expect(pricing).toBeDefined();
+    expect(pricing.input).toBe(0.3);
+    expect(pricing.output).toBe(1.2);
+    expect(pricing.cacheRead).toBe(0.06);
+
+    const hsPricing = MODEL_PRICING["MiniMax-M2.7-highspeed"];
+    expect(hsPricing).toBeDefined();
+    expect(hsPricing.input).toBe(0.6);
+    expect(hsPricing.output).toBe(2.4);
+  });
+
+  it("has a default autocomplete model", () => {
+    expect(DEFAULT_AUTOCOMPLETE_MODEL["minimax" as ProviderId]).toBe(
+      "MiniMax-M2.7-highspeed",
+    );
+  });
+});
+
+describe("MiniMax base URL handling", () => {
+  it("constructs correct Anthropic-compatible base URL", () => {
+    const baseURL = "https://api.minimax.io/anthropic";
+    const normalized = baseURL.endsWith("/v1")
+      ? baseURL
+      : `${baseURL.replace(/\/$/, "")}/v1`;
+    expect(normalized).toBe("https://api.minimax.io/anthropic/v1");
+  });
+
+  it("does not use api.minimax.chat domain", () => {
+    const provider = PROVIDERS.find((p) => p.id === "minimax");
+    expect(provider!.consoleUrl).not.toContain("minimax.chat");
+  });
+});

--- a/src/modules/ai/__tests__/minimax-provider.test.ts
+++ b/src/modules/ai/__tests__/minimax-provider.test.ts
@@ -27,30 +27,46 @@ describe("MiniMax provider registration", () => {
 });
 
 describe("MiniMax model registration", () => {
-  it("registers MiniMax-M2.7", () => {
+  it("registers MiniMax-M3 as the default (first) MiniMax model", () => {
+    const m = MODELS.find((m) => m.id === "MiniMax-M3");
+    expect(m).toBeDefined();
+    expect(m!.provider).toBe("minimax");
+
+    const minimaxModels = MODELS.filter((m) => m.provider === "minimax");
+    expect(minimaxModels[0]!.id).toBe("MiniMax-M3");
+  });
+
+  it("keeps MiniMax-M2.7 as a legacy alternative", () => {
     const m = MODELS.find((m) => m.id === "MiniMax-M2.7");
     expect(m).toBeDefined();
     expect(m!.provider).toBe("minimax");
   });
 
-  it("registers MiniMax-M2.7-highspeed", () => {
+  it("keeps MiniMax-M2.7-highspeed as a legacy alternative", () => {
     const m = MODELS.find((m) => m.id === "MiniMax-M2.7-highspeed");
     expect(m).toBeDefined();
     expect(m!.provider).toBe("minimax");
   });
 
   it("is retrievable via getModel", () => {
-    const m = getModel("MiniMax-M2.7" as ModelId);
+    const m = getModel("MiniMax-M3" as ModelId);
     expect(m.provider).toBe("minimax");
     expect(m.label).toContain("MiniMax");
   });
 
   it("has context limits defined", () => {
+    expect(MODEL_CONTEXT_LIMITS["MiniMax-M3"]).toBe(512_000);
     expect(MODEL_CONTEXT_LIMITS["MiniMax-M2.7"]).toBe(204_800);
     expect(MODEL_CONTEXT_LIMITS["MiniMax-M2.7-highspeed"]).toBe(204_800);
   });
 
   it("has pricing defined", () => {
+    const m3 = MODEL_PRICING["MiniMax-M3"];
+    expect(m3).toBeDefined();
+    expect(m3.input).toBe(0.6);
+    expect(m3.output).toBe(2.4);
+    expect(m3.cacheRead).toBe(0.12);
+
     const pricing = MODEL_PRICING["MiniMax-M2.7"];
     expect(pricing).toBeDefined();
     expect(pricing.input).toBe(0.3);

--- a/src/modules/ai/__tests__/minimax-provider.test.ts
+++ b/src/modules/ai/__tests__/minimax-provider.test.ts
@@ -8,6 +8,7 @@ import {
   getProvider,
   getModel,
   DEFAULT_AUTOCOMPLETE_MODEL,
+  MINIMAX_ANTHROPIC_BASE_URL,
   type ProviderId,
   type ModelId,
 } from "../config";
@@ -88,11 +89,17 @@ describe("MiniMax model registration", () => {
 });
 
 describe("MiniMax base URL handling", () => {
+  it("keeps the official Anthropic base URL", () => {
+    expect(MINIMAX_ANTHROPIC_BASE_URL).toBe(
+      "https://api.minimax.io/anthropic",
+    );
+  });
+
   it("constructs the Anthropic-compatible messages URL", async () => {
     let requestedURL = "";
     const model = createAnthropic({
       apiKey: "test-key",
-      baseURL: "https://api.minimax.io/anthropic/v1",
+      baseURL: `${MINIMAX_ANTHROPIC_BASE_URL}/v1`,
       fetch: async (url) => {
         requestedURL = String(url);
         throw new Error("request intercepted");

--- a/src/modules/ai/__tests__/minimax-provider.test.ts
+++ b/src/modules/ai/__tests__/minimax-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import {
   PROVIDERS,
   MODELS,
@@ -87,12 +88,27 @@ describe("MiniMax model registration", () => {
 });
 
 describe("MiniMax base URL handling", () => {
-  it("constructs correct Anthropic-compatible base URL", () => {
-    const baseURL = "https://api.minimax.io/anthropic";
-    const normalized = baseURL.endsWith("/v1")
-      ? baseURL
-      : `${baseURL.replace(/\/$/, "")}/v1`;
-    expect(normalized).toBe("https://api.minimax.io/anthropic/v1");
+  it("constructs the Anthropic-compatible messages URL", async () => {
+    let requestedURL = "";
+    const model = createAnthropic({
+      apiKey: "test-key",
+      baseURL: "https://api.minimax.io/anthropic/v1",
+      fetch: async (url) => {
+        requestedURL = String(url);
+        throw new Error("request intercepted");
+      },
+    })("MiniMax-M3");
+
+    await expect(
+      model.doGenerate({
+        prompt: [
+          { role: "user", content: [{ type: "text", text: "ping" }] },
+        ],
+      }),
+    ).rejects.toThrow("request intercepted");
+    expect(requestedURL).toBe(
+      "https://api.minimax.io/anthropic/v1/messages",
+    );
   });
 
   it("does not use api.minimax.chat domain", () => {

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -13,6 +13,7 @@ import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import {
   Add01Icon,
   AiBookIcon,
+  AiGenerativeIcon,
   ArrowDown01Icon,
   ArrowUpIcon,
   BrainIcon,
@@ -63,6 +64,7 @@ const PROVIDER_ICON = {
   cerebras: CpuIcon,
   groq: FlashIcon,
   deepseek: DeepseekIcon,
+  minimax: AiGenerativeIcon,
   openrouter: GlobeIcon,
   "openai-compatible": PlugIcon,
   lmstudio: ComputerIcon,

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -8,6 +8,7 @@ export type ProviderId =
   | "cerebras"
   | "groq"
   | "deepseek"
+  | "minimax"
   | "openrouter"
   | "openai-compatible"
   | "lmstudio";
@@ -71,6 +72,13 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     keyringAccount: "deepseek-api-key",
     keyPrefix: "sk-",
     consoleUrl: "https://platform.deepseek.com/api_keys",
+  },
+  {
+    id: "minimax",
+    label: "MiniMax",
+    keyringAccount: "minimax-api-key",
+    keyPrefix: null,
+    consoleUrl: "https://platform.minimax.io/",
   },
   {
     id: "openrouter",
@@ -305,6 +313,26 @@ export const MODELS = [
     description: "Chain-of-thought at open-weight prices.",
     capabilities: { intelligence: 5, speed: 2, cost: 4 },
     tags: ["reasoning", "coding"],
+  },
+
+  // ── MiniMax ──────────────────────────────────────────────────────────────
+  {
+    id: "MiniMax-M2.7",
+    provider: "minimax",
+    label: "MiniMax M2.7",
+    hint: "Best",
+    description: "Peak performance. Master the complex.",
+    capabilities: { intelligence: 5, speed: 3, cost: 5 },
+    tags: ["tools", "coding"],
+  },
+  {
+    id: "MiniMax-M2.7-highspeed",
+    provider: "minimax",
+    label: "MiniMax M2.7 Highspeed",
+    hint: "Fast",
+    description: "Same performance, faster and more agile.",
+    capabilities: { intelligence: 5, speed: 4, cost: 4 },
+    tags: ["tools", "coding"],
   },
 
   // ── Cerebras (autocomplete-tier) ──────────────────────────────────────────
@@ -556,6 +584,8 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "deepseek-v4-pro": 1_000_000,
   "deepseek-v4-flash": 1_000_000,
   "deepseek-reasoner": 128_000,
+  "MiniMax-M2.7": 204_800,
+  "MiniMax-M2.7-highspeed": 204_800,
   "gpt-oss-120b": 128_000,
   "llama3.3-70b": 128_000,
   "qwen-3-32b": 32_000,
@@ -612,6 +642,8 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "deepseek-v4-pro": { input: 0.28, output: 1.1, cacheRead: 0.028 },
   "deepseek-v4-flash": { input: 0.07, output: 0.27, cacheRead: 0.007 },
   "deepseek-reasoner": { input: 0.55, output: 2.19, cacheRead: 0.14 },
+  "MiniMax-M2.7": { input: 0.3, output: 1.2, cacheRead: 0.06 },
+  "MiniMax-M2.7-highspeed": { input: 0.6, output: 2.4, cacheRead: 0.06 },
 };
 
 export function estimateCost(
@@ -661,6 +693,7 @@ export const DEFAULT_AUTOCOMPLETE_MODEL: Partial<Record<ProviderId, string>> = {
   google: "gemini-2.5-flash",
   xai: "grok-4-fast-reasoning",
   deepseek: "deepseek-v4-flash",
+  minimax: "MiniMax-M2.7-highspeed",
   openrouter: "openai/gpt-5.4-mini",
   "openai-compatible": "",
 };

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -718,6 +718,8 @@ export function getAutocompleteEligibleModels(): readonly ModelInfo[] {
 
 export const LMSTUDIO_DEFAULT_BASE_URL = "http://localhost:1234/v1";
 export const OPENAI_COMPATIBLE_DEFAULT_BASE_URL = "";
+export const MINIMAX_ANTHROPIC_BASE_URL =
+  "https://api.minimax.io/anthropic";
 export const MAX_AGENT_STEPS = 24;
 export const TERMINAL_BUFFER_LINES = 300;
 

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -317,11 +317,20 @@ export const MODELS = [
 
   // ── MiniMax ──────────────────────────────────────────────────────────────
   {
+    id: "MiniMax-M3",
+    provider: "minimax",
+    label: "MiniMax M3",
+    hint: "Best",
+    description: "512K context, 128K output, image input.",
+    capabilities: { intelligence: 5, speed: 3, cost: 4 },
+    tags: ["vision", "tools", "coding"],
+  },
+  {
     id: "MiniMax-M2.7",
     provider: "minimax",
     label: "MiniMax M2.7",
-    hint: "Best",
-    description: "Peak performance. Master the complex.",
+    hint: "Legacy",
+    description: "Previous-generation MiniMax.",
     capabilities: { intelligence: 5, speed: 3, cost: 5 },
     tags: ["tools", "coding"],
   },
@@ -330,7 +339,7 @@ export const MODELS = [
     provider: "minimax",
     label: "MiniMax M2.7 Highspeed",
     hint: "Fast",
-    description: "Same performance, faster and more agile.",
+    description: "Previous-generation low-latency variant.",
     capabilities: { intelligence: 5, speed: 4, cost: 4 },
     tags: ["tools", "coding"],
   },
@@ -584,6 +593,7 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "deepseek-v4-pro": 1_000_000,
   "deepseek-v4-flash": 1_000_000,
   "deepseek-reasoner": 128_000,
+  "MiniMax-M3": 512_000,
   "MiniMax-M2.7": 204_800,
   "MiniMax-M2.7-highspeed": 204_800,
   "gpt-oss-120b": 128_000,
@@ -642,6 +652,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "deepseek-v4-pro": { input: 0.28, output: 1.1, cacheRead: 0.028 },
   "deepseek-v4-flash": { input: 0.07, output: 0.27, cacheRead: 0.007 },
   "deepseek-reasoner": { input: 0.55, output: 2.19, cacheRead: 0.14 },
+  "MiniMax-M3": { input: 0.6, output: 2.4, cacheRead: 0.12 },
   "MiniMax-M2.7": { input: 0.3, output: 1.2, cacheRead: 0.06 },
   "MiniMax-M2.7-highspeed": { input: 0.6, output: 2.4, cacheRead: 0.06 },
 };

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -118,6 +118,14 @@ export async function buildLanguageModel(
       })(resolvedModelId);
       break;
     }
+    case "minimax": {
+      const { createAnthropic } = await import("@ai-sdk/anthropic");
+      built = createAnthropic({
+        apiKey: key,
+        baseURL: "https://api.minimax.io/anthropic/v1",
+      })(resolvedModelId);
+      break;
+    }
     case "groq": {
       const { createGroq } = await import("@ai-sdk/groq");
       built = createGroq({ apiKey: key })(resolvedModelId);

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -12,6 +12,7 @@ import {
   getModelContextLimit,
   LMSTUDIO_DEFAULT_BASE_URL,
   MAX_AGENT_STEPS,
+  MINIMAX_ANTHROPIC_BASE_URL,
   providerNeedsKey,
   selectSystemPrompt,
   type ModelId,
@@ -122,7 +123,7 @@ export async function buildLanguageModel(
       const { createAnthropic } = await import("@ai-sdk/anthropic");
       built = createAnthropic({
         apiKey: key,
-        baseURL: "https://api.minimax.io/anthropic/v1",
+        baseURL: `${MINIMAX_ANTHROPIC_BASE_URL}/v1`,
       })(resolvedModelId);
       break;
     }

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -17,6 +17,7 @@ export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   cerebras: null,
   groq: null,
   deepseek: null,
+  minimax: null,
   openrouter: null,
   "openai-compatible": null,
   lmstudio: null,

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -10,6 +10,7 @@ import {
   DeepseekIcon,
   GlobeIcon,
   PlugIcon,
+  AiGenerativeIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -21,6 +22,7 @@ const ICON_BY_PROVIDER = {
   cerebras: CpuIcon,
   groq: FlashIcon,
   deepseek: DeepseekIcon,
+  minimax: AiGenerativeIcon,
   openrouter: GlobeIcon,
   "openai-compatible": PlugIcon,
   lmstudio: ComputerIcon,


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io/) as a first-class AI provider in Terax. The default MiniMax chat model is the new **MiniMax-M3** (512K context, 128K max output, image input). M2.7 and M2.7-highspeed remain available as legacy alternatives.

## Models

- **MiniMax-M3** — Default. 512K context, 128K max output, image input. $0.6/M input · $2.4/M output · $0.12/M cache read.
- **MiniMax-M2.7** — Previous-generation peak-performance model, kept as legacy.
- **MiniMax-M2.7-highspeed** — Previous-generation low-latency variant, kept as legacy and as the default autocomplete model for this provider.

## Changes

- **`src/modules/ai/config.ts`** — Register `minimax` provider; add `MiniMax-M3` to the model list and set it as the first (default) MiniMax entry; keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as legacy alternatives (description/hint relabelled accordingly); add context limits and pricing for M3; define the official Anthropic Base URL as `https://api.minimax.io/anthropic`.
- **`src/modules/ai/lib/agent.ts`** — `minimax` case appends `/v1` to the official MiniMax Anthropic Base URL only at the `@ai-sdk/anthropic` adapter boundary; the SDK then appends `/messages`, producing requests to `https://api.minimax.io/anthropic/v1/messages`.
- **`src/modules/ai/lib/keyring.ts`** — Add `minimax` to the empty keys record.
- **`src/settings/components/ProviderIcon.tsx`** — Provider icon in the settings UI.
- **`src/modules/ai/components/AiStatusBarControls.tsx`** — Provider icon in the status-bar dropdown.
- **`src/modules/ai/__tests__/`** — Unit tests cover provider registration, M3 default ordering, M3/M2.7 context limits + pricing, and the final Anthropic-compatible request URL. E2E test calls `MiniMax-M3` via the OpenAI-compatible endpoint.

## How it works

MiniMax exposes an [Anthropic-compatible API](https://platform.minimax.io/docs/api-reference/text-anthropic-api) at the official Base URL `https://api.minimax.io/anthropic`. The adapter internally appends `/v1` for `@ai-sdk/anthropic`, which appends `/messages` and sends requests to `https://api.minimax.io/anthropic/v1/messages`. The derived endpoint prefix is not exposed as a Base URL or separate setting. No new dependencies are introduced. The API key is stored in the OS keychain alongside other provider keys (BYOK).

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm vite build` — clean
- [x] Unit tests updated to assert M3 ordering, context, and pricing
- [x] E2E test points at `MiniMax-M3` for live verification

## API docs

- Chat (Anthropic Compatible): https://platform.minimax.io/docs/api-reference/text-anthropic-api
- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported AI provider.
  * Added MiniMax M3, M2.7, and M2.7 Highspeed models with pricing and context details.
  * Added MiniMax model selection for autocomplete.
  * Added MiniMax provider icons in AI controls and settings.
  * Added support for MiniMax’s Anthropic-compatible API.

* **Tests**
  * Added coverage for MiniMax configuration, model availability, API routing, and live completions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
