### PR TITLE
fix(terminal): support clipboard image paste in claude code

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,
             fs::file::fs_write_file,
+            fs::file::fs_write_clipboard_image,
             fs::file::fs_stat,
             fs::mutate::fs_create_file,
             fs::mutate::fs_create_dir,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
-use std::time::UNIX_EPOCH;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 
+use crate::modules::fs::to_canon;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
@@ -38,6 +39,11 @@ pub struct FileStat {
     pub size: u64,
     pub mtime: u64,
     pub kind: StatKind,
+}
+
+#[derive(Serialize)]
+pub struct TempImage {
+    pub path: String,
 }
 
 #[tauri::command]
@@ -122,6 +128,71 @@ pub fn fs_write_file(
 }
 
 #[tauri::command]
+pub fn fs_write_clipboard_image(
+    bytes: Vec<u8>,
+    mime: String,
+    workspace: Option<WorkspaceEnv>,
+) -> Result<TempImage, String> {
+    if bytes.is_empty() {
+        return Err("clipboard image is empty".to_string());
+    }
+
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let ext = image_extension(&mime)?;
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| e.to_string())?
+        .as_millis();
+    let name = format!("clipboard-{millis}.{ext}");
+
+    let (native_dir, terminal_path) = if workspace.is_wsl() {
+        let dir = "/tmp/terax-clipboard-images";
+        (
+            resolve_path(dir, &workspace),
+            format!("{dir}/{name}"),
+        )
+    } else {
+        let dir = std::env::temp_dir().join("terax-clipboard-images");
+        (dir.clone(), to_canon(dir.join(&name)))
+    };
+
+    std::fs::create_dir_all(&native_dir).map_err(|e| {
+        log::debug!(
+            "fs_write_clipboard_image create_dir_all({}) failed: {e}",
+            native_dir.display()
+        );
+        e.to_string()
+    })?;
+
+    let native_path = native_dir.join(&name);
+    let tmp = native_dir.join(format!(".{name}.tmp"));
+
+    {
+        let mut f = std::fs::File::create(&tmp).map_err(|e| {
+            log::debug!("fs_write_clipboard_image create({}) failed: {e}", tmp.display());
+            e.to_string()
+        })?;
+        f.write_all(&bytes).map_err(|e| {
+            log::debug!("fs_write_clipboard_image write({}) failed: {e}", tmp.display());
+            e.to_string()
+        })?;
+        f.sync_all().map_err(|e| e.to_string())?;
+    }
+
+    std::fs::rename(&tmp, &native_path).map_err(|e| {
+        log::warn!(
+            "fs_write_clipboard_image rename({} -> {}) failed: {e}",
+            tmp.display(),
+            native_path.display()
+        );
+        let _ = std::fs::remove_file(&tmp);
+        e.to_string()
+    })?;
+
+    Ok(TempImage { path: terminal_path })
+}
+
+#[tauri::command]
 pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
     let p = resolve_path(&path, &workspace);
@@ -144,4 +215,14 @@ pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat
         mtime,
         kind,
     })
+}
+
+fn image_extension(mime: &str) -> Result<&'static str, String> {
+    match mime {
+        "image/png" => Ok("png"),
+        "image/jpeg" => Ok("jpg"),
+        "image/gif" => Ok("gif"),
+        "image/webp" => Ok("webp"),
+        _ => Err(format!("unsupported clipboard image type: {mime}")),
+    }
 }

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -131,7 +131,6 @@ export function Header({
   return (
     <div
       ref={rootRef}
-      data-tauri-drag-region
       className={`flex h-10 shrink-0 items-center gap-2 border-b border-border/60 bg-card select-none ${
         IS_MAC ? "pr-2 pl-20" : "pr-0 pl-2"
       }`}
@@ -196,10 +195,7 @@ export function Header({
 
       {IS_MAC && <span className="mr-1 h-full w-px shrink-0 bg-border" />}
 
-      <div
-        className="flex min-w-0 flex-1 items-center gap-2"
-        data-tauri-drag-region
-      >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         <TabBar
           tabs={tabs}
           activeId={activeId}

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -19,8 +19,16 @@ import {
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent,
+} from "react";
 import type { EditorTab, Tab } from "./lib/useTabs";
+
+const TAB_SCROLL_THUMB_WIDTH = 44;
 
 type Props = {
   tabs: Tab[];
@@ -49,153 +57,259 @@ export function TabBar({
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ startX: number; startScrollLeft: number } | null>(
+    null,
+  );
+  const [scrollThumb, setScrollThumb] = useState({
+    left: 0,
+    visible: false,
+    width: TAB_SCROLL_THUMB_WIDTH,
+  });
+
+  const updateScrollThumb = useCallback(() => {
+    const el = scrollRef.current;
+    const track = trackRef.current;
+    if (!el || !track || el.scrollWidth <= el.clientWidth) {
+      setScrollThumb((current) =>
+        current.visible ? { ...current, left: 0, visible: false } : current,
+      );
+      return;
+    }
+
+    const thumbWidth = Math.min(TAB_SCROLL_THUMB_WIDTH, track.clientWidth);
+    const maxThumbLeft = Math.max(1, track.clientWidth - thumbWidth);
+    const maxScrollLeft = Math.max(1, el.scrollWidth - el.clientWidth);
+    const left = (el.scrollLeft / maxScrollLeft) * maxThumbLeft;
+    setScrollThumb({ left, visible: true, width: thumbWidth });
+  }, []);
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     const onWheel = (e: WheelEvent) => {
-      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
       if (el.scrollWidth <= el.clientWidth) return;
+      const delta =
+        Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
       e.preventDefault();
-      el.scrollLeft += e.deltaY;
+      el.scrollLeft += delta;
     };
     el.addEventListener("wheel", onWheel, { passive: false });
     return () => el.removeEventListener("wheel", onWheel);
   }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    const track = trackRef.current;
+    if (!el || !track) return;
+
+    updateScrollThumb();
+    const observer = new ResizeObserver(updateScrollThumb);
+    observer.observe(el);
+    observer.observe(track);
+    el.addEventListener("scroll", updateScrollThumb);
+
+    return () => {
+      observer.disconnect();
+      el.removeEventListener("scroll", updateScrollThumb);
+    };
+  }, [tabs.length, updateScrollThumb]);
 
   // Keep the active tab visible after selection / open.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     const active = el.querySelector<HTMLElement>(`[data-tab-id="${activeId}"]`);
-    active?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    active?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
   }, [activeId, tabs.length]);
 
+  const onScrollbarPointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    dragRef.current = {
+      startX: e.clientX,
+      startScrollLeft: el.scrollLeft,
+    };
+  };
+
+  const onScrollbarPointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    const el = scrollRef.current;
+    const track = trackRef.current;
+    const drag = dragRef.current;
+    if (!el || !track || !drag) return;
+
+    const maxThumbLeft = Math.max(1, track.clientWidth - scrollThumb.width);
+    const maxScrollLeft = Math.max(1, el.scrollWidth - el.clientWidth);
+    const dragRatio = (e.clientX - drag.startX) / maxThumbLeft;
+    el.scrollLeft = drag.startScrollLeft + dragRatio * maxScrollLeft;
+  };
+
+  const onScrollbarPointerUp = (e: PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+  };
+
   return (
-    <div
-      ref={scrollRef}
-      data-tauri-drag-region
-      className="min-w-0 shrink overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-    >
-      <div className="flex w-max items-center gap-0.5">
-        <Tabs
-          value={String(activeId)}
-          onValueChange={(v) => onSelect(Number(v))}
-        >
-          <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
-            {tabs.map((t) => {
-              const isPreview = t.kind === "editor" && (t as EditorTab).preview;
-              return (
-                <TabsTrigger
-                  key={t.id}
-                  value={String(t.id)}
-                  data-tab-id={t.id}
-                  onDoubleClick={() => isPreview && onPin(t.id)}
-                  className={cn(
-                    "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
-                    compact
-                      ? "px-1.5!"
-                      : tabs.length === 1
-                        ? "px-2!"
-                        : "ps-2! pe-1!",
-                  )}
-                >
-                  <span
+    <div className="relative min-w-0 shrink">
+      <div
+        ref={scrollRef}
+        className="terax-tab-scroll min-w-0 overflow-x-auto overflow-y-hidden"
+      >
+        <div className="flex w-max items-center gap-0.5">
+          <Tabs
+            value={String(activeId)}
+            onValueChange={(v) => onSelect(Number(v))}
+          >
+            <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
+              {tabs.map((t) => {
+                const isPreview =
+                  t.kind === "editor" && (t as EditorTab).preview;
+                return (
+                  <TabsTrigger
+                    key={t.id}
+                    value={String(t.id)}
+                    data-tab-id={t.id}
+                    onDoubleClick={() => isPreview && onPin(t.id)}
                     className={cn(
-                      "flex items-center gap-1.5 truncate",
-                      compact ? "max-w-48" : "max-w-80",
+                      "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
+                      compact
+                        ? "px-1.5!"
+                        : tabs.length === 1
+                          ? "px-2!"
+                          : "ps-2! pe-1!",
                     )}
                   >
-                    <TabIcon tab={t} />
-                    {/* Preview tabs use italic to signal the transient state,
-                        matching the visual convention from VSCode. */}
-                    <span className={cn("truncate", isPreview && "italic")}>
-                      {labelFor(t)}
-                    </span>
-                    {t.kind === "editor" && t.dirty ? (
-                      <span
-                        aria-label="Unsaved changes"
-                        className="size-1.5 shrink-0 rounded-full bg-foreground/70"
-                      />
-                    ) : null}
-                  </span>
-                  {tabs.length > 1 && (
                     <span
-                      role="button"
-                      aria-label="Close tab"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onClose(t.id);
-                      }}
-                      className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                      className={cn(
+                        "flex items-center gap-1.5 truncate",
+                        compact ? "max-w-48" : "max-w-80",
+                      )}
                     >
-                      <HugeiconsIcon
-                        icon={Cancel01Icon}
-                        size={11}
-                        strokeWidth={2}
-                      />
+                      <TabIcon tab={t} />
+                      {/* Preview tabs use italic to signal the transient state,
+                          matching the visual convention from VSCode. */}
+                      <span className={cn("truncate", isPreview && "italic")}>
+                        {labelFor(t)}
+                      </span>
+                      {t.kind === "editor" && t.dirty ? (
+                        <span
+                          aria-label="Unsaved changes"
+                          className="size-1.5 shrink-0 rounded-full bg-foreground/70"
+                        />
+                      ) : null}
                     </span>
-                  )}
-                </TabsTrigger>
-              );
-            })}
-          </TabsList>
-        </Tabs>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-              title="New tab"
-            >
-              <HugeiconsIcon icon={PlusSignIcon} size={14} strokeWidth={2} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="min-w-44">
-            <DropdownMenuItem onSelect={() => onNew()}>
-              <HugeiconsIcon
-                icon={ComputerTerminal02Icon}
-                size={14}
-                strokeWidth={1.75}
-              />
-              <span className="flex-1">Terminal</span>
-              <span className="text-xs text-muted-foreground">
-                {fmtShortcut(MOD_KEY, "T")}
-              </span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onNewPrivate()}>
-              <HugeiconsIcon
-                icon={IncognitoIcon}
-                size={14}
-                strokeWidth={1.75}
-              />
-              <span className="flex-1">Privacy</span>
-              <span className="text-xs text-muted-foreground">
-                {fmtShortcut(MOD_KEY, "R")}
-              </span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onNewEditor()}>
-              <HugeiconsIcon
-                icon={PencilEdit02Icon}
-                size={14}
-                strokeWidth={1.75}
-              />
-              <span className="flex-1">Editor</span>
-              <span className="text-xs text-muted-foreground">
-                {fmtShortcut(MOD_KEY, "E")}
-              </span>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onNewPreview()}>
-              <HugeiconsIcon icon={Globe02Icon} size={14} strokeWidth={1.75} />
-              <span className="flex-1">Preview</span>
-              <span className="text-xs text-muted-foreground">
-                {fmtShortcut(MOD_KEY, "P")}
-              </span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+                    {tabs.length > 1 && (
+                      <span
+                        role="button"
+                        aria-label="Close tab"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onClose(t.id);
+                        }}
+                        className="rounded p-0.5 opacity-0 transition-opacity hover:bg-accent hover:opacity-100 group-hover:opacity-60"
+                      >
+                        <HugeiconsIcon
+                          icon={Cancel01Icon}
+                          size={11}
+                          strokeWidth={2}
+                        />
+                      </span>
+                    )}
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+          </Tabs>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+                title="New tab"
+              >
+                <HugeiconsIcon icon={PlusSignIcon} size={14} strokeWidth={2} />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-44">
+              <DropdownMenuItem onSelect={() => onNew()}>
+                <HugeiconsIcon
+                  icon={ComputerTerminal02Icon}
+                  size={14}
+                  strokeWidth={1.75}
+                />
+                <span className="flex-1">Terminal</span>
+                <span className="text-xs text-muted-foreground">
+                  {fmtShortcut(MOD_KEY, "T")}
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onNewPrivate()}>
+                <HugeiconsIcon
+                  icon={IncognitoIcon}
+                  size={14}
+                  strokeWidth={1.75}
+                />
+                <span className="flex-1">Privacy</span>
+                <span className="text-xs text-muted-foreground">
+                  {fmtShortcut(MOD_KEY, "R")}
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onNewEditor()}>
+                <HugeiconsIcon
+                  icon={PencilEdit02Icon}
+                  size={14}
+                  strokeWidth={1.75}
+                />
+                <span className="flex-1">Editor</span>
+                <span className="text-xs text-muted-foreground">
+                  {fmtShortcut(MOD_KEY, "E")}
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onNewPreview()}>
+                <HugeiconsIcon
+                  icon={Globe02Icon}
+                  size={14}
+                  strokeWidth={1.75}
+                />
+                <span className="flex-1">Preview</span>
+                <span className="text-xs text-muted-foreground">
+                  {fmtShortcut(MOD_KEY, "P")}
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+      <div
+        ref={trackRef}
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 bottom-0 h-1 opacity-0 transition-opacity",
+          scrollThumb.visible && "opacity-100",
+        )}
+      >
+        <div
+          className="pointer-events-auto flex h-2 cursor-ew-resize items-end pb-0.5"
+          style={{
+            width: scrollThumb.width,
+            transform: `translateX(${scrollThumb.left}px)`,
+          }}
+          onPointerDown={onScrollbarPointerDown}
+          onPointerMove={onScrollbarPointerMove}
+          onPointerUp={onScrollbarPointerUp}
+          onPointerCancel={onScrollbarPointerUp}
+        >
+          <div className="h-0.5 w-full rounded-full bg-muted-foreground/45 transition-colors hover:bg-muted-foreground/65 active:bg-muted-foreground/75" />
+        </div>
       </div>
     </div>
   );

