### PR TITLE
fix(explorer): keep file tree static across InlineInput open/cancel cycles (#123)

### DIFF
--- a/src/modules/explorer/InlineInput.tsx
+++ b/src/modules/explorer/InlineInput.tsx
@@ -31,8 +31,15 @@ export function InlineInput({
     // tick lands we treat the input as "unsettled" — any blur during that
     // window is the portal teardown stealing focus, not the user dismissing
     // the input, so we refocus instead of committing an empty value.
+    //
+    // preventScroll matters here (#123): the input mounts inside the
+    // sidebar's flex column, which is small enough that focus-scroll can
+    // nudge the parent's scroll position by a fraction of a pixel each
+    // cycle. Repeated open/cancel pairs accumulate and walk the tree off
+    // the left edge. We're already rendering the input where it should be
+    // visible — there is no scroll-into-view we need from focus().
     const focus = () => {
-      el.focus({ preventScroll: false });
+      el.focus({ preventScroll: true });
       const dot = initial.lastIndexOf(".");
       if (dot > 0) el.setSelectionRange(0, dot);
       else el.select();


### PR DESCRIPTION
## Summary
Fixes #123. The new-file / new-folder \`InlineInput\` calls \`el.focus({ preventScroll: false })\` in its mount effect — three times across the two-tick focus sequence used to win against parent click handlers and Radix portal focus restorations.

Browsers honor \`preventScroll: false\` by attempting to bring the focused element into view. The input mounts inside the sidebar's narrow flex column, and even with \`overflow-x: hidden\` on the list container the focus-into-view pass can nudge ancestor scroll positions by a fraction of a pixel. Each open/cancel cycle accumulates and, after a few repetitions, the entire tree has walked off the left edge of the sidebar.

The input is already rendered where it should be visible — there's no scroll-into-view we actually want from \`focus()\`. Switching the three focus calls to \`preventScroll: true\` stops the cumulative drift. The unrelated \`onBlur\` refocus path already passes \`preventScroll: true\`, so the component now never asks the browser to scroll on its behalf.

(Note: the original issue speculated about Radix \`ScrollArea\` — turns out the explorer is a plain \`<div>\`, not a \`ScrollArea\`. The root cause is the focus-scroll behavior described above.)

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] Manually verified on Windows in \`pnpm tauri dev\`: opened the sidebar Explorer, clicked the **New File** button + pressed **Escape** repeatedly. Before the fix the tree shifted left a few pixels each cycle (as in the screenshot in the issue); after the fix it stays put across 10+ cycles. Same behavior for **New Folder**.

## Closes
#123