### PR TITLE
fix(editor): auto-reload files when AI modifies them

### DIFF
--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
+use tauri::Emitter;
 
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
@@ -82,6 +83,7 @@ pub fn fs_write_file(
     path: String,
     content: String,
     workspace: Option<WorkspaceEnv>,
+    app: tauri::AppHandle,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
     let target = resolve_path(&path, &workspace);
@@ -117,6 +119,9 @@ pub fn fs_write_file(
         let _ = std::fs::remove_file(&tmp);
         e.to_string()
     })?;
+
+    // Emit event to notify frontend that file was modified
+    let _ = app.emit("fs:file-written", path.clone());
 
     Ok(())
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -84,6 +84,7 @@ import {
   type WorkspaceEnv,
 } from "@/modules/workspace";
 import { homeDir } from "@tauri-apps/api/path";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { SearchAddon } from "@xterm/addon-search";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -447,6 +448,30 @@ export default function App() {
       }
     }
   }, [tabs]);
+
+  // Listen for file write events from the backend (when AI modifies files)
+  // and reload any open editor tabs for that path.
+  useEffect(() => {
+    const unlistenPromise = getCurrentWebviewWindow().listen<string>(
+      "fs:file-written",
+      (event) => {
+        const filePath = event.payload;
+        // Normalize path for comparison (handle Windows backslashes)
+        const normalizedPath = filePath.replace(/\\/g, "/");
+        const currentTabs = tabsRef.current;
+        for (const t of currentTabs) {
+          if (t.kind !== "editor") continue;
+          const tabPath = t.path.replace(/\\/g, "/");
+          if (tabPath === normalizedPath) {
+            editorRefs.current.get(t.id)?.reload();
+          }
+        }
+      },
+    );
+    return () => {
+      void unlistenPromise.then((un) => un());
+    };
+  }, []);
 
   const { explorerRoot, inheritedCwdForNewTab } = useWorkspaceCwd(
     activeTab,


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Added file watching mechanism to auto-reload editor tabs when AI modifies files

## Why
Files opened in editor weren't refreshing when AI modified them, requiring manual reopen

## How
Opened a file in editor, asked AI to modify it, verified it auto-reloaded without manual reopen

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
