### PR TITLE
fix(pty): capture launch cwd, prefer it over $HOME for new terminals (#168)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,6 +61,10 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Snapshot the launch cwd before anything has a chance to chdir away —
+    // see #168 and modules::pty::shell_init::LAUNCH_CWD.
+    pty::shell_init::init_launch_cwd();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -1,8 +1,59 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use portable_pty::CommandBuilder;
 
 use crate::modules::workspace::WorkspaceEnv;
+
+// Directory Terax was launched from, captured exactly once at startup.
+//
+// `apply_common` used to fall back to live `std::env::current_dir()`, which
+// works in `tauri dev` (the dev runner cd's into the repo before exec) but
+// is fragile in the long run: the process cwd can drift later in a session
+// (file dialogs, plugin code, IPC handlers), and on macOS a Finder/dock
+// launch leaves cwd inside the `.app` bundle, which is a hostile place to
+// drop the user.
+//
+// We snapshot the launch cwd once here, filter out obviously useless values
+// (filesystem roots, macOS app bundle paths), and put the captured value
+// ahead of `home_dir()` in the resolution chain. See #168.
+static LAUNCH_CWD: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Capture the process cwd at app startup. Idempotent.
+pub fn init_launch_cwd() {
+    LAUNCH_CWD.set(detect_launch_cwd()).ok();
+}
+
+fn detect_launch_cwd() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    if is_uninteresting_launch_cwd(&cwd) {
+        return None;
+    }
+    Some(cwd)
+}
+
+// "Uninteresting" launch cwds are places we'd rather fall through to $HOME
+// than open a terminal in. Kept narrow — over-filtering steals legitimate
+// launch directories.
+fn is_uninteresting_launch_cwd(p: &Path) -> bool {
+    // Filesystem roots: `/` on unix, drive root like `C:\` on Windows.
+    if p.parent().is_none() {
+        return true;
+    }
+    // macOS .app bundle launch (Finder/dock): cwd is something like
+    // `/Applications/Terax.app/Contents/MacOS`.
+    if cfg!(target_os = "macos") {
+        let s = p.to_string_lossy();
+        if s.contains(".app/Contents/MacOS") {
+            return true;
+        }
+    }
+    false
+}
+
+fn launch_cwd() -> Option<PathBuf> {
+    LAUNCH_CWD.get().and_then(|o| o.clone())
+}
 
 #[cfg(windows)]
 const BASHRC_SCRIPT: &str = include_str!("scripts/bashrc.bash");
@@ -53,13 +104,17 @@ fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
     cmd.env("TERAX_TERMINAL", "1");
     ensure_utf8_locale(cmd);
 
+    // Resolution order (see LAUNCH_CWD doc for context):
+    //   1. explicit cwd from the frontend (active workspace, OSC 7, etc.)
+    //   2. captured launch cwd, so `terax ~/proj` opens new terminals there
+    //   3. $HOME as the safe fallback for GUI / .app-bundle launches
+    //   4. live current_dir as a last resort
     let resolved_cwd = cwd
         .map(PathBuf::from)
         .filter(|p| p.is_dir())
-        // In `tauri dev`, inherit the repo cwd so explorer/source-control
-        // point at the project the user launched from instead of `$HOME`.
-        .or_else(|| std::env::current_dir().ok().filter(|p| p.is_dir()))
-        .or_else(|| dirs::home_dir().filter(|p| p.is_dir()));
+        .or_else(|| launch_cwd().filter(|p| p.is_dir()))
+        .or_else(|| dirs::home_dir().filter(|p| p.is_dir()))
+        .or_else(|| std::env::current_dir().ok());
     if let Some(cwd) = resolved_cwd {
         #[cfg(windows)]
         let cwd = PathBuf::from(cwd.to_string_lossy().replace('/', "\\"));
@@ -401,4 +456,53 @@ fn which_in_path(name: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_uninteresting_launch_cwd;
+    use std::path::Path;
+
+    #[test]
+    fn filesystem_root_is_uninteresting() {
+        #[cfg(unix)]
+        assert!(is_uninteresting_launch_cwd(Path::new("/")));
+        #[cfg(windows)]
+        assert!(is_uninteresting_launch_cwd(Path::new(r"C:\")));
+    }
+
+    #[test]
+    fn normal_directories_are_interesting() {
+        #[cfg(unix)]
+        {
+            assert!(!is_uninteresting_launch_cwd(Path::new("/home/user")));
+            assert!(!is_uninteresting_launch_cwd(Path::new(
+                "/home/user/projects/foo"
+            )));
+            assert!(!is_uninteresting_launch_cwd(Path::new("/tmp")));
+        }
+        #[cfg(windows)]
+        {
+            assert!(!is_uninteresting_launch_cwd(Path::new(r"C:\Users\user")));
+            assert!(!is_uninteresting_launch_cwd(Path::new(
+                r"C:\Users\user\projects\foo"
+            )));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_app_bundle_is_uninteresting() {
+        assert!(is_uninteresting_launch_cwd(Path::new(
+            "/Applications/Terax.app/Contents/MacOS"
+        )));
+        assert!(is_uninteresting_launch_cwd(Path::new(
+            "/Users/me/Applications/Terax.app/Contents/MacOS"
+        )));
+        // A path that mentions .app but isn't the MacOS bundle dir
+        // should still be considered interesting.
+        assert!(!is_uninteresting_launch_cwd(Path::new(
+            "/Users/me/projects/my.app"
+        )));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #168. New terminals were opening in `$HOME` instead of the directory the user ran `terax` from. The reporter (and a contributor follow-up) had already pinpointed `src-tauri/src/modules/pty/shell_init.rs:apply_common` — the chain preferred `home_dir()` over `current_dir()`, so `terax ~/projects/foo` always landed new terminals in `~`.

`main` has since been adjusted to prefer `std::env::current_dir()` inline, which fixes the dev loop but is fragile in the long run:

- The process cwd can drift later in a session (file dialogs, plugin code, IPC handlers), so a terminal opened five minutes in can end up wherever the process happened to be left.
- A Finder / dock launch on macOS leaves `cwd` inside `/Applications/Terax.app/Contents/MacOS`, which is a hostile place to drop the user.

This PR snapshots the launch cwd exactly once at app startup (`OnceLock<Option<PathBuf>>`), filters out obviously useless values, and puts the captured value ahead of `home_dir()` in the resolution chain.

### New resolution order
1. explicit cwd from the frontend (active workspace, OSC 7, etc.)
2. **captured launch cwd** ← new
3. `home_dir()` — safe fallback for GUI / `.app`-bundle launches
4. live `current_dir()` — defensive last resort

### Filtered "uninteresting" launch cwds (fall through to `$HOME`)
- Filesystem roots (`/` on unix, drive root like `C:\` on Windows)
- macOS `.app` bundle `Contents/MacOS` paths (Finder / dock launches)

Filter kept deliberately narrow — over-filtering would steal legitimate launch directories.

## Test plan
- [x] `cargo check --no-default-features` clean
- [x] `cargo test --no-default-features shell_init` — 2 passed (filter behaves on unix + windows, macOS branch unit-tested behind `cfg(target_os = "macos")`)
- [x] Manually verified in `pnpm tauri dev` on Windows: dev log changed from `pty cwd: C:\Users\su1ph` (pre-fix) to `pty cwd: C:\Users\su1ph\Github\terax-ai\src-tauri` (post-fix — the directory cargo launches `terax.exe` from)

## Closes
#168