### PR TITLE
feat(explorer): group dotfiles under a collapsible node

### DIFF
--- a/src/modules/explorer/DirChildren.tsx
+++ b/src/modules/explorer/DirChildren.tsx
@@ -1,0 +1,79 @@
+import { memo } from "react";
+import { DotfilesGroupNode } from "./DotfilesGroupNode";
+import { FileTreeNode } from "./FileTreeNode";
+import { partitionDotfiles } from "./lib/partitionDotfiles";
+import type { DirEntry, useFileTree } from "./lib/useFileTree";
+
+type Tree = ReturnType<typeof useFileTree>;
+
+type Props = {
+  entries: DirEntry[];
+  parentPath: string;
+  rootPath: string;
+  depth: number;
+  tree: Tree;
+  onOpenFile: (path: string, pin?: boolean) => void;
+  onRevealInTerminal?: (path: string) => void;
+  onAttachToAgent?: (path: string) => void;
+  selectedPath: string | null;
+  onSelectPath: (path: string) => void;
+};
+
+/**
+ * Renders the ordered child rows of a directory. In "grouped" mode, dotfiles
+ * are collected into a single leading DotfilesGroupNode; otherwise every entry
+ * renders inline as a FileTreeNode.
+ */
+function DirChildrenImpl({
+  entries,
+  parentPath,
+  rootPath,
+  depth,
+  tree,
+  onOpenFile,
+  onRevealInTerminal,
+  onAttachToAgent,
+  selectedPath,
+  onSelectPath,
+}: Props) {
+  const grouped = tree.hiddenFiles === "grouped";
+  const { regular, dotfiles } = grouped
+    ? partitionDotfiles(entries)
+    : { regular: entries, dotfiles: [] as DirEntry[] };
+
+  return (
+    <>
+      {grouped && dotfiles.length > 0 && (
+        <DotfilesGroupNode
+          parentPath={parentPath}
+          rootPath={rootPath}
+          depth={depth}
+          dotfiles={dotfiles}
+          tree={tree}
+          onOpenFile={onOpenFile}
+          onRevealInTerminal={onRevealInTerminal}
+          onAttachToAgent={onAttachToAgent}
+          selectedPath={selectedPath}
+          onSelectPath={onSelectPath}
+        />
+      )}
+      {regular.map((entry) => (
+        <FileTreeNode
+          key={entry.name}
+          entry={entry}
+          parentPath={parentPath}
+          rootPath={rootPath}
+          depth={depth}
+          tree={tree}
+          onOpenFile={onOpenFile}
+          onRevealInTerminal={onRevealInTerminal}
+          onAttachToAgent={onAttachToAgent}
+          selectedPath={selectedPath}
+          onSelectPath={onSelectPath}
+        />
+      ))}
+    </>
+  );
+}
+
+export const DirChildren = memo(DirChildrenImpl);

