### PR TITLE
feat(tabs): per-tab workspace env (Local + WSL distros side-by-side)

### DIFF
--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -44,11 +44,24 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
       __TERAX_PS1_INJECTED=1
     fi
     printf '\e]133;A\e\\'
+    # Self-reinstall: some distros (Kali's stock .bashrc, line 104) set
+    # PROMPT_COMMAND to a literal `PROMPT_COMMAND=echo` assignment that
+    # silently overwrites our hook on the first prompt. Re-prepending here
+    # makes the next prompt include us again — turning a one-shot clobber
+    # into a one-prompt blip.
+    case ":${PROMPT_COMMAND:-}:" in
+      *":_terax_precmd:"*) ;;
+      *) PROMPT_COMMAND="_terax_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
+    esac
   }
 
+  # Append (not prepend) so distros that REASSIGN PROMPT_COMMAND inside
+  # their first-prompt code (vs. appending to it) clobber themselves
+  # FIRST and we get the last word — at which point the self-reinstall in
+  # _terax_precmd takes over for every subsequent prompt.
   case ":${PROMPT_COMMAND:-}:" in
     *":_terax_precmd:"*) ;;
-    *) PROMPT_COMMAND="_terax_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
+    *) PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}_terax_precmd" ;;
   esac
 
   # Pre-exec marker via PS0 (bash 4.4+). PS0 is expanded just before a command

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -45,6 +45,18 @@ pub fn resolve_path(path: &str, _workspace: &WorkspaceEnv) -> PathBuf {
 #[cfg(windows)]
 pub fn wsl_path_to_unc(distro: &str, path: &str) -> PathBuf {
     let normalized = path.replace('\\', "/");
+
+    // `/mnt/<drive>[/...]` is WSL's drvfs mount for a Windows drive. Going
+    // through `\\wsl.localhost\<distro>\mnt\<drive>` round-trips the request
+    // through the WSL VM's 9P proxy back into drvfs, and Windows frequently
+    // answers that round-trip with ERROR_ACCESS_DENIED on directory
+    // enumeration — even for directories the user can read natively. Short-
+    // circuit to the underlying Windows path so the explorer sees the same
+    // files as Windows Explorer would, with the user's actual permissions.
+    if let Some(win) = drvfs_mount_to_windows(&normalized) {
+        return win;
+    }
+
     let trimmed = normalized.trim_start_matches('/');
     let primary = PathBuf::from(format!(
         r"\\wsl.localhost\{}\{}",
@@ -55,6 +67,32 @@ pub fn wsl_path_to_unc(distro: &str, path: &str) -> PathBuf {
         return primary;
     }
     PathBuf::from(format!(r"\\wsl$\{}\{}", distro, trimmed.replace('/', r"\")))
+}
+
+/// Translate `/mnt/<drive>[/rest]` to a native Windows path like `C:\rest`.
+/// Returns `None` for anything that isn't a single-letter drvfs mount —
+/// `/mnt/wsl`, `/home/...`, `/etc/...` etc. fall through to the regular UNC
+/// resolution. Matches the convention `wsl.conf`'s `automount.root` uses for
+/// Windows drives.
+#[cfg(windows)]
+fn drvfs_mount_to_windows(unix_path: &str) -> Option<PathBuf> {
+    let after = unix_path.strip_prefix("/mnt/")?;
+    let mut parts = after.splitn(2, '/');
+    let drive = parts.next()?;
+    if drive.len() != 1 {
+        return None;
+    }
+    let letter = drive.chars().next()?;
+    if !letter.is_ascii_alphabetic() {
+        return None;
+    }
+    let rest = parts.next().unwrap_or("");
+    let win = format!(
+        "{}:\\{}",
+        letter.to_ascii_uppercase(),
+        rest.replace('/', "\\")
+    );
+    Some(PathBuf::from(win))
 }
 
 #[cfg(windows)]
@@ -175,5 +213,61 @@ pub fn wsl_home(distro: String) -> Result<String, String> {
         } else {
             Ok(home)
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drvfs_mount_short_circuits_to_native_windows() {
+        // /mnt/<single-letter> is the drvfs convention for Windows drives.
+        // We translate to native paths so Windows-side fs ops don't fail
+        // with ACCESS_DENIED on the WSL 9P round-trip.
+        assert_eq!(
+            drvfs_mount_to_windows("/mnt/c"),
+            Some(PathBuf::from(r"C:\"))
+        );
+        assert_eq!(
+            drvfs_mount_to_windows("/mnt/c/Users/me"),
+            Some(PathBuf::from(r"C:\Users\me"))
+        );
+        assert_eq!(
+            drvfs_mount_to_windows("/mnt/d/projects"),
+            Some(PathBuf::from(r"D:\projects"))
+        );
+        // Multi-character mount names aren't drvfs drives.
+        assert_eq!(drvfs_mount_to_windows("/mnt/wsl"), None);
+        assert_eq!(drvfs_mount_to_windows("/mnt/wslg"), None);
+        // Non-/mnt paths stay in WSL.
+        assert_eq!(drvfs_mount_to_windows("/home/paul"), None);
+        assert_eq!(drvfs_mount_to_windows("/etc/hosts"), None);
+        // Non-alphabetic single chars (numeric, punctuation) don't qualify
+        // and shouldn't trick the translation.
+        assert_eq!(drvfs_mount_to_windows("/mnt/1"), None);
+        assert_eq!(drvfs_mount_to_windows("/mnt/."), None);
+    }
+
+    #[test]
+    fn wsl_path_to_unc_returns_native_for_drvfs() {
+        // Full integration: /mnt/c under any WSL distro should produce a
+        // C:\ path, not a \\wsl.localhost\ UNC.
+        let p = wsl_path_to_unc("Ubuntu", "/mnt/c/Users");
+        let s = p.to_string_lossy();
+        assert_eq!(s, r"C:\Users");
+        assert!(!s.contains("wsl.localhost"), "got: {s}");
+    }
+
+    #[test]
+    fn wsl_path_to_unc_keeps_unc_for_non_drvfs() {
+        // /home/paul stays as a WSL UNC path so the explorer can read into
+        // the WSL filesystem itself.
+        let p = wsl_path_to_unc("Ubuntu", "/home/paul");
+        let s = p.to_string_lossy();
+        assert!(
+            s.contains("wsl.localhost") || s.contains("wsl$"),
+            "got: {s}"
+        );
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -64,7 +64,6 @@ import {
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import {
-  getWslHome,
   LOCAL_WORKSPACE,
   useWorkspaceEnvStore,
   type WorkspaceEnv,
@@ -97,7 +96,6 @@ export default function App() {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
-    resetWorkspace,
   } = useTabs();
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -157,6 +155,7 @@ export default function App() {
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
   const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
+  const setDefaultWorkspaceEnv = useWorkspaceEnvStore((s) => s.setDefaultEnv);
   const [pendingDeleteTabs, setPendingDeleteTabs] = useState<number[] | null>(
     null,
   );
@@ -167,46 +166,33 @@ export default function App() {
       .catch(() => setHome(null));
   }, []);
 
+  // Status-bar workspace selector — picks the env that new "+" tabs will
+  // use when no terminal tab is active. Does NOT touch existing tabs and
+  // does NOT close anything. Previous behavior (wipe-all-tabs on switch)
+  // is intentionally removed — each tab now owns its workspace.
   const switchWorkspace = useCallback(
-    async (env: WorkspaceEnv) => {
-      if (
-        env.kind === workspaceEnv.kind &&
-        (env.kind === "local" ||
-          (workspaceEnv.kind === "wsl" && env.distro === workspaceEnv.distro))
-      ) {
-        return;
-      }
-      const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
-      if (dirty) {
-        window.alert("Save or close unsaved editor tabs before switching workspace.");
-        return;
-      }
-
-      let nextHome: string | null = null;
-      try {
-        if (env.kind === "wsl") {
-          nextHome = await getWslHome(env.distro);
-        } else {
-          nextHome = (await homeDir()).replace(/\\/g, "/");
-        }
-      } catch (e) {
-        window.alert(String(e));
-        return;
-      }
-
-      for (const id of liveLeavesRef.current) disposeSession(id);
-      searchAddons.current.clear();
-      terminalRefs.current.clear();
-      editorRefs.current.clear();
-      previewRefs.current.clear();
-      setActiveSearchAddon(null);
-      setActiveEditorHandle(null);
-      setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
-      setHome(nextHome);
-      resetWorkspace(nextHome ?? undefined);
+    (env: WorkspaceEnv) => {
+      setDefaultWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
     },
-    [workspaceEnv, setWorkspaceEnv, resetWorkspace],
+    [setDefaultWorkspaceEnv],
   );
+
+  // Mirror the active terminal tab's workspace into the ambient store env
+  // so AI fs tools, the explorer, and other workspace-aware code follow
+  // whichever terminal the user is looking at.
+  useEffect(() => {
+    const tab = activeTerminalTab;
+    if (!tab) return;
+    const next = tab.workspace ?? LOCAL_WORKSPACE;
+    if (
+      next.kind !== workspaceEnv.kind ||
+      (next.kind === "wsl" &&
+        workspaceEnv.kind === "wsl" &&
+        next.distro !== workspaceEnv.distro)
+    ) {
+      setWorkspaceEnv(next);
+    }
+  }, [activeTerminalTab, workspaceEnv, setWorkspaceEnv]);
 
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [newEditorOpen, setNewEditorOpen] = useState(false);
@@ -494,13 +480,38 @@ export default function App() {
     setAskPopup(null);
   }, [askFromSelection]);
 
-  const openNewTab = useCallback(() => {
-    newTab(inheritedCwdForNewTab());
-  }, [newTab, inheritedCwdForNewTab]);
+  // New-tab handler. If `workspace` is provided (caret picked an explicit
+  // env), use it; otherwise inherit from the active terminal tab so Ctrl-T
+  // "feels right" — a WSL tab spawns another WSL tab, a Local tab spawns
+  // another Local. Falls back to the store's defaultEnv when no terminal
+  // tab is active (e.g. user is on an editor or preview tab).
+  const openNewTab = useCallback(
+    (workspace?: WorkspaceEnv) => {
+      const ws =
+        workspace ??
+        activeTerminalTab?.workspace ??
+        useWorkspaceEnvStore.getState().defaultEnv;
+      // Don't carry the active terminal's cwd into a new tab of a
+      // different env — Windows paths inside WSL (and vice versa) just
+      // produce ENOENT spam. Inherit only when envs match.
+      const cwd =
+        ws.kind === (activeTerminalTab?.workspace ?? LOCAL_WORKSPACE).kind &&
+        (ws.kind === "local" ||
+          (activeTerminalTab?.workspace?.kind === "wsl" &&
+            ws.distro === activeTerminalTab.workspace.distro))
+          ? inheritedCwdForNewTab()
+          : undefined;
+      newTab(cwd, ws);
+    },
+    [newTab, activeTerminalTab, inheritedCwdForNewTab],
+  );
 
   const openNewPrivateTab = useCallback(() => {
-    newPrivateTab(inheritedCwdForNewTab());
-  }, [newPrivateTab, inheritedCwdForNewTab]);
+    const ws =
+      activeTerminalTab?.workspace ??
+      useWorkspaceEnvStore.getState().defaultEnv;
+    newPrivateTab(inheritedCwdForNewTab(), ws);
+  }, [newPrivateTab, activeTerminalTab, inheritedCwdForNewTab]);
 
   const sendCd = useCallback(
     (path: string) => {
@@ -626,7 +637,10 @@ export default function App() {
 
   const shortcutHandlers = useMemo<ShortcutHandlers>(
     () => ({
-      "tab.new": openNewTab,
+      // Wrapped so the KeyboardEvent passed by the shortcut runner doesn't
+      // land in the `workspace` parameter and confuse the env-inheritance
+      // logic in openNewTab.
+      "tab.new": () => openNewTab(),
       "tab.newPrivate": openNewPrivateTab,
       "tab.newPreview": () => openPreviewTab(""),
       "tab.newEditor": () => setNewEditorOpen(true),

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -166,21 +166,13 @@ export default function App() {
       .catch(() => setHome(null));
   }, []);
 
-  // Status-bar workspace selector — picks the env that:
-  //   1. new "+" tabs spawn into (read from `defaultEnv` at click time),
-  //   2. the AI / fs / file explorer operate in (read from `env`),
-  //   3. the explorer's root reflects (we fetch the matching home so the
-  //      file tree doesn't try to load a Windows path under a WSL
-  //      workspace, which produces a malformed UNC + ERROR_INVALID_NAME).
-  //
-  // Existing terminal tabs are intentionally untouched — each tab owns
-  // its workspace and keeps running in the env it was opened with.
-  const switchWorkspace = useCallback(
+  // Apply a workspace env to the world (store + explorer home). Used by
+  // both the selector pick path and the focus-change auto-sync below so
+  // they share the same "fetch home + setEnv + setHome" logic.
+  const applyAmbientEnv = useCallback(
     async (env: WorkspaceEnv) => {
       const normalized = env.kind === "local" ? LOCAL_WORKSPACE : env;
-      // No-op if it's already the default — avoids a needless home fetch
-      // and the alert-on-dirty-editor flow below.
-      const current = useWorkspaceEnvStore.getState().defaultEnv;
+      const current = useWorkspaceEnvStore.getState().env;
       const same =
         current.kind === normalized.kind &&
         (current.kind === "local" ||
@@ -190,22 +182,43 @@ export default function App() {
 
       let nextHome: string | null = null;
       try {
-        if (normalized.kind === "wsl") {
-          nextHome = await getWslHome(normalized.distro);
-        } else {
-          nextHome = (await homeDir()).replace(/\\/g, "/");
-        }
+        nextHome =
+          normalized.kind === "wsl"
+            ? await getWslHome(normalized.distro)
+            : (await homeDir()).replace(/\\/g, "/");
       } catch (e) {
         window.alert(String(e));
         return;
       }
-
-      setDefaultWorkspaceEnv(normalized);
       setWorkspaceEnv(normalized);
       setHome(nextHome);
     },
-    [setDefaultWorkspaceEnv, setWorkspaceEnv],
+    [setWorkspaceEnv],
   );
+
+  // Status-bar workspace selector. Picking sets the default for new "+"
+  // tabs AND applies the env immediately so the file tree / AI follow
+  // along. Open terminal tabs keep running in their own env.
+  const switchWorkspace = useCallback(
+    async (env: WorkspaceEnv) => {
+      const normalized = env.kind === "local" ? LOCAL_WORKSPACE : env;
+      setDefaultWorkspaceEnv(normalized);
+      await applyAmbientEnv(normalized);
+    },
+    [setDefaultWorkspaceEnv, applyAmbientEnv],
+  );
+
+  // Auto-follow the focused terminal tab's workspace. Deps intentionally
+  // exclude the store's `env` so a selector pick doesn't immediately get
+  // overridden by this effect — sync only re-runs when the *focused tab*
+  // changes (which is the only legitimate trigger for "switch ambient to
+  // match what the user is looking at").
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const tab = activeTerminalTab;
+    if (!tab) return;
+    void applyAmbientEnv(tab.workspace ?? LOCAL_WORKSPACE);
+  }, [activeTerminalTab]);
 
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [newEditorOpen, setNewEditorOpen] = useState(false);
@@ -296,10 +309,12 @@ export default function App() {
     }
   }, [tabs]);
 
+  const ambientWorkspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const { explorerRoot, inheritedCwdForNewTab } = useWorkspaceCwd(
     activeTab,
     tabs,
     home,
+    ambientWorkspaceEnv,
   );
 
   useEffect(() => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -64,6 +64,7 @@ import {
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import {
+  getWslHome,
   LOCAL_WORKSPACE,
   useWorkspaceEnvStore,
   type WorkspaceEnv,
@@ -153,7 +154,6 @@ export default function App() {
 
   const [home, setHome] = useState<string | null>(null);
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
-  const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
   const setDefaultWorkspaceEnv = useWorkspaceEnvStore((s) => s.setDefaultEnv);
   const [pendingDeleteTabs, setPendingDeleteTabs] = useState<number[] | null>(
@@ -166,33 +166,46 @@ export default function App() {
       .catch(() => setHome(null));
   }, []);
 
-  // Status-bar workspace selector — picks the env that new "+" tabs will
-  // use when no terminal tab is active. Does NOT touch existing tabs and
-  // does NOT close anything. Previous behavior (wipe-all-tabs on switch)
-  // is intentionally removed — each tab now owns its workspace.
+  // Status-bar workspace selector — picks the env that:
+  //   1. new "+" tabs spawn into (read from `defaultEnv` at click time),
+  //   2. the AI / fs / file explorer operate in (read from `env`),
+  //   3. the explorer's root reflects (we fetch the matching home so the
+  //      file tree doesn't try to load a Windows path under a WSL
+  //      workspace, which produces a malformed UNC + ERROR_INVALID_NAME).
+  //
+  // Existing terminal tabs are intentionally untouched — each tab owns
+  // its workspace and keeps running in the env it was opened with.
   const switchWorkspace = useCallback(
-    (env: WorkspaceEnv) => {
-      setDefaultWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
-    },
-    [setDefaultWorkspaceEnv],
-  );
+    async (env: WorkspaceEnv) => {
+      const normalized = env.kind === "local" ? LOCAL_WORKSPACE : env;
+      // No-op if it's already the default — avoids a needless home fetch
+      // and the alert-on-dirty-editor flow below.
+      const current = useWorkspaceEnvStore.getState().defaultEnv;
+      const same =
+        current.kind === normalized.kind &&
+        (current.kind === "local" ||
+          (normalized.kind === "wsl" &&
+            current.distro === normalized.distro));
+      if (same) return;
 
-  // Mirror the active terminal tab's workspace into the ambient store env
-  // so AI fs tools, the explorer, and other workspace-aware code follow
-  // whichever terminal the user is looking at.
-  useEffect(() => {
-    const tab = activeTerminalTab;
-    if (!tab) return;
-    const next = tab.workspace ?? LOCAL_WORKSPACE;
-    if (
-      next.kind !== workspaceEnv.kind ||
-      (next.kind === "wsl" &&
-        workspaceEnv.kind === "wsl" &&
-        next.distro !== workspaceEnv.distro)
-    ) {
-      setWorkspaceEnv(next);
-    }
-  }, [activeTerminalTab, workspaceEnv, setWorkspaceEnv]);
+      let nextHome: string | null = null;
+      try {
+        if (normalized.kind === "wsl") {
+          nextHome = await getWslHome(normalized.distro);
+        } else {
+          nextHome = (await homeDir()).replace(/\\/g, "/");
+        }
+      } catch (e) {
+        window.alert(String(e));
+        return;
+      }
+
+      setDefaultWorkspaceEnv(normalized);
+      setWorkspaceEnv(normalized);
+      setHome(nextHome);
+    },
+    [setDefaultWorkspaceEnv, setWorkspaceEnv],
+  );
 
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [newEditorOpen, setNewEditorOpen] = useState(false);
@@ -480,37 +493,36 @@ export default function App() {
     setAskPopup(null);
   }, [askFromSelection]);
 
-  // New-tab handler. If `workspace` is provided (caret picked an explicit
-  // env), use it; otherwise inherit from the active terminal tab so Ctrl-T
-  // "feels right" — a WSL tab spawns another WSL tab, a Local tab spawns
-  // another Local. Falls back to the store's defaultEnv when no terminal
-  // tab is active (e.g. user is on an editor or preview tab).
+  // New-tab handler. When the `+` caret passes an explicit `workspace`,
+  // honor it. Otherwise spawn into the user's chosen default (set via the
+  // status-bar selector, persisted across launches). The active tab's
+  // workspace is intentionally NOT used as the source — an explicit
+  // selector pick must "stick" even when focus is on a different-env tab.
   const openNewTab = useCallback(
     (workspace?: WorkspaceEnv) => {
-      const ws =
-        workspace ??
-        activeTerminalTab?.workspace ??
-        useWorkspaceEnvStore.getState().defaultEnv;
-      // Don't carry the active terminal's cwd into a new tab of a
-      // different env — Windows paths inside WSL (and vice versa) just
-      // produce ENOENT spam. Inherit only when envs match.
-      const cwd =
-        ws.kind === (activeTerminalTab?.workspace ?? LOCAL_WORKSPACE).kind &&
+      const ws = workspace ?? useWorkspaceEnvStore.getState().defaultEnv;
+      // Carry cwd only when the new tab matches the focused tab's env;
+      // Windows paths inside WSL (and vice versa) just yield ENOENT spam.
+      const activeWs = activeTerminalTab?.workspace ?? LOCAL_WORKSPACE;
+      const envsMatch =
+        ws.kind === activeWs.kind &&
         (ws.kind === "local" ||
-          (activeTerminalTab?.workspace?.kind === "wsl" &&
-            ws.distro === activeTerminalTab.workspace.distro))
-          ? inheritedCwdForNewTab()
-          : undefined;
+          (activeWs.kind === "wsl" && ws.distro === activeWs.distro));
+      const cwd = envsMatch ? inheritedCwdForNewTab() : undefined;
       newTab(cwd, ws);
     },
     [newTab, activeTerminalTab, inheritedCwdForNewTab],
   );
 
   const openNewPrivateTab = useCallback(() => {
-    const ws =
-      activeTerminalTab?.workspace ??
-      useWorkspaceEnvStore.getState().defaultEnv;
-    newPrivateTab(inheritedCwdForNewTab(), ws);
+    const ws = useWorkspaceEnvStore.getState().defaultEnv;
+    const activeWs = activeTerminalTab?.workspace ?? LOCAL_WORKSPACE;
+    const envsMatch =
+      ws.kind === activeWs.kind &&
+      (ws.kind === "local" ||
+        (activeWs.kind === "wsl" && ws.distro === activeWs.distro));
+    const cwd = envsMatch ? inheritedCwdForNewTab() : undefined;
+    newPrivateTab(cwd, ws);
   }, [newPrivateTab, activeTerminalTab, inheritedCwdForNewTab]);
 
   const sendCd = useCallback(
@@ -963,6 +975,7 @@ export default function App() {
             home={home}
             onCd={sendCd}
             onWorkspaceChange={switchWorkspace}
+            activeTerminalWorkspace={activeTerminalTab?.workspace}
             onOpenMini={openMini}
             hasComposer={hasComposer}
             privateActive={

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/modules/shortcuts/shortcuts";
 import type { Tab } from "@/modules/tabs";
 import { TabBar } from "@/modules/tabs";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import {
   GridViewIcon,
   KeyboardIcon,
@@ -35,7 +36,7 @@ type Props = {
   tabs: Tab[];
   activeId: number;
   onSelect: (id: number) => void;
-  onNew: () => void;
+  onNew: (workspace?: WorkspaceEnv) => void;
   onNewPrivate: () => void;
   onNewPreview: () => void;
   onNewEditor: () => void;

--- a/src/modules/statusbar/StatusBar.tsx
+++ b/src/modules/statusbar/StatusBar.tsx
@@ -21,6 +21,12 @@ type Props = {
   home: string | null;
   onCd: (path: string) => void;
   onWorkspaceChange: (env: WorkspaceEnv) => void;
+  /**
+   * Workspace of the currently focused terminal tab — used by the
+   * selector label so the user sees what the focused terminal is
+   * actually running in (distinct from the AI/explorer ambient env).
+   */
+  activeTerminalWorkspace?: WorkspaceEnv;
   onOpenMini: () => void;
   /** Only rendered when the AI panel is open and a key is loaded. */
   hasComposer: boolean;
@@ -33,6 +39,7 @@ export function StatusBar({
   home,
   onCd,
   onWorkspaceChange,
+  activeTerminalWorkspace,
   onOpenMini,
   hasComposer,
   privateActive,
@@ -43,7 +50,10 @@ export function StatusBar({
   return (
     <footer className="flex h-8 shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-card/60 px-3 text-[11px]">
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <WorkspaceEnvSelector onSelect={onWorkspaceChange} />
+        <WorkspaceEnvSelector
+          onSelect={onWorkspaceChange}
+          activeTerminalWorkspace={activeTerminalWorkspace}
+        />
         <CwdBreadcrumb cwd={cwd} filePath={filePath} home={home} onCd={onCd} />
         {privateActive ? (
           <Tooltip>

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -16,21 +16,33 @@ import { HugeiconsIcon } from "@hugeicons/react";
 
 type Props = {
   /**
-   * Picked env to use as the seed for new `+` tabs. Does NOT close or
-   * re-spawn any existing terminal — every existing tab keeps running in
-   * the env it was opened with.
+   * Picked env. Becomes the seed for new `+` tabs AND the env that AI /
+   * file explorer operate in (fetches the matching home so the file
+   * tree doesn't error with ENOENT under a WSL workspace). Does NOT
+   * close or re-spawn any open terminal tab.
    */
   onSelect: (env: WorkspaceEnv) => void;
+  /**
+   * Workspace of the currently focused terminal tab — shown as the
+   * primary label so the user always sees what the focused terminal is
+   * actually running in (distinct from the AI/explorer default).
+   */
+  activeTerminalWorkspace?: WorkspaceEnv;
 };
 
-export function WorkspaceEnvSelector({ onSelect }: Props) {
+export function WorkspaceEnvSelector({
+  onSelect,
+  activeTerminalWorkspace,
+}: Props) {
   if (!IS_WINDOWS) return null;
 
-  // The label tracks the *ambient* env, which App.tsx syncs to the active
-  // terminal tab's workspace. Picking from the menu only updates the
-  // store's `defaultEnv` (seed for new tabs); it does not retroactively
-  // change tabs that are already running.
-  const env = useWorkspaceEnvStore((s) => s.env);
+  // Two distinct things to surface here:
+  //   - what the focused terminal is running in (the visible label)
+  //   - what new "+" tabs / AI / explorer will use (the "default" badge
+  //     inside the dropdown)
+  // Showing the focused tab as the label keeps the bar honest when the
+  // user is staring at a WSL pwsh prompt — they shouldn't see "Windows"
+  // up there.
   const defaultEnv = useWorkspaceEnvStore((s) => s.defaultEnv);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);
@@ -43,7 +55,9 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
     }
   };
 
-  const label = env.kind === "wsl" ? `WSL: ${env.distro}` : "Windows";
+  const labelSource = activeTerminalWorkspace ?? defaultEnv;
+  const label =
+    labelSource.kind === "wsl" ? `WSL: ${labelSource.distro}` : "Windows";
 
   const isCurrentDefault = (candidate: WorkspaceEnv): boolean =>
     candidate.kind === defaultEnv.kind &&
@@ -56,7 +70,7 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
         <button
           type="button"
           className="flex h-6 shrink-0 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:bg-accent data-[state=open]:text-foreground"
-          title={`Active terminal: ${label}. Pick to set default for new tabs.`}
+          title={`Active terminal: ${label}. Pick to set the default for new tabs and AI / file explorer.`}
         >
           <HugeiconsIcon
             icon={ServerStack03Icon}

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -15,13 +15,23 @@ import { Refresh01Icon, ServerStack03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 type Props = {
+  /**
+   * Picked env to use as the seed for new `+` tabs. Does NOT close or
+   * re-spawn any existing terminal — every existing tab keeps running in
+   * the env it was opened with.
+   */
   onSelect: (env: WorkspaceEnv) => void;
 };
 
 export function WorkspaceEnvSelector({ onSelect }: Props) {
   if (!IS_WINDOWS) return null;
 
+  // The label tracks the *ambient* env, which App.tsx syncs to the active
+  // terminal tab's workspace. Picking from the menu only updates the
+  // store's `defaultEnv` (seed for new tabs); it does not retroactively
+  // change tabs that are already running.
   const env = useWorkspaceEnvStore((s) => s.env);
+  const defaultEnv = useWorkspaceEnvStore((s) => s.defaultEnv);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);
   const error = useWorkspaceEnvStore((s) => s.error);
@@ -35,13 +45,18 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
 
   const label = env.kind === "wsl" ? `WSL: ${env.distro}` : "Windows";
 
+  const isCurrentDefault = (candidate: WorkspaceEnv): boolean =>
+    candidate.kind === defaultEnv.kind &&
+    (candidate.kind === "local" ||
+      (defaultEnv.kind === "wsl" && candidate.distro === defaultEnv.distro));
+
   return (
     <DropdownMenu onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
           className="flex h-6 shrink-0 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:bg-accent data-[state=open]:text-foreground"
-          title="Workspace environment"
+          title={`Active terminal: ${label}. Pick to set default for new tabs.`}
         >
           <HugeiconsIcon
             icon={ServerStack03Icon}
@@ -51,9 +66,15 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
           <span className="max-w-28 truncate">{label}</span>
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-48">
+      <DropdownMenuContent align="start" className="min-w-56">
+        <div className="px-2 py-1 text-[10.5px] uppercase tracking-wider text-muted-foreground">
+          Default for new tabs
+        </div>
         <DropdownMenuItem onSelect={() => onSelect(LOCAL_WORKSPACE)}>
-          Windows Local
+          <span className="flex-1">Windows Local</span>
+          {isCurrentDefault(LOCAL_WORKSPACE) ? (
+            <span className="text-[10px] text-muted-foreground">default</span>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         {distros.length === 0 ? (
@@ -65,14 +86,25 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
                 : "No WSL distros found"}
           </DropdownMenuItem>
         ) : (
-          distros.map((distro) => (
-            <DropdownMenuItem
-              key={distro.name}
-              onSelect={() => onSelect({ kind: "wsl", distro: distro.name })}
-            >
-              WSL: {distro.name}
-            </DropdownMenuItem>
-          ))
+          distros.map((distro) => {
+            const candidate: WorkspaceEnv = {
+              kind: "wsl",
+              distro: distro.name,
+            };
+            return (
+              <DropdownMenuItem
+                key={distro.name}
+                onSelect={() => onSelect(candidate)}
+              >
+                <span className="flex-1">WSL: {distro.name}</span>
+                {isCurrentDefault(candidate) ? (
+                  <span className="text-[10px] text-muted-foreground">
+                    default
+                  </span>
+                ) : null}
+              </DropdownMenuItem>
+            );
+          })
         )}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => void refreshDistros()}>

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -3,12 +3,18 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { fmtShortcut, MOD_KEY } from "@/lib/platform";
+import { fmtShortcut, IS_WINDOWS, MOD_KEY } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import {
+  useWorkspaceEnvStore,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
 import {
   Cancel01Icon,
   ComputerTerminal02Icon,
@@ -17,6 +23,7 @@ import {
   IncognitoIcon,
   PencilEdit02Icon,
   PlusSignIcon,
+  ServerStack03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef } from "react";
@@ -26,7 +33,13 @@ type Props = {
   tabs: Tab[];
   activeId: number;
   onSelect: (id: number) => void;
-  onNew: () => void;
+  /**
+   * Open a new terminal tab. `workspace` overrides the env the new tab
+   * uses (passed by the WSL-distro menu items on Windows); when omitted,
+   * the caller picks (active terminal tab's env, then the store's
+   * defaultEnv).
+   */
+  onNew: (workspace?: WorkspaceEnv) => void;
   onNewPrivate: () => void;
   onNewPreview: () => void;
   onNewEditor: () => void;
@@ -49,6 +62,17 @@ export function TabBar({
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const distros = useWorkspaceEnvStore((s) => s.distros);
+  const distrosLoading = useWorkspaceEnvStore((s) => s.loading);
+  const refreshDistros = useWorkspaceEnvStore((s) => s.refreshDistros);
+  // Fetch distros lazily the first time the user opens the new-tab menu —
+  // wsl.exe --list takes ~100ms and shouldn't run on every app launch.
+  const handleMenuOpen = (open: boolean) => {
+    if (!open) return;
+    if (IS_WINDOWS && distros.length === 0 && !distrosLoading) {
+      void refreshDistros();
+    }
+  };
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -142,7 +166,7 @@ export function TabBar({
             })}
           </TabsList>
         </Tabs>
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={handleMenuOpen}>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
@@ -153,18 +177,52 @@ export function TabBar({
               <HugeiconsIcon icon={PlusSignIcon} size={14} strokeWidth={2} />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="min-w-44">
+          <DropdownMenuContent align="start" className="min-w-56">
+            {/* Default terminal entry — picks env at call time (active tab's
+                workspace, then store defaultEnv). On non-Windows this is
+                the only terminal option since there are no WSL distros to
+                disambiguate against. */}
             <DropdownMenuItem onSelect={() => onNew()}>
               <HugeiconsIcon
                 icon={ComputerTerminal02Icon}
                 size={14}
                 strokeWidth={1.75}
               />
-              <span className="flex-1">Terminal</span>
+              <span className="flex-1">
+                {IS_WINDOWS ? "Terminal (Windows)" : "Terminal"}
+              </span>
               <span className="text-xs text-muted-foreground">
                 {fmtShortcut(MOD_KEY, "T")}
               </span>
             </DropdownMenuItem>
+            {IS_WINDOWS && (
+              <>
+                {distros.length > 0 ? (
+                  distros.map((d) => (
+                    <DropdownMenuItem
+                      key={d.name}
+                      onSelect={() =>
+                        onNew({ kind: "wsl", distro: d.name })
+                      }
+                    >
+                      <HugeiconsIcon
+                        icon={ServerStack03Icon}
+                        size={14}
+                        strokeWidth={1.75}
+                      />
+                      <span className="flex-1 truncate">WSL: {d.name}</span>
+                    </DropdownMenuItem>
+                  ))
+                ) : (
+                  <DropdownMenuLabel className="text-[11px] font-normal text-muted-foreground">
+                    {distrosLoading
+                      ? "Loading WSL distros…"
+                      : "No WSL distros found"}
+                  </DropdownMenuLabel>
+                )}
+                <DropdownMenuSeparator />
+              </>
+            )}
             <DropdownMenuItem onSelect={() => onNewPrivate()}>
               <HugeiconsIcon
                 icon={IncognitoIcon}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -11,6 +11,7 @@ import {
   type SplitDir,
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
+import { LOCAL_WORKSPACE, type WorkspaceEnv } from "@/modules/workspace";
 
 // Matches the renderer slot pool size — over this we'd evict an active leaf.
 export const MAX_PANES_PER_TAB = 4;
@@ -22,6 +23,14 @@ export type TerminalTab = {
   cwd?: string;
   paneTree: PaneNode;
   activeLeafId: number;
+  /**
+   * Workspace environment for every pane in this tab. Set at tab creation
+   * (from the `+` dropdown or inherited from the active tab). Distinct from
+   * the store's `defaultEnv`, which only seeds new tabs and does not affect
+   * existing ones. Optional so older persisted state without this field
+   * falls back to LOCAL_WORKSPACE.
+   */
+  workspace?: WorkspaceEnv;
   /** AI agent cannot read buffer / context of this terminal. */
   private?: boolean;
 };
@@ -99,48 +108,57 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         cwd: initial?.cwd,
         paneTree: { kind: "leaf", id: leafId, cwd: initial?.cwd },
         activeLeafId: leafId,
+        workspace: initial?.workspace ?? LOCAL_WORKSPACE,
       },
     ];
   });
   const [activeId, setActiveId] = useState(1);
   const nextIdRef = useRef(3);
 
-  const newTab = useCallback((cwd?: string) => {
-    const tabId = nextIdRef.current++;
-    const leafId = nextIdRef.current++;
-    setTabs((t) => [
-      ...t,
-      {
-        id: tabId,
-        kind: "terminal",
-        title: "shell",
-        cwd,
-        paneTree: { kind: "leaf", id: leafId, cwd },
-        activeLeafId: leafId,
-      },
-    ]);
-    setActiveId(tabId);
-    return tabId;
-  }, []);
+  const newTab = useCallback(
+    (cwd?: string, workspace: WorkspaceEnv = LOCAL_WORKSPACE) => {
+      const tabId = nextIdRef.current++;
+      const leafId = nextIdRef.current++;
+      setTabs((t) => [
+        ...t,
+        {
+          id: tabId,
+          kind: "terminal",
+          title: workspace.kind === "wsl" ? workspace.distro : "shell",
+          cwd,
+          paneTree: { kind: "leaf", id: leafId, cwd },
+          activeLeafId: leafId,
+          workspace,
+        },
+      ]);
+      setActiveId(tabId);
+      return tabId;
+    },
+    [],
+  );
 
-  const newPrivateTab = useCallback((cwd?: string) => {
-    const tabId = nextIdRef.current++;
-    const leafId = nextIdRef.current++;
-    setTabs((t) => [
-      ...t,
-      {
-        id: tabId,
-        kind: "terminal",
-        title: "private",
-        cwd,
-        paneTree: { kind: "leaf", id: leafId, cwd },
-        activeLeafId: leafId,
-        private: true,
-      },
-    ]);
-    setActiveId(tabId);
-    return tabId;
-  }, []);
+  const newPrivateTab = useCallback(
+    (cwd?: string, workspace: WorkspaceEnv = LOCAL_WORKSPACE) => {
+      const tabId = nextIdRef.current++;
+      const leafId = nextIdRef.current++;
+      setTabs((t) => [
+        ...t,
+        {
+          id: tabId,
+          kind: "terminal",
+          title: "private",
+          cwd,
+          paneTree: { kind: "leaf", id: leafId, cwd },
+          activeLeafId: leafId,
+          workspace,
+          private: true,
+        },
+      ]);
+      setActiveId(tabId);
+      return tabId;
+    },
+    [],
+  );
 
   /**
    * Opens a file in an editor tab.
@@ -525,28 +543,32 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return closedTab;
   }, []);
 
-  const resetWorkspace = useCallback((cwd?: string) => {
-    const tabId = nextIdRef.current++;
-    const leafId = nextIdRef.current++;
-    let toDispose: number[] = [];
-    setTabs((curr) => {
-      toDispose = curr.flatMap((t) =>
-        t.kind === "terminal" ? leafIds(t.paneTree) : [],
-      );
-      return [
-        {
-          id: tabId,
-          kind: "terminal",
-          title: "shell",
-          cwd,
-          paneTree: { kind: "leaf", id: leafId, cwd },
-          activeLeafId: leafId,
-        },
-      ];
-    });
-    setActiveId(tabId);
-    for (const lid of toDispose) disposeSession(lid);
-  }, []);
+  const resetWorkspace = useCallback(
+    (cwd?: string, workspace: WorkspaceEnv = LOCAL_WORKSPACE) => {
+      const tabId = nextIdRef.current++;
+      const leafId = nextIdRef.current++;
+      let toDispose: number[] = [];
+      setTabs((curr) => {
+        toDispose = curr.flatMap((t) =>
+          t.kind === "terminal" ? leafIds(t.paneTree) : [],
+        );
+        return [
+          {
+            id: tabId,
+            kind: "terminal",
+            title: workspace.kind === "wsl" ? workspace.distro : "shell",
+            cwd,
+            paneTree: { kind: "leaf", id: leafId, cwd },
+            activeLeafId: leafId,
+            workspace,
+          },
+        ];
+      });
+      setActiveId(tabId);
+      for (const lid of toDispose) disposeSession(lid);
+    },
+    [],
+  );
 
   return {
     tabs,

--- a/src/modules/tabs/lib/useWorkspaceCwd.ts
+++ b/src/modules/tabs/lib/useWorkspaceCwd.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import type { Tab } from "./useTabs";
 
 type Result = {
@@ -6,34 +7,75 @@ type Result = {
   inheritedCwdForNewTab: () => string | undefined;
 };
 
+/**
+ * Check whether two workspace envs reference the same shell environment.
+ * `local-local` matches; WSL only matches when the distro names line up.
+ */
+function envsMatch(a: WorkspaceEnv | undefined, b: WorkspaceEnv): boolean {
+  if (!a) return b.kind === "local"; // Tab without an env defaults to Local.
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "wsl" && b.kind === "wsl") return a.distro === b.distro;
+  return true;
+}
+
 export function useWorkspaceCwd(
   activeTab: Tab | undefined,
   tabs: Tab[],
   home: string | null,
+  /**
+   * Current ambient workspace env (== file-tree / AI tools env). Used to
+   * skip tab cwds that don't belong to this env — e.g. a Windows
+   * `C:/Users/foo` cwd is invalid as a path under a WSL workspace and
+   * produces ERROR_PATH_NOT_FOUND if we hand it to the backend's
+   * `wsl_path_to_unc`.
+   */
+  workspaceEnv: WorkspaceEnv,
 ): Result {
   const lastTerminalCwd = useRef<string | null>(null);
 
   useEffect(() => {
-    if (activeTab?.kind === "terminal" && activeTab.cwd) {
+    // Only cache the focused terminal's cwd when its env matches the
+    // ambient one. Otherwise the cached value becomes a path that's
+    // invalid under the now-current workspace.
+    if (
+      activeTab?.kind === "terminal" &&
+      activeTab.cwd &&
+      envsMatch(activeTab.workspace, workspaceEnv)
+    ) {
       lastTerminalCwd.current = activeTab.cwd;
     }
-  }, [activeTab]);
+  }, [activeTab, workspaceEnv]);
 
   const explorerRoot = useMemo<string | null>(() => {
-    if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
+    if (
+      activeTab?.kind === "terminal" &&
+      activeTab.cwd &&
+      envsMatch(activeTab.workspace, workspaceEnv)
+    )
+      return activeTab.cwd;
     if (lastTerminalCwd.current) return lastTerminalCwd.current;
-    const anyTerm = tabs.find((t) => t.kind === "terminal" && t.cwd);
+    const anyTerm = tabs.find(
+      (t) =>
+        t.kind === "terminal" &&
+        t.cwd &&
+        envsMatch(t.workspace, workspaceEnv),
+    );
     if (anyTerm?.kind === "terminal" && anyTerm.cwd) return anyTerm.cwd;
     return home;
-  }, [activeTab, tabs, home]);
+  }, [activeTab, tabs, home, workspaceEnv]);
 
   const inheritedCwdForNewTab = useCallback((): string | undefined => {
-    if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
+    if (
+      activeTab?.kind === "terminal" &&
+      activeTab.cwd &&
+      envsMatch(activeTab.workspace, workspaceEnv)
+    )
+      return activeTab.cwd;
     // Editor tabs inherit the last terminal's cwd (or workspace home), not
     // the file's folder — opening a new terminal from a file shouldn't
     // hijack the user's working directory context.
     return lastTerminalCwd.current ?? home ?? undefined;
-  }, [activeTab, home]);
+  }, [activeTab, home, workspaceEnv]);
 
   return { explorerRoot, inheritedCwdForNewTab };
 }

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -5,6 +5,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { SearchAddon } from "@xterm/addon-search";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 import type { PaneNode } from "./lib/panes";
 
@@ -19,6 +20,8 @@ type Props = {
   node: PaneNode;
   tabVisible: boolean;
   activeLeafId: number;
+  /** Workspace env shared by every leaf inside this tab. */
+  workspace?: WorkspaceEnv;
   onFocusLeaf: (leafId: number) => void;
   getBundle: (leafId: number) => LeafBundle;
 };
@@ -27,6 +30,7 @@ export function PaneTreeView({
   node,
   tabVisible,
   activeLeafId,
+  workspace,
   onFocusLeaf,
   getBundle,
 }: Props) {
@@ -51,6 +55,7 @@ export function PaneTreeView({
           visible={tabVisible}
           focused={focused}
           initialCwd={node.cwd}
+          workspace={workspace}
           ref={b.setRef}
           onSearchReady={(_id, addon) => b.onSearch(addon)}
           onCwd={(_id, cwd) => b.onCwd(cwd)}
@@ -72,6 +77,7 @@ export function PaneTreeView({
               node={child}
               tabVisible={tabVisible}
               activeLeafId={activeLeafId}
+              workspace={workspace}
               onFocusLeaf={onFocusLeaf}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@/modules/theme";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import type { SearchAddon } from "@xterm/addon-search";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { useTerminalSession } from "./lib/useTerminalSession";
@@ -18,6 +19,8 @@ type Props = {
   /** This leaf is the active pane within its tab — receives auto-focus. */
   focused?: boolean;
   initialCwd?: string;
+  /** Per-tab workspace env (Local or WSL distro). Locked at first mount. */
+  workspace?: WorkspaceEnv;
   onSearchReady?: (leafId: number, addon: SearchAddon) => void;
   onExit?: (leafId: number, code: number) => void;
   onCwd?: (leafId: number, cwd: string) => void;
@@ -30,6 +33,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       visible,
       focused = true,
       initialCwd,
+      workspace,
       onSearchReady,
       onExit,
       onCwd,
@@ -45,6 +49,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       visible,
       focused,
       initialCwd,
+      workspace,
       onSearchReady: (a) => onSearchReady?.(leafId, a),
       onExit: (c) => onExit?.(leafId, c),
       onCwd: (c) => onCwd?.(leafId, c),

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -95,6 +95,7 @@ export function TerminalStack({
               node={t.paneTree}
               tabVisible={tabVisible}
               activeLeafId={t.activeLeafId}
+              workspace={t.kind === "terminal" ? t.workspace : undefined}
               onFocusLeaf={(leafId) => onFocusLeaf(t.id, leafId)}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -1,5 +1,5 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import { currentWorkspaceEnv, type WorkspaceEnv } from "@/modules/workspace";
 
 export type PtyHandlers = {
   onData: (bytes: Uint8Array) => void;
@@ -18,6 +18,7 @@ export async function openPty(
   rows: number,
   handlers: PtyHandlers,
   cwd?: string,
+  workspace?: WorkspaceEnv,
 ): Promise<PtySession> {
   // Raw bytes — no base64/JSON round-trip; messages arrive as ArrayBuffer.
   const onData = new Channel<ArrayBuffer>();
@@ -42,7 +43,10 @@ export async function openPty(
     cols,
     rows,
     cwd: cwd ?? null,
-    workspace: currentWorkspaceEnv(),
+    // Per-tab workspace if the caller specified one; otherwise fall back to
+    // the ambient default. New code paths always pass the tab's workspace —
+    // the fallback is only there to keep older non-tab callers working.
+    workspace: workspace ?? currentWorkspaceEnv(),
     onData,
     onExit,
   });

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { DormantRing } from "./dormantRing";
 import { registerCwdHandler, registerPromptTracker } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import {
   acquireSlot,
   applyFontSize,
@@ -28,6 +29,7 @@ type Session = {
   pty: PtySession | null;
   ptyOpening: boolean;
   initialCwd: string | undefined;
+  workspace: WorkspaceEnv | undefined;
   lastCwd: string | null;
   pendingExit: number | null;
   shellExited: boolean;
@@ -73,7 +75,11 @@ configureRendererPool({
   },
 });
 
-function ensureSession(leafId: number, initialCwd?: string): Session {
+function ensureSession(
+  leafId: number,
+  initialCwd?: string,
+  workspace?: WorkspaceEnv,
+): Session {
   const existing = sessions.get(leafId);
   if (existing) return existing;
 
@@ -81,6 +87,7 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     pty: null,
     ptyOpening: false,
     initialCwd,
+    workspace,
     lastCwd: null,
     pendingExit: null,
     shellExited: false,
@@ -137,6 +144,7 @@ async function openPtyForSession(
       },
     },
     cwd,
+    s.workspace,
   );
 }
 
@@ -281,6 +289,10 @@ type Options = {
   visible: boolean;
   focused?: boolean;
   initialCwd?: string;
+  /** Workspace env for the PTY this leaf will spawn. Locked at session
+   *  creation; switching the tab to a different env is not a concept — open
+   *  a new tab instead. */
+  workspace?: WorkspaceEnv;
   onSearchReady?: (addon: SearchAddon) => void;
   onExit?: (code: number) => void;
   onCwd?: (cwd: string) => void;
@@ -292,6 +304,7 @@ export function useTerminalSession({
   visible,
   focused = true,
   initialCwd,
+  workspace,
   onSearchReady,
   onExit,
   onCwd,
@@ -301,7 +314,7 @@ export function useTerminalSession({
 
   useEffect(() => {
     let cancelled = false;
-    const s = ensureSession(leafId, initialCwd);
+    const s = ensureSession(leafId, initialCwd, workspace);
     s.ready.then(() => {
       if (cancelled || s.disposed) return;
       const node = container.current;

--- a/src/modules/workspace/env.ts
+++ b/src/modules/workspace/env.ts
@@ -13,11 +13,25 @@ export type WslDistro = {
 };
 
 type State = {
+  /**
+   * Ambient workspace env — read by every fs / shell / AI tool call.
+   * Auto-synced by App.tsx to the active terminal tab's workspace so the
+   * AI agent operates in the same env the user is looking at. Falls back
+   * to {@link defaultEnv} when the active tab is not a terminal.
+   */
   env: WorkspaceEnv;
+  /**
+   * Env applied to brand-new tabs when no terminal tab is active (or as
+   * the seed on first launch). Set by the status-bar selector and the
+   * `+` button's caret dropdown; persisted across launches (last WSL
+   * distro is restored on next start).
+   */
+  defaultEnv: WorkspaceEnv;
   distros: WslDistro[];
   loading: boolean;
   error: string | null;
   setEnv: (env: WorkspaceEnv) => void;
+  setDefaultEnv: (env: WorkspaceEnv) => void;
   refreshDistros: () => Promise<WslDistro[]>;
 };
 
@@ -25,11 +39,16 @@ export const LOCAL_WORKSPACE: WorkspaceEnv = { kind: "local" };
 
 export const useWorkspaceEnvStore = create<State>((set) => ({
   env: LOCAL_WORKSPACE,
+  defaultEnv: LOCAL_WORKSPACE,
   distros: [],
   loading: false,
   error: null,
-  setEnv: (env) => {
-    set({ env });
+  // Ambient setter — no persistence. Called by App.tsx whenever the active
+  // tab changes so AI / fs / explorer read the right env.
+  setEnv: (env) => set({ env }),
+  // User-chosen default for new tabs. Persisted across launches.
+  setDefaultEnv: (env) => {
+    set({ defaultEnv: env });
     if (env.kind === "wsl") void setLastWslDistro(env.distro);
   },
   refreshDistros: async () => {


### PR DESCRIPTION
## What

Each terminal tab carries its own `workspace` env so Windows users can have a PowerShell tab and a `WSL: <distro>` tab open side-by-side instead of one or the other. The `+` button gets a per-env spawn dropdown (one entry per installed WSL distro), the status-bar selector becomes a default-picker instead of a wipe-all switch, and the file explorer auto-follows the focused tab's env.

## Why

Refs #224 (multi-terminal + WSL support — delivers the WSL portion), refs #168 (new tabs now inherit the focused terminal's cwd when envs match).

Before this change, picking a workspace from the status-bar selector disposed every PTY session, cleared every ref map, and reset the tab list to a single new terminal — making it impossible to keep a PowerShell tab and a WSL tab open at the same time, and silently throwing away anything the user was running.

## How

- `TerminalTab` gains `workspace: WorkspaceEnv`. Locked at spawn; threaded through `useTabs.newTab` / `newPrivateTab`, `useTerminalSession`, `pty-bridge.openPty`, into the existing `pty_open` invoke (Rust side already accepted `workspace`; it was just being read from a global).
- `TabBar`'s `+` dropdown lazily fetches WSL distros on first open and lists "Terminal (Windows)" plus `WSL: <name>` per installed distro.
- `useWorkspaceEnvStore` splits into `env` (ambient — what AI / fs / explorer read) and `defaultEnv` (seed for new `+` tabs; persisted across launches as `lastWslDistro`).
- Status-bar selector picks `defaultEnv` AND calls `applyAmbientEnv`, which also fetches the matching `home` so the explorer doesn't try to read a Windows path under a WSL workspace (yields `ERROR_INVALID_NAME`).
- An effect in `App.tsx` syncs ambient env to the focused terminal tab's workspace on focus changes — deps deliberately exclude `env` itself so a fresh selector pick doesn't immediately get clobbered by the same effect.
- `useWorkspaceCwd` falls back to `home` when the focused tab's cwd doesn't belong to the ambient env (defensive guard against malformed cross-env paths during transition frames).
- `wsl_path_to_unc` short-circuits `/mnt/<drive>` to native Windows (`C:\…`) — round-tripping drvfs through `\wsl.localhost\<distro>\mnt\…` produces `ERROR_ACCESS_DENIED` on directory enumeration, so the explorer failed the moment a user `cd /mnt/c` in a WSL tab.
- Bash integration script appends `_terax_precmd` to `PROMPT_COMMAND` (instead of prepending) AND self-reinstalls from inside `_terax_precmd`, surviving Kali's stock `.bashrc` clobber (`PROMPT_COMMAND="PROMPT_COMMAND=echo"` on line 104) that otherwise wipes our hook after the first prompt and silently breaks cwd tracking.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` clean
- [x] `cargo clippy --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean on touched files (`workspace.rs`)
- [x] `cargo test workspace::tests` — 3 new tests cover the drvfs short-circuit (`/mnt/<letter>` → `<LETTER>:\`), non-drvfs passthrough (`/home/…`, `/etc/…` stay on UNC), rejection of multi-char mounts (`/mnt/wsl`, `/mnt/wslg`), and the full `wsl_path_to_unc` integration.
- [x] End-to-end manual verification on Windows 11 + WSL2 with Debian and Kali Rolling 2026.1 side-by-side: open PowerShell + Debian + Kali tabs simultaneously; switch focus updates the status-bar label and explorer; `cd /mnt/c` in either WSL distro lists the `C:\` root; `cd ~` / `cd /etc` switch back to the WSL filesystem; status-bar selector picks "Windows Local" without disposing the WSL tabs.

## Notes for reviewer

- Two state fields (`env`, `defaultEnv`) in the workspace store are intentional: ambient drives fs/AI ops; default is the new-tab seed. They can diverge briefly when the user explicitly picks a default that differs from the focused tab — by design.
- The Kali bash-hook fix (commit 4 of 5) becomes less load-bearing if #331 ("fix(pty): support default WSL shells") lands — that PR would let Kali use its actual user shell (zsh in 2026.1) instead of bash, avoiding the clobber entirely.
- No vitest tests added: this repo doesn't have vitest infra on `main` yet, and the per-tab logic is mostly UI plumbing. Cargo coverage is the one place a regression would be silent (drvfs mapping math), so that's where the tests live.