### PR TITLE
fix :split divider bleed from inactive terminal tabs

### DIFF
--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -79,7 +79,15 @@ export function TerminalStack({
       {terminals.map((t) => {
         const tabVisible = t.id === activeId;
         return (
-          <div key={t.id} className="absolute inset-0">
+          <div
+            key={t.id}
+            className="absolute inset-0"
+            style={{
+              visibility: tabVisible ? "visible" : "hidden",
+              pointerEvents: tabVisible ? "auto" : "none",
+            }}
+            aria-hidden={!tabVisible}
+          >
             <PaneTreeView
               node={t.paneTree}
               tabVisible={tabVisible}


### PR DESCRIPTION
# Fix split divider lines leaking across terminal tabs
#213 
## Summary
This PR fixes a UI issue where split divider lines from one terminal tab remained visible after switching to another tab.

## Problem
When a terminal tab contained multiple split panes, its divider handles continued to render even after navigating to a different tab. As a result, inactive tabs could visually leak vertical or horizontal split lines into the currently active tab, even when that tab had no splits.

## Root Cause
Only the terminal pane contents were being hidden for inactive tabs. The parent split layout container and its resize handles were still rendered and visible, causing the divider lines to appear across tabs.

## Solution
Inactive terminal tab containers are now hidden at the tab wrapper level using:

- `visibility: hidden`
- `pointer-events: none`

This approach keeps terminal sessions mounted in the background while preventing inactive split layouts and resize handles from appearing in other tabs.

## Result
- Split divider lines no longer leak between tabs
- Background terminal sessions remain preserved
- Inactive tabs are fully non-interactive
- Tab switching behavior is visually consistent

## Before
  - Split a terminal into multiple panes in one tab.
  - Switch to another tab without splits.
  - Divider lines from the split tab were still visible.
<img width="1920" height="1080" alt="Screenshot from 2026-05-13 18-16-25" src="https://github.com/user-attachments/assets/c59e069c-dd7f-4a26-a539-e2759d9cf7ee" />
Due to the tab next to it
<img width="1920" height="1080" alt="Screenshot from 2026-05-13 18-13-09" src="https://github.com/user-attachments/assets/ec6cb4a2-8770-4b73-b17b-2b42e48a0002" />
After

  - Split dividers only appear in the tab where the split panes actually exist.
  - Other tabs remain visually clean.
  - Terminal sessions are still preserved when switching tabs.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a85c08a-c6d4-4dd2-918b-f35291f4e708" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/509c1e5a-1e2e-48ad-be8a-f2658a278463" />