--- a/src/modules/explorer/DotfilesGroupNode.tsx
+++ b/src/modules/explorer/DotfilesGroupNode.tsx
@@ -1,0 +1,91 @@
+import { cn } from "@/lib/utils";
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { memo } from "react";
+import { FileTreeNode } from "./FileTreeNode";
+import { dotfilesGroupKey } from "./lib/partitionDotfiles";
+import type { DirEntry, useFileTree } from "./lib/useFileTree";
+
+type Tree = ReturnType<typeof useFileTree>;
+
+type Props = {
+  parentPath: string;
+  rootPath: string;
+  depth: number;
+  dotfiles: DirEntry[];
+  tree: Tree;
+  onOpenFile: (path: string, pin?: boolean) => void;
+  onRevealInTerminal?: (path: string) => void;
+  onAttachToAgent?: (path: string) => void;
+  selectedPath: string | null;
+  onSelectPath: (path: string) => void;
+};
+
+function DotfilesGroupNodeImpl({
+  parentPath,
+  rootPath,
+  depth,
+  dotfiles,
+  tree,
+  onOpenFile,
+  onRevealInTerminal,
+  onAttachToAgent,
+  selectedPath,
+  onSelectPath,
+}: Props) {
+  const groupKey = dotfilesGroupKey(parentPath);
+  const isExpanded = tree.expanded.has(groupKey);
+  const isSelected = selectedPath === groupKey;
+
+  return (
+    <>
+      <button
+        type="button"
+        data-fs-path={groupKey}
+        onClick={() => {
+          onSelectPath(groupKey);
+          tree.toggle(groupKey);
+        }}
+        className={cn(
+          "group flex w-full min-w-0 items-center gap-2 rounded-sm px-1.5 py-0.5 text-left text-[13px] text-muted-foreground transition-colors hover:bg-accent/70 cursor-pointer",
+          isSelected && "bg-accent text-foreground",
+        )}
+        style={{ paddingLeft: 6 + depth * 12 }}
+      >
+        <span className="flex size-3.5 shrink-0 items-center justify-center">
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            size={12}
+            strokeWidth={2.25}
+            className={cn("transition-transform", isExpanded && "rotate-90")}
+          />
+        </span>
+        <span className="size-4 shrink-0 text-center text-[13px] leading-4">
+          ...
+        </span>
+        <span className="min-w-0 flex-1 truncate">
+          dotfiles ({dotfiles.length})
+        </span>
+      </button>
+
+      {isExpanded &&
+        dotfiles.map((entry) => (
+          <FileTreeNode
+            key={entry.name}
+            entry={entry}
+            parentPath={parentPath}
+            rootPath={rootPath}
+            depth={depth + 1}
+            tree={tree}
+            onOpenFile={onOpenFile}
+            onRevealInTerminal={onRevealInTerminal}
+            onAttachToAgent={onAttachToAgent}
+            selectedPath={selectedPath}
+            onSelectPath={onSelectPath}
+          />
+        ))}
+    </>
+  );
+}
+
+export const DotfilesGroupNode = memo(DotfilesGroupNodeImpl);

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -70,7 +70,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
 }: Props,
   ref,
 ) {
-  const showHidden = usePreferencesStore((s) => s.showHidden);
+  const showHidden = usePreferencesStore((s) => s.hiddenFiles !== "hidden");
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchHit[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -22,8 +22,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { DirChildren } from "./DirChildren";
 import { ExplorerSearch, type ExplorerSearchHandle } from "./ExplorerSearch";
-import { FileTreeNode } from "./FileTreeNode";
 import { InlineInput } from "./InlineInput";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
@@ -336,22 +336,20 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
                       {root.message}
                     </div>
                   )}
-                  {root?.status === "loaded" &&
-                    root.entries.map((entry) => (
-                      <FileTreeNode
-                        key={entry.name}
-                        entry={entry}
-                        parentPath={rootPath}
-                        rootPath={rootPath}
-                        depth={0}
-                        tree={tree}
-                        onOpenFile={onOpenFile}
-                        onRevealInTerminal={onRevealInTerminal}
-                        onAttachToAgent={onAttachToAgent}
-                        selectedPath={selectedPath}
-                        onSelectPath={setSelectedPath}
-                      />
-                    ))}
+                  {root?.status === "loaded" && (
+                    <DirChildren
+                      entries={root.entries}
+                      parentPath={rootPath}
+                      rootPath={rootPath}
+                      depth={0}
+                      tree={tree}
+                      onOpenFile={onOpenFile}
+                      onRevealInTerminal={onRevealInTerminal}
+                      onAttachToAgent={onAttachToAgent}
+                      selectedPath={selectedPath}
+                      onSelectPath={setSelectedPath}
+                    />
+                  )}
                 </div>
               </div>
             </ContextMenuTrigger>

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -28,6 +28,7 @@ import { InlineInput } from "./InlineInput";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
+import { dotfilesGroupKey, partitionDotfiles } from "./lib/partitionDotfiles";
 import { useFileTree } from "./lib/useFileTree";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
 
@@ -70,23 +71,52 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
     const searchRef = useRef<ExplorerSearchHandle>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
