### PR TITLE
fix(settings): avoid parenting settings window on macOS

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,7 +46,7 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         return Ok(());
     }
 
-    let mut builder = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(url_path.into()))
+    let builder = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(url_path.into()))
         .title("Settings")
         .inner_size(720.0, 520.0)
         .min_inner_size(720.0, 520.0)
@@ -57,10 +57,18 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         // when the user clicks back into the editor or terminal (#33).
         .always_on_top(true);
 
-    // Tie lifecycle to the main window so settings minimizes/closes with it.
-    if let Some(main) = app.get_webview_window("main") {
-        builder = builder.parent(&main).map_err(|e| e.to_string())?;
-    }
+    // On non-macOS, tie lifecycle to the main window so settings minimizes/closes with it.
+    // On macOS Tauri implements `parent` as AppKit `addChildWindow`, which
+    // breaks display reassignment for the Settings window when moving between
+    // monitors.
+    #[cfg(not(target_os = "macos"))]
+    let builder = {
+        let mut builder = builder;
+        if let Some(main) = app.get_webview_window("main") {
+            builder = builder.parent(&main).map_err(|e| e.to_string())?;
+        }
+        builder
+    };
 
     #[cfg(target_os = "macos")]
     let builder = builder


### PR DESCRIPTION
## What

Avoid using `parent(&main)` for the Settings window on macOS while preserving the existing parent/owner behavior on Windows and Linux.

## Why

Fixes #384.

On macOS, the Settings window can disappear when the Settings window itself is moved between displays. This is related to #33 and is a follow-up to #49, which kept Settings above the main app by combining `always_on_top(true)` with `parent(&main)`.

This issue was reproduced on macOS, and the suspected cause is macOS-specific because Tauri maps `parent(&main)` to AppKit child-window behavior there. That makes Settings an AppKit child window of the main window, which can break independent movement across displays.

References:
- https://docs.rs/tauri/latest/tauri/webview/struct.WebviewWindowBuilder.html#method.parent
- https://developer.apple.com/documentation/appkit/nswindow/addchildwindow%28_%3Aordered%3A%29?language=objc
- https://stackoverflow.com/questions/71213724/stop-child-nswindow-disappearing-when-moved-to-another-screen

## How

The Settings window builder still uses `always_on_top(true)`, but `parent(&main)` is now applied only on non-macOS targets.

This keeps Windows/Linux behavior unchanged and limits the behavior change to the macOS path where the issue was reproduced and where Tauri maps `parent()` to AppKit child-window behavior.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

Manual testing performed:
- Reproduced the issue on macOS by moving the Settings window between displays.
- Verified the same issue reproduces on 0.7.0 before this change.
- Verified the patched dev build keeps the Settings window visible when moving it between displays.
- Verified this path is not covered by existing tests because the repo does not currently have native macOS multi-display window/e2e coverage.

Additional checks:
- `git diff --check` clean

## Screenshots / GIFs

N/A. This is native window behavior rather than an in-app visual rendering change.

## Notes for reviewer

Related to #33 and follow-up to #49.

This intentionally keeps `always_on_top(true)` unchanged. The only behavior change is that `parent(&main)` is no longer applied on macOS, because Tauri maps that API to AppKit `NSWindow.addChildWindow` there. Windows and Linux keep the existing owner/transient parent behavior.