### PR TITLE
feat: live rendering of updates in the file explorer

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1314,6 +1314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,6 +2165,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2358,26 @@ dependencies = [
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -2535,6 +2593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2625,6 +2684,34 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "num-conv"
@@ -3492,7 +3579,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5156,6 +5243,7 @@ dependencies = [
  "ignore",
  "keyring",
  "log",
+ "notify",
  "portable-pty",
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tauri-plugin-process = "2"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 bytes = "1"
 futures-util = "0.3"
+notify = "7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6", default-features = false, features = [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
         // Skip restoring VISIBLE — frontend calls window.show() after first
         // paint so the user never sees a transparent window-shadow flash on
         // Windows/Linux.
+        .manage(fs::watch::FsWatchState::default())
         .plugin(
             tauri_plugin_window_state::Builder::new()
                 .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
@@ -139,6 +140,10 @@ pub fn run() {
             fs::search::fs_search,
             fs::grep::fs_grep,
             fs::grep::fs_glob,
+            fs::watch::fs_watch_start,
+            fs::watch::fs_watch_stop,
+            fs::watch::fs_watch_add,
+            fs::watch::fs_watch_remove,
             shell::shell_run_command,
             shell::shell_session_open,
             shell::shell_session_run,

--- a/src-tauri/src/modules/fs/mod.rs
+++ b/src-tauri/src/modules/fs/mod.rs
@@ -3,6 +3,7 @@ pub mod grep;
 pub mod mutate;
 pub mod search;
 pub mod tree;
+pub mod watch;
 
 use std::path::Path;
 

--- a/src-tauri/src/modules/fs/watch.rs
+++ b/src-tauri/src/modules/fs/watch.rs
@@ -1,0 +1,227 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use notify::{event::EventKind, recommended_watcher, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::Serialize;
+use tauri::Emitter;
+
+use super::to_canon;
+
+const FS_CHANGED_EVENT: &str = "fs://changed";
+
+#[derive(Default)]
+pub struct FsWatchState {
+    inner: Mutex<FsWatchInner>,
+}
+
+#[derive(Default)]
+struct FsWatchInner {
+    watcher: Option<RecommendedWatcher>,
+    root: Option<String>,
+    canonical_root: Option<PathBuf>,
+    watched_paths: HashSet<String>,
+}
+
+#[derive(Clone, Serialize)]
+struct FsChangedPayload {
+    root: String,
+    paths: Vec<String>,
+}
+
+fn normalize_input_path(path: &str) -> String {
+    let normalized = to_canon(PathBuf::from(path));
+    if normalized == "/" {
+        normalized
+    } else {
+        normalized.trim_end_matches('/').to_string()
+    }
+}
+
+fn canonical_watch_path(path: &str) -> Result<PathBuf, String> {
+    Path::new(path).canonicalize().map_err(|e| e.to_string())
+}
+
+fn should_emit(kind: &EventKind) -> bool {
+    !matches!(kind, EventKind::Access(_))
+}
+
+fn remap_event_path(event_path: PathBuf, canonical_root: &Path, requested_root: &str) -> String {
+    match event_path.strip_prefix(canonical_root) {
+        Ok(relative) => to_canon(PathBuf::from(requested_root).join(relative)),
+        Err(_) => to_canon(event_path),
+    }
+}
+
+fn should_stop_active_root(active_root: Option<&str>, requested_root: &str) -> bool {
+    matches!(active_root, Some(root) if root == requested_root)
+}
+
+fn is_inside_active_root(path: &Path, active_root: Option<&Path>) -> bool {
+    active_root.is_some_and(|root| path == root || path.starts_with(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_only_matches_active_root() {
+        assert!(should_stop_active_root(Some("/workspace"), "/workspace"));
+        assert!(!should_stop_active_root(Some("/workspace"), "/other"));
+        assert!(!should_stop_active_root(None, "/workspace"));
+    }
+}
+
+/// Start the filesystem watcher for the workspace root.
+///
+/// The root itself is watched non-recursively. Expanded directories are added
+/// with `fs_watch_add`, keeping watch counts bounded on large home folders.
+#[tauri::command]
+pub fn fs_watch_start(
+    path: String,
+    app: tauri::AppHandle,
+    state: tauri::State<FsWatchState>,
+) -> Result<(), String> {
+    let root = normalize_input_path(&path);
+    let watch_path = canonical_watch_path(&path)?;
+    log::info!("fs_watch_start: path={path}, root={root}, watch_path={watch_path:?}");
+    let event_root = root.clone();
+    let event_canonical_root = watch_path.clone();
+
+    let mut watcher =
+        recommended_watcher(move |result: notify::Result<notify::Event>| match result {
+            Ok(event) => {
+                log::debug!(
+                    "watcher event: kind={:?}, paths={:?}",
+                    event.kind,
+                    event.paths
+                );
+                if !should_emit(&event.kind) {
+                    return;
+                }
+
+                let paths = event
+                    .paths
+                    .into_iter()
+                    .map(|path| remap_event_path(path, &event_canonical_root, &event_root))
+                    .collect::<Vec<_>>();
+
+                if paths.is_empty() {
+                    return;
+                }
+
+                log::info!("emitting {FS_CHANGED_EVENT}: root={event_root}, paths={paths:?}");
+                if let Err(e) = app.emit(
+                    FS_CHANGED_EVENT,
+                    FsChangedPayload {
+                        root: event_root.clone(),
+                        paths,
+                    },
+                ) {
+                    log::warn!("failed to emit {FS_CHANGED_EVENT}: {e}");
+                }
+            }
+            Err(e) => log::warn!("filesystem watcher error for {event_root}: {e}"),
+        })
+        .map_err(|e| e.to_string())?;
+
+    // Watch only the root directory. Subdirectories are added lazily
+    // via fs_watch_add when the user expands them in the explorer.
+    // This avoids hitting the inotify limit on large directory trees.
+    watcher
+        .watch(&watch_path, RecursiveMode::NonRecursive)
+        .map_err(|e| e.to_string())?;
+    log::info!("watcher started for {root} (canonical: {watch_path:?}), watching root only");
+
+    let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+    inner.watched_paths.clear();
+    inner
+        .watched_paths
+        .insert(watch_path.to_string_lossy().to_string());
+    inner.root = Some(root);
+    inner.canonical_root = Some(watch_path);
+    inner.watcher = Some(watcher);
+    Ok(())
+}
+
+/// Stop all filesystem watchers.
+#[tauri::command]
+pub fn fs_watch_stop(path: String, state: tauri::State<FsWatchState>) -> Result<(), String> {
+    let requested_root = normalize_input_path(&path);
+    let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+    if !should_stop_active_root(inner.root.as_deref(), &requested_root) {
+        log::debug!(
+            "fs_watch_stop ignored: requested={requested_root}, active={:?}",
+            inner.root
+        );
+        return Ok(());
+    }
+
+    log::info!("fs_watch_stop: path={path}, root={requested_root}");
+    inner.watcher = None;
+    inner.root = None;
+    inner.canonical_root = None;
+    inner.watched_paths.clear();
+    Ok(())
+}
+
+/// Add a single directory to the watcher (non-recursive).
+/// Used for lazy watching: only watch directories the user has expanded.
+#[tauri::command]
+pub fn fs_watch_add(path: String, state: tauri::State<FsWatchState>) -> Result<(), String> {
+    let normalized = normalize_input_path(&path);
+    let canonical = canonical_watch_path(&path)?;
+
+    let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+    if !is_inside_active_root(&canonical, inner.canonical_root.as_deref()) {
+        log::debug!("fs_watch_add ignored outside active root: {normalized}");
+        return Ok(());
+    }
+
+    let key = canonical.to_string_lossy().to_string();
+    if inner.watched_paths.contains(&key) {
+        return Ok(()); // Already watching
+    }
+
+    if let Some(ref mut watcher) = inner.watcher {
+        match watcher.watch(&canonical, RecursiveMode::NonRecursive) {
+            Ok(()) => {
+                inner.watched_paths.insert(key);
+                log::info!("fs_watch_add: watching {normalized} (canonical: {canonical:?})");
+            }
+            Err(e) => {
+                log::warn!("fs_watch_add: cannot watch {normalized}: {e}");
+                return Err(e.to_string());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Remove a single directory from the watcher.
+#[tauri::command]
+pub fn fs_watch_remove(path: String, state: tauri::State<FsWatchState>) -> Result<(), String> {
+    let normalized = normalize_input_path(&path);
+    let canonical = canonical_watch_path(&path)?;
+
+    let mut inner = state.inner.lock().map_err(|e| e.to_string())?;
+    let key = canonical.to_string_lossy().to_string();
+    if !inner.watched_paths.contains(&key) {
+        return Ok(()); // Not watching
+    }
+
+    if let Some(ref mut watcher) = inner.watcher {
+        match watcher.unwatch(&canonical) {
+            Ok(()) => {
+                inner.watched_paths.remove(&key);
+                log::info!("fs_watch_remove: stopped watching {normalized}");
+            }
+            Err(e) => {
+                log::warn!("fs_watch_remove: cannot unwatch {normalized}: {e}");
+                return Err(e.to_string());
+            }
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/modules/net.rs
+++ b/src-tauri/src/modules/net.rs
@@ -22,7 +22,9 @@ pub async fn lm_ping(base_url: String) -> Result<u16, String> {
         s => return Err(format!("scheme not allowed: {s}")),
     }
 
-    let host = parsed.host_str().ok_or_else(|| "missing host".to_string())?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "missing host".to_string())?;
     if is_blocked_host(host) {
         return Err(format!("host not allowed: {host}"));
     }
@@ -43,10 +45,7 @@ pub async fn lm_ping(base_url: String) -> Result<u16, String> {
 fn is_blocked_host(host: &str) -> bool {
     matches!(
         host,
-        "169.254.169.254"
-            | "fd00:ec2::254"
-            | "metadata.google.internal"
-            | "metadata.azure.com"
+        "169.254.169.254" | "fd00:ec2::254" | "metadata.google.internal" | "metadata.azure.com"
     )
 }
 

--- a/src-tauri/src/modules/secrets.rs
+++ b/src-tauri/src/modules/secrets.rs
@@ -45,10 +45,7 @@ fn key(service: &str, account: &str) -> String {
 
 #[cfg(target_os = "linux")]
 fn store_path(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_local_data_dir()
-        .map_err(|e| e.to_string())?;
+    let dir = app.path().app_local_data_dir().map_err(|e| e.to_string())?;
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     Ok(dir.join("secrets.json"))
 }
@@ -87,11 +84,7 @@ fn write_store(app: &AppHandle, map: &HashMap<String, String>) -> Result<(), Str
 }
 
 #[cfg(target_os = "linux")]
-fn with_store<F, R>(
-    app: &AppHandle,
-    state: &SecretsState,
-    f: F,
-) -> Result<R, String>
+fn with_store<F, R>(app: &AppHandle, state: &SecretsState, f: F) -> Result<R, String>
 where
     F: FnOnce(&mut HashMap<String, String>) -> R,
 {

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -68,7 +68,7 @@ export function FileExplorer({
         if (isDir && tree.expanded.has(p)) walk(p);
       }
     };
-    walk(rootPath);
+    walk(tree.rootPath ?? "");
     return out;
   }, [rootPath, tree.nodes, tree.expanded, tree.joinPath]);
 

--- a/src/modules/explorer/lib/pathUtils.ts
+++ b/src/modules/explorer/lib/pathUtils.ts
@@ -35,3 +35,19 @@ export function affectedDirsForPath(
   dirs.add(rootPath);
   return [...dirs];
 }
+
+export function togglePathExpansion(
+  expanded: ReadonlySet<string>,
+  path: string,
+): { next: Set<string>; isCollapsing: boolean } {
+  const next = new Set(expanded);
+  const isCollapsing = next.has(path);
+
+  if (isCollapsing) {
+    next.delete(path);
+  } else {
+    next.add(path);
+  }
+
+  return { next, isCollapsing };
+}

--- a/src/modules/explorer/lib/pathUtils.ts
+++ b/src/modules/explorer/lib/pathUtils.ts
@@ -1,0 +1,37 @@
+export function joinPath(parent: string, name: string): string {
+  if (parent.endsWith("/")) return `${parent}${name}`;
+  return `${parent}/${name}`;
+}
+
+export function dirname(path: string): string {
+  const i = path.lastIndexOf("/");
+  if (i <= 0) return "/";
+  return path.slice(0, i);
+}
+
+export function affectedDirsForPath(
+  path: string,
+  rootPath: string,
+  isLoadedDir: (path: string) => boolean = () => true,
+): string[] {
+  if (rootPath !== "/" && path !== rootPath && !path.startsWith(joinPath(rootPath, ""))) {
+    return [];
+  }
+  if (rootPath === "/" && !path.startsWith("/")) return [];
+
+  const dirs = new Set<string>();
+  let current = path;
+
+  const parent = dirname(current);
+  if (parent === rootPath || isLoadedDir(parent)) dirs.add(parent);
+
+  while (current && current !== rootPath && current !== "/") {
+    if (current === rootPath || isLoadedDir(current)) dirs.add(current);
+    const next = dirname(current);
+    if (next === current) break;
+    current = next;
+  }
+
+  dirs.add(rootPath);
+  return [...dirs];
+}

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { affectedDirsForPath, dirname, joinPath } from "./pathUtils";
 
 export type DirEntry = {
   name: string;
@@ -22,37 +23,6 @@ export type PendingCreate = {
   parentPath: string;
   kind: "file" | "dir";
 };
-
-export function joinPath(parent: string, name: string): string {
-  if (parent.endsWith("/")) return `${parent}${name}`;
-  return `${parent}/${name}`;
-}
-
-export function dirname(path: string): string {
-  const i = path.lastIndexOf("/");
-  if (i <= 0) return "/";
-  return path.slice(0, i);
-}
-
-export function affectedDirsForPath(path: string, rootPath: string): string[] {
-  if (rootPath !== "/" && path !== rootPath && !path.startsWith(joinPath(rootPath, ""))) return [];
-  if (rootPath === "/" && !path.startsWith("/")) return [];
-
-  const dirs = new Set<string>();
-  let current = path;
-
-  dirs.add(dirname(current));
-
-  while (current && current !== rootPath && current !== "/") {
-    dirs.add(current);
-    const parent = dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-
-  dirs.add(rootPath);
-  return [...dirs];
-}
 
 type Options = {
   onPathRenamed?: (from: string, to: string) => void;
@@ -124,11 +94,12 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
 
     const affectedDirs = new Set<string>();
     for (const path of paths) {
-      for (const dir of affectedDirsForPath(path, rootPath)) {
-        const node = nodesRef.current[dir];
-        if (dir === rootPath || node?.status === "loaded") {
-          affectedDirs.add(dir);
-        }
+      for (const dir of affectedDirsForPath(
+        path,
+        rootPath,
+        (dir) => nodesRef.current[dir]?.status === "loaded",
+      )) {
+        affectedDirs.add(dir);
       }
     }
 

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,7 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import { affectedDirsForPath, dirname, joinPath } from "./pathUtils";
+import {
+  affectedDirsForPath,
+  dirname,
+  joinPath,
+  togglePathExpansion,
+} from "./pathUtils";
 import { useFileTreeWatcher } from "./useFileTreeWatcher";
 
 export type DirEntry = {
@@ -42,6 +47,7 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
   const [nodes, setNodes] = useState<TreeState>({});
   const nodesRef = useRef<TreeState>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const expandedRef = useRef<Set<string>>(new Set());
   const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(
     null,
   );
@@ -54,6 +60,10 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
   useEffect(() => {
     nodesRef.current = nodes;
   }, [nodes]);
+
+  useEffect(() => {
+    expandedRef.current = expanded;
+  }, [expanded]);
 
   const fetchChildren = useCallback(async (path: string) => {
     setNodes((s) =>
@@ -129,15 +139,10 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
 
   const toggle = useCallback(
     (path: string) => {
-      let isCollapsing = false;
+      const isCollapsing = expandedRef.current.has(path);
       setExpanded((curr) => {
-        const next = new Set(curr);
-        if (next.has(path)) {
-          next.delete(path);
-          isCollapsing = true;
-        } else {
-          next.add(path);
-        }
+        const { next } = togglePathExpansion(curr, path);
+        expandedRef.current = next;
         return next;
       });
       if (isCollapsing) {

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 
@@ -33,15 +34,52 @@ export function dirname(path: string): string {
   return path.slice(0, i);
 }
 
+export function affectedDirsForPath(path: string, rootPath: string): string[] {
+  if (rootPath !== "/" && path !== rootPath && !path.startsWith(joinPath(rootPath, ""))) return [];
+  if (rootPath === "/" && !path.startsWith("/")) return [];
+
+  const dirs = new Set<string>();
+  let current = path;
+
+  dirs.add(dirname(current));
+
+  while (current && current !== rootPath && current !== "/") {
+    dirs.add(current);
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  dirs.add(rootPath);
+  return [...dirs];
+}
+
 type Options = {
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
 };
 
-export function useFileTree(rootPath: string | null, options?: Options) {
+type FsChangedPayload = {
+  root: string;
+  paths: string[];
+};
+
+export function useFileTree(rawRootPath: string | null, options?: Options) {
+  // Normalize: strip trailing slash (except for root "/") to prevent
+  // watcher restart + root mismatch when terminal CWD has trailing slash.
+  const rootPath = rawRootPath
+    ? rawRootPath === "/"
+      ? "/"
+      : rawRootPath.replace(/\/+$/, "")
+    : null;
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const showHiddenRef = useRef(showHidden);
   const [nodes, setNodes] = useState<TreeState>({});
+  const nodesRef = useRef<TreeState>({});
+  const pendingWatcherPathsRef = useRef<Set<string>>(new Set());
+  const watcherFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(
     null,
@@ -52,14 +90,24 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     showHiddenRef.current = showHidden;
   }, [showHidden]);
 
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
+
   const fetchChildren = useCallback(async (path: string) => {
-    setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
+    setNodes((s) =>
+      s[path]?.status === "loaded"
+        ? s // already loaded — keep showing entries during refresh
+        : { ...s, [path]: { status: "loading" } },
+    );
     try {
       const entries = await invoke<DirEntry[]>("fs_read_dir", {
         path,
         showHidden: showHiddenRef.current,
       });
       setNodes((s) => ({ ...s, [path]: { status: "loaded", entries } }));
+      // Add this directory to the watcher so changes are detected.
+      void invoke("fs_watch_add", { path }).catch(() => {});
     } catch (e) {
       setNodes((s) => ({
         ...s,
@@ -68,7 +116,28 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     }
   }, []);
 
-  // Root change → reset state.
+  const flushWatcherRefresh = useCallback(() => {
+    if (!rootPath) return;
+    const paths = [...pendingWatcherPathsRef.current];
+    pendingWatcherPathsRef.current.clear();
+    if (paths.length === 0) return;
+
+    const affectedDirs = new Set<string>();
+    for (const path of paths) {
+      for (const dir of affectedDirsForPath(path, rootPath)) {
+        const node = nodesRef.current[dir];
+        if (dir === rootPath || node?.status === "loaded") {
+          affectedDirs.add(dir);
+        }
+      }
+    }
+
+    for (const dir of affectedDirs) {
+      void fetchChildren(dir);
+    }
+  }, [fetchChildren, rootPath]);
+
+  // Root change → reset state and fetch.
   useEffect(() => {
     if (!rootPath) {
       setNodes({});
@@ -96,20 +165,90 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showHidden, rootPath, fetchChildren]);
 
+  useEffect(() => {
+    if (!rootPath) return;
+
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+
+    const setup = async () => {
+      try {
+        const unlistenFn = await listen<FsChangedPayload>("fs://changed", (event) => {
+          if (event.payload.root !== rootPath) return;
+
+          for (const path of event.payload.paths) {
+            pendingWatcherPathsRef.current.add(path);
+          }
+
+          if (watcherFlushTimerRef.current) {
+            clearTimeout(watcherFlushTimerRef.current);
+          }
+          watcherFlushTimerRef.current = setTimeout(() => {
+            watcherFlushTimerRef.current = null;
+            flushWatcherRefresh();
+          }, 100);
+        });
+
+        if (disposed) {
+          unlistenFn();
+          return;
+        }
+
+        unlisten = unlistenFn;
+
+        try {
+          await invoke("fs_watch_start", { path: rootPath });
+          if (disposed) {
+            await invoke("fs_watch_stop", { path: rootPath });
+          }
+        } catch (e) {
+          console.error("fs_watch_start failed:", e);
+        }
+      } catch (e) {
+        console.error("fs://changed listen failed:", e);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+      if (watcherFlushTimerRef.current) {
+        clearTimeout(watcherFlushTimerRef.current);
+        watcherFlushTimerRef.current = null;
+      }
+      pendingWatcherPathsRef.current.clear();
+      void invoke("fs_watch_stop", { path: rootPath }).catch((e) => {
+        console.error("fs_watch_stop failed:", e);
+      });
+    };
+  }, [rootPath, flushWatcherRefresh]);
+
   const toggle = useCallback(
     (path: string) => {
+      let isCollapsing = false;
       setExpanded((curr) => {
         const next = new Set(curr);
-        if (next.has(path)) next.delete(path);
-        else next.add(path);
+        if (next.has(path)) {
+          next.delete(path);
+          isCollapsing = true;
+        } else {
+          next.add(path);
+        }
         return next;
       });
-      setNodes((curr) => {
-        if (!curr[path] || curr[path].status === "error") {
-          void fetchChildren(path);
-        }
-        return curr;
-      });
+      if (isCollapsing) {
+        // Remove watcher for collapsed directory
+        void invoke("fs_watch_remove", { path }).catch(() => {});
+      } else {
+        setNodes((curr) => {
+          if (!curr[path] || curr[path].status === "error") {
+            void fetchChildren(path);
+          }
+          return curr;
+        });
+      }
     },
     [fetchChildren],
   );
@@ -245,5 +384,6 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     commitRename,
     deletePath,
     joinPath,
+    rootPath,
   };
 }

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,8 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { affectedDirsForPath, dirname, joinPath } from "./pathUtils";
+import { useFileTreeWatcher } from "./useFileTreeWatcher";
 
 export type DirEntry = {
   name: string;
@@ -29,11 +29,6 @@ type Options = {
   onPathDeleted?: (path: string) => void;
 };
 
-type FsChangedPayload = {
-  root: string;
-  paths: string[];
-};
-
 export function useFileTree(rawRootPath: string | null, options?: Options) {
   // Normalize: strip trailing slash (except for root "/") to prevent
   // watcher restart + root mismatch when terminal CWD has trailing slash.
@@ -46,10 +41,6 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
   const showHiddenRef = useRef(showHidden);
   const [nodes, setNodes] = useState<TreeState>({});
   const nodesRef = useRef<TreeState>({});
-  const pendingWatcherPathsRef = useRef<Set<string>>(new Set());
-  const watcherFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(
     null,
@@ -86,10 +77,8 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
     }
   }, []);
 
-  const flushWatcherRefresh = useCallback(() => {
+  const handleWatcherInvalidate = useCallback((paths: string[]) => {
     if (!rootPath) return;
-    const paths = [...pendingWatcherPathsRef.current];
-    pendingWatcherPathsRef.current.clear();
     if (paths.length === 0) return;
 
     const affectedDirs = new Set<string>();
@@ -107,6 +96,8 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
       void fetchChildren(dir);
     }
   }, [fetchChildren, rootPath]);
+
+  useFileTreeWatcher(rootPath, { onInvalidate: handleWatcherInvalidate });
 
   // Root change → reset state and fetch.
   useEffect(() => {
@@ -135,66 +126,6 @@ export function useFileTree(rawRootPath: string | null, options?: Options) {
     // every expanded directory.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showHidden, rootPath, fetchChildren]);
-
-  useEffect(() => {
-    if (!rootPath) return;
-
-    let disposed = false;
-    let unlisten: (() => void) | null = null;
-
-    const setup = async () => {
-      try {
-        const unlistenFn = await listen<FsChangedPayload>("fs://changed", (event) => {
-          if (event.payload.root !== rootPath) return;
-
-          for (const path of event.payload.paths) {
-            pendingWatcherPathsRef.current.add(path);
-          }
-
-          if (watcherFlushTimerRef.current) {
-            clearTimeout(watcherFlushTimerRef.current);
-          }
-          watcherFlushTimerRef.current = setTimeout(() => {
-            watcherFlushTimerRef.current = null;
-            flushWatcherRefresh();
-          }, 100);
-        });
-
-        if (disposed) {
-          unlistenFn();
-          return;
-        }
-
-        unlisten = unlistenFn;
-
-        try {
-          await invoke("fs_watch_start", { path: rootPath });
-          if (disposed) {
-            await invoke("fs_watch_stop", { path: rootPath });
-          }
-        } catch (e) {
-          console.error("fs_watch_start failed:", e);
-        }
-      } catch (e) {
-        console.error("fs://changed listen failed:", e);
-      }
-    };
-
-    void setup();
-
-    return () => {
-      disposed = true;
-      unlisten?.();
-      if (watcherFlushTimerRef.current) {
-        clearTimeout(watcherFlushTimerRef.current);
-        watcherFlushTimerRef.current = null;
-      }
-      pendingWatcherPathsRef.current.clear();
-      void invoke("fs_watch_stop", { path: rootPath }).catch((e) => {
-        console.error("fs_watch_stop failed:", e);
-      });
-    };
-  }, [rootPath, flushWatcherRefresh]);
 
   const toggle = useCallback(
     (path: string) => {

--- a/src/modules/explorer/lib/useFileTreeWatcher.ts
+++ b/src/modules/explorer/lib/useFileTreeWatcher.ts
@@ -1,0 +1,80 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useRef } from "react";
+
+type FsChangedPayload = {
+  root: string;
+  paths: string[];
+};
+
+type Options = {
+  onInvalidate: (paths: string[]) => void;
+};
+
+export function useFileTreeWatcher(rootPath: string | null, { onInvalidate }: Options) {
+  const pendingPathsRef = useRef<Set<string>>(new Set());
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onInvalidateRef = useRef(onInvalidate);
+
+  useEffect(() => {
+    onInvalidateRef.current = onInvalidate;
+  }, [onInvalidate]);
+
+  useEffect(() => {
+    if (!rootPath) return;
+
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+
+    const flush = () => {
+      flushTimerRef.current = null;
+      const paths = [...pendingPathsRef.current];
+      pendingPathsRef.current.clear();
+      if (paths.length > 0) onInvalidateRef.current(paths);
+    };
+
+    const setup = async () => {
+      try {
+        const unlistenFn = await listen<FsChangedPayload>("fs://changed", (event) => {
+          if (event.payload.root !== rootPath) return;
+
+          for (const path of event.payload.paths) pendingPathsRef.current.add(path);
+
+          if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
+          flushTimerRef.current = setTimeout(flush, 100);
+        });
+
+        if (disposed) {
+          unlistenFn();
+          return;
+        }
+
+        unlisten = unlistenFn;
+
+        try {
+          await invoke("fs_watch_start", { path: rootPath });
+          if (disposed) await invoke("fs_watch_stop", { path: rootPath });
+        } catch (e) {
+          console.error("fs_watch_start failed:", e);
+        }
+      } catch (e) {
+        console.error("fs://changed listen failed:", e);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+      pendingPathsRef.current.clear();
+      void invoke("fs_watch_stop", { path: rootPath }).catch((e) => {
+        console.error("fs_watch_stop failed:", e);
+      });
+    };
+  }, [rootPath]);
+}

--- a/src/modules/tabs/lib/useWorkspaceCwd.ts
+++ b/src/modules/tabs/lib/useWorkspaceCwd.ts
@@ -20,11 +20,19 @@ export function useWorkspaceCwd(
   }, [activeTab]);
 
   const explorerRoot = useMemo<string | null>(() => {
-    if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
-    if (lastTerminalCwd.current) return lastTerminalCwd.current;
-    const anyTerm = tabs.find((t) => t.kind === "terminal" && t.cwd);
-    if (anyTerm?.kind === "terminal" && anyTerm.cwd) return anyTerm.cwd;
-    return home;
+    const raw =
+      (activeTab?.kind === "terminal" && activeTab.cwd
+        ? activeTab.cwd
+        : null) ??
+      lastTerminalCwd.current ??
+      (() => {
+        const anyTerm = tabs.find((t) => t.kind === "terminal" && t.cwd);
+        return anyTerm?.kind === "terminal" ? anyTerm.cwd : null;
+      })() ??
+      home;
+    if (!raw) return null;
+    // Normalise trailing slashes so useFileTree's rootPath stays stable.
+    return raw === "/" ? "/" : raw.replace(/\/+$/, "") || "/";
   }, [activeTab, tabs, home]);
 
   const inheritedCwdForNewTab = useCallback((): string | undefined => {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
Adds real-time Explorer updates when files or directories change under the active workspace root. Like creation/rename, and deletes.  

Explorer now receives backend filesystem invalidation events, batches them, and refreshes affected loaded directories without requiring manual refrresh. Currently, the user has to manually click the refresh button just to see the changes in the project folder when there are new files, renames, or deletes.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
The file explorer state became stale when files changed outside explorer actions, such as via touch, rm, or yazi, and even editor saves or git checkout. THe user has to manually click the refresh button just to see the chagnes reflect in the file explorer.

closes #209

## How
<!-- Brief notes on the approach, only if non-obvious. -->
Implemented a custom Rust notify watcher instead of the Tauri FS plugin because explorer needs bounded, lazy watch lifecycle control like:
- watch the root plus expanded/loaded directories only
- or unwatch collapsed directories
- avoid recursive failures on unreadable folders
- and avoid exhausting Linux inotify limits on large roots

The wtcher events only invalidate paths. File listing remains owned by existing fs_read_dir while the Frontend watcher lifecycle is isoled in useFileTreeWatcher, and the useFileTree stays the same and focused on tree state and mutations.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->
No screenshots since it renders instantly now.

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
Custom watcher is intentionally non-recursive. New changes inside a directory are observed after that directory is loaded/expanded. If it's not expanded or if the directory is closed then it's not watched.

<img width="1863" height="906" alt="1778703771169476799" src="https://github.com/user-attachments/assets/3dcca32e-42d2-4b75-bd16-230eb4dbad75" />

