### PR TITLE
Add Sobrio and Vesper themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Terax is a fast, lightweight AI terminal (ADE) built on Tauri 2 + Rust and React
 - CodeMirror 6 with language support for TS/JS, Rust, Python, HTML/CSS, JSON, Markdown
 - Inline AI autocomplete and AI edit diffs
 - Vim mode
-- Prebuilt themes: Tokyo Night, Nord, GitHub, Atom One, Aura, Copilot, Xcode
+- Prebuilt themes: Tokyo Night, Nord, GitHub, Atom One, Aura, Copilot, Sobrio, Vesper, Xcode
 
 **File Explorer**
 - Catppuccin icon theme (Material Icon Theme resolver)

--- a/TERAX.md
+++ b/TERAX.md
@@ -53,7 +53,7 @@ Single-window React app. Path alias `@/*` → `src/*`. Tabs are tagged-union (`{
 Each module is self-contained, exports a thin barrel via `index.ts`, and owns its hooks under `lib/`.
 
 - **terminal/** — `TerminalStack` keeps one mounted xterm per tab via `useTerminalSession` + `pty-bridge`. `osc-handlers.ts` parses OSC 7 (with Windows drive-letter normalization: `/C:/Users/foo` → `C:/Users/foo`) and OSC 133 markers. Themes in `themes.ts`.
-- **editor/** — CodeMirror 6 stack (`EditorStack` mirrors `TerminalStack`). `extensions.ts` configures language modes; supports vim mode and prebuilt themes (Tokyo Night, Nord, GitHub, Atom One, Aura, Copilot, Xcode).
+- **editor/** — CodeMirror 6 stack (`EditorStack` mirrors `TerminalStack`). `extensions.ts` configures language modes; supports vim mode and prebuilt themes (Tokyo Night, Nord, GitHub, Atom One, Aura, Copilot, Sobrio, Vesper, Xcode).
 - **explorer/** — file tree with Material/Catppuccin icons (`iconResolver.ts`), fuzzy search, keyboard nav, inline rename, context actions. Backslash-aware `basename`.
 - **preview/** — auto-detected dev-server preview tab (status-bar pill suggests opening when a localhost URL is detected).
 - **tabs/** — `useTabs` is the source of truth for tab list + active id. `useWorkspaceCwd` derives explorer root + inherited cwd for new tabs from active tab. `basename` splits on both `/` and `\`.

--- a/src/modules/editor/lib/themes.test.ts
+++ b/src/modules/editor/lib/themes.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { EDITOR_THEME_EXT } from "./themes";
+
+describe("editor themes", () => {
+  it("registers Vesper as a CodeMirror theme extension", () => {
+    expect(EDITOR_THEME_EXT.vesper).toBeDefined();
+  });
+
+  it("registers Sobrio as a CodeMirror theme extension", () => {
+    expect(EDITOR_THEME_EXT).toHaveProperty("sobrio");
+  });
+});

--- a/src/modules/editor/lib/themes.ts
+++ b/src/modules/editor/lib/themes.ts
@@ -5,8 +5,74 @@ import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
 import { nord } from "@uiw/codemirror-theme-nord";
 import { tokyoNight } from "@uiw/codemirror-theme-tokyo-night";
 import { xcodeDark, xcodeLight } from "@uiw/codemirror-theme-xcode";
+import { createTheme } from "@uiw/codemirror-themes";
 import type { Extension } from "@codemirror/state";
+import { tags as t } from "@lezer/highlight";
 import type { EditorThemeId } from "@/modules/settings/store";
+
+const vesper = createTheme({
+  theme: "dark",
+  settings: {
+    background: "#101010",
+    foreground: "#FFFFFF",
+    caret: "#FFFFFF",
+    selection: "#FFFFFF25",
+    selectionMatch: "#FFFFFF25",
+    gutterBackground: "#101010",
+    gutterForeground: "#505050",
+    gutterActiveForeground: "#FFFFFF",
+    gutterBorder: "transparent",
+    lineHighlight: "#28282880",
+  },
+  styles: [
+    { tag: [t.comment, t.lineComment, t.blockComment], color: "#8b8b8b94" },
+    { tag: [t.keyword, t.operatorKeyword, t.modifier, t.atom], color: "#A0A0A0" },
+    { tag: [t.operator, t.punctuation, t.separator, t.bracket], color: "#A0A0A0" },
+    { tag: [t.string, t.special(t.string), t.regexp], color: "#99FFE4" },
+    { tag: [t.number, t.bool, t.null, t.character, t.constant(t.name)], color: "#FFC799" },
+    { tag: [t.function(t.variableName), t.function(t.propertyName), t.definition(t.function(t.variableName))], color: "#FFC799" },
+    { tag: [t.className, t.typeName, t.namespace, t.labelName], color: "#FFC799" },
+    { tag: [t.tagName, t.heading], color: "#FFC799" },
+    { tag: [t.attributeName, t.propertyName], color: "#A0A0A0" },
+    { tag: [t.variableName, t.self, t.definition(t.variableName)], color: "#FFFFFF" },
+    { tag: t.invalid, color: "#FF8080" },
+    { tag: t.link, color: "#FFC799", textDecoration: "underline" },
+    { tag: t.emphasis, color: "#FFFFFF", fontStyle: "italic" },
+    { tag: t.strong, color: "#FFFFFF", fontWeight: "700" },
+  ],
+});
+
+const sobrio = createTheme({
+  theme: "dark",
+  settings: {
+    background: "#121212",
+    foreground: "#FFFFFF",
+    caret: "#FFFFFF",
+    selection: "#4E4E4E",
+    selectionMatch: "#4E4E4E80",
+    gutterBackground: "#121212",
+    gutterForeground: "#333333",
+    gutterActiveForeground: "#AFAFAF",
+    gutterBorder: "transparent",
+    lineHighlight: "#181818",
+  },
+  styles: [
+    { tag: [t.comment, t.lineComment, t.blockComment], color: "#3A3B3F", fontStyle: "italic" },
+    { tag: [t.keyword, t.operatorKeyword, t.modifier, t.atom], color: "#FD6389", fontStyle: "italic" },
+    { tag: [t.operator, t.punctuation, t.separator, t.bracket], color: "#FD6389" },
+    { tag: [t.string, t.special(t.string), t.regexp], color: "#87AFD7" },
+    { tag: [t.number, t.bool, t.null, t.character, t.constant(t.name)], color: "#D7D7FF" },
+    { tag: [t.function(t.variableName), t.function(t.propertyName), t.definition(t.function(t.variableName))], color: "#FFFFFF", fontWeight: "700" },
+    { tag: [t.className, t.typeName, t.namespace, t.labelName], color: "#AFAFAF", fontStyle: "italic" },
+    { tag: [t.tagName, t.heading], color: "#FD6389", fontWeight: "700" },
+    { tag: [t.attributeName, t.propertyName], color: "#AFAFAF" },
+    { tag: [t.variableName, t.self, t.definition(t.variableName)], color: "#CCCCCC" },
+    { tag: t.invalid, color: "#FD6389" },
+    { tag: t.link, color: "#7CDCE7", textDecoration: "underline" },
+    { tag: t.emphasis, color: "#AFAFAF", fontStyle: "italic" },
+    { tag: t.strong, color: "#EEEEEE", fontWeight: "700" },
+  ],
+});
 
 export const EDITOR_THEME_EXT: Record<EditorThemeId, Extension> = {
   atomone,
@@ -15,7 +81,9 @@ export const EDITOR_THEME_EXT: Record<EditorThemeId, Extension> = {
   "github-dark": githubDark,
   "github-light": githubLight,
   nord,
+  sobrio,
   "tokyo-night": tokyoNight,
+  vesper,
   "xcode-dark": xcodeDark,
   "xcode-light": xcodeLight,
 };

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -19,7 +19,9 @@ export const EDITOR_THEMES = [
   "github-dark",
   "github-light",
   "nord",
+  "sobrio",
   "tokyo-night",
+  "vesper",
   "xcode-dark",
   "xcode-light",
 ] as const;
@@ -33,7 +35,9 @@ export const EDITOR_THEME_LABELS: Record<EditorThemeId, string> = {
   "github-dark": "GitHub Dark",
   "github-light": "GitHub Light",
   nord: "Nord",
+  sobrio: "Sobrio",
   "tokyo-night": "Tokyo Night",
+  vesper: "Vesper",
   "xcode-dark": "Xcode Dark",
   "xcode-light": "Xcode Light",
 };

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@/modules/theme";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { useTerminalSession } from "./lib/useTerminalSession";
@@ -38,6 +39,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
   ) {
     const containerRef = useRef<HTMLDivElement>(null);
     const { resolvedTheme } = useTheme();
+    const editorTheme = usePreferencesStore((s) => s.editorTheme);
 
     const session = useTerminalSession({
       leafId,
@@ -54,7 +56,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       // Defer one frame so CSS-variable token resolution sees the new class.
       const id = requestAnimationFrame(() => session.applyTheme());
       return () => cancelAnimationFrame(id);
-    }, [resolvedTheme, session]);
+    }, [editorTheme, resolvedTheme, session]);
 
     useImperativeHandle(
       ref,

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -79,7 +79,7 @@ function termOptions() {
   return {
     fontFamily: detectMonoFontFamily(),
     fontSize: Math.max(4, Math.round(prefs.terminalFontSize * prefs.zoomLevel)),
-    theme: buildTerminalTheme(),
+    theme: buildTerminalTheme(undefined, prefs.editorTheme),
     cursorBlink: false,
     cursorStyle: "bar" as const,
     cursorInactiveStyle: "outline" as const,
@@ -540,7 +540,10 @@ export function applyScrollback(value: number): void {
 }
 
 export function applyTheme(): void {
-  const theme = buildTerminalTheme();
+  const theme = buildTerminalTheme(
+    undefined,
+    usePreferencesStore.getState().editorTheme,
+  );
   for (const slot of slots) {
     slot.term.options.theme = theme;
   }

--- a/src/styles/terminalTheme.test.ts
+++ b/src/styles/terminalTheme.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildTerminalTheme } from "./terminalTheme";
+import type { AppTokens } from "./tokens";
+
+const appTokens: AppTokens = {
+  background: "rgb(10, 10, 10)",
+  foreground: "rgb(250, 250, 250)",
+  card: "rgb(20, 20, 20)",
+  muted: "rgb(30, 30, 30)",
+  "muted-foreground": "rgb(160, 160, 160)",
+  accent: "rgb(40, 40, 40)",
+  "accent-foreground": "rgb(255, 255, 255)",
+  border: "rgb(50, 50, 50)",
+  primary: "rgb(60, 60, 60)",
+  destructive: "rgb(255, 0, 0)",
+  ring: "rgb(70, 70, 70)",
+};
+
+describe("buildTerminalTheme", () => {
+  it("uses the Vesper palette when the editor theme is Vesper", () => {
+    expect(buildTerminalTheme(appTokens, "vesper")).toMatchObject({
+      background: "#101010",
+      foreground: "#FFFFFF",
+      cursor: "#FFFFFF",
+      cursorAccent: "#101010",
+      selectionBackground: "#FFFFFF25",
+      black: "#101010",
+      red: "#FF8080",
+      green: "#99FFE4",
+      yellow: "#FFC799",
+      blue: "#A0A0A0",
+      magenta: "#FF7300",
+      cyan: "#99FFE4",
+      white: "#FFFFFF",
+      brightBlack: "#505050",
+      brightYellow: "#FFCFA8",
+    });
+  });
+
+  it("uses the Sobrio palette when the editor theme is Sobrio", () => {
+    expect(buildTerminalTheme(appTokens, "sobrio")).toMatchObject({
+      background: "#121212",
+      foreground: "#FFFFFF",
+      cursor: "#FFFFFF",
+      cursorAccent: "#121212",
+      selectionBackground: "#4E4E4E",
+      black: "#121212",
+      red: "#FD6389",
+      green: "#2EC27E",
+      yellow: "#D7AF87",
+      blue: "#87AFD7",
+      magenta: "#7CDCE7",
+      cyan: "#7CDCE7",
+      white: "#CCCCCC",
+      brightBlack: "#5F5F5F",
+      brightWhite: "#FFFFFF",
+    });
+  });
+
+  it("keeps app chrome tokens for non-Vesper editor themes", () => {
+    expect(buildTerminalTheme(appTokens, "atomone")).toMatchObject({
+      background: "rgb(10, 10, 10)",
+      foreground: "rgb(250, 250, 250)",
+      cursor: "rgb(250, 250, 250)",
+      cursorAccent: "rgb(10, 10, 10)",
+      selectionBackground: "rgb(40, 40, 40)",
+    });
+  });
+});

--- a/src/styles/terminalTheme.ts
+++ b/src/styles/terminalTheme.ts
@@ -1,4 +1,6 @@
 import { readAppTokens } from "@/styles/tokens";
+import type { AppTokens } from "@/styles/tokens";
+import type { EditorThemeId } from "@/modules/settings/store";
 import type { ITheme } from "@xterm/xterm";
 
 /**
@@ -30,6 +32,46 @@ const ansi = {
   brightWhite: "#fafafa",
 } as const;
 
+const vesperAnsi = {
+  black: "#101010",
+  red: "#FF8080",
+  green: "#99FFE4",
+  yellow: "#FFC799",
+  blue: "#A0A0A0",
+  magenta: "#FF7300",
+  cyan: "#99FFE4",
+  white: "#FFFFFF",
+
+  brightBlack: "#505050",
+  brightRed: "#FF8080",
+  brightGreen: "#99FFE4",
+  brightYellow: "#FFCFA8",
+  brightBlue: "#A0A0A0",
+  brightMagenta: "#FF8080",
+  brightCyan: "#99FFE4",
+  brightWhite: "#FFFFFF",
+} as const;
+
+const sobrioAnsi = {
+  black: "#121212",
+  red: "#FD6389",
+  green: "#2EC27E",
+  yellow: "#D7AF87",
+  blue: "#87AFD7",
+  magenta: "#7CDCE7",
+  cyan: "#7CDCE7",
+  white: "#CCCCCC",
+
+  brightBlack: "#5F5F5F",
+  brightRed: "#FD6389",
+  brightGreen: "#2EC27E",
+  brightYellow: "#D7D7FF",
+  brightBlue: "#87AFD7",
+  brightMagenta: "#D7AF87",
+  brightCyan: "#7CDCE7",
+  brightWhite: "#FFFFFF",
+} as const;
+
 /** Semantic palette reused by the code editor. Kept in one place so the
  *  terminal's ANSI colors and syntax highlighting stay visually coherent. */
 export const syntaxPalette = {
@@ -51,8 +93,33 @@ export const syntaxPalette = {
  * called after the DOM is ready (after first paint); globals.css variables
  * are resolved via getComputedStyle.
  */
-export function buildTerminalTheme(): ITheme {
-  const t = readAppTokens();
+export function buildTerminalTheme(
+  tokens: AppTokens = readAppTokens(),
+  editorTheme?: EditorThemeId,
+): ITheme {
+  if (editorTheme === "vesper") {
+    return {
+      background: "#101010",
+      foreground: "#FFFFFF",
+      cursor: "#FFFFFF",
+      cursorAccent: "#101010",
+      selectionBackground: "#FFFFFF25",
+      ...vesperAnsi,
+    };
+  }
+
+  if (editorTheme === "sobrio") {
+    return {
+      background: "#121212",
+      foreground: "#FFFFFF",
+      cursor: "#FFFFFF",
+      cursorAccent: "#121212",
+      selectionBackground: "#4E4E4E",
+      ...sobrioAnsi,
+    };
+  }
+
+  const t = tokens;
   return {
     background: t.background,
     foreground: t.foreground,


### PR DESCRIPTION
Hi Crynta!

I’m still learning open-source contribution, but I’d like to make a small first contribution to Terax by adding two new built-in themes: **Sobrio** and **Vesper**.

The idea is to expand the default theme options with two minimal dark themes:

- **Vesper**: a dark theme with a near-black background, warm accent colors, soft cyan highlights, and low-contrast gray syntax tones.
- **Sobrio**: a clean, understated dark theme focused on readability, reduced visual noise, and a more neutral professional look.

Proposed scope:

- Add Sobrio and Vesper to the built-in theme list
- Map both themes to Terax’s existing terminal/editor theme structure
- Keep the contribution small and focused
- Add no new dependencies
- Avoid unrelated refactors
- Include tests for theme registration and terminal palette mapping

Test plan:

- [x] pnpm test
- [x] pnpm exec tsc --noEmit
- [x] pnpm build
- [x] Manual native app validation via pnpm tauri dev