### PR TITLE
fix(terminal): repaint TUIs on resume instead of replaying dormant bytes

### DIFF
--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -23,6 +23,11 @@ export type SlotAdapter = {
 export type LeafBridge = {
   writeToPty(data: string): void;
   resizePty(cols: number, rows: number): void;
+  // Force a SIGWINCH on the underlying PTY at the given dims. Implemented
+  // as a +1 row / restore bump because the Linux kernel suppresses winsize
+  // ioctls that don't actually change the size. Used to make alt-screen
+  // TUIs repaint from scratch after they were dormant.
+  kickPty(cols: number, rows: number): void;
 };
 
 export type Slot = {
@@ -196,6 +201,10 @@ export type AcquireParams = {
   leafId: number;
   container: HTMLDivElement;
   snapshot: string | null;
+  // True if the slot was in alt-screen mode (TUI like vim, htop, dofek)
+  // at the time it was released. When set, bindSlot skips ring replay
+  // and kicks SIGWINCH so the TUI repaints from scratch.
+  altScreen: boolean;
   drainRing: (write: (bytes: Uint8Array) => void) => void;
   shellExited: boolean;
   searchQuery: string | null;
@@ -257,7 +266,14 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
       console.warn("[terax] snapshot replay failed:", e);
     }
   }
-  p.drainRing((bytes) => slot.term.write(bytes));
+  if (p.altScreen) {
+    // Discard the dormant ring. TUI output is incremental cursor-positioned
+    // updates that can't be replayed coherently on top of a stale snapshot
+    // — see the SIGWINCH kick below, which makes the TUI redraw from scratch.
+    p.drainRing(() => {});
+  } else {
+    p.drainRing((bytes) => slot.term.write(bytes));
+  }
   try {
     slot.term.write("\x1b[?25h");
   } catch {}
@@ -286,6 +302,10 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
   }
 
   applyCursorBlinkOnSlot(slot, adapter?.isLeafFocused(p.leafId) ?? false);
+
+  if (p.altScreen && !p.shellExited) {
+    adapter?.resolveLeaf(p.leafId)?.kickPty(slot.term.cols, slot.term.rows);
+  }
 
   scheduleUnhide(slot);
 
@@ -369,6 +389,7 @@ export type SerializeOutput = {
   snapshot: string | null;
   cols: number;
   rows: number;
+  altScreen: boolean;
 };
 
 export function releaseSlot(leafId: number): SerializeOutput | null {
@@ -390,7 +411,12 @@ function serializeSlot(slot: Slot): SerializeOutput {
   } catch (e) {
     console.warn("[terax] serialize failed:", e);
   }
-  return { snapshot, cols: slot.term.cols, rows: slot.term.rows };
+  return {
+    snapshot,
+    cols: slot.term.cols,
+    rows: slot.term.rows,
+    altScreen: isAltScreen(slot),
+  };
 }
 
 function detachSlotFromLeaf(slot: Slot): void {

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -47,6 +47,10 @@ type Session = {
   searchQuery: string | null;
   dormantRing: DormantRing;
   hasSlot: boolean;
+  // True if the slot was in alt-screen mode (TUI like vim, htop, dofek)
+  // at the most recent release. Read once on the next bind to trigger a
+  // SIGWINCH-driven repaint instead of replaying dormant bytes.
+  altScreenAtRelease: boolean;
 };
 
 const sessions = new Map<number, Session>();
@@ -63,6 +67,17 @@ configureRendererPool({
         s.cols = cols;
         s.rows = rows;
         s.pty?.resize(cols, rows);
+      },
+      kickPty: (cols, rows) => {
+        const pty = s.pty;
+        if (!pty || cols <= 0 || rows <= 0) return;
+        // Linux only emits SIGWINCH when the winsize ioctl actually
+        // changes dims, so bump +1 row then restore. The TUI receives
+        // (possibly two) SIGWINCHes and repaints from scratch.
+        pty
+          .resize(cols, rows + 1)
+          .then(() => pty.resize(cols, rows))
+          .catch((e) => console.warn("[terax] kickPty failed:", e));
       },
     };
   },
