### PR TITLE
Add Astro syntax highlighting

### DIFF
--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -71,6 +71,10 @@ const loaders: Record<string, LanguageLoader> = {
 
   html: () => import("@codemirror/lang-html").then((m) => m.html()),
   htm: () => import("@codemirror/lang-html").then((m) => m.html()),
+  astro: () =>
+    import("@codemirror/lang-html").then((m) =>
+      m.html({ selfClosingTags: true }),
+    ),
   css: () => import("@codemirror/lang-css").then((m) => m.css()),
 
   php: () => import("@codemirror/lang-php").then((m) => m.php({ plain: true })),


### PR DESCRIPTION
Adds .astro file support to the editor language resolver using CodeMirror HTML highlighting with self-closing tag support.