### PR TITLE
fix(ai): implement responsive scrollable todo list in mini-window

### DIFF
--- a/src/modules/ai/components/TodoStrip.tsx
+++ b/src/modules/ai/components/TodoStrip.tsx
@@ -1,4 +1,5 @@
 import { Progress } from "@/components/ui/progress";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import {
   Tooltip,
@@ -33,19 +34,21 @@ export function TodoStrip({ sessionId }: Props) {
   const pct = Math.round((completed / todos.length) * 100);
 
   return (
-    <div className="shrink-0 border-t border-border/80 bg-muted/20 px-3 py-1.5">
-      <div className="my-1.5 flex items-center gap-2">
+    <div className="flex flex-col min-h-0 shrink-0 border-t-2 border-border/40 bg-muted/80 px-3 py-1.5 h-[35%] shadow-[0_-4px_12px_-8px_rgba(0,0,0,0.2)]">
+      <div className="my-1.5 flex items-center gap-2 shrink-0">
         <span className="text-[11px] font-medium text-foreground">Todos</span>
         <Progress value={pct} className="h-1 flex-1" />
         <span className="text-[11px] tabular-nums font-mono text-muted-foreground">
           {completed}/{todos.length}
         </span>
       </div>
-      <ul className="flex flex-col gap-0.5">
-        {todos.map((t) => (
-          <TodoRow key={t.id} todo={t} />
-        ))}
-      </ul>
+      <ScrollArea className="flex-1 min-h-0">
+        <ul className="flex flex-col gap-0.5">
+          {todos.map((t) => (
+            <TodoRow key={t.id} todo={t} />
+          ))}
+        </ul>
+      </ScrollArea>
     </div>
   );
 }


### PR DESCRIPTION
**PR Title:** `fix(ai): prevent todo list from overflowing mini-window #326`

## What
This PR implements a responsive, scrollable container for the Todo list in the AI mini-window. It limits the task list's vertical space to 35% of the window height and introduces a distinct background for better visual separation.

## Why
Closes #326. Previously, a long list of tasks would expand the `TodoStrip` without limit, eventually hiding the chat conversation and preventing users from seeing or interacting with tool approval buttons.

## How
- Wrapped the task list in the project's standard `ScrollArea` component.
- Applied a responsive height constraint (`h-[35%]`) to ensure the layout remains consistent regardless of the number of tasks or screen resolution.
- Enhanced the visual distinction of the Todo panel using a higher opacity background (`bg-muted/80`), a thicker top border, and a subtle shadow.
- Used `flex-col` with `min-h-0` to ensure the "Todos" header remains pinned while only the list itself scrolls.

## Testing
- Verified that the Todo panel maintains a consistent 35% height whether 1 task or 50+ tasks are present.
- Confirmed that the chat area and approval cards remain fully visible and interactive even with an overflowed task list.
- Tested responsive behavior by resizing the application window; the 35% proportion adapted correctly.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

| Before Fix (Issue #326) | After Fix (This PR) |
| :---: | :---: |
| ![Original Overflow](https://github.com/user-attachments/assets/d0e318a1-cc28-441a-b832-f7ea9609b0bc) | ![Fixed Scrolling](https://github.com/user-attachments/assets/03702b9e-5164-4305-9f47-07afffa0cbfc) |



## Notes for reviewer
The 35% height was chosen to ensure that even on smaller displays, the chat area retains at least 65% of the vertical space, which is sufficient for displaying multiple chat bubbles or a tool approval card.