### PR TITLE
feat(window): quake mode

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1678,6 +1678,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,7 +3510,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4873,6 +4891,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,6 +5198,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-os",
@@ -6728,6 +6762,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6736,6 +6787,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -64,6 +64,7 @@ windows-sys = { version = "0.59", features = [
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2"
+tauri-plugin-global-shortcut = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,8 @@
 mod modules;
 
-use modules::{fs, git, net, pty, secrets, shell, workspace};
+use modules::{fs, git, net, pty, secrets, shell, tray, workspace};
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri_plugin_global_shortcut::ShortcutState;
 use tauri_plugin_window_state::StateFlags;
 
 #[tauri::command]
@@ -73,6 +74,19 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_autostart::Builder::new().build())
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_shortcut("Ctrl+Space")
+                .expect("invalid Ctrl+Space global shortcut")
+                .with_handler(|app, _shortcut, event| {
+                    if event.state == ShortcutState::Pressed {
+                        if let Err(err) = tray::toggle_quake_window(app) {
+                            log::error!("failed to toggle quake window: {err}");
+                        }
+                    }
+                })
+                .build(),
+        )
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .plugin(
@@ -81,6 +95,19 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .setup(|app| Ok(tray::setup(app)?))
+        .on_window_event(|window, event| {
+            if window.label() != "main" {
+                return;
+            }
+
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                if let Err(err) = tray::hide_main_window(window.app_handle()) {
+                    log::error!("failed to hide main window to tray: {err}");
+                }
+            }
+        })
         .manage(pty::PtyState::default())
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -4,4 +4,5 @@ pub mod net;
 pub mod pty;
 pub mod secrets;
 pub mod shell;
+pub mod tray;
 pub mod workspace;

--- a/src-tauri/src/modules/tray.rs
+++ b/src-tauri/src/modules/tray.rs
@@ -1,0 +1,91 @@
+use tauri::{
+    menu::{MenuBuilder, MenuItemBuilder},
+    tray::{TrayIconBuilder, TrayIconEvent},
+    App, AppHandle, Manager,
+};
+
+const MAIN_WINDOW_LABEL: &str = "main";
+const TRAY_ID_SHOW: &str = "tray_show";
+const TRAY_ID_QUIT: &str = "tray_quit";
+
+pub fn setup(app: &mut App) -> tauri::Result<()> {
+    let show = MenuItemBuilder::with_id(TRAY_ID_SHOW, "Show Terax").build(app)?;
+    let quit = MenuItemBuilder::with_id(TRAY_ID_QUIT, "Quit Terax").build(app)?;
+    let menu = MenuBuilder::new(app).items(&[&show, &quit]).build()?;
+
+    if let Some(icon) = app.default_window_icon() {
+        let app_handle = app.handle().clone();
+        let app_handle_click = app_handle.clone();
+
+        TrayIconBuilder::new()
+            .icon(icon.clone())
+            .menu(&menu)
+            .show_menu_on_left_click(false)
+            .on_tray_icon_event(move |_tray, event| {
+                if let TrayIconEvent::DoubleClick { .. } = event {
+                    if let Err(err) = toggle_main_window(&app_handle_click) {
+                        log::error!("failed to toggle window on tray double-click: {err}");
+                    }
+                }
+            })
+            .on_menu_event(move |_tray, event| match event.id().as_ref() {
+                TRAY_ID_SHOW => {
+                    if let Err(err) = show_main_window(&app_handle) {
+                        log::error!("failed to show main window from tray: {err}");
+                    }
+                }
+                TRAY_ID_QUIT => {
+                    app_handle.exit(0);
+                }
+                _ => {}
+            })
+            .build(app)?;
+    } else {
+        log::warn!("tray icon skipped: default window icon is missing");
+    }
+
+    Ok(())
+}
+
+pub fn hide_main_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = window.set_focus();
+        window.hide()?;
+    }
+    Ok(())
+}
+
+pub fn show_main_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        if window.is_minimized().unwrap_or(false) {
+            let _ = window.unminimize();
+        }
+        window.show()?;
+        let _ = window.set_focus();
+    }
+    Ok(())
+}
+
+pub fn toggle_main_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        if window.is_visible().unwrap_or(false) {
+            hide_main_window(app)?
+        } else {
+            show_main_window(app)?
+        }
+    }
+    Ok(())
+}
+
+pub fn toggle_quake_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        if window.is_fullscreen().unwrap_or(false) {
+            window.set_fullscreen(false)?;
+            hide_main_window(app)?
+        } else {
+            window.set_fullscreen(true)?;
+            show_main_window(app)?
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
PoC for quake mode feature
Allows the app to be closed to a tray and open at anytime using a global shortcut

## Why
For #365 

## How
- uses the tauri rust api to enable support tray, this also has react support but used the rust api because i think this feature should live on the native side ( no other reason )
- adds a event listener on the main window when closed to hidden instead
- adds a global listener for `ctrl + space` to toggle the app fullscreen

## Testing
- tested most of the feature to see if they are still working like:
 - terminal and multiple terminal tabs
 - change directory from the bottom bar
 - git
 - file previews
 - multiple tabs if different types

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
- i don't have experience with rust and the code was mostly generated by claude, don't expect to be merged or anything just a starting point for the discussion
