### PR TITLE
fix(pty): support default WSL shells

### DIFF
--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -8,8 +8,48 @@ use crate::modules::workspace::WorkspaceEnv;
 const BASHRC_SCRIPT: &str = include_str!("scripts/bashrc.bash");
 
 #[cfg(windows)]
+const ZSHENV_SCRIPT: &str = include_str!("scripts/zshenv.zsh");
+
+#[cfg(windows)]
+const ZPROFILE_SCRIPT: &str = include_str!("scripts/zprofile.zsh");
+
+#[cfg(windows)]
+const ZLOGIN_SCRIPT: &str = include_str!("scripts/zlogin.zsh");
+
+#[cfg(windows)]
+const ZSHRC_SCRIPT: &str = include_str!("scripts/zshrc.zsh");
+
+#[cfg(windows)]
+const FISH_INIT_SCRIPT: &str = include_str!("scripts/init.fish");
+
+#[cfg(windows)]
 fn bashrc_script() -> &'static str {
     BASHRC_SCRIPT
+}
+
+#[cfg(windows)]
+fn zshenv_script() -> &'static str {
+    ZSHENV_SCRIPT
+}
+
+#[cfg(windows)]
+fn zprofile_script() -> &'static str {
+    ZPROFILE_SCRIPT
+}
+
+#[cfg(windows)]
+fn zlogin_script() -> &'static str {
+    ZLOGIN_SCRIPT
+}
+
+#[cfg(windows)]
+fn zshrc_script() -> &'static str {
+    ZSHRC_SCRIPT
+}
+
+#[cfg(windows)]
+fn fish_init_script() -> &'static str {
+    FISH_INIT_SCRIPT
 }
 
 pub fn build_command(
@@ -249,9 +289,27 @@ mod windows {
     use std::path::{Path, PathBuf};
 
     use crate::modules::workspace::WorkspaceEnv;
+    use crate::modules::workspace::{WslShellResolution, WslShellSource};
     use portable_pty::CommandBuilder;
 
     const PROFILE_PS1: &str = include_str!("scripts/profile.ps1");
+    const DEFAULT_WSL_CWD: &str = "~";
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum ShellKind {
+        Zsh,
+        Bash,
+        Fish,
+        Other,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum WslIntegration {
+        Zsh { zdotdir: String },
+        Bash { rcfile: String },
+        Fish { init: String },
+        None,
+    }
 
     pub fn build(cwd: Option<String>, workspace: WorkspaceEnv) -> Result<CommandBuilder, String> {
         if let WorkspaceEnv::Wsl { distro } = workspace {
@@ -291,44 +349,178 @@ mod windows {
     }
 
     fn build_wsl(cwd: Option<String>, distro: String) -> Result<CommandBuilder, String> {
-        let mut cmd = CommandBuilder::new("wsl.exe");
-        cmd.arg("-d");
-        cmd.arg(&distro);
-        cmd.arg("--cd");
-        cmd.arg(cwd.as_deref().filter(|s| !s.is_empty()).unwrap_or("~"));
-        cmd.arg("--exec");
-        cmd.arg("bash");
-        match prepare_wsl_bash_rcfile(&distro) {
-            Ok(rc) => {
-                cmd.arg("--rcfile");
-                cmd.arg(rc);
-            }
-            Err(e) => {
-                log::warn!("WSL bash shell integration disabled for {distro}: {e}");
-            }
+        let resolved_shell = crate::modules::workspace::resolve_wsl_shell(distro.clone())?;
+        if resolved_shell.source == WslShellSource::Fallback {
+            log::warn!("WSL shell resolution fell back to /bin/bash for {distro}");
         }
-        cmd.arg("-i");
-        cmd.env("TERM", "xterm-256color");
-        cmd.env("COLORTERM", "truecolor");
-        cmd.env("TERAX_TERMINAL", "1");
-        super::ensure_utf8_locale(&mut cmd);
+        let shell_kind = classify_shell(&resolved_shell.path);
+        let mut cmd = CommandBuilder::new("wsl.exe");
+        super::apply_common(&mut cmd, None);
+        cmd.clear_cwd();
+        apply_wsl_base_args(
+            &mut cmd,
+            &distro,
+            cwd.as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(DEFAULT_WSL_CWD),
+            &resolved_shell.path,
+        );
+
+        let integration = match shell_kind {
+            ShellKind::Zsh => match prepare_wsl_zdotdir(&distro) {
+                Ok(zdotdir) => WslIntegration::Zsh { zdotdir },
+                Err(e) => {
+                    log::warn!("WSL zsh shell integration disabled for {distro}: {e}");
+                    WslIntegration::None
+                }
+            },
+            ShellKind::Bash => match prepare_wsl_bash_rcfile(&distro) {
+                Ok(rcfile) => WslIntegration::Bash { rcfile },
+                Err(e) => {
+                    log::warn!("WSL bash shell integration disabled for {distro}: {e}");
+                    WslIntegration::None
+                }
+            },
+            ShellKind::Fish => match prepare_wsl_fish_init(&distro) {
+                Ok(init) => WslIntegration::Fish { init },
+                Err(e) => {
+                    log::warn!("WSL fish shell integration disabled for {distro}: {e}");
+                    WslIntegration::None
+                }
+            },
+            ShellKind::Other => {
+                log::info!(
+                    "unsupported WSL shell '{}', spawning without integration",
+                    resolved_shell.path
+                );
+                WslIntegration::None
+            }
+        };
+        apply_wsl_shell_behavior(&mut cmd, &resolved_shell, integration);
         log::info!("spawning WSL shell: {distro}");
         Ok(cmd)
     }
 
+    fn classify_shell(shell_path: &str) -> ShellKind {
+        match shell_path.rsplit('/').next().unwrap_or(shell_path) {
+            "zsh" => ShellKind::Zsh,
+            "bash" => ShellKind::Bash,
+            "fish" => ShellKind::Fish,
+            _ => ShellKind::Other,
+        }
+    }
+
+    fn apply_wsl_base_args(cmd: &mut CommandBuilder, distro: &str, cwd: &str, shell_path: &str) {
+        cmd.arg("-d");
+        cmd.arg(distro);
+        cmd.arg("--cd");
+        cmd.arg(cwd);
+        cmd.arg("--exec");
+        cmd.arg(shell_path);
+    }
+
+    fn apply_wsl_shell_behavior(
+        cmd: &mut CommandBuilder,
+        shell: &WslShellResolution,
+        integration: WslIntegration,
+    ) {
+        match integration {
+            WslIntegration::Zsh { zdotdir } => {
+                cmd.env("ZDOTDIR", zdotdir);
+                cmd.arg("-l");
+            }
+            WslIntegration::Bash { rcfile } => {
+                cmd.arg("--rcfile");
+                cmd.arg(rcfile);
+                cmd.arg("-i");
+            }
+            WslIntegration::Fish { init } => {
+                cmd.arg("--init-command");
+                cmd.arg(format!("source {}", shell_quote_str(&init)));
+                cmd.arg("-i");
+            }
+            WslIntegration::None => match classify_shell(&shell.path) {
+                ShellKind::Zsh => cmd.arg("-l"),
+                ShellKind::Bash | ShellKind::Fish => cmd.arg("-i"),
+                ShellKind::Other => {
+                    if shell.source == WslShellSource::Fallback {
+                        cmd.arg("-i");
+                    }
+                }
+            },
+        }
+    }
+
     fn prepare_wsl_bash_rcfile(distro: &str) -> Result<String, String> {
+        let linux_dir = wsl_integration_dir(distro, "bash")?;
+        let linux_rc = format!("{linux_dir}/bashrc");
+        let content = super::bashrc_script().replace("\r\n", "\n");
+        write_wsl_integration_file(distro, &linux_rc, &content)?;
+        Ok(linux_rc)
+    }
+
+    fn prepare_wsl_zdotdir(distro: &str) -> Result<String, String> {
+        let linux_dir = wsl_integration_dir(distro, "zsh")?;
+        write_wsl_integration_file(
+            distro,
+            &format!("{linux_dir}/.zshenv"),
+            &normalize_script(super::zshenv_script()),
+        )?;
+        write_wsl_integration_file(
+            distro,
+            &format!("{linux_dir}/.zprofile"),
+            &normalize_script(super::zprofile_script()),
+        )?;
+        write_wsl_integration_file(
+            distro,
+            &format!("{linux_dir}/.zshrc"),
+            &normalize_script(super::zshrc_script()),
+        )?;
+        write_wsl_integration_file(
+            distro,
+            &format!("{linux_dir}/.zlogin"),
+            &normalize_script(super::zlogin_script()),
+        )?;
+        Ok(linux_dir)
+    }
+
+    fn prepare_wsl_fish_init(distro: &str) -> Result<String, String> {
+        let linux_dir = wsl_integration_dir(distro, "fish")?;
+        let linux_init = format!("{linux_dir}/init.fish");
+        write_wsl_integration_file(
+            distro,
+            &linux_init,
+            &normalize_script(super::fish_init_script()),
+        )?;
+        Ok(linux_init)
+    }
+
+    fn wsl_integration_dir(distro: &str, shell: &str) -> Result<String, String> {
         let home = crate::modules::workspace::wsl_home(distro.to_string())?;
         let linux_dir = format!(
-            "{}/.cache/terax/shell-integration/bash",
+            "{}/.cache/terax/shell-integration/{shell}",
             home.trim_end_matches('/')
         );
-        let linux_rc = format!("{linux_dir}/bashrc");
         let unc_dir = crate::modules::workspace::wsl_path_to_unc(distro, &linux_dir);
         fs::create_dir_all(&unc_dir).map_err(|e| format!("create {}: {e}", unc_dir.display()))?;
-        let unc_file = crate::modules::workspace::wsl_path_to_unc(distro, &linux_rc);
-        let content = super::bashrc_script().replace("\r\n", "\n");
-        write_if_changed(&unc_file, &content)?;
-        Ok(linux_rc)
+        Ok(linux_dir)
+    }
+
+    fn write_wsl_integration_file(
+        distro: &str,
+        linux_path: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        let unc_file = crate::modules::workspace::wsl_path_to_unc(distro, linux_path);
+        write_if_changed(&unc_file, content)
+    }
+
+    fn normalize_script(content: &str) -> String {
+        content.replace("\r\n", "\n")
+    }
+
+    fn shell_quote_str(p: &str) -> String {
+        format!("'{}'", p.replace('\'', "'\\''"))
     }
 
     fn integration_root() -> Result<PathBuf, String> {
@@ -360,6 +552,181 @@ mod windows {
             let _ = fs::remove_file(&tmp);
             format!("rename {} -> {}: {e}", tmp.display(), path.display())
         })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{
+            apply_wsl_base_args, apply_wsl_shell_behavior, classify_shell, ShellKind,
+            WslIntegration, DEFAULT_WSL_CWD,
+        };
+        use crate::modules::workspace::{WslShellResolution, WslShellSource};
+        use portable_pty::CommandBuilder;
+
+        fn argv(cmd: &CommandBuilder) -> Vec<String> {
+            cmd.get_argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect()
+        }
+
+        #[test]
+        fn classify_shell_matches_supported_names() {
+            assert_eq!(classify_shell("/usr/bin/zsh"), ShellKind::Zsh);
+            assert_eq!(classify_shell("/bin/bash"), ShellKind::Bash);
+            assert_eq!(classify_shell("/usr/bin/fish"), ShellKind::Fish);
+            assert_eq!(classify_shell("/usr/bin/tcsh"), ShellKind::Other);
+        }
+
+        #[test]
+        fn wsl_zsh_launch_uses_login_shell_and_zdotdir() {
+            let shell = WslShellResolution {
+                path: "/usr/bin/zsh".into(),
+                source: WslShellSource::Passwd,
+            };
+            let mut cmd = CommandBuilder::new("wsl.exe");
+            apply_wsl_base_args(&mut cmd, "Ubuntu", "/work", &shell.path);
+            apply_wsl_shell_behavior(
+                &mut cmd,
+                &shell,
+                WslIntegration::Zsh {
+                    zdotdir: "/home/me/.cache/terax/shell-integration/zsh".into(),
+                },
+            );
+
+            assert_eq!(
+                argv(&cmd),
+                vec![
+                    "wsl.exe",
+                    "-d",
+                    "Ubuntu",
+                    "--cd",
+                    "/work",
+                    "--exec",
+                    "/usr/bin/zsh",
+                    "-l",
+                ]
+            );
+            assert_eq!(
+                cmd.get_env("ZDOTDIR").and_then(|v| v.to_str()),
+                Some("/home/me/.cache/terax/shell-integration/zsh")
+            );
+        }
+
+        #[test]
+        fn wsl_bash_launch_uses_rcfile_and_interactive_mode() {
+            let shell = WslShellResolution {
+                path: "/bin/bash".into(),
+                source: WslShellSource::Passwd,
+            };
+            let mut cmd = CommandBuilder::new("wsl.exe");
+            apply_wsl_base_args(&mut cmd, "Ubuntu", DEFAULT_WSL_CWD, &shell.path);
+            apply_wsl_shell_behavior(
+                &mut cmd,
+                &shell,
+                WslIntegration::Bash {
+                    rcfile: "/home/me/.cache/terax/shell-integration/bash/bashrc".into(),
+                },
+            );
+
+            assert_eq!(
+                argv(&cmd),
+                vec![
+                    "wsl.exe",
+                    "-d",
+                    "Ubuntu",
+                    "--cd",
+                    "~",
+                    "--exec",
+                    "/bin/bash",
+                    "--rcfile",
+                    "/home/me/.cache/terax/shell-integration/bash/bashrc",
+                    "-i",
+                ]
+            );
+        }
+
+        #[test]
+        fn wsl_fish_launch_uses_init_command() {
+            let shell = WslShellResolution {
+                path: "/usr/bin/fish".into(),
+                source: WslShellSource::Passwd,
+            };
+            let mut cmd = CommandBuilder::new("wsl.exe");
+            apply_wsl_base_args(&mut cmd, "Ubuntu", "/work", &shell.path);
+            apply_wsl_shell_behavior(
+                &mut cmd,
+                &shell,
+                WslIntegration::Fish {
+                    init: "/home/me/.cache/terax/shell-integration/fish/init.fish".into(),
+                },
+            );
+
+            assert_eq!(
+                argv(&cmd),
+                vec![
+                    "wsl.exe",
+                    "-d",
+                    "Ubuntu",
+                    "--cd",
+                    "/work",
+                    "--exec",
+                    "/usr/bin/fish",
+                    "--init-command",
+                    "source '/home/me/.cache/terax/shell-integration/fish/init.fish'",
+                    "-i",
+                ]
+            );
+        }
+
+        #[test]
+        fn unsupported_wsl_shell_stays_usable_without_integration() {
+            let shell = WslShellResolution {
+                path: "/usr/bin/tcsh".into(),
+                source: WslShellSource::Passwd,
+            };
+            let mut cmd = CommandBuilder::new("wsl.exe");
+            apply_wsl_base_args(&mut cmd, "Ubuntu", "/work", &shell.path);
+            apply_wsl_shell_behavior(&mut cmd, &shell, WslIntegration::None);
+
+            assert_eq!(
+                argv(&cmd),
+                vec![
+                    "wsl.exe",
+                    "-d",
+                    "Ubuntu",
+                    "--cd",
+                    "/work",
+                    "--exec",
+                    "/usr/bin/tcsh",
+                ]
+            );
+        }
+
+        #[test]
+        fn fallback_shell_stays_interactive_without_rcfile() {
+            let shell = WslShellResolution {
+                path: "/bin/bash".into(),
+                source: WslShellSource::Fallback,
+            };
+            let mut cmd = CommandBuilder::new("wsl.exe");
+            apply_wsl_base_args(&mut cmd, "Ubuntu", "/work", &shell.path);
+            apply_wsl_shell_behavior(&mut cmd, &shell, WslIntegration::None);
+
+            assert_eq!(
+                argv(&cmd),
+                vec![
+                    "wsl.exe",
+                    "-d",
+                    "Ubuntu",
+                    "--cd",
+                    "/work",
+                    "--exec",
+                    "/bin/bash",
+                    "-i",
+                ]
+            );
+        }
     }
 }
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -87,11 +87,15 @@ fn ensure_utf8_locale(cmd: &mut CommandBuilder) {
     cmd.env("LANG", fallback);
 }
 
-fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
+fn apply_common_env(cmd: &mut CommandBuilder) {
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     cmd.env("TERAX_TERMINAL", "1");
     ensure_utf8_locale(cmd);
+}
+
+fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
+    apply_common_env(cmd);
 
     let resolved_cwd = cwd
         .map(PathBuf::from)
@@ -355,8 +359,7 @@ mod windows {
         }
         let shell_kind = classify_shell(&resolved_shell.path);
         let mut cmd = CommandBuilder::new("wsl.exe");
-        super::apply_common(&mut cmd, None);
-        cmd.clear_cwd();
+        super::apply_common_env(&mut cmd);
         apply_wsl_base_args(
             &mut cmd,
             &distro,

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -50,8 +50,6 @@ pub async fn workspace_current_dir(
     Ok(canonical.to_string_lossy().replace('\\', "/"))
 }
 
-
-
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum WorkspaceEnv {
@@ -126,6 +124,21 @@ pub fn decode_command_output(bytes: &[u8]) -> String {
 }
 
 #[cfg(windows)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WslShellSource {
+    Passwd,
+    Env,
+    Fallback,
+}
+
+#[cfg(windows)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WslShellResolution {
+    pub path: String,
+    pub source: WslShellSource,
+}
+
+#[cfg(windows)]
 fn looks_utf16le(bytes: &[u8]) -> bool {
     if bytes.len() < 4 || !bytes.len().is_multiple_of(2) {
         return false;
@@ -145,6 +158,71 @@ fn run_wsl(args: &[&str]) -> Result<String, String> {
         return Err(stderr.trim().to_string());
     }
     Ok(decode_command_output(&out.stdout))
+}
+
+#[cfg(windows)]
+fn parse_passwd_shell(raw: &str) -> Option<String> {
+    let line = raw.trim();
+    if line.is_empty() {
+        return None;
+    }
+    let shell = if line.contains(':') {
+        line.rsplit(':').next().unwrap_or("")
+    } else {
+        line
+    };
+    normalize_wsl_shell(shell)
+}
+
+#[cfg(windows)]
+fn normalize_wsl_shell(raw: &str) -> Option<String> {
+    let shell = raw.trim();
+    if shell.is_empty() {
+        None
+    } else {
+        Some(shell.to_string())
+    }
+}
+
+#[cfg(windows)]
+fn resolve_wsl_shell_from_outputs(passwd: &str, shell_env: &str) -> WslShellResolution {
+    if let Some(path) = parse_passwd_shell(passwd) {
+        return WslShellResolution {
+            path,
+            source: WslShellSource::Passwd,
+        };
+    }
+    if let Some(path) = normalize_wsl_shell(shell_env) {
+        return WslShellResolution {
+            path,
+            source: WslShellSource::Env,
+        };
+    }
+    WslShellResolution {
+        path: "/bin/bash".into(),
+        source: WslShellSource::Fallback,
+    }
+}
+
+#[cfg(windows)]
+pub fn resolve_wsl_shell(distro: String) -> Result<WslShellResolution, String> {
+    let passwd = run_wsl(&[
+        "-d",
+        &distro,
+        "--exec",
+        "sh",
+        "-lc",
+        "getent passwd \"$(id -un)\" 2>/dev/null || true",
+    ])?;
+    let shell_env = run_wsl(&[
+        "-d",
+        &distro,
+        "--exec",
+        "sh",
+        "-lc",
+        "printf %s \"${SHELL:-}\"",
+    ])?;
+    Ok(resolve_wsl_shell_from_outputs(&passwd, &shell_env))
 }
 
 #[cfg(windows)]
@@ -225,5 +303,48 @@ pub fn wsl_home(distro: String) -> Result<String, String> {
         } else {
             Ok(home)
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::{
+        decode_command_output, parse_passwd_shell, resolve_wsl_shell_from_outputs, WslShellSource,
+    };
+
+    #[test]
+    fn decode_command_output_handles_utf16le_without_bom() {
+        let bytes = b"h\0i\0";
+        assert_eq!(decode_command_output(bytes), "hi");
+    }
+
+    #[test]
+    fn parse_passwd_shell_extracts_last_field() {
+        let line = "user:x:1000:1000::/home/user:/usr/bin/zsh";
+        assert_eq!(parse_passwd_shell(line).as_deref(), Some("/usr/bin/zsh"));
+    }
+
+    #[test]
+    fn resolve_wsl_shell_prefers_passwd() {
+        let resolved = resolve_wsl_shell_from_outputs(
+            "user:x:1000:1000::/home/user:/usr/bin/fish",
+            "/bin/bash",
+        );
+        assert_eq!(resolved.path, "/usr/bin/fish");
+        assert_eq!(resolved.source, WslShellSource::Passwd);
+    }
+
+    #[test]
+    fn resolve_wsl_shell_falls_back_to_env() {
+        let resolved = resolve_wsl_shell_from_outputs("", "/bin/zsh");
+        assert_eq!(resolved.path, "/bin/zsh");
+        assert_eq!(resolved.source, WslShellSource::Env);
+    }
+
+    #[test]
+    fn resolve_wsl_shell_falls_back_to_bash() {
+        let resolved = resolve_wsl_shell_from_outputs("", "");
+        assert_eq!(resolved.path, "/bin/bash");
+        assert_eq!(resolved.source, WslShellSource::Fallback);
     }
 }


### PR DESCRIPTION
## What
Improve WSL terminal startup on Windows so Terax resolves and launches the user's default shell instead of hardcoding `bash`, with shell-specific integration for `zsh`, `bash`, and `fish` plus regression tests.

## Why


WSL terminals were opening as a non-login or wrong shell, which skipped user init files like `.zshrc` and `.zprofile` and broke shell-specific behavior.

## How
Detect the WSL shell from `getent passwd` with `$SHELL` and `/bin/bash` fallbacks, classify supported shells, write per-shell integration files, and launch each shell with the right flags (`-l`, `--rcfile`, or `--init-command`). Added unit coverage for shell resolution and command construction.

## Testing
- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

Additional automated checks run:
- `cargo test workspace::tests --manifest-path src-tauri/Cargo.toml`
- `cargo test shell_init --manifest-path src-tauri/Cargo.toml`

## Screenshots / GIFs
Not applicable.

## Notes for reviewer
This PR contains one commit and only the WSL shell integration files.
