### PR TITLE
fix(terminal): stop split pane lines bleeding into other tabs

### DIFF
--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import type { Tab } from "@/modules/tabs";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useEffect, useRef } from "react";
@@ -79,7 +80,13 @@ export function TerminalStack({
       {terminals.map((t) => {
         const tabVisible = t.id === activeId;
         return (
-          <div key={t.id} className="absolute inset-0">
+          <div
+            key={t.id}
+            className={cn(
+              "absolute inset-0",
+              !tabVisible && "invisible pointer-events-none",
+            )}
+          >
             <PaneTreeView
               node={t.paneTree}
               tabVisible={tabVisible}


### PR DESCRIPTION
## What

Hide inactive terminal tabs' pane-tree DOM so their `ResizableHandle` dividers stop painting through the active tab.

## Why

Closes #213.

`TerminalStack` mounts every terminal tab and toggles them via a `tabVisible` prop that gates xterm refresh. With single-pane tabs this was enough — the inactive xterm canvas is blank and visually matches the background. After #16 (split panes), the pane tree also renders `ResizableHandle` divider `<div>`s. Those keep painting whether the tab is active or not, so the crosshair from a split tab leaks into single-pane tabs.

Repro:
1. Split a terminal tab into 4 panes.
2. Switch to a different terminal tab that has no splits.
3. Center crosshair lines from the split tab show through.

## How

Apply `invisible pointer-events-none` to the per-tab wrapper when it's not the active tab. Mirrors the existing pattern in `EditorStack`, `PreviewStack`, and `AiDiffStack`. The `tabVisible` prop still flows down to drive xterm refresh, so backgrounded PTYs keep streaming and resume instantly on tab switch.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test in `pnpm tauri dev`:
  - 4-way split in tab B, switch to tab A → no ghost lines.
  - Switch back to tab B → splits intact, prompts alive.
  - `Cmd+]` / `Cmd+[` cycle focus inside split tab.
  - `Cmd+W` closes a pane, then closes the tab on the last pane.
  - Long-running output (`yes`) in one pane keeps streaming when switching tabs and coming back.
- [x] (If UI) tested in `pnpm tauri dev`

## Notes for reviewer

`visibility: hidden` keeps layout, so xterm's fit/resize observers still see the right dimensions when the tab returns to visible — no flash or reflow. `display: none` would have broken sizing.