### PR TITLE
fix(terminal): support Option arrow word navigation

### DIFF
--- a/src/modules/terminal/lib/keymap.test.mjs
+++ b/src/modules/terminal/lib/keymap.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+function loadKeymapFunction(name) {
+  const source = fs.readFileSync(
+    new URL("./keymap.ts", import.meta.url),
+    "utf8",
+  );
+  const match = source.match(
+    new RegExp(
+      `export function ${name}\\(event: TerminalKeyEvent\\): string \\| null \\{([\\s\\S]*?)\\n\\}`,
+    ),
+  );
+  if (!match) throw new Error(`${name} export not found`);
+  return new Function(
+    `return function ${name}(event) {${match[1]}\n}`,
+  )();
+}
+
+test("maps Option+Left to readline word-left", () => {
+  const terminalWordNavigationSequence = loadKeymapFunction(
+    "terminalWordNavigationSequence",
+  );
+
+  assert.equal(
+    terminalWordNavigationSequence({
+      altKey: true,
+      ctrlKey: false,
+      metaKey: false,
+      key: "ArrowLeft",
+      code: "ArrowLeft",
+    }),
+    "\x1bb",
+  );
+});
+
+test("maps Option+Right to readline word-right", () => {
+  const terminalWordNavigationSequence = loadKeymapFunction(
+    "terminalWordNavigationSequence",
+  );
+
+  assert.equal(
+    terminalWordNavigationSequence({
+      altKey: true,
+      ctrlKey: false,
+      metaKey: false,
+      key: "ArrowRight",
+      code: "ArrowRight",
+    }),
+    "\x1bf",
+  );
+});
+
+test("does not remap plain arrows", () => {
+  const terminalWordNavigationSequence = loadKeymapFunction(
+    "terminalWordNavigationSequence",
+  );
+
+  assert.equal(
+    terminalWordNavigationSequence({
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      key: "ArrowLeft",
+      code: "ArrowLeft",
+    }),
+    null,
+  );
+});

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -1,0 +1,11 @@
+export type TerminalKeyEvent = Pick<
+  KeyboardEvent,
+  "altKey" | "ctrlKey" | "metaKey" | "key" | "code"
+>;
+
+export function terminalWordNavigationSequence(event: TerminalKeyEvent): string | null {
+  if (!event.altKey || event.ctrlKey || event.metaKey) return null;
+  if (event.key === "ArrowLeft" || event.code === "ArrowLeft") return "\x1bb";
+  if (event.key === "ArrowRight" || event.code === "ArrowRight") return "\x1bf";
+  return null;
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -8,6 +8,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { terminalWordNavigationSequence } from "./keymap";
 
 export const POOL_MAX_SIZE = 5;
 const FIT_DEBOUNCE_MS = 8;
@@ -135,6 +136,12 @@ function createSlot(): Slot {
     if (leafId === null) return false;
     const bridge = adapter?.resolveLeaf(leafId);
     if (!bridge) return true;
+    const wordNavigation = terminalWordNavigationSequence(event);
+    if (wordNavigation) {
+      event.preventDefault();
+      if (event.type === "keydown") bridge.writeToPty(wordNavigation);
+      return false;
+    }
     if (isCtrlBackspace(event)) {
       event.preventDefault();
       if (event.type === "keydown") bridge.writeToPty("\x17");


### PR DESCRIPTION
## Summary

Fixes macOS terminal word navigation so `Option` + `Left` / `Right` moves the cursor by word in the integrated terminal.

Before this change, xterm passed those keys through in a way that could surface as visible `D` / `C` characters instead of readline word movement. This PR intercepts only the unmodified `Option` / `Alt` arrow shortcuts and writes the readline-compatible `ESC b` / `ESC f` sequences to the PTY.

## Test plan

- [x] `node --test src/modules/terminal/lib/keymap.test.mjs` — 3/3 pass
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Manual macOS smoke-test: `Option` + `Left` / `Right` moves by word in the terminal

## Notes for reviewer

No Rust changes. This intentionally does not map `Command` shortcuts or select-all behavior; the PR is limited to `Option` / `Alt` word navigation.
