### PR TITLE
fix(settings): emit prefs-changed event from setShortcuts and resetSh…

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -286,13 +286,11 @@ export async function setLastWslDistro(value: string | null): Promise<void> {
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {}
 ): Promise<void> {
-  await store.set(KEY_SHORTCUTS, value);
-  await store.save();
+  await writePref(KEY_SHORTCUTS, value);
 }
 
 export async function resetShortcuts(): Promise<void> {
-  await store.set(KEY_SHORTCUTS, DEFAULT_PREFERENCES.shortcuts);
-  await store.save();
+  await writePref(KEY_SHORTCUTS, DEFAULT_PREFERENCES.shortcuts);
 }
 
 export type PrefKey = keyof Preferences;


### PR DESCRIPTION
## What
`setShortcuts` and `resetShortcuts` wrote to the store directly without calling `writePref`, so they never emitted `terax://prefs-changed`. Every other preference setter uses `writePref` which fires the event.

## Why
Without the event, shortcut changes made in the settings webview never propagate to the main window until restart.

## How
Route both functions through `writePref` like all other setters.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] `onPreferencesChange` already maps `KEY_SHORTCUTS` — listener side was correct, only the emit was missing