@@ -100,6 +115,7 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     searchQuery: null,
     dormantRing: new DormantRing(),
     hasSlot: false,
+    altScreenAtRelease: false,
   };
   sessions.set(leafId, session);
 
@@ -146,10 +162,13 @@ async function openPtyForSession(
 
 function bindLeafToSlot(leafId: number, s: Session): void {
   if (!s.container) return;
+  const altScreen = s.altScreenAtRelease;
+  s.altScreenAtRelease = false;
   acquireSlot({
     leafId,
     container: s.container,
     snapshot: s.snapshot,
+    altScreen,
     drainRing: (write) => s.dormantRing.drain(write),
     shellExited: s.shellExited,
     searchQuery: s.searchQuery,
@@ -196,6 +215,7 @@ function unbindLeafFromSlot(leafId: number, s: Session): void {
     s.snapshot = out.snapshot;
     if (out.cols > 0) s.cols = out.cols;
     if (out.rows > 0) s.rows = out.rows;
+    s.altScreenAtRelease = out.altScreen;
   }
   s.hasSlot = false;
 }
@@ -251,6 +271,7 @@ export async function respawnSession(
   s.dormantRing = new DormantRing();
   s.shellExited = false;
   s.pendingExit = null;
+  s.altScreenAtRelease = false;
 
   const slot = getSlotForLeaf(leafId);
   if (slot) {


### PR DESCRIPTION
## Summary
- TUIs (vim, htop, btop, dofek, less, …) emit incremental cursor-positioned updates. When their tab was dormant, those bytes were buffered in the 256 KB dormant ring and replayed on resume — but at high refresh rates the cap is blown, older frames get dropped, and the surviving partial updates corrupt the screen on top of a stale snapshot. The visible symptom was the `[terax: dropped output during hibernation]` banner sitting over a garbled UI.
- This change tracks whether the slot was in alt-screen mode at release time (via the existing `isAltScreen()` helper / `term.buffer.active.type`). On the next bind, the dormant bytes are discarded and a SIGWINCH is forced on the PTY so the TUI repaints from scratch. The bridge implements the kick as a `resize(cols, rows+1)` → `resize(cols, rows)` bump because Linux only emits SIGWINCH on `TIOCSWINSZ` ioctls that actually change dimensions.
- Non-alt-screen sessions are unaffected — append-only shell output still replays normally and the overflow notice still fires when the ring overruns.
- `respawnSession` clears the flag defensively so a fresh shell after a dead TUI doesn't get a stray nudge.

## Files
- `src/modules/terminal/lib/rendererPool.ts` — `AcquireParams.altScreen`, `SerializeOutput.altScreen`, `LeafBridge.kickPty`, branch in `bindSlot`.
- `src/modules/terminal/lib/useTerminalSession.ts` — `Session.altScreenAtRelease`, `kickPty` bridge impl, plumbing through bind/release/respawn.

## Test plan
- [ ] Open a TUI (`htop`, `btop`, `vim`, `less`, `dofek`) in tab A.
- [ ] Open a new terminal tab and wait ~30 s so the dormant ring would overflow.
- [ ] Switch back to tab A → screen renders cleanly, no garble, no `[terax: dropped output during hibernation]` banner.
- [ ] Repeat across vim / htop / btop / less to confirm cross-TUI behavior.
- [ ] Regression — run `find / -name '*.rs' 2>/dev/null` in tab A (plain shell, alt-screen off), switch away, switch back → buffered output replays as before, overflow notice still appears if cap exceeded.
- [ ] Inside the TUI on resume, confirm input still reaches the PTY (keys work, mouse if applicable).
- [ ] Exit the TUI while its tab is dormant, switch back → no spurious kick, shell prompt visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)