### PR TITLE
feat(settings): add configurable context limit for OpenAI-compatible …

### DIFF
--- a/src/modules/ai/components/AiMiniWindow.tsx
+++ b/src/modules/ai/components/AiMiniWindow.tsx
@@ -33,6 +33,7 @@ import { estimateCost, getModel, getModelContextLimit } from "../config";
 import type { SessionMeta } from "../lib/sessions";
 import { useAgentsStore } from "../store/agentsStore";
 import { getOrCreateChat, useChatStore } from "../store/chatStore";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { usePlanStore } from "../store/planStore";
 import { AgentSwitcher } from "./AgentSwitcher";
 import { AiChatView } from "./AiChat";
@@ -291,7 +292,10 @@ function ContextIndicator({ messages }: { messages: UIMessage[] }) {
   const estimated = useMemo(() => estimateTokens(messages), [messages]);
   const used = lastInput > 0 ? lastInput : estimated;
   const reported = tokens.inputTokens + tokens.outputTokens;
-  const max = getModelContextLimit(modelId);
+  const openaiCompatibleContextLimit = usePreferencesStore(
+    (s) => s.openaiCompatibleContextLimit,
+  );
+  const max = getModelContextLimit(modelId, openaiCompatibleContextLimit);
   const modelLabel = useMemo(() => {
     try {
       return getModel(modelId).label;

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -621,8 +621,13 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "codestral-latest": 256_000,
 };
 
-export function getModelContextLimit(modelId: string | undefined): number {
+export function getModelContextLimit(
+  modelId: string | undefined,
+  compatOverride?: number,
+): number {
   if (!modelId) return 128_000;
+  if (modelId === "openai-compatible-custom" && compatOverride)
+    return compatOverride;
   return MODEL_CONTEXT_LIMITS[modelId] ?? 128_000;
 }
 

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -291,6 +291,7 @@ export type RunAgentOptions = {
   lmstudioModelId?: string;
   openaiCompatibleBaseURL?: string;
   openaiCompatibleModelId?: string;
+  openaiCompatibleContextLimit?: number;
   planMode?: boolean;
   projectMemory?: string | null;
   uiMessages: UIMessage[];
@@ -319,7 +320,7 @@ export async function runAgentStream(opts: RunAgentOptions) {
   const history = await convertToModelMessages(opts.uiMessages);
   const compact = compactModelMessagesDetailed(
     history,
-    getModelContextLimit(getModel(modelId).id),
+    getModelContextLimit(getModel(modelId).id, opts.openaiCompatibleContextLimit),
   );
   const compactedHistory = compact.messages;
   if (compact.compacted) {

--- a/src/modules/ai/lib/transport.ts
+++ b/src/modules/ai/lib/transport.ts
@@ -50,6 +50,7 @@ type Deps = {
   getLmstudioModelId?: () => string | undefined;
   getOpenaiCompatibleBaseURL?: () => string | undefined;
   getOpenaiCompatibleModelId?: () => string | undefined;
+  getOpenaiCompatibleContextLimit?: () => number | undefined;
   onStep?: (step: string | null) => void;
   onUsage?: (delta: AgentUsageDelta) => void;
   onCompact?: (info: { droppedCount: number }) => void;
@@ -85,6 +86,7 @@ export function createContextAwareTransport(deps: Deps) {
       lmstudioModelId: deps.getLmstudioModelId?.(),
       openaiCompatibleBaseURL: deps.getOpenaiCompatibleBaseURL?.(),
       openaiCompatibleModelId: deps.getOpenaiCompatibleModelId?.(),
+      openaiCompatibleContextLimit: deps.getOpenaiCompatibleContextLimit?.(),
       planMode: deps.getPlanMode?.(),
       projectMemory,
       uiMessages: messagesForRun,

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -251,6 +251,8 @@ function makeChat(sessionId: string): Chat<UIMessage> {
       usePreferencesStore.getState().openaiCompatibleBaseURL,
     getOpenaiCompatibleModelId: () =>
       usePreferencesStore.getState().openaiCompatibleModelId,
+    getOpenaiCompatibleContextLimit: () =>
+      usePreferencesStore.getState().openaiCompatibleContextLimit,
     onStep: (step) => {
       useChatStore.getState().patchAgentMeta({ step });
     },

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -52,6 +52,7 @@ export type Preferences = {
   lmstudioModelId: string;
   openaiCompatibleBaseURL: string;
   openaiCompatibleModelId: string;
+  openaiCompatibleContextLimit: number;
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
@@ -78,6 +79,7 @@ const KEY_LMSTUDIO_BASE_URL = "lmstudioBaseURL";
 const KEY_LMSTUDIO_MODEL_ID = "lmstudioModelId";
 const KEY_OPENAI_COMPAT_BASE_URL = "openaiCompatibleBaseURL";
 const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
+const KEY_OPENAI_COMPAT_CONTEXT_LIMIT = "openaiCompatibleContextLimit";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
@@ -119,6 +121,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   lmstudioModelId: "",
   openaiCompatibleBaseURL: OPENAI_COMPATIBLE_DEFAULT_BASE_URL,
   openaiCompatibleModelId: "",
+  openaiCompatibleContextLimit: 128_000,
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
@@ -183,6 +186,9 @@ export async function loadPreferences(): Promise<Preferences> {
     openaiCompatibleModelId:
       get<string>(KEY_OPENAI_COMPAT_MODEL_ID) ??
       DEFAULT_PREFERENCES.openaiCompatibleModelId,
+    openaiCompatibleContextLimit:
+      get<number>(KEY_OPENAI_COMPAT_CONTEXT_LIMIT) ??
+      DEFAULT_PREFERENCES.openaiCompatibleContextLimit,
     favoriteModelIds:
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds,
@@ -267,6 +273,15 @@ export async function setOpenaiCompatibleModelId(value: string): Promise<void> {
   await writePref(KEY_OPENAI_COMPAT_MODEL_ID, value);
 }
 
+export async function setOpenaiCompatibleContextLimit(
+  value: number,
+): Promise<void> {
+  const clamped = Number.isFinite(value)
+    ? Math.max(1_000, Math.round(value))
+    : DEFAULT_PREFERENCES.openaiCompatibleContextLimit;
+  await writePref(KEY_OPENAI_COMPAT_CONTEXT_LIMIT, clamped);
+}
+
 export async function setFavoriteModelIds(value: string[]): Promise<void> {
   await writePref(KEY_FAVORITE_MODELS, value);
 }
@@ -349,6 +364,7 @@ export async function onPreferencesChange(
     [KEY_LMSTUDIO_MODEL_ID]: "lmstudioModelId",
     [KEY_OPENAI_COMPAT_BASE_URL]: "openaiCompatibleBaseURL",
     [KEY_OPENAI_COMPAT_MODEL_ID]: "openaiCompatibleModelId",
+    [KEY_OPENAI_COMPAT_CONTEXT_LIMIT]: "openaiCompatibleContextLimit",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -30,6 +30,7 @@ import {
   setLmstudioBaseURL,
   setLmstudioModelId,
   setOpenaiCompatibleBaseURL,
+  setOpenaiCompatibleContextLimit,
   setOpenaiCompatibleModelId,
 } from "@/modules/settings/store";
 import { invoke } from "@tauri-apps/api/core";
@@ -341,8 +342,12 @@ function OpenAICompatibleBlock({
 }) {
   const baseURL = usePreferencesStore((s) => s.openaiCompatibleBaseURL);
   const modelId = usePreferencesStore((s) => s.openaiCompatibleModelId);
+  const contextLimit = usePreferencesStore(
+    (s) => s.openaiCompatibleContextLimit,
+  );
   const [urlDraft, setUrlDraft] = useState(baseURL);
   const [modelDraft, setModelDraft] = useState(modelId);
+  const [contextDraft, setContextDraft] = useState(String(contextLimit));
   const [keyDraft, setKeyDraft] = useState("");
   const [testStatus, setTestStatus] = useState<
     "idle" | "testing" | "ok" | "fail"
@@ -350,15 +355,20 @@ function OpenAICompatibleBlock({
 
   useEffect(() => setUrlDraft(baseURL), [baseURL]);
   useEffect(() => setModelDraft(modelId), [modelId]);
+  useEffect(() => setContextDraft(String(contextLimit)), [contextLimit]);
 
   const dirty =
-    urlDraft.trim() !== baseURL || modelDraft.trim() !== modelId;
+    urlDraft.trim() !== baseURL ||
+    modelDraft.trim() !== modelId ||
+    parseInt(contextDraft) !== contextLimit;
 
   const save = async () => {
     const u = urlDraft.trim();
     const m = modelDraft.trim();
+    const c = parseInt(contextDraft);
     if (u !== baseURL) await setOpenaiCompatibleBaseURL(u);
     if (m !== modelId) await setOpenaiCompatibleModelId(m);
+    if (c !== contextLimit) await setOpenaiCompatibleContextLimit(c);
   };
 
   const test = async () => {
@@ -429,6 +439,25 @@ function OpenAICompatibleBlock({
             spellCheck={false}
             className="h-8 font-mono text-[11.5px]"
           />
+        </FieldRow>
+
+        <FieldRow label="Context limit">
+          <div className="flex flex-1 items-center gap-1.5">
+            <Input
+              value={contextDraft}
+              onChange={(e) => setContextDraft(e.target.value)}
+              onBlur={() => {
+                const v = parseInt(contextDraft);
+                if (Number.isFinite(v) && v >= 1000)
+                  void setOpenaiCompatibleContextLimit(v);
+                else setContextDraft(String(contextLimit));
+              }}
+              placeholder="128000"
+              spellCheck={false}
+              className="h-8 w-28 font-mono text-[11.5px]"
+            />
+            <span className="text-[10.5px] text-muted-foreground">tokens</span>
+          </div>
         </FieldRow>
 
         <FieldRow label="API key">


### PR DESCRIPTION
…endpoint

Adds a "Context limit" field to the OpenAI-compatible endpoint settings block.

Users can now set the context window size (in tokens) for their custom endpoint model. Default is 128,000. The value is passed 

files changed short: store (preference + setter), config (override in getModelContextLimit), transport/chatStore (wire it through), ModelsSection (UI field).

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [X] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`
## Notes for reviewer

The override follows the same pattern as lmstudioModelId — preference stored, wired through transport deps, consumed at the call site. getModelContextLimit now accepts an optional second arg that only applies to openai-compatible-custom.
