### PR TITLE
fix(editor): apply selected editor theme (#32)

### DIFF
--- a/src/modules/editor/lib/extensions.ts
+++ b/src/modules/editor/lib/extensions.ts
@@ -15,6 +15,13 @@ export const vimCompartment = new Compartment();
 // basicSetup gives us line numbers, fold gutter, history, indentOnInput,
 // bracketMatching, closeBrackets, autocompletion, highlightActiveLine,
 // highlightSelectionMatches and the search keymap.
+//
+// Color choices (background, foreground, caret, selection, gutter, active
+// line) intentionally live on the editor theme extension — see EDITOR_THEMES
+// in modules/settings/store and the @uiw/codemirror-theme-* packages. Putting
+// color overrides here would silently win over the user-picked theme because
+// react-codemirror concatenates user extensions after the `theme` prop, and
+// the last extension wins on CSS rules with the same selector (#32).
 export function buildSharedExtensions(): Extension[] {
   return [
     indentUnit.of("  "),
@@ -23,8 +30,6 @@ export function buildSharedExtensions(): Extension[] {
     lintGutter(),
     EditorView.theme({
       "&, &.cm-editor, &.cm-editor.cm-focused": {
-        backgroundColor: "transparent !important",
-        color: "var(--foreground)",
         outline: "none",
         padding: "8px",
       },
@@ -32,43 +37,17 @@ export function buildSharedExtensions(): Extension[] {
         fontFamily: detectMonoFontFamily(),
         fontSize: "13px",
         lineHeight: "1.55",
-        backgroundColor: "transparent !important",
-      },
-      ".cm-content": {
-        caretColor: "var(--foreground)",
-        backgroundColor: "transparent !important",
-      },
-      ".cm-gutters": {
-        backgroundColor: "transparent !important",
-        color: "var(--muted-foreground)",
       },
       ".cm-gutter-lint": {
         width: "0px",
       },
-      ".cm-gutter": { backgroundColor: "transparent !important" },
-      ".cm-lineNumbers .cm-gutterElement": {
-        opacity: "0.55",
-      },
       ".cm-foldGutter": { width: "10px" },
-      ".cm-foldGutter .cm-gutterElement": {
-        color: "var(--muted-foreground)",
-        opacity: "0.5",
-      },
-      ".cm-activeLine": {
-        borderTopRightRadius: "5px",
-        borderBottomRightRadius: "5px",
-        backgroundColor:
-          "color-mix(in srgb, var(--foreground) 4%, transparent)",
-      },
       ".cm-lineNumbers .cm-activeLineGutter": {
-        borderTopLeftRadius: "5px",
-        borderBottomLeftRadius: "5px",
         userSelect: "none",
       },
-      ".cm-cursor, .cm-dropCursor": {
-        borderLeftColor: "var(--foreground)",
-      },
       // Vim normal-mode block cursor — translucent foreground, no rose hue.
+      // Keyed to app color tokens because Vim mode is an app-level feature,
+      // not a per-theme one.
       ".cm-fat-cursor": {
         background:
           "color-mix(in srgb, var(--foreground) 35%, transparent) !important",
@@ -81,11 +60,8 @@ export function buildSharedExtensions(): Extension[] {
         outline:
           "1px solid color-mix(in srgb, var(--foreground) 35%, transparent) !important",
       },
-      ".cm-selectionBackground, &.cm-focused .cm-selectionBackground, ::selection":
-        {
-          backgroundColor:
-            "color-mix(in srgb, var(--foreground) 18%, transparent) !important",
-        },
+      // Search panel is an app UI surface — keep it matched to the app
+      // chrome regardless of the editor theme.
       ".cm-panels": {
         backgroundColor: "var(--popover)",
         color: "var(--popover-foreground)",


### PR DESCRIPTION
## Summary
Fixes #32. The editor theme dropdown saved the picked value and the CodeMirror view reconfigured, but every visible color was still pinned to the app's CSS variables — so picking Nord, GitHub Light, Xcode Dark, etc. looked like a no-op.

`buildSharedExtensions` was setting `backgroundColor: transparent !important`, `color: var(--foreground)`, and matching overrides on `.cm-content`, `.cm-gutters`, `.cm-cursor`, the active line, and the selection layer. Because `@uiw/react-codemirror` concatenates the user-extensions array **after** the `theme` prop, the shared layer always won over whatever editor theme the user picked.

This drop removes the color rules from the shared layer and lets the chosen editor theme paint its own background, foreground, gutter, caret, selection, and active-line colors. App-level concerns are kept:

- font family / size / line-height
- editor padding
- gutter widths (`.cm-gutter-lint`, `.cm-foldGutter`)
- `user-select: none` on the active line gutter
- the vim fat-cursor style (vim mode is app-level, not theme-level)
- the search panel chrome (`.cm-panels` → `var(--popover)` — matches the app surface)

A comment is added so the trap doesn't get re-introduced.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 35/35 pass
- [x] Manually verified in `pnpm tauri dev` on Windows 11: cycled Atom One → GitHub Light → Nord → Xcode Dark with a `.ts` file open; editor background, gutter, line numbers, caret, and selection all change visibly per theme
- [x] Search panel still matches app chrome (popover-colored, not editor-themed)
- [x] Vim fat cursor still translucent / app-colored