### PR TITLE
fix(ui): restore composer focus and allow typing during agent's response generation

### DIFF
--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -288,7 +288,6 @@ export function AiInputBar() {
                 }}
                 placeholder="Ask Terax anything   -   # for snippets and commands, @ for files"
                 rows={1}
-                disabled={c.isBusy}
                 className={cn(
                   "max-h-40 flex-1 resize-none bg-transparent text-[13px] leading-relaxed outline-none",
                   "placeholder:text-muted-foreground/60",

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -96,6 +96,15 @@ export function AiComposerProvider({ children }: ProviderProps) {
     }
   }, [focusSignal, pendingPrefill, consumePrefill]);
 
+  // Re-focus the textarea whenever the agent finishes a response
+  const prevIsBusyRef = useRef(false);
+  useEffect(() => {
+    if (prevIsBusyRef.current && !isBusy) {
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    }
+    prevIsBusyRef.current = isBusy;
+  }, [isBusy, textareaRef]);
+
   // Listen for explorer's "Attach to Agent" event.
   useEffect(() => {
     const onAttach = (e: Event) => {
@@ -306,6 +315,8 @@ export function AiComposerProvider({ children }: ProviderProps) {
     setFiles([]);
     setPickedSnippets([]);
     setPickedCommands([]);
+    // Re-focus immediately after submit so the user can type a follow-up
+    requestAnimationFrame(() => textareaRef.current?.focus());
   };
 
   const stop = () => {


### PR DESCRIPTION
## What
Restores composer focus after a message is submitted and allows users to continue typing their next query while the agent's response is still being generated. 

## Why
On Windows, disabling the textarea when the agent was busy caused the OS to permanently steal focus from the input, requiring the user to manually click the text field again. Furthermore, users were previously blocked from typing follow-up questions during active generations, breaking the conversational flow.

## How
- Removed the `disabled={c.isBusy}` prop from the input textarea to prevent the OS from stealing focus and to allow uninterrupted typing.
- Added `requestAnimationFrame(() => textareaRef.current?.focus())` immediately after `submit()` is called.
- Added a `useEffect` hook to automatically re-focus the textarea when the agent's busy state transitions from `true` to `false` (when streaming finishes).
- Relied on the existing `if (isBusy) return;` check inside `submit()` to ensure new messages are only sent after the current response is completed.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
- Before
<img width="1344" height="718" alt="before" src="https://github.com/user-attachments/assets/b0fd4f2f-9a09-4e91-bb4c-63e1e91672b5" />

- After
<img width="1344" height="718" alt="after" src="https://github.com/user-attachments/assets/3192b4b7-136f-4241-8584-768f162e48ba" />
