### PR TITLE
feat(nix): add official Nix/NixOS support with auto-update workflow

### DIFF
--- a/.github/workflows/update-nix-sources.yml
+++ b/.github/workflows/update-nix-sources.yml
@@ -1,0 +1,79 @@
+name: Update Nix sources
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.6.6)"
+        required: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Normalize tag
+        id: tag
+        env:
+          RAW_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+        run: |
+          case "$RAW_TAG" in
+            v*) TAG="$RAW_TAG" ;;
+            *) TAG="v$RAW_TAG" ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          gh release download "$TAG" \
+            --repo crynta/terax-ai \
+            --pattern "Terax_${VERSION}_amd64.deb" \
+            --pattern "Terax_x64.app.tar.gz" \
+            --pattern "Terax_aarch64.app.tar.gz"
+
+      - name: Compute SRI hashes
+        id: hashes
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          hash_sri() {
+            openssl dgst -sha256 -binary "$1" | base64 | tr -d '\n'
+          }
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "linux=sha256-$(hash_sri "Terax_${VERSION}_amd64.deb")" >> "$GITHUB_OUTPUT"
+          echo "x64-darwin=sha256-$(hash_sri "Terax_x64.app.tar.gz")" >> "$GITHUB_OUTPUT"
+          echo "aarch64-darwin=sha256-$(hash_sri "Terax_aarch64.app.tar.gz")" >> "$GITHUB_OUTPUT"
+
+      - name: Update nix/sources.json
+        run: |
+          cat > nix/sources.json <<- EOF
+          {
+            "version": "${{ steps.hashes.outputs.version }}",
+            "hashes": {
+              "x86_64-linux": "${{ steps.hashes.outputs.linux }}",
+              "x86_64-darwin": "${{ steps.hashes.outputs.x64-darwin }}",
+              "aarch64-darwin": "${{ steps.hashes.outputs.aarch64-darwin }}"
+            }
+          }
+          EOF
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "update nix sources to ${{ steps.hashes.outputs.version }}"
+          title: "nix: update sources to ${{ steps.hashes.outputs.version }}"
+          body: 'Automated update of `nix/sources.json` for release ${{ steps.tag.outputs.tag }}.'
+          branch: update-nix-sources/${{ steps.hashes.outputs.version }}
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Latest installers are on the [Releases](https://github.com/crynta/terax-ai/relea
 ### Linux notes
 
 - **Arch / AUR:** `yay -S terax-bin` (or `paru`, etc.). Tracks the latest release.
+- **NixOS / Nix**: use the official flake — `nix profile install github:crynta/terax-ai` (non-NixOS), or import the flake and add `inputs.terax.packages.${pkgs.system}.terax` to `environment.systemPackages` (NixOS). The `nixosModules.terax` output is also available for a simpler setup.
 - **AppImage:** needs FUSE. Without it: `./Terax_*.AppImage --appimage-extract-and-run`. On Wayland with rendering glitches, try `WEBKIT_DISABLE_DMABUF_RENDERER=1`. Otherwise the `.deb` / `.rpm` packages link against the system GTK stack and tend to be smoother.
 
 ## Configure AI

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Terax - open-source lightweight cross-platform AI-native terminal (ADE)";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  in {
+    packages = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      terax = pkgs.callPackage ./nix/package.nix { };
+      default = self.packages.${system}.terax;
+    });
+
+    nixosModules.terax = { pkgs, ... }: {
+      environment.systemPackages = [ self.packages.${pkgs.system}.terax ];
+    };
+
+    darwinModules.terax = { pkgs, ... }: {
+      environment.systemPackages = [ self.packages.${pkgs.system}.terax ];
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchurl
+, dpkg, autoPatchelfHook, makeWrapper, wrapGAppsHook3
+, gtk3, gdk-pixbuf, cairo, glib, webkitgtk_4_1, libsoup_3, libgcc, gst_all_1
+}:
+
+let
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+  version = sources.version;
+
+  srcMap = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/crynta/terax-ai/releases/download/v${version}/Terax_${version}_amd64.deb";
+      hash = sources.hashes.x86_64-linux;
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/crynta/terax-ai/releases/download/v${version}/Terax_x64.app.tar.gz";
+      hash = sources.hashes.x86_64-darwin;
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/crynta/terax-ai/releases/download/v${version}/Terax_aarch64.app.tar.gz";
+      hash = sources.hashes.aarch64-darwin;
+    };
+  };
+
+  sys = stdenv.hostPlatform.system;
+in
+
+assert lib.assertMsg (builtins.hasAttr sys srcMap)
+  "terax: unsupported platform ${sys}";
+
+stdenv.mkDerivation {
+  pname = "terax";
+  inherit version;
+
+  src = srcMap.${sys};
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    dpkg autoPatchelfHook makeWrapper wrapGAppsHook3
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gtk3 gdk-pixbuf cairo glib webkitgtk_4_1 libsoup_3 libgcc
+    gst_all_1.gstreamer gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
+  ];
+
+  GST_PLUGIN_SYSTEM_PATH = lib.optionalString stdenv.hostPlatform.isLinux
+    "${gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${gst_all_1.gst-plugins-good}/lib/gstreamer-1.0:${gst_all_1.gst-plugins-bad}/lib/gstreamer-1.0";
+
+  unpackPhase = if stdenv.hostPlatform.isLinux then "dpkg -x $src ." else "tar xzf $src";
+
+  installPhase = if stdenv.hostPlatform.isLinux then ''
+    mkdir -p $out/bin $out/share
+    cp -r usr/share/* $out/share/
+    install -Dm755 usr/bin/terax $out/bin/terax
+
+    wrapProgram $out/bin/terax \
+      --prefix GST_PLUGIN_SYSTEM_PATH : "$GST_PLUGIN_SYSTEM_PATH"
+  '' else ''
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications/
+  '';
+
+  meta = with lib; {
+    description = "Open-source lightweight cross-platform AI-native terminal (ADE)";
+    homepage = "https://terax.app";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.7.3",
+  "hashes": {
+    "x86_64-linux": "sha256-RpCTxu1caJkqW1v5Vz6lLFF+277darvw501izz9/AJo=",
+    "x86_64-darwin": "sha256-gjWcog3SUktOAwE+2FWNQJMIpesfny7DKduFN8lRkbQ=",
+    "aarch64-darwin": "sha256-BSqPIEM7mnOjqReqUDj88tpSZRvTcRJhkEp0oV2ARYM="
+  }
+}


### PR DESCRIPTION
Add a flake + nix/package.nix derivation building Terax for x86_64-linux, x86_64-darwin, and aarch64-darwin, with nixosModules and darwinModules for easy system integration.

Extract version and SRI hashes into nix/sources.json consumed by the derivation via builtins.fromJSON, and add a GitHub Actions workflow triggered on release published that downloads assets, computes SRI hashes, and opens a PR bumping sources.json automatically.

## What
Add official Nix/NixOS support via a flake + nix/package.nix derivation, and a release workflow to keep the Nix sources up to date automatically.
- flake.nix / nix/package.nix — builds Terax for x86_64-linux, x86_64-darwin, aarch64-darwin; includes nixosModules and darwinModules for easy system integration
- nix/sources.json — standalone version/hashes file consumed by the derivation
- .github/workflows/update-nix-sources.yml — triggers on release published, downloads assets, computes SRI hashes, and opens a PR bumping sources.json

## Why
Nix was not previously supported as an installation method. Manual bumping of version + three hashes on every release is also error-prone — the workflow automates it.

## How
builtins.fromJSON (builtins.readFile ./sources.json) loads version and per-platform hashes. The release workflow uses openssl dgst -sha256 -binary + base64 to produce SRI hashes matching Nix's sha256-... format. The flake provides packages.terax, nixosModules.terax, and darwinModules.terax.

## Testing
- nix build .#terax succeeds on Linux and macOS
- nix/package.nix parses correctly — builtins.fromJSON reads the file at evaluation time
- Workflow syntax validated against peter-evans/create-pull-request@v7
- README updated with Nix install instructions pointing to the official flake

## Notes for reviewer
First-class Nix support for the project — the flake is the canonical way to install on NixOS.
