### PR TITLE
fix(terminal): kill terminal shortcut and block Ctrl+P print dialog

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -881,9 +881,19 @@ export default function App() {
       "view.zoomIn": zoomIn,
       "view.zoomOut": zoomOut,
       "view.zoomReset": zoomReset,
+      "terminal.kill": () => {
+        if (activeLeafId === null) return;
+        const tab = tabsRef.current.find(
+          (t) => t.kind === "terminal" && hasLeaf(t.paneTree, activeLeafId),
+        );
+        if (!tab || tab.kind !== "terminal") return;
+        const cwd = findLeafCwd(tab.paneTree, activeLeafId) ?? tab.cwd;
+        void respawnSession(activeLeafId, cwd);
+      },
     }),
     [
       activeId,
+      activeLeafId,
       cycleTab,
       handleCloseTabOrPane,
       openNewTab,
@@ -904,6 +914,14 @@ export default function App() {
   );
 
   useGlobalShortcuts(shortcutHandlers);
+
+  useEffect(() => {
+    const block = (e: KeyboardEvent) => {
+      if (e.key === "p" && (e.ctrlKey || e.metaKey)) e.preventDefault();
+    };
+    window.addEventListener("keydown", block, { capture: true });
+    return () => window.removeEventListener("keydown", block, { capture: true });
+  }, []);
 
   const registerTerminalHandle = useCallback(
     (leafId: number, h: TerminalPaneHandle | null) => {

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -28,7 +28,8 @@ export type ShortcutId =
   | "ai.askSelection"
   | "shortcuts.open"
   | "settings.open"
-  | "sidebar.toggle";
+  | "sidebar.toggle"
+  | "terminal.kill";
 
 export type ShortcutGroup =
   | "General"
@@ -36,6 +37,7 @@ export type ShortcutGroup =
   | "Panes"
   | "Search"
   | "AI"
+  | "Terminal"
   | "View";
 
 export type KeyBinding = {
@@ -158,6 +160,12 @@ export const SHORTCUTS: Shortcut[] = [
     defaultBindings: [{ [MOD_PROP]: true, key: "f" }],
   },
   {
+    id: "terminal.kill",
+    label: "Kill terminal process",
+    group: "Terminal",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "k" }],
+  },
+  {
     id: "ai.toggle",
     label: "Toggle AI agent",
     group: "AI",
@@ -213,6 +221,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   "General",
   "Tabs",
   "Panes",
+  "Terminal",
   "View",
   "Search",
   "AI",


### PR DESCRIPTION
Closes #315

Adds `terminal.kill` shortcut (Ctrl+Shift+K) that respawns the active terminal — kills the stuck process and opens a fresh shell in the same cwd.
Blocks the browser Ctrl+P print dialog from appearing in the Tauri webview.
Testing
- [X] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

Notes for reviewer
The kill shortcut reuses the existing respawnSession helper — closes PTY, resets terminal, spawns a new shell. The Ctrl+P block is a capture-phase keydown listener that calls preventDefault() before the browser can open its print dialog.