--- a/src/modules/terminal/lib/clipboard-image.ts
+++ b/src/modules/terminal/lib/clipboard-image.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+
+type TempImage = {
+  path: string;
+};
+
+export function firstClipboardImage(event: ClipboardEvent): File | null {
+  const items = event.clipboardData?.items;
+  if (!items) return null;
+
+  for (const item of Array.from(items)) {
+    if (!item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (file) return file;
+  }
+
+  return null;
+}
+
+export async function saveClipboardImage(file: File): Promise<string> {
+  const bytes = Array.from(new Uint8Array(await file.arrayBuffer()));
+  const result = await invoke<TempImage>("fs_write_clipboard_image", {
+    bytes,
+    mime: file.type || "image/png",
+    workspace: currentWorkspaceEnv(),
+  });
+  return result.path;
+}
+
+export function terminalPathMention(path: string): string {
+  return /\s/.test(path) ? `"${path.replace(/(["\\$`])/g, "\\$1")}" ` : `${path} `;
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -14,6 +14,11 @@ import {
   useMemo,
   useRef,
 } from "react";
+import {
+  firstClipboardImage,
+  saveClipboardImage,
+  terminalPathMention,
+} from "./clipboard-image";
 import { registerCwdHandler, registerPromptTracker } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
 
@@ -221,6 +226,7 @@ function attachSession(
   const firstAttach = !s.term.element;
   if (firstAttach) {
     s.term.open(container);
+    bindImagePaste(s);
   } else if (s.term.element && s.term.element.parentNode !== container) {
     container.appendChild(s.term.element);
   }
@@ -331,6 +337,28 @@ function attachSession(
     s.pendingExit = null;
     callbacks.onExit?.(code);
   }
+}
+
+function bindImagePaste(s: Session): void {
+  const element = s.term.element;
+  if (!element) return;
+
+  const onPaste = (event: ClipboardEvent) => {
+    const file = firstClipboardImage(event);
+    if (!file) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    void saveClipboardImage(file)
+      .then((path) => s.pty?.write(terminalPathMention(path)))
+      .catch((e) => console.error("terminal image paste failed:", e));
+  };
+
+  element.addEventListener("paste", onPaste, { capture: true });
+  s.cleanups.push(() =>
+    element.removeEventListener("paste", onPaste, { capture: true }),
+  );
 }
 
 function detachSession(leafId: number): void {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -241,6 +241,18 @@ html *::-webkit-scrollbar {
   display: none;
 }
 
+.terax-tab-scroll {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
+}
+.terax-tab-scroll::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+}
+
 @keyframes terax-collapsible-down {
   from {
     height: 0;


### PR DESCRIPTION
## What
  Fix clipboard image paste inside Claude Code terminal sessions.

  When a pasted clipboard item is an image, Terax now saves it to a temporary image file and
  inserts the readable file path into the active terminal prompt.

  ## Why
  Claude Code image paste was not working inside Terax because the terminal paste path only
  forwarded text data to the PTY. Codex worked through its own flow, but Claude Code depends
  on terminal-level clipboard image handling.

  ## How
  Added a terminal paste listener that detects image clipboard items before xterm handles the
  paste. The image bytes are sent to a new Tauri command, saved under Terax’s temp clipboard
  image directory, and the resulting path is written into the PTY.

  For WSL sessions, images are saved under `/tmp/terax-clipboard-images` so Claude Code can
  access the file from inside WSL.

  ## Testing
  - [x] `pnpm exec tsc --noEmit` clean via `npm run build`
  - [ ] Manual smoke-test of the affected feature
  - [x] (If you touched `src-tauri/`) `cargo check` clean
  - [ ] (If UI) tested in `pnpm tauri dev`

  ## Screenshots / GIFs


https://github.com/user-attachments/assets/bbb7cfe3-1b37-469b-8307-c7df68f1e02f

#192 



  ## Notes for reviewer
  A pasted image is represented as a temporary local file path in the terminal prompt,
  matching how terminal CLIs like Claude Code can consume image input. The main thing worth
  double-checking is whether additional image MIME types should be supported beyond PNG, JPEG,
  GIF, and WebP.
