### PR TITLE
feat: terminal font family selector with Nerd Font support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: set this to true or false
+  msw: set this to true or false

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,3 +1,8 @@
+import {
+  TERMINAL_FONT_FAMILY_CSS,
+  type TerminalFontFamilyId,
+} from "@/modules/settings/store";
+
 const NERD_FONT_CANDIDATES = [
   "JetBrainsMono Nerd Font",
   "JetBrainsMono Nerd Font Mono",
@@ -21,6 +26,8 @@ const FALLBACK_CHAIN = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
 let detected: string | null = null;
 let monoReady: Promise<void> | null = null;
 
+const loadedFonts = new Set<string>();
+
 export function ensureMonoFontsLoaded(): Promise<void> {
   if (monoReady) return monoReady;
   if (typeof document === "undefined" || !document.fonts?.load) {
@@ -34,7 +41,30 @@ export function ensureMonoFontsLoaded(): Promise<void> {
   return monoReady;
 }
 
-export function detectMonoFontFamily(): string {
+/** Loads a specific font family so that document.fonts.check() works reliably. */
+export async function loadFontFamily(family: string): Promise<void> {
+  if (typeof document === "undefined" || !document.fonts?.load) return;
+  if (loadedFonts.has(family)) return;
+  loadedFonts.add(family);
+  try {
+    await Promise.allSettled([
+      document.fonts.load(`400 14px ${family}`),
+      document.fonts.load(`700 14px ${family}`),
+    ]);
+  } catch {
+    // Ignore font loading errors.
+  }
+}
+
+export function detectMonoFontFamily(preference?: TerminalFontFamilyId): string {
+  // Honor explicit preference
+  if (preference && preference !== "auto") {
+    const explicit = TERMINAL_FONT_FAMILY_CSS[preference];
+    if (explicit) {
+      return `${explicit}, ${FALLBACK_CHAIN}`;
+    }
+  }
+
   if (detected) return detected;
   if (typeof document === "undefined" || !document.fonts) {
     detected = FALLBACK_CHAIN;

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -38,6 +38,50 @@ export const EDITOR_THEME_LABELS: Record<EditorThemeId, string> = {
   "xcode-light": "Xcode Light",
 };
 
+export type TerminalFontFamilyId = "auto" | "jetbrains-mono" | "jetbrains-mono-nerd" | "fira-code" | "fira-code-nerd" | "meslo" | "hack" | "caskaydia" | "iosevka" | "sf-mono" | "menlo";
+
+export const TERMINAL_FONT_FAMILIES: TerminalFontFamilyId[] = [
+  "auto",
+  "jetbrains-mono",
+  "jetbrains-mono-nerd",
+  "fira-code",
+  "fira-code-nerd",
+  "meslo",
+  "hack",
+  "caskaydia",
+  "iosevka",
+  "sf-mono",
+  "menlo",
+];
+
+export const TERMINAL_FONT_FAMILY_LABELS: Record<TerminalFontFamilyId, string> = {
+  auto: "Auto (detect)",
+  "jetbrains-mono": "JetBrains Mono",
+  "jetbrains-mono-nerd": "JetBrainsMono Nerd Font",
+  "fira-code": "Fira Code",
+  "fira-code-nerd": "FiraCode Nerd Font",
+  meslo: "MesloLGS NF",
+  hack: "Hack Nerd Font",
+  caskaydia: "CaskaydiaCove Nerd Font",
+  iosevka: "Iosevka Nerd Font",
+  "sf-mono": "SF Mono",
+  menlo: "Menlo",
+};
+
+export const TERMINAL_FONT_FAMILY_CSS: Record<TerminalFontFamilyId, string> = {
+  auto: "",
+  "jetbrains-mono": '"JetBrains Mono"',
+  "jetbrains-mono-nerd": '"JetBrainsMono Nerd Font"',
+  "fira-code": '"Fira Code"',
+  "fira-code-nerd": '"FiraCode Nerd Font"',
+  meslo: '"MesloLGS NF"',
+  hack: '"Hack Nerd Font"',
+  caskaydia: '"CaskaydiaCove Nerd Font"',
+  iosevka: '"Iosevka Nerd Font"',
+  "sf-mono": '"SFMono-Regular"',
+  menlo: "Menlo",
+};
+
 export type Preferences = {
   theme: ThemePref;
   defaultModelId: ModelId;
@@ -59,6 +103,7 @@ export type Preferences = {
   terminalWebglEnabled: boolean;
   terminalFontSize: number;
   terminalScrollback: number;
+  terminalFontFamily: TerminalFontFamilyId;
   lastWslDistro: string | null;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
@@ -85,6 +130,7 @@ const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_SHORTCUTS = "shortcuts";
 
@@ -124,6 +170,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalWebglEnabled: true,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  terminalFontFamily: "auto",
   lastWslDistro: null,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
@@ -200,6 +247,9 @@ export async function loadPreferences(): Promise<Preferences> {
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
     ),
+    terminalFontFamily:
+      get<TerminalFontFamilyId>(KEY_TERMINAL_FONT_FAMILY) ??
+      DEFAULT_PREFERENCES.terminalFontFamily,
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
@@ -305,6 +355,12 @@ export async function setTerminalScrollback(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_SCROLLBACK, clampScrollback(value));
 }
 
+export async function setTerminalFontFamily(
+  value: TerminalFontFamilyId,
+): Promise<void> {
+  await writePref(KEY_TERMINAL_FONT_FAMILY, value);
+}
+
 export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
@@ -348,6 +404,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_SHORTCUTS]: "shortcuts",
   };

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,4 +1,4 @@
-import { detectMonoFontFamily } from "@/lib/fonts";
+import { detectMonoFontFamily, loadFontFamily } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -76,8 +76,10 @@ function getRecycler(): HTMLDivElement {
 
 function termOptions() {
   const prefs = usePreferencesStore.getState();
+  const family = detectMonoFontFamily(prefs.terminalFontFamily);
+  void loadFontFamily(family);
   return {
-    fontFamily: detectMonoFontFamily(),
+    fontFamily: family,
     fontSize: prefs.terminalFontSize,
     theme: buildTerminalTheme(),
     cursorBlink: false,
@@ -522,6 +524,20 @@ export function applyFontSize(size: number): void {
   for (const slot of slots) {
     if (slot.term.options.fontSize === size) continue;
     slot.term.options.fontSize = size;
+    slot.fitAddon.fit();
+    if (slot.currentLeafId !== null) {
+      slot.lastCols = slot.term.cols;
+      slot.lastRows = slot.term.rows;
+      const bridge = adapter?.resolveLeaf(slot.currentLeafId);
+      bridge?.resizePty(slot.term.cols, slot.term.rows);
+    }
+  }
+}
+
+export function applyFontFamily(family: string): void {
+  for (const slot of slots) {
+    if (slot.term.options.fontFamily === family) continue;
+    slot.term.options.fontFamily = family;
     slot.fitAddon.fit();
     if (slot.currentLeafId !== null) {
       slot.lastCols = slot.term.cols;

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,4 +1,4 @@
-import { ensureMonoFontsLoaded } from "@/lib/fonts";
+import { detectMonoFontFamily, ensureMonoFontsLoaded } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -7,6 +7,7 @@ import { registerCwdHandler, registerPromptTracker } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
 import {
   acquireSlot,
+  applyFontFamily,
   applyFontSize,
   applyScrollback,
   applyTheme as applyPoolTheme,
@@ -333,6 +334,11 @@ export function useTerminalSession({
   useEffect(() => {
     applyWebglPreference(webglPref);
   }, [webglPref]);
+
+  const fontFamily = usePreferencesStore((p) => p.terminalFontFamily);
+  useEffect(() => {
+    applyFontFamily(detectMonoFontFamily(fontFamily));
+  }, [fontFamily]);
 
   useEffect(() => {
     const s = sessions.get(leafId);

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -18,17 +18,21 @@ import type { ThemePref } from "@/modules/settings/store";
 import {
   EDITOR_THEME_LABELS,
   EDITOR_THEMES,
+  TERMINAL_FONT_FAMILIES,
+  TERMINAL_FONT_FAMILY_LABELS,
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAutostart,
   setEditorTheme,
   setRestoreWindowState,
   setShowHidden,
+  setTerminalFontFamily,
   setTerminalFontSize,
   setTerminalScrollback,
   setTerminalWebglEnabled,
   setVimMode,
   type EditorThemeId,
+  type TerminalFontFamilyId,
 } from "@/modules/settings/store";
 import { useTheme } from "@/modules/theme";
 import {
@@ -64,6 +68,7 @@ export function GeneralSection() {
     (s) => s.terminalWebglEnabled,
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
+  const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
 
   // Reconcile autostart pref with the actual OS state on mount — the user may
@@ -102,6 +107,9 @@ export function GeneralSection() {
   };
 
   const onPickTerminalFontSize = (size: number) => void setTerminalFontSize(size);
+
+  const onPickTerminalFontFamily = (id: TerminalFontFamilyId) =>
+    void setTerminalFontFamily(id);
 
   const onPickScrollback = (lines: number) => void setTerminalScrollback(lines);
 
@@ -253,6 +261,44 @@ export function GeneralSection() {
                   )}
                 >
                   {size} px
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SettingRow>
+        <SettingRow
+          title="Font family"
+          description="Monospace font for the terminal. Nerd Font variants support icons and glyphs."
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="h-8 justify-between gap-2 rounded-none px-2.5 text-[12px]"
+              >
+                <span>{TERMINAL_FONT_FAMILY_LABELS[terminalFontFamily]}</span>
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  size={12}
+                  strokeWidth={2}
+                  className="opacity-70"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="min-w-[180px] rounded-none border border-border bg-popover p-0 shadow-none ring-0"
+            >
+              {TERMINAL_FONT_FAMILIES.map((id) => (
+                <DropdownMenuItem
+                  key={id}
+                  onSelect={() => onPickTerminalFontFamily(id)}
+                  className={cn(
+                    "rounded-none px-3 py-1.5 text-[12px]",
+                    id === terminalFontFamily && "bg-accent/50",
+                  )}
+                >
+                  {TERMINAL_FONT_FAMILY_LABELS[id]}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>


### PR DESCRIPTION
## Summary

Adds a font family dropdown in **Settings > Terminal** so users can explicitly choose their terminal monospace font, including popular Nerd Font variants.

### Motivation

Terax already auto-detects Nerd Fonts via `document.fonts.check()`, but this is unreliable in Tauri webviews — the font may not be registered in the document's font list at the time the terminal initializes, causing icons and glyphs to render as blank boxes or fallback characters. A manual selector guarantees the correct font is used.

### Changes

- **New preference** `terminalFontFamily` with options:
  - `auto` — preserves existing auto-detection behavior
  - `jetbrains-mono-nerd`, `fira-code-nerd`, `meslo`, `hack`, `caskaydia`, `iosevka` — Nerd Font variants
  - `jetbrains-mono`, `sf-mono`, `menlo` — standard monospace fonts
- **Proactive font loading** — `loadFontFamily()` calls `document.fonts.load()` for the selected font before the terminal renders, eliminating the race condition that made `check()` unreliable
- **Live application** — `applyFontFamily()` updates all open terminal slots immediately when the preference changes, no restart required
- **Settings UI** — dropdown added in General > Terminal, between Font size and Scrollback

### How to test

1. Install any Nerd Font (e.g. `brew install --cask font-jetbrains-mono-nerd-font`)
2. Open Terax Settings > Terminal
3. Select the installed Nerd Font from the Font family dropdown
4. Open a new terminal tab — powerline symbols and icons should render correctly
5. Toggle back to Auto — should fall back to existing detection behavior

### Checklist

- [x] `pnpm exec tsc --noEmit` passes
- [x] No Rust changes (no `cargo clippy` needed)
- [x] Follows branch naming convention (`feat/terminal-font-family`)
