### PR TITLE
feat(ui): add markdown and HTML file preview support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1894,6 +1894,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +4750,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,13 @@
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "opener:default",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        { "path": "$HOME/**" }
+      ]
+    },
+    "opener:allow-open-url",
     "log:default",
     "os:default",
     "store:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,11 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**", "/**", "$HOME/**"]
+      },
+      "csp": "default-src 'self'; script-src 'self' asset: https://asset.localhost 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' asset: https://asset.localhost 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data: asset: https://asset.localhost; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' asset: https://asset.localhost http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
     }
   },
   "bundle": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -594,6 +594,17 @@ export default function App() {
 
   const activeFilePath = activeTab?.kind === "editor" ? activeTab.path : null;
 
+  const isPreviewableFile = useCallback((path: string | null) => {
+    if (!path) return false;
+    const normalized = path.toLowerCase();
+    return (
+      normalized.endsWith(".md") ||
+      normalized.endsWith(".markdown") ||
+      normalized.endsWith(".html") ||
+      normalized.endsWith(".htm")
+    );
+  }, []);
+
   const openPreviewTab = useCallback(
     (url: string) => {
       const id = newPreviewTab(url);
@@ -604,6 +615,13 @@ export default function App() {
       return id;
     },
     [newPreviewTab],
+  );
+
+  const handlePreviewFile = useCallback(
+    (path: string) => {
+      openPreviewTab(`file://${path}`);
+    },
+    [openPreviewTab],
   );
 
   const splitActivePaneInActiveTab = useCallback(
@@ -629,6 +647,11 @@ export default function App() {
       "tab.new": openNewTab,
       "tab.newPrivate": openNewPrivateTab,
       "tab.newPreview": () => openPreviewTab(""),
+      "tab.previewCurrent": () => {
+        if (isPreviewableFile(activeFilePath)) {
+          openPreviewTab(`file://${activeFilePath}`);
+        }
+      },
       "tab.newEditor": () => setNewEditorOpen(true),
       "tab.close": handleCloseTabOrPane,
       "tab.next": () => cycleTab(1),
@@ -844,6 +867,7 @@ export default function App() {
                     ref={explorerRef}
                     rootPath={explorerRoot}
                     onOpenFile={handleOpenFile}
+                    onPreviewFile={handlePreviewFile}
                     onPathRenamed={handlePathRenamed}
                     onPathDeleted={handlePathDeleted}
                     onRevealInTerminal={cdInNewTab}

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -47,6 +47,7 @@ const DEBOUNCE_MS = 300;
 type Props = {
   rootPath: string;
   onOpenFile: (path: string) => void;
+  onPreviewFile?: (path: string) => void;
   open: boolean;
   onRequestClose: () => void;
   onActiveChange?: (active: boolean) => void;
@@ -62,6 +63,7 @@ export type ExplorerSearchHandle = {
 export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function ExplorerSearch({
   rootPath,
   onOpenFile,
+  onPreviewFile,
   open,
   onRequestClose,
   onActiveChange,
@@ -81,6 +83,16 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   const lastKeyboardNavAt = useRef(0);
 
   const active = query.trim().length > 0;
+
+  const isPreviewableFile = (path: string) => {
+    const normalized = path.toLowerCase();
+    return (
+      normalized.endsWith(".md") ||
+      normalized.endsWith(".markdown") ||
+      normalized.endsWith(".html") ||
+      normalized.endsWith(".htm")
+    );
+  };
 
   useEffect(() => {
     onActiveChange?.(active);
@@ -283,6 +295,16 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                           Open
                         </ContextMenuItem>
                       )}
+                      {!hit.is_dir &&
+                        onPreviewFile &&
+                        isPreviewableFile(hit.path) && (
+                          <ContextMenuItem
+                            className={COMPACT_ITEM}
+                            onSelect={() => onPreviewFile(hit.path)}
+                          >
+                            Preview
+                          </ContextMenuItem>
+                        )}
                       {hit.is_dir && onRevealInTerminal && (
                         <ContextMenuItem
                           className={COMPACT_ITEM}

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -39,6 +39,7 @@ export type FileExplorerHandle = {
 type Props = {
   rootPath: string | null;
   onOpenFile: (path: string, pin?: boolean) => void;
+  onPreviewFile?: (path: string) => void;
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
   onRevealInTerminal?: (path: string) => void;
@@ -55,6 +56,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
     {
       rootPath,
       onOpenFile,
+      onPreviewFile,
       onPathRenamed,
       onPathDeleted,
       onRevealInTerminal,
@@ -287,6 +289,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
           ref={searchRef}
           rootPath={rootPath}
           onOpenFile={onOpenFile}
+          onPreviewFile={onPreviewFile}
           open={isSearchOpen}
           onRequestClose={() => setIsSearchOpen(false)}
           onActiveChange={setIsSearchActive}
@@ -346,6 +349,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
                         depth={0}
                         tree={tree}
                         onOpenFile={onOpenFile}
+                        onPreviewFile={onPreviewFile}
                         onRevealInTerminal={onRevealInTerminal}
                         onAttachToAgent={onAttachToAgent}
                         selectedPath={selectedPath}

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -33,6 +33,7 @@ type Props = {
    * omitting it means the caller decides the default (preview).
    */
   onOpenFile: (path: string, pin?: boolean) => void;
+  onPreviewFile?: (path: string) => void;
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   selectedPath: string | null;
@@ -46,6 +47,7 @@ function FileTreeNodeImpl({
   depth,
   tree,
   onOpenFile,
+  onPreviewFile,
   onRevealInTerminal,
   onAttachToAgent,
   selectedPath,
@@ -148,6 +150,14 @@ function FileTreeNodeImpl({
               onSelect={() => onOpenFile(path, true)}
             >
               Open
+            </ContextMenuItem>
+          )}
+          {!isDir && (path.endsWith(".md") || path.endsWith(".html") || path.endsWith(".htm")) && onPreviewFile && (
+            <ContextMenuItem
+              className={COMPACT_ITEM}
+              onSelect={() => onPreviewFile(path)}
+            >
+              Preview
             </ContextMenuItem>
           )}
           {isDir && onRevealInTerminal && (
@@ -276,6 +286,7 @@ function FileTreeNodeImpl({
             depth={depth + 1}
             tree={tree}
             onOpenFile={onOpenFile}
+            onPreviewFile={onPreviewFile}
             onRevealInTerminal={onRevealInTerminal}
             onAttachToAgent={onAttachToAgent}
             selectedPath={selectedPath}

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -1,6 +1,8 @@
+import React from "react";
 import { Alert02Icon, Globe02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  useCallback,
   forwardRef,
   useEffect,
   useImperativeHandle,
@@ -11,6 +13,9 @@ import {
   PreviewAddressBar,
   type PreviewAddressBarHandle,
 } from "./PreviewAddressBar";
+import { Streamdown, defaultRehypePlugins } from "streamdown";
+import { MarkdownCode } from "@/components/ai-elements/markdown-code";
+import { convertFileSrc } from "@tauri-apps/api/core";
 
 export type PreviewPaneHandle = {
   reload: () => void;
@@ -28,6 +33,280 @@ type Props = {
 // server page can hold hundreds of MB inside the WebView.
 const SUSPEND_AFTER_MS = 30_000;
 
+/**
+ * Build an asset-protocol URL for use as an **iframe src**, preserving real `/`
+ * separators so the browser can resolve relative sub-resources (CSS, JS, etc.).
+ * Not suitable for direct file fetches — see `convertFileSrc` for that.
+ *
+ * How the two URL styles differ:
+ *   convertFileSrc("/Users/.../f.html") → asset://localhost/%2FUsers%2F...%2Ff.html
+ *     Tauri decodes %2F → /, finds the file ✓   Relative URLs break ✗
+ *   assetUrlForFile("/Users/.../f.html") → asset://localhost/Users/.../f.html
+ *     Browser resolves relative URLs correctly ✓   Tauri sees 'Users/...' (no /) ✗
+ * For iframes we accept the latter trade-off; for fetch() we use convertFileSrc.
+ */
+function assetUrlForFile(absPath: string): string {
+  const isWindows = navigator.userAgent.includes("Windows");
+  // Strip the leading slash and encode each segment individually so the browser
+  // keeps real "/" separators and can resolve relative sub-resources in iframes.
+  const stripped = absPath.startsWith("/") ? absPath.slice(1) : absPath;
+  const encoded = stripped
+    .split("/")
+    .map((s) => encodeURIComponent(s))
+    .join("/");
+  return isWindows
+    ? `http://asset.localhost/${encoded}`
+    : `asset://localhost/${encoded}`;
+}
+
+/**
+ * Rewrite relative image paths (both Markdown and HTML formats) to fetchable
+ * asset:// URLs. Uses convertFileSrc() which encodes the entire absolute path
+ * as a single URI component (%2FUsers%2F...). Tauri decodes %2F back to /
+ * giving the correct filesystem path — unlike per-segment encoding where the
+ * browser strips the leading slash and Tauri looks up "Users/..." (not found).
+ */
+function resolveMarkdownRelativePaths(markdown: string, fileDir: string): string {
+  if (!fileDir) return markdown;
+
+  const isRelative = (path: string) =>
+    !path.startsWith("http://") &&
+    !path.startsWith("https://") &&
+    !path.startsWith("data:") &&
+    !path.startsWith("file://") &&
+    !path.startsWith("asset://") &&
+    !path.startsWith("http://asset.localhost/") &&
+    !path.startsWith("/");
+
+  const toFetchUrl = (relPath: string): string => {
+    let clean = relPath.trim();
+    if (clean.startsWith("./")) clean = clean.slice(2);
+    // convertFileSrc encodes the whole path with encodeURIComponent so slashes
+    // become %2F. Tauri decodes %2F → / giving the correct absolute file path.
+    return convertFileSrc(`${fileDir}${clean}`);
+  };
+
+  // 1. Markdown images: ![alt](path)
+  let resolved = markdown.replace(
+    /!\[([^\]]*)\]\(([^)]+)\)/g,
+    (match, alt, src) => {
+      const parts = src.split(/\s+/);
+      const pathOnly = parts[0];
+      const title = parts.slice(1).join(" ");
+      if (!isRelative(pathOnly)) return match;
+      const fetchUrl = toFetchUrl(pathOnly);
+      console.log("[PreviewPane] md-img:", pathOnly, "→", fetchUrl);
+      return `![${alt}](${fetchUrl}${title ? " " + title : ""})`;
+    },
+  );
+
+  // 2. HTML images: <img src="path" ...> or <img ... src="path" ...>
+  resolved = resolved.replace(
+    /<img\b([^>]*?)\bsrc=(["'])([^"'\s>]+)\2([^>]*?)(\/?)>/gi,
+    (match, before, quote, src, after, selfClose) => {
+      if (!isRelative(src)) return match;
+      const fetchUrl = toFetchUrl(src);
+      console.log("[PreviewPane] html-img:", src, "→", fetchUrl);
+      return `<img${before || " "}src=${quote}${fetchUrl}${quote}${after}${selfClose}>`;
+    },
+  );
+
+  return resolved;
+}
+
+function resolveHtmlRelativePaths(html: string, fileDir: string): string {
+  if (!fileDir) return html;
+
+  const isRelative = (path: string) =>
+    !path.startsWith("http://") &&
+    !path.startsWith("https://") &&
+    !path.startsWith("//") &&
+    !path.startsWith("data:") &&
+    !path.startsWith("file://") &&
+    !path.startsWith("asset://") &&
+    !path.startsWith("http://asset.localhost/") &&
+    !path.startsWith("/") &&
+    !path.startsWith("#") &&
+    !path.startsWith("?") &&
+    !path.startsWith("mailto:") &&
+    !path.startsWith("tel:");
+
+  const toFetchUrl = (relPath: string): string => {
+    let clean = relPath.trim();
+    if (clean.startsWith("./")) clean = clean.slice(2);
+    return convertFileSrc(`${fileDir}${clean}`);
+  };
+
+  let resolved = html.replace(
+    /<link\b([^>]*?)\bhref=("|')([^"'\s>]+)\2([^>]*?)>/gi,
+    (match, before, quote, href, after) => {
+      if (!isRelative(href)) return match;
+      return `<link${before || " "}href=${quote}${toFetchUrl(href)}${quote}${after}>`;
+    },
+  );
+
+  resolved = resolved.replace(
+    /<script\b([^>]*?)\bsrc=("|')([^"'\s>]+)\2([^>]*?)>([\s\S]*?)<\/script>/gi,
+    (match, before, quote, src, after, body) => {
+      if (!isRelative(src)) return match;
+      return `<script${before || " "}src=${quote}${toFetchUrl(src)}${quote}${after}>${body}</script>`;
+    },
+  );
+
+  resolved = resolved.replace(
+    /<img\b([^>]*?)\bsrc=("|')([^"'\s>]+)\2([^>]*?)(\/?)>/gi,
+    (match, before, quote, src, after, selfClose) => {
+      if (!isRelative(src)) return match;
+      return `<img${before || " "}src=${quote}${toFetchUrl(src)}${quote}${after}${selfClose}>`;
+    },
+  );
+
+  return resolved;
+}
+
+function resolveHtmlLinkTarget(href: string, filePath: string, fileDir: string): string | null {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return null;
+  if (trimmed.startsWith("//")) return null;
+  if (trimmed.startsWith("data:")) return null;
+  if (trimmed.startsWith("file://")) return trimmed;
+  if (trimmed.startsWith("asset://")) return trimmed;
+  if (trimmed.startsWith("http://asset.localhost/")) return trimmed;
+  if (trimmed.startsWith("mailto:") || trimmed.startsWith("tel:")) return null;
+  if (trimmed.startsWith("#") || trimmed.startsWith("?")) return null;
+
+  const hashIndex = trimmed.indexOf("#");
+  const queryIndex = trimmed.indexOf("?");
+  const cutIndex =
+    hashIndex === -1
+      ? queryIndex
+      : queryIndex === -1
+        ? hashIndex
+        : Math.min(hashIndex, queryIndex);
+  const suffix = cutIndex === -1 ? "" : trimmed.slice(cutIndex);
+  const hrefPath = cutIndex === -1 ? trimmed : trimmed.slice(0, cutIndex);
+
+  const normalizePath = (path: string) => {
+    if (path.endsWith("/")) return `${path}index.html`;
+    if (!path.includes(".")) return `${path}.html`;
+    return path;
+  };
+
+  if (hrefPath.startsWith("/")) {
+    const relPath = hrefPath.replace(/^\/+/, "");
+    const firstSegment = relPath.split("/")[0] || "";
+    const marker = firstSegment ? `/${firstSegment}/` : "";
+    let base = fileDir;
+    if (marker) {
+      const idx = filePath.indexOf(marker);
+      if (idx !== -1) {
+        base = filePath.slice(0, idx + 1);
+      }
+    }
+    return `file://${normalizePath(`${base}${relPath}`)}${suffix}`;
+  }
+
+  return new URL(normalizePath(hrefPath), `file://${fileDir}`).toString() + suffix;
+}
+
+/**
+ * Module-level blob cache: assetUrl → blobUrl.
+ * Persists across poll cycles so images are only fetched once per session.
+ */
+const _blobCache = new Map<string, string>();
+
+const streamdownRehypePlugins = (() => {
+  const { raw, sanitize, harden } = defaultRehypePlugins;
+  if (Array.isArray(sanitize) && sanitize.length === 2) {
+    const [sanitizePlugin, sanitizeSchema] = sanitize as [
+      (...args: unknown[]) => unknown,
+      Record<string, unknown>
+    ];
+    const protocols =
+      typeof sanitizeSchema?.protocols === "object" && sanitizeSchema?.protocols
+        ? (sanitizeSchema.protocols as Record<string, string[]>)
+        : {};
+    const srcProtocols = new Set([...(protocols.src ?? []), "blob", "asset"]);
+    return [
+      raw,
+      [
+        sanitizePlugin,
+        {
+          ...sanitizeSchema,
+          protocols: {
+            ...protocols,
+            src: Array.from(srcProtocols),
+          },
+        },
+      ],
+      harden,
+    ];
+  }
+
+  return [raw, sanitize, harden].filter(Boolean) as unknown[];
+})();
+
+/**
+ * Swap every asset:// (or http://asset.localhost/) URL in `markdown` for a
+ * pre-fetched blob: URL. Streamdown's linkSafety="harden" allows blob: but
+ * strips asset://, so this conversion must happen before the string is passed
+ * to <Streamdown>.
+ */
+async function blobifyMarkdown(markdown: string): Promise<string> {
+  // Match both convertFileSrc-style (%2F-encoded) and plain asset:// URLs.
+  const assetUrlRegex =
+    /(asset:\/\/localhost\/[^\s"')]+|http:\/\/asset\.localhost\/[^\s"')]+)/g;
+  const hits = new Set<string>(markdown.match(assetUrlRegex) ?? []);
+  if (hits.size === 0) return markdown;
+
+  // Fetch any uncached URLs in parallel.
+  await Promise.all(
+    [...hits].map(async (url) => {
+      if (_blobCache.has(url)) return;
+      try {
+        const blob = await fetch(url).then((r) => r.blob());
+        _blobCache.set(url, URL.createObjectURL(blob));
+        console.log("[PreviewPane] cached blob for:", url);
+      } catch (e) {
+        console.warn("[PreviewPane] asset fetch failed:", url, e);
+      }
+    }),
+  );
+
+  // Replace all asset:// occurrences with their blob: counterparts.
+  return markdown.replace(assetUrlRegex, (url) => _blobCache.get(url) ?? url);
+}
+
+/**
+ * Markdown preview container.
+ * By the time `markdownContent` reaches here, every local image URL has already
+ * been converted to a blob: URL by `blobifyMarkdown`, so Streamdown's
+ * linkSafety="harden" filter never sees an asset:// URL and never blocks them.
+ */
+function MarkdownPreview({ markdownContent }: { markdownContent: string }) {
+  const MarkdownTable: React.ComponentType<
+    React.TableHTMLAttributes<HTMLTableElement> & { node?: unknown }
+  > = (props) => (
+    <div className="not-prose my-2 overflow-x-auto rounded-md border border-border/50">
+      <table className="w-full text-sm" {...props} />
+    </div>
+  );
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-background p-6 text-foreground">
+      <Streamdown
+        linkSafety={{ enabled: true }}
+        rehypePlugins={streamdownRehypePlugins as any}
+        components={{ code: MarkdownCode as any, table: MarkdownTable }}
+      >
+        {markdownContent}
+      </Streamdown>
+    </div>
+  );
+}
+
 export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
   function PreviewPane({ url, visible, onUrlChange }, ref) {
     // `nonce` is part of the iframe `key`. Bumping it remounts the iframe,
@@ -36,6 +315,99 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
     const [nonce, setNonce] = useState(0);
     const [loaded, setLoaded] = useState(visible);
     const addressRef = useRef<PreviewAddressBarHandle>(null);
+    const htmlFrameRef = useRef<HTMLIFrameElement>(null);
+    const htmlCleanupRef = useRef<(() => void) | null>(null);
+
+    const [liveNonce, setLiveNonce] = useState(0);
+    const [markdownContent, setMarkdownContent] = useState("");
+    const [htmlContent, setHtmlContent] = useState("");
+
+    const isFile = url.startsWith("file://");
+    const filePath = isFile ? decodeURIComponent(url.slice(7)) : "";
+    const isMarkdown =
+      isFile && (filePath.endsWith(".md") || filePath.endsWith(".markdown"));
+    const isHtml =
+      isFile &&
+      (filePath.endsWith(".html") ||
+        filePath.endsWith(".htm") ||
+        filePath.endsWith(".xhtml"));
+
+    const fileDir = isFile
+      ? filePath.slice(0, filePath.lastIndexOf("/") + 1)
+      : "";
+
+    // For iframes: URL with real slashes so relative sub-resources resolve.
+    // For fetch: convertFileSrc is fine (single-file fetch doesn't need path resolution).
+    const iframeSrc = isFile ? assetUrlForFile(filePath) : url;
+    const fetchUrl = isFile ? convertFileSrc(filePath) : url;
+
+    // Poll for file changes — drives live preview.
+    useEffect(() => {
+      if (!isFile) return;
+      let canceled = false;
+      let lastText = "";
+
+      const check = async () => {
+        try {
+          const text = await fetch(fetchUrl).then((r) => r.text());
+          if (canceled) return;
+          if (lastText !== "" && lastText !== text) {
+            setLiveNonce((n) => n + 1);
+          }
+          lastText = text;
+          if (isMarkdown) {
+            // Step 1: rewrite relative paths → asset:// URLs (sync)
+            const withAssetUrls = resolveMarkdownRelativePaths(text, fileDir);
+            // Step 2: pre-fetch every asset:// URL → blob: URL so Streamdown's
+            //         linkSafety="harden" filter never sees a non-https URL.
+            const withBlobUrls = await blobifyMarkdown(withAssetUrls);
+            if (!canceled) setMarkdownContent(withBlobUrls);
+          } else if (isHtml) {
+            const withResolvedUrls = resolveHtmlRelativePaths(text, fileDir);
+            if (!canceled) setHtmlContent(withResolvedUrls);
+          }
+        } catch {
+          // ignore transient fetch errors
+        }
+      };
+      check();
+      const timer = setInterval(check, 1000);
+      return () => {
+        canceled = true;
+        clearInterval(timer);
+      };
+    }, [isFile, fetchUrl, isMarkdown, isHtml, fileDir]);
+
+    const attachHtmlLinkHandler = useCallback(() => {
+      if (!isHtml) return;
+      const frame = htmlFrameRef.current;
+      const doc = frame?.contentDocument;
+      if (!doc) return;
+
+      const onClick = (event: MouseEvent) => {
+        const target = event.target as Element | null;
+        const anchor = target?.closest("a") as HTMLAnchorElement | null;
+        if (!anchor) return;
+        const href = anchor.getAttribute("href")?.trim();
+        if (!href) return;
+        const nextUrl = resolveHtmlLinkTarget(href, filePath, fileDir);
+        if (!nextUrl) return;
+        event.preventDefault();
+        event.stopPropagation();
+        onUrlChange(nextUrl);
+      };
+
+      doc.addEventListener("click", onClick);
+      htmlCleanupRef.current?.();
+      htmlCleanupRef.current = () => doc.removeEventListener("click", onClick);
+    }, [isHtml, fileDir, filePath, onUrlChange]);
+
+    useEffect(() => {
+      return () => {
+        htmlCleanupRef.current?.();
+        htmlCleanupRef.current = null;
+      };
+    }, []);
 
     useEffect(() => {
       if (visible) {
@@ -59,7 +431,7 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
       [url],
     );
 
-    const showXfoHint = url ? !isLocalUrl(url) : false;
+    const showXfoHint = url ? !isLocalUrl(url) && !isFile : false;
 
     return (
       <div
@@ -98,13 +470,27 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
         >
           {url ? (
             loaded ? (
-              <iframe
-                key={`${url}#${nonce}`}
-                src={url}
-                title="Preview"
-                className="h-full w-full border-0"
-                allow="clipboard-read; clipboard-write; fullscreen"
-              />
+              isMarkdown ? (
+                <MarkdownPreview markdownContent={markdownContent} />
+              ) : isHtml ? (
+                <iframe
+                  ref={htmlFrameRef}
+                  key={`${filePath}#${nonce}-${liveNonce}`}
+                  srcDoc={htmlContent}
+                  title="Preview"
+                  className="h-full w-full border-0"
+                  onLoad={attachHtmlLinkHandler}
+                  allow="clipboard-read; clipboard-write"
+                />
+              ) : (
+                <iframe
+                  key={`${iframeSrc}#${nonce}-${liveNonce}`}
+                  src={iframeSrc}
+                  title="Preview"
+                  className="h-full w-full border-0"
+                  allow="clipboard-read; clipboard-write; fullscreen"
+                />
+              )
             ) : (
               <SuspendedState
                 onReload={() => {

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -8,6 +8,7 @@ export type ShortcutId =
   | "tab.new"
   | "tab.newPrivate"
   | "tab.newPreview"
+  | "tab.previewCurrent"
   | "tab.newEditor"
   | "tab.close"
   | "tab.next"
@@ -83,6 +84,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "New preview tab",
     group: "Tabs",
     defaultBindings: [{ [MOD_PROP]: true, key: "p" }],
+  },
+  {
+    id: "tab.previewCurrent",
+    label: "Preview current file",
+    group: "Tabs",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "v" }],
   },
   {
     id: "tab.newEditor",

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -81,6 +81,9 @@ function basename(path: string): string {
 function titleFromUrl(url: string): string {
   try {
     const u = new URL(url);
+    if (u.protocol === "file:") {
+      return basename(u.pathname) || "preview";
+    }
     return u.host || url;
   } catch {
     return url || "preview";


### PR DESCRIPTION
## What
Added built-in preview support for Markdown (`.md`) and HTML (`.html`) files. You can trigger it from the explorer, search, or by just hitting `Cmd/Ctrl + Shift + V` in the active tab.

## Why
We needed a way to actually view these files in the app.

## How
- Hooked up Tauri's `protocol-asset` capability to safely serve local files straight from the OS.
- Added a workaround in `PreviewPane.tsx` that catches relative paths (like local images) and maps them to blob URLs on the fly so they actually load.
- Wired up live-reloading so the preview updates when you save, and made sure internal link clicking doesn't break the app.


## Testing
- **Markdown**: Previewed several `.md` files packed with tables, local and web images to ensure everything parses correctly and the local image paths resolve without breaking.
- **HTML & Assets**: Loaded up a multi-page HTML setup where the CSS and JS files lived in separate directories. Verified that all external scripts, stylesheets, and images were fetched correctly using the new Tauri asset protocol.
- **Navigation**: Clicked through anchor tags (`href`) linking the different HTML pages to confirm that internal navigation actually routes you correctly inside the preview pane without kicking you out.


- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
- File Explorer Context Menu "Preview" Button
<img width="661" height="313" alt="image" src="https://github.com/user-attachments/assets/8fb6572d-74f7-46e9-9cfb-41bd75811597" />

- Markdown Render
<img width="1680" height="1005" alt="Screenshot 2026-05-17 at 10 19 32 PM" src="https://github.com/user-attachments/assets/c97e14c0-7e40-49bc-82a1-f74fe6b1b464" />

- HTML Render
<img width="1077" height="595" alt="image" src="https://github.com/user-attachments/assets/6f9e65a2-36c7-4b11-b1ef-3f0641a29767" />


## Notes for reviewer
This thing took me close to 7 hours to get it right. I don't know why I did this. this is my 6th PR for Terax-AI