+    // Locate a tree row by its data-fs-path. Iterates dataset rather than a CSS
+    // selector so paths with any character (including the NUL byte in synthetic
+    // dotfiles-group keys) match correctly.
+    const findRow = (path: string): HTMLElement | null => {
+      const rows = listRef.current?.querySelectorAll<HTMLElement>(
+        "[data-fs-path]",
+      );
+      if (!rows) return null;
+      for (const row of rows) {
+        if (row.dataset.fsPath === path) return row;
+      }
+      return null;
+    };
+
     type FlatItem = { path: string; isDir: boolean };
     const flat = useMemo<FlatItem[]>(() => {
       if (!rootPath) return [];
       const out: FlatItem[] = [];
-      const walk = (parent: string) => {
+      const grouped = tree.hiddenFiles === "grouped";
+      // Push one directory entry (and recurse into expanded subdirectories).
+      const pushEntry = (parent: string, name: string, kind: string) => {
+        const p = tree.joinPath(parent, name);
+        const isDir = kind === "dir";
+        out.push({ path: p, isDir });
+        if (isDir && tree.expanded.has(p)) walk(p);
+      };
+      function walk(parent: string) {
         const node = tree.nodes[parent];
         if (!node || node.status !== "loaded") return;
-        for (const e of node.entries) {
-          const p = tree.joinPath(parent, e.name);
-          const isDir = e.kind === "dir";
-          out.push({ path: p, isDir });
-          if (isDir && tree.expanded.has(p)) walk(p);
+        if (grouped) {
+          const { regular, dotfiles } = partitionDotfiles(node.entries);
+          if (dotfiles.length > 0) {
+            const groupKey = dotfilesGroupKey(parent);
+            out.push({ path: groupKey, isDir: true });
+            if (tree.expanded.has(groupKey)) {
+              for (const e of dotfiles) pushEntry(parent, e.name, e.kind);
+            }
+          }
+          for (const e of regular) pushEntry(parent, e.name, e.kind);
+          return;
         }
-      };
+        for (const e of node.entries) pushEntry(parent, e.name, e.kind);
+      }
       walk(rootPath);
       return out;
-    }, [rootPath, tree.nodes, tree.expanded, tree.joinPath]);
+    }, [rootPath, tree.nodes, tree.expanded, tree.joinPath, tree.hiddenFiles]);
   
     useEffect(() => {
       if (selectedPath && !flat.some((f) => f.path === selectedPath)) {
@@ -103,10 +133,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
             const first = flat[0].path;
             setSelectedPath(first);
             requestAnimationFrame(() => {
-              const el = listRef.current?.querySelector<HTMLElement>(
-                `[data-fs-path="${CSS.escape(first)}"]`,
-              );
-              el?.scrollIntoView({ block: "nearest" });
+              findRow(first)?.scrollIntoView({ block: "nearest" });
             });
           }
         },
@@ -171,10 +198,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
         const path = flat[clamped].path;
         setSelectedPath(path);
         requestAnimationFrame(() => {
-          const el = listRef.current?.querySelector<HTMLElement>(
-            `[data-fs-path="${CSS.escape(path)}"]`
-          );
-          el?.scrollIntoView({ block: "nearest" });
+          findRow(path)?.scrollIntoView({ block: "nearest" });
         });
       };
   

--- a/src/modules/explorer/FileTreeNode.tsx
+++ b/src/modules/explorer/FileTreeNode.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useCallback, useState } from "react";
+import { DirChildren } from "./DirChildren";
 import { InlineInput } from "./InlineInput";
 import {
   copyToClipboard,
@@ -264,24 +265,20 @@ function FileTreeNodeImpl({
           {children.message}
         </div>
       )}
-      {isDir &&
-        isExpanded &&
-        children?.status === "loaded" &&
-        children.entries.map((child) => (
-          <FileTreeNode
-            key={child.name}
-            entry={child}
-            parentPath={path}
-            rootPath={rootPath}
-            depth={depth + 1}
-            tree={tree}
-            onOpenFile={onOpenFile}
-            onRevealInTerminal={onRevealInTerminal}
-            onAttachToAgent={onAttachToAgent}
-            selectedPath={selectedPath}
-            onSelectPath={onSelectPath}
-          />
-        ))}
+      {isDir && isExpanded && children?.status === "loaded" && (
+        <DirChildren
+          entries={children.entries}
+          parentPath={path}
+          rootPath={rootPath}
+          depth={depth + 1}
+          tree={tree}
+          onOpenFile={onOpenFile}
+          onRevealInTerminal={onRevealInTerminal}
+          onAttachToAgent={onAttachToAgent}
+          selectedPath={selectedPath}
+          onSelectPath={onSelectPath}
+        />
+      )}
     </>
   );
 }

--- a/src/modules/explorer/lib/partitionDotfiles.ts
+++ b/src/modules/explorer/lib/partitionDotfiles.ts
@@ -1,0 +1,38 @@
+import type { DirEntry } from "./useFileTree";
+
+/** A dotfile is any entry whose name begins with a literal ".". */
+export function isDotfile(entry: DirEntry): boolean {
+  return entry.name.startsWith(".");
+}
+
+/**
+ * Split a directory's entries into regular entries and dotfiles, preserving
+ * the backend's original ordering within each list.
+ */
+export function partitionDotfiles(entries: DirEntry[]): {
+  regular: DirEntry[];
+  dotfiles: DirEntry[];
+} {
+  const regular: DirEntry[] = [];
+  const dotfiles: DirEntry[] = [];
+  for (const entry of entries) {
+    (isDotfile(entry) ? dotfiles : regular).push(entry);
+  }
+  return { regular, dotfiles };
+}
+
+// A NUL byte cannot appear in a real filename on macOS / Linux / Windows, so a
+// path ending in this segment can never collide with a real filesystem path.
+const DOTFILES_GROUP_SEGMENT = "\0dotfiles";
+
+/** The synthetic expand/collapse key for a directory's dotfiles group node. */
+export function dotfilesGroupKey(parentPath: string): string {
+  return parentPath.endsWith("/")
+    ? `${parentPath}${DOTFILES_GROUP_SEGMENT}`
+    : `${parentPath}/${DOTFILES_GROUP_SEGMENT}`;
+}
+
+/** True if `path` is a synthetic dotfiles-group key (not a real filesystem path). */
+export function isDotfilesGroupKey(path: string): boolean {
+  return path.endsWith(DOTFILES_GROUP_SEGMENT);
+}

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { isDotfilesGroupKey } from "./partitionDotfiles";
 
 export type DirEntry = {
   name: string;
@@ -107,6 +108,9 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         else next.add(path);
         return next;
       });
+      // The synthetic dotfiles-group node has no backing directory — its
+      // children are a slice of the parent's already-loaded entries.
+      if (isDotfilesGroupKey(path)) return;
       setNodes((curr) => {
         if (!curr[path] || curr[path].status === "error") {
           void fetchChildren(path);
@@ -125,6 +129,8 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         next.add(path);
         return next;
       });
+      // The synthetic dotfiles-group node has no backing directory.
+      if (isDotfilesGroupKey(path)) return;
       setNodes((curr) => {
         if (!curr[path]) void fetchChildren(path);
         return curr;

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -40,7 +40,8 @@ type Options = {
 };
 
 export function useFileTree(rootPath: string | null, options?: Options) {
-  const showHidden = usePreferencesStore((s) => s.showHidden);
+  const hiddenFiles = usePreferencesStore((s) => s.hiddenFiles);
+  const showHidden = hiddenFiles !== "hidden";
   const showHiddenRef = useRef(showHidden);
   const [nodes, setNodes] = useState<TreeState>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -237,6 +238,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
 
   return {
     nodes,
+    hiddenFiles,
     expanded,
     pendingCreate,
     renaming,

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -12,6 +12,15 @@ import { LazyStore } from "@tauri-apps/plugin-store";
 
 export type ThemePref = "system" | "light" | "dark";
 
+export type HiddenFilesMode = "hidden" | "inline" | "grouped";
+
+/** Ordered option list for the explorer "Hidden files" setting control. */
+export const HIDDEN_FILES_MODES: { id: HiddenFilesMode; label: string }[] = [
+  { id: "hidden", label: "Hidden" },
+  { id: "inline", label: "Shown inline" },
+  { id: "grouped", label: "Grouped" },
+];
+
 export const EDITOR_THEMES = [
   "atomone",
   "aura",
@@ -55,7 +64,7 @@ export type Preferences = {
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
-  showHidden: boolean;
+  hiddenFiles: HiddenFilesMode;
   terminalWebglEnabled: boolean;
   terminalFontSize: number;
   terminalScrollback: number;
@@ -81,6 +90,7 @@ const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
+const KEY_HIDDEN_FILES = "hiddenFiles";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
@@ -122,7 +132,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
-  showHidden: false,
+  hiddenFiles: "hidden",
   terminalWebglEnabled: true,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
@@ -189,10 +199,23 @@ export async function loadPreferences(): Promise<Preferences> {
     recentModelIds:
       get<string[]>(KEY_RECENT_MODELS) ?? DEFAULT_PREFERENCES.recentModelIds,
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
-    showHidden:
-      get<boolean>(KEY_SHOW_HIDDEN) ??
-      get<boolean>(LEGACY_KEY_SHOW_HIDDEN_DIRS) ??
-      DEFAULT_PREFERENCES.showHidden,
+    hiddenFiles: ((): HiddenFilesMode => {
+      const explicit = get<HiddenFilesMode>(KEY_HIDDEN_FILES);
+      if (
+        explicit === "hidden" ||
+        explicit === "inline" ||
+        explicit === "grouped"
+      ) {
+        return explicit;
+      }
+      // Migrate from the legacy boolean toggle: true -> inline, false -> hidden.
+      const legacy =
+        get<boolean>(KEY_SHOW_HIDDEN) ??
+        get<boolean>(LEGACY_KEY_SHOW_HIDDEN_DIRS);
+      if (legacy === true) return "inline";
+      if (legacy === false) return "hidden";
+      return DEFAULT_PREFERENCES.hiddenFiles;
+    })(),
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
@@ -279,8 +302,8 @@ export async function setVimMode(value: boolean): Promise<void> {
   await writePref(KEY_VIM_MODE, value);
 }
 
-export async function setShowHidden(value: boolean): Promise<void> {
-  await writePref(KEY_SHOW_HIDDEN, value);
+export async function setHiddenFiles(value: HiddenFilesMode): Promise<void> {
+  await writePref(KEY_HIDDEN_FILES, value);
 }
 
 export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
@@ -352,7 +375,7 @@ export async function onPreferencesChange(
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",
-    [KEY_SHOW_HIDDEN]: "showHidden",
+    [KEY_HIDDEN_FILES]: "hiddenFiles",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",

--- a/src/modules/statusbar/CwdBreadcrumb.tsx
+++ b/src/modules/statusbar/CwdBreadcrumb.tsx
@@ -179,7 +179,7 @@ function CurrentSegmentDropdown({
   path: string;
   onCd: (p: string) => void;
 }) {
-  const showHidden = usePreferencesStore((s) => s.showHidden);
+  const showHidden = usePreferencesStore((s) => s.hiddenFiles !== "hidden");
   const [open, setOpen] = useState(false);
   const [children, setChildren] = useState<string[] | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -180,30 +180,47 @@ export function GeneralSection() {
 
       <div className="flex flex-col gap-2">
         <Label>Explorer</Label>
-        <div className="flex flex-col gap-1.5 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
-          <span className="text-[12.5px] font-medium">Hidden files</span>
-          <span className="text-[10.5px] leading-relaxed text-muted-foreground">
-            How dot-prefixed files and folders (.env, .gitignore, .config)
-            appear in the file explorer and search.
-          </span>
-          <div className="mt-1 grid grid-cols-3 gap-2">
-            {HIDDEN_FILES_MODES.map((m) => (
-              <button
-                key={m.id}
-                type="button"
-                onClick={() => void setHiddenFiles(m.id)}
-                className={cn(
-                  "rounded-md border px-2 py-1.5 text-[11.5px] transition-all",
-                  hiddenFiles === m.id
-                    ? "border-foreground/60 ring-1 ring-foreground/20"
-                    : "border-border/60 hover:border-border",
-                )}
+        <SettingRow
+          title="Hidden files"
+          description="How dot-prefixed files and folders (.env, .gitignore, .config) appear in the file explorer and search."
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="h-8 justify-between gap-2 rounded-none px-2.5 text-[12px]"
               >
-                {m.label}
-              </button>
-            ))}
-          </div>
-        </div>
+                <span>
+                  {HIDDEN_FILES_MODES.find((m) => m.id === hiddenFiles)
+                    ?.label ?? hiddenFiles}
+                </span>
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  size={12}
+                  strokeWidth={2}
+                  className="opacity-70"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="min-w-[140px] rounded-none border border-border bg-popover p-0 shadow-none ring-0"
+            >
+              {HIDDEN_FILES_MODES.map((m) => (
+                <DropdownMenuItem
+                  key={m.id}
+                  onSelect={() => void setHiddenFiles(m.id)}
+                  className={cn(
+                    "rounded-none px-3 py-1.5 text-[12px]",
+                    m.id === hiddenFiles && "bg-accent/50",
+                  )}
+                >
+                  {m.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SettingRow>
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -18,12 +18,13 @@ import type { ThemePref } from "@/modules/settings/store";
 import {
   EDITOR_THEME_LABELS,
   EDITOR_THEMES,
+  HIDDEN_FILES_MODES,
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAutostart,
   setEditorTheme,
+  setHiddenFiles,
   setRestoreWindowState,
-  setShowHidden,
   setTerminalFontSize,
   setTerminalScrollback,
   setTerminalWebglEnabled,
@@ -59,7 +60,7 @@ export function GeneralSection() {
   const autostart = usePreferencesStore((s) => s.autostart);
   const restoreWindowState = usePreferencesStore((s) => s.restoreWindowState);
   const vimMode = usePreferencesStore((s) => s.vimMode);
-  const showHidden = usePreferencesStore((s) => s.showHidden);
+  const hiddenFiles = usePreferencesStore((s) => s.hiddenFiles);
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
   );
@@ -179,15 +180,30 @@ export function GeneralSection() {
 
       <div className="flex flex-col gap-2">
         <Label>Explorer</Label>
-        <SettingRow
-          title="Show hidden files"
-          description="Include dot-prefixed files and folders (.env, .gitignore, .config) in the file explorer and search."
-        >
-          <Switch
-            checked={showHidden}
-            onCheckedChange={(v) => void setShowHidden(v)}
-          />
-        </SettingRow>
+        <div className="flex flex-col gap-1.5 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
+          <span className="text-[12.5px] font-medium">Hidden files</span>
+          <span className="text-[10.5px] leading-relaxed text-muted-foreground">
+            How dot-prefixed files and folders (.env, .gitignore, .config)
+            appear in the file explorer and search.
+          </span>
+          <div className="mt-1 grid grid-cols-3 gap-2">
+            {HIDDEN_FILES_MODES.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => void setHiddenFiles(m.id)}
+                className={cn(
+                  "rounded-md border px-2 py-1.5 text-[11.5px] transition-all",
+                  hiddenFiles === m.id
+                    ? "border-foreground/60 ring-1 ring-foreground/20"
+                    : "border-border/60 hover:border-border",
+                )}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## What

Adds a third explorer display mode for hidden files. Settings → General → Explorer now has a **Hidden files** dropdown with three modes:

- **Hidden** — dot-prefixed files and folders are not shown.
- **Shown inline** — dotfiles appear inline in every directory.
- **Grouped** — each directory collects its dotfiles under a single collapsible `... dotfiles (N)` row at the top of the listing.

This replaces the previous on/off "Show hidden files" toggle; the old boolean preference is migrated automatically.

## Why

With hidden files shown, dotfiles (`.github`, `.env`, `.gitignore`, …) scatter through every directory listing and bury the files you actually work on. **Grouped** keeps them one click away without the clutter — the rest of the tree stays clean — while **Shown inline** preserves the old behaviour for anyone who prefers it.

## How

Frontend-only — `src-tauri/` is untouched. `fs_read_dir` still receives a `showHidden` boolean (true for both *inline* and *grouped*); grouping is purely a render concern.

- `src/modules/settings/store.ts` — replaces the `showHidden` boolean with a `hiddenFiles: "hidden" | "inline" | "grouped"` preference. `loadPreferences` migrates the legacy boolean (`true → inline`, `false → hidden`), mirroring the existing `showHiddenDirectories` fallback. Persists through the existing `writePref` + `PREFS_CHANGED_EVENT` plumbing.
- `src/settings/sections/GeneralSection.tsx` — the three-mode `DropdownMenu`, matching the existing Editor theme / Font size dropdown style.
- `src/modules/explorer/lib/partitionDotfiles.ts` *(new)* — pure helpers: split entries into regular/dotfiles, and build a synthetic group key. The key is suffixed with a NUL byte, which cannot occur in a real path, so it never collides with a filesystem entry.
- `src/modules/explorer/DotfilesGroupNode.tsx` *(new)* — the collapsible `... dotfiles (N)` row. Reuses the existing expand/collapse `Set`; its dotfile children render as ordinary `FileTreeNode`s with the real parent path, so open / rename / delete work with no special-casing.
- `src/modules/explorer/DirChildren.tsx` *(new)* — shared directory-listing renderer used by both the root and every subdirectory; partitions and inserts the group node in *grouped* mode, renders entries inline otherwise.
- `src/modules/explorer/FileTreeNode.tsx`, `FileExplorer.tsx` — render children through `DirChildren`. `FileExplorer`'s keyboard-nav `flat` walker is made group-aware so arrow keys can't land on collapsed dotfiles; row lookup now matches on `dataset.fsPath` instead of a `CSS.escape` selector (the NUL key isn't selector-safe).
- `src/modules/explorer/lib/useFileTree.ts` — reads `hiddenFiles`, derives the `showHidden` boolean for `fs_read_dir`, exposes `hiddenFiles` to the renderer, and guards `toggle` / `expand` against the synthetic key so it never triggers a directory read.
- `src/modules/explorer/ExplorerSearch.tsx`, `src/modules/statusbar/CwdBreadcrumb.tsx` — updated to read the new preference.

## Testing

Automated checks pass:

- `pnpm exec tsc --noEmit` — clean.
- `pnpm build` (`tsc` + `vite build`) — clean.

Manual smoke-test flows exercised in `pnpm tauri dev`:

- all three modes (Hidden / Shown inline / Grouped);
- group expand/collapse at the root and in nested directories;
- rename + delete a dotfile from inside an expanded group;
- arrow-key navigation reaches/expands/collapses the group row and skips collapsed dotfiles;
- selected mode persists across a restart.

- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean — n/a, no `src-tauri/` changes
- [ ] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

_To follow before this is marked ready for review._

## Notes for reviewer

- Opened as a **draft** — screenshots/GIF and the final manual smoke-test still to be added before marking ready.
- The migration keeps `KEY_SHOW_HIDDEN` / `LEGACY_KEY_SHOW_HIDDEN_DIRS` as read-only keys so existing installs keep their setting.
- The synthetic group node is intentionally invisible to filesystem operations — it has no context menu, and `isDotfilesGroupKey` guards both `toggle` and `expand`.
- `DirChildren` ↔ `FileTreeNode` form a recursive import cycle; this is safe because both are only referenced inside JSX at render time, not at module evaluation.
