### PR TITLE
fix(ai): strip reasoning blocks before sending history to LLM

### DIFF
--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -306,8 +306,19 @@ export async function runAgentStream(opts: RunAgentOptions) {
   );
 
   const history = await convertToModelMessages(opts.uiMessages);
+  const strippedHistory = history.map((m) => {
+    if (m.role === "assistant" && Array.isArray(m.content)) {
+      const filtered = m.content.filter(
+        (p): p is Exclude<typeof p, { type: "reasoning" }> =>
+          !("type" in p && p.type === "reasoning"),
+      );
+      if (filtered.length === m.content.length) return m;
+      return { ...m, content: filtered.length === 0 ? "" : filtered };
+    }
+    return m;
+  });
   const compact = compactModelMessagesDetailed(
-    history,
+    strippedHistory,
     getModelContextLimit(getModel(modelId).id),
   );
   const compactedHistory = compact.messages;


### PR DESCRIPTION
## What
Strips reasoning blocks from the message history before sending it back to the LLM, and moves this filter to run prior to message compaction.

## Why
Echoing reasoning/thinking blocks back in the history was causing API failures, particularly with Cerebras models, as most providers do not accept reasoning blocks in inbound requests. Furthermore, because these blocks were previously filtered *after* compaction, reasoning tokens were unnecessarily eating up the context budget and causing older, valid messages to be dropped prematurely.

## How
- Added a `.map()` + `.filter()` pass over the converted history that removes all content parts with `type: "reasoning"` from assistant messages before they reach the LLM.
- Moved this filter to execute before `compactModelMessagesDetailed` so compaction only counts the actual tokens being sent.
- Added a short-circuit to return the original message object when no reasoning blocks are found, avoiding unnecessary object allocations.


## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
- Before: 
<img width="542" height="467" alt="before" src="https://github.com/user-attachments/assets/224b93cf-4bec-4215-b696-f7517d5e68f6" />

- After:
<img width="548" height="676" alt="after" src="https://github.com/user-attachments/assets/3d05a704-4a74-4118-8642-dcf00b1dc19e" />
