### PR TITLE
fix(settings): make model dropdowns scrollable

### DIFF
--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -171,49 +171,54 @@ function DefaultModelBlock({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          className="max-h-[28rem] min-w-[280px] overflow-y-auto"
+          side="bottom"
+          sideOffset={6}
+          avoidCollisions={false}
+          className="min-w-[280px] p-1"
         >
-          {PROVIDERS.map((p) => {
-            const models = MODELS.filter((x) => x.provider === p.id);
-            if (models.length === 0) return null;
-            const hasKey = providerNeedsKey(p.id) ? !!keys[p.id] : true;
-            return (
-              <div key={p.id} className="px-1 pt-1.5 first:pt-1">
-                <div className="mb-0.5 flex items-center gap-1.5 px-2 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
-                  <ProviderIcon provider={p.id} size={11} />
-                  <span>{p.label}</span>
-                  {!hasKey ? (
-                    <span className="ml-auto text-[9.5px] normal-case tracking-normal text-muted-foreground/70">
-                      no key
-                    </span>
-                  ) : null}
-                </div>
-                {models.map((mod) => {
-                  const available = isAvailable(mod.id, p.id);
-                  return (
-                    <DropdownMenuItem
-                      key={mod.id}
-                      disabled={!available}
-                      onSelect={() =>
-                        available && void setDefaultModel(mod.id as ModelId)
-                      }
-                      className={cn(
-                        "flex items-start gap-2 text-[12px]",
-                        mod.id === defaultModel && "bg-accent/50",
-                      )}
-                    >
-                      <span className="flex flex-1 flex-col">
-                        <span>{mod.label}</span>
-                        <span className="text-[10px] text-muted-foreground">
-                          {mod.description}
-                        </span>
+          <div className="max-h-[240px] overflow-y-auto overscroll-contain pr-1">
+            {PROVIDERS.map((p) => {
+              const models = MODELS.filter((x) => x.provider === p.id);
+              if (models.length === 0) return null;
+              const hasKey = providerNeedsKey(p.id) ? !!keys[p.id] : true;
+              return (
+                <div key={p.id} className="px-1 pt-1.5 first:pt-1">
+                  <div className="mb-0.5 flex items-center gap-1.5 px-2 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+                    <ProviderIcon provider={p.id} size={11} />
+                    <span>{p.label}</span>
+                    {!hasKey ? (
+                      <span className="ml-auto text-[9.5px] normal-case tracking-normal text-muted-foreground/70">
+                        no key
                       </span>
-                    </DropdownMenuItem>
-                  );
-                })}
-              </div>
-            );
-          })}
+                    ) : null}
+                  </div>
+                  {models.map((mod) => {
+                    const available = isAvailable(mod.id, p.id);
+                    return (
+                      <DropdownMenuItem
+                        key={mod.id}
+                        disabled={!available}
+                        onSelect={() =>
+                          available && void setDefaultModel(mod.id as ModelId)
+                        }
+                        className={cn(
+                          "flex items-start gap-2 text-[12px]",
+                          mod.id === defaultModel && "bg-accent/50",
+                        )}
+                      >
+                        <span className="flex flex-1 flex-col">
+                          <span>{mod.label}</span>
+                          <span className="text-[10px] text-muted-foreground">
+                            {mod.description}
+                          </span>
+                        </span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
## What
Fixes the model dropdowns in Settings so long model lists can be scrolled and all model options can be reached.

## Why
The Default model dropdown could extend past the bottom of the settings window, making some models inaccessible. This was especially visible when the model list contained many provider groups.

Closes #225 

## How
Moved the scroll behavior into an inner wrapper inside the dropdown content and reduced the max height so the menu fits better within the settings window.

Applied the same pattern to:
- Default model dropdown


## Testing
- [ ] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

Manual testing performed:
- Opened Terax with `pnpm tauri dev`
- Opened Settings -> Models
- Opened the Default model dropdown
- Verified the dropdown scrolls farther than before and no longer stops around the GLM entries
- Verified the lower model entries can be reached by scrolling


## Screenshots / GIFs
Before: dropdown was clipped near the bottom of the settings window and could not reach all models.
<img width="898" height="646" alt="Before_terax" src="https://github.com/user-attachments/assets/3e16d63b-1d8c-4888-b1d5-379bab21e427" />


After: dropdown uses an internal scroll area, allowing lower model entries to be reached.
<img width="898" height="652" alt="After_terax" src="https://github.com/user-attachments/assets/5e7d285c-dd54-4ade-98ea-dc0eb2723f56" />

## Notes for reviewer
None