### PR TITLE
feat(slash-commands): add /weather and /exchange commands

### DIFF
--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { UIMessage } from "@ai-sdk/react";
 import { useWhisperRecording } from "../hooks/useWhisperRecording";
 import { expandSnippetTokens, type Snippet } from "../lib/snippets";
 import { tryRunSlashCommand, type SlashCommandMeta } from "./slashCommands";
@@ -230,6 +231,40 @@ export function AiComposerProvider({ children }: ProviderProps) {
       if (outcome.kind === "handled") {
         setValue("");
         if (outcome.toast) console.info(outcome.toast);
+        return;
+      }
+      if (outcome.kind === "local-run") {
+        const sid = sessionId;
+        if (!sid) return;
+        const inputText = commandSource;
+        setValue("");
+        setFiles([]);
+        setPickedSnippets([]);
+        setPickedCommands([]);
+        void (async () => {
+          const chat = getOrCreateChat(sid);
+          const userMsg: UIMessage = {
+            id: crypto.randomUUID(),
+            role: "user",
+            parts: [{ type: "text", text: inputText }],
+          };
+          chat.messages = [...chat.messages, userMsg];
+          let resultText: string;
+          try {
+            resultText = await outcome.execute();
+          } catch (e) {
+            resultText = `Error: ${String(e)}`;
+          }
+          const asstMsg: UIMessage = {
+            id: crypto.randomUUID(),
+            role: "assistant",
+            parts: [{ type: "text", text: resultText }],
+          };
+          chat.messages = [...chat.messages, asstMsg];
+          if (!useChatStore.getState().mini.open) {
+            useChatStore.getState().openMini();
+          }
+        })();
         return;
       }
       if (outcome.kind === "send-prompt") {

--- a/src/modules/ai/lib/slashCommands.ts
+++ b/src/modules/ai/lib/slashCommands.ts
@@ -1,5 +1,11 @@
-import { CheckListIcon, SparklesIcon } from "@hugeicons/core-free-icons";
+import {
+  CheckListIcon,
+  Exchange01Icon,
+  SparklesIcon,
+  Sun01Icon,
+} from "@hugeicons/core-free-icons";
 import { usePlanStore } from "../store/planStore";
+import { lookupExchangeRate, lookupWeather } from "./webLookup";
 
 /**
  * Outcome of intercepting a slash command from the composer.
@@ -10,6 +16,7 @@ import { usePlanStore } from "../store/planStore";
  */
 export type SlashOutcome =
   | { kind: "handled"; toast?: string }
+  | { kind: "local-run"; execute: () => Promise<string> }
   | { kind: "send-prompt"; prompt: string; commandName?: string }
   | { kind: "none" };
 
@@ -42,6 +49,18 @@ export const SLASH_COMMANDS: Record<string, SlashCommandMeta> = {
     invocation: "/plan",
     label: "Plan mode",
     icon: CheckListIcon,
+  },
+  weather: {
+    name: "weather",
+    invocation: "/weather",
+    label: "Get weather",
+    icon: Sun01Icon,
+  },
+  exchange: {
+    name: "exchange",
+    invocation: "/exchange",
+    label: "Exchange rate",
+    icon: Exchange01Icon,
   },
 };
 
@@ -79,6 +98,27 @@ export function tryRunSlashCommand(input: string): SlashOutcome {
         kind: "send-prompt",
         prompt: INIT_PROMPT,
         commandName: "init",
+      };
+    }
+    case "weather": {
+      const city = tail || "London";
+      const parts = city.split(/\s+/);
+      const units =
+        parts[parts.length - 1] === "imperial" ? "imperial" : "metric";
+      const cityName =
+        units === "imperial" ? parts.slice(0, -1).join(" ") || city : city;
+      return {
+        kind: "local-run",
+        execute: () => lookupWeather(cityName, units),
+      };
+    }
+    case "exchange": {
+      const [from = "USD", to = "EUR", amtStr] = tail.split(/\s+/);
+      const amount = amtStr ? parseFloat(amtStr) : 1;
+      return {
+        kind: "local-run",
+        execute: () =>
+          lookupExchangeRate(from, to, Number.isFinite(amount) ? amount : 1),
       };
     }
     default:

--- a/src/modules/ai/lib/webLookup.ts
+++ b/src/modules/ai/lib/webLookup.ts
@@ -1,0 +1,99 @@
+import { invoke } from "@tauri-apps/api/core";
+import { KEYRING_SERVICE } from "../config";
+
+type HttpResp = { status: number; body: number[] };
+
+async function getJson(url: string): Promise<unknown> {
+  const resp = await invoke<HttpResp>("ai_http_request", {
+    url,
+    method: "GET",
+    headers: null,
+    body: null,
+  });
+  if (resp.status < 200 || resp.status >= 300) {
+    throw new Error(`HTTP ${resp.status}`);
+  }
+  return JSON.parse(new TextDecoder().decode(new Uint8Array(resp.body)));
+}
+
+export async function lookupWeather(
+  city: string,
+  units: "metric" | "imperial" = "metric",
+): Promise<string> {
+  let apiKey: string | null = null;
+  try {
+    apiKey = await invoke<string | null>("secrets_get", {
+      service: KEYRING_SERVICE,
+      account: "openweathermap",
+    });
+  } catch {
+    // key absent from keychain
+  }
+
+  if (!apiKey) {
+    return "OpenWeatherMap API key not set. Add it in **Settings → API Keys** with account name `openweathermap`. Get a free key at openweathermap.org.";
+  }
+
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=${units}`;
+  const data = (await getJson(url)) as {
+    name: string;
+    sys: { country: string };
+    weather: { description: string }[];
+    main: {
+      temp: number;
+      feels_like: number;
+      temp_min: number;
+      temp_max: number;
+      humidity: number;
+    };
+    wind: { speed: number };
+    visibility: number;
+  };
+
+  const unit = units === "metric" ? "°C" : "°F";
+  const speedUnit = units === "metric" ? "m/s" : "mph";
+
+  return [
+    `**${data.name}, ${data.sys.country}** — ${data.weather[0]?.description ?? "unknown"}`,
+    ``,
+    `| | |`,
+    `|---|---|`,
+    `| Temperature | ${Math.round(data.main.temp)}${unit} (feels ${Math.round(data.main.feels_like)}${unit}) |`,
+    `| Hi / Lo | ${Math.round(data.main.temp_max)}${unit} / ${Math.round(data.main.temp_min)}${unit} |`,
+    `| Humidity | ${data.main.humidity}% |`,
+    `| Wind | ${data.wind.speed} ${speedUnit} |`,
+    `| Visibility | ${(data.visibility / 1000).toFixed(1)} km |`,
+  ].join("\n");
+}
+
+export async function lookupExchangeRate(
+  from: string,
+  to: string,
+  amount: number = 1,
+): Promise<string> {
+  const fromCode = from.toUpperCase();
+  const toCode = to.toUpperCase();
+
+  const data = (await getJson(
+    `https://api.frankfurter.app/latest?from=${fromCode}&to=${toCode}`,
+  )) as {
+    base: string;
+    date: string;
+    rates: Record<string, number>;
+  };
+
+  const rate = data.rates[toCode];
+  if (rate === undefined) {
+    return `Currency **${toCode}** not supported. Frankfurter supports ~33 major currencies (USD, EUR, GBP, INR, JPY, AUD, CAD, CHF, CNY…).`;
+  }
+
+  const lines = [
+    `**${fromCode} → ${toCode}** · as of ${data.date}`,
+    ``,
+    `1 ${fromCode} = ${rate.toFixed(6)} ${toCode}`,
+  ];
+  if (amount !== 1) {
+    lines.push(`${amount} ${fromCode} = ${(amount * rate).toFixed(2)} ${toCode}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What
Two new slash commands — `/weather <city>` and `/exchange <FROM> <TO> [amount]` — that run directly in the composer without invoking the AI model. Results are injected into the chat as local messages.

## Why
Closes #249. Quick factual lookups shouldn't cost tokens or require waiting for a model response.

## How
Added a `local-run` outcome type to `SlashOutcome`. When returned, `composer.tsx` awaits the execute function and injects user + result messages directly via `Chat.messages` setter, bypassing the transport layer entirely. API calls go through the existing `ai_http_request` Tauri command. `/weather` reads the OWM key from the OS keychain via `secrets_get`; `/exchange` uses frankfurter.app (no key needed).

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] `/weather Mumbai` — returns conditions table
- [x] `/weather New York imperial` — returns °F
- [x] `/exchange USD INR` — returns rate
- [x] `/exchange USD INR 500` — returns converted amount
- [x] `/weather` with no OWM key — returns helpful setup message

## Notes for reviewer
`/weather` requires a free OpenWeatherMap key saved in Settings → API Keys (`account: openweathermap`). `/exchange` works out of the box.