### PR TITLE
fix(shortcuts): let Ctrl+L reach xterm when no selection

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -905,7 +905,20 @@ export default function App() {
     ],
   );
 
-  useGlobalShortcuts(shortcutHandlers);
+  useGlobalShortcuts(shortcutHandlers, {
+    isDisabled: (id, e) => {
+      // When an xterm has keyboard focus and nothing is selected, let the
+      // keydown fall through to xterm so the shell receives it (e.g. Ctrl+L
+      // → \x0c → clear screen). Only relax ai.askSelection — it has nothing
+      // to do when there's no selection anyway.
+      if (id !== "ai.askSelection") return false;
+      const target = (e.target as HTMLElement | null) ?? document.activeElement;
+      const inTerminal = !!(target as HTMLElement | null)?.closest?.(".xterm");
+      if (!inTerminal) return false;
+      const sel = captureActiveSelection();
+      return !sel || !sel.trim();
+    },
+  });
 
   const registerTerminalHandle = useCallback(
     (leafId: number, h: TerminalPaneHandle | null) => {


### PR DESCRIPTION
## Summary
- `ai.askSelection` (Ctrl/Cmd+L) was captured globally even when focus was inside a terminal with no active selection — the keystroke was swallowed and silently moved focus to the AI input instead of letting the shell clear the screen.
- Pass an `isDisabled` callback to `useGlobalShortcuts` that only relaxes `ai.askSelection`, and only when the event target is inside an `.xterm` container **and** there is no (non-whitespace) selection. The keystroke then falls through to xterm and the shell receives `\x0c` as expected.
- Behavior with a selection is unchanged: Ctrl/Cmd+L still pulls the selected text into the AI panel.
- Scope is intentionally narrow — other global shortcuts continue to fire from terminal focus.

## Test plan
- [ ] Open a terminal tab, type some text, press Ctrl/Cmd+L with **no** selection → shell clears the screen.
- [ ] Select text in the terminal, press Ctrl/Cmd+L → selection is attached to the AI panel as before.
- [ ] Select text in an editor tab, press Ctrl/Cmd+L → selection is attached to the AI panel as before.
- [ ] Focus the AI input or sidebar, press Ctrl/Cmd+L → shortcut still triggers (no terminal in focus).
- [ ] Other global shortcuts (Cmd+T, Cmd+I, Cmd+B…) still work from terminal focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)