### PR TITLE
fix(editor): set the original file's permissions into the renamed tmp…

### DIFF
--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -1,6 +1,6 @@
-use std::io::Write;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
+use std::{fs, io::Write};
 
 use serde::Serialize;
 use tauri::Emitter;
@@ -108,12 +108,15 @@ pub fn fs_write_file(
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
     let target = resolve_path(&path, &workspace);
-
+    let original_permissions = fs::metadata(&target).ok().map(|m| m.permissions());
     write_atomic(&target, content.as_bytes()).map_err(|e| {
         log::warn!("fs_write_file({}) failed: {e}", target.display());
         e.to_string()
     })?;
 
+    if let Some(perms) = original_permissions {
+        let _ = fs::set_permissions(&target, perms);
+    }
     let _ = app.emit(
         "fs:file-written",
         FileWrittenEvent {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
Copy the original file's permissions, then set into the new renamed tmp file

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
Saving a file in the editor override the original file permission

## How
<!-- Brief notes on the approach, only if non-obvious. -->


## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->
1. create `test.sh` file
2. run `chmod +x test.sh`
3. modify the file
4. save the file
5. check the file permission, and it's fixed

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
