### PR TITLE
fix(ui): restore composer focus and allow typing during generation

### DIFF
--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -288,7 +288,6 @@ export function AiInputBar() {
                 }}
                 placeholder="Ask Terax anything   -   # for snippets and commands, @ for files"
                 rows={1}
-                disabled={c.isBusy}
                 className={cn(
                   "max-h-40 flex-1 resize-none bg-transparent text-[13px] leading-relaxed outline-none",
                   "placeholder:text-muted-foreground/60",

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -96,6 +96,15 @@ export function AiComposerProvider({ children }: ProviderProps) {
     }
   }, [focusSignal, pendingPrefill, consumePrefill]);
 
+  // Re-focus the textarea whenever the agent finishes a response
+  const prevIsBusyRef = useRef(false);
+  useEffect(() => {
+    if (prevIsBusyRef.current && !isBusy) {
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    }
+    prevIsBusyRef.current = isBusy;
+  }, [isBusy, textareaRef]);
+
   // Listen for explorer's "Attach to Agent" event.
   useEffect(() => {
     const onAttach = (e: Event) => {
@@ -306,6 +315,8 @@ export function AiComposerProvider({ children }: ProviderProps) {
     setFiles([]);
     setPickedSnippets([]);
     setPickedCommands([]);
+    // Re-focus immediately after submit so the user can type a follow-up
+    requestAnimationFrame(() => textareaRef.current?.focus());
   };
 
   const stop = () => {


### PR DESCRIPTION
Fixes a Windows-specific bug where the chat input textarea permanently loses focus after sending a message. Also enables users to type follow-up questions while the current response is still being generated.

Changes:
- Re-focus the textarea immediately after submit() is called.
- Add an effect to re-focus the textarea when the agent's busy state transitions from true to false (streaming finishes).
- Remove the `disabled={c.isBusy}` prop from the input textarea to allow uninterrupted typing during active agent generations.
- Ensure that the submission is only sent once the current response is completed (as submit already returns early when busy).

<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
