### PR TITLE
[codex] Fix zsh history under shell integration

### DIFF
--- a/src-tauri/src/modules/pty/scripts/zlogin.zsh
+++ b/src-tauri/src/modules/pty/scripts/zlogin.zsh
@@ -6,8 +6,30 @@
 # first render — themes that condition prompt color on `%?` (robbyrussell etc.)
 # show a red error indicator on a clean shell start.
 {
-  _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
+  _terax_wrapper_zdotdir="${ZDOTDIR:-}"
+  _terax_had_wrapper_zdotdir=0
+  [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+
+  if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
+    export ZDOTDIR="$TERAX_USER_ZDOTDIR"
+  else
+    unset ZDOTDIR
+  fi
+
+  _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
   [ -f "$_terax_user_zdotdir/.zlogin" ] && source "$_terax_user_zdotdir/.zlogin"
-  unset _terax_user_zdotdir
+
+  if [ -n "${ZDOTDIR+x}" ]; then
+    export TERAX_USER_ZDOTDIR="$ZDOTDIR"
+  else
+    unset TERAX_USER_ZDOTDIR
+  fi
+
+  if [ "$_terax_had_wrapper_zdotdir" = 1 ]; then
+    export ZDOTDIR="$_terax_wrapper_zdotdir"
+  else
+    unset ZDOTDIR
+  fi
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zlogin.zsh
+++ b/src-tauri/src/modules/pty/scripts/zlogin.zsh
@@ -9,6 +9,8 @@
   _terax_wrapper_zdotdir="${ZDOTDIR:-}"
   _terax_had_wrapper_zdotdir=0
   [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+  _terax_wrapper_default_histfile=""
+  [ -n "$_terax_wrapper_zdotdir" ] && _terax_wrapper_default_histfile="$_terax_wrapper_zdotdir/.zsh_history"
 
   if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
     export ZDOTDIR="$TERAX_USER_ZDOTDIR"
@@ -17,6 +19,9 @@
   fi
 
   _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
+  if [ -n "$_terax_wrapper_default_histfile" ] && [ "${HISTFILE:-}" = "$_terax_wrapper_default_histfile" ]; then
+    HISTFILE="$_terax_user_zdotdir/.zsh_history"
+  fi
   [ -f "$_terax_user_zdotdir/.zlogin" ] && source "$_terax_user_zdotdir/.zlogin"
 
   if [ -n "${ZDOTDIR+x}" ]; then
@@ -30,6 +35,6 @@
   else
     unset ZDOTDIR
   fi
-  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_wrapper_default_histfile _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zprofile.zsh
+++ b/src-tauri/src/modules/pty/scripts/zprofile.zsh
@@ -5,6 +5,8 @@
   _terax_wrapper_zdotdir="${ZDOTDIR:-}"
   _terax_had_wrapper_zdotdir=0
   [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+  _terax_wrapper_default_histfile=""
+  [ -n "$_terax_wrapper_zdotdir" ] && _terax_wrapper_default_histfile="$_terax_wrapper_zdotdir/.zsh_history"
 
   if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
     export ZDOTDIR="$TERAX_USER_ZDOTDIR"
@@ -13,6 +15,9 @@
   fi
 
   _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
+  if [ -n "$_terax_wrapper_default_histfile" ] && [ "${HISTFILE:-}" = "$_terax_wrapper_default_histfile" ]; then
+    HISTFILE="$_terax_user_zdotdir/.zsh_history"
+  fi
   [ -f "$_terax_user_zdotdir/.zprofile" ] && source "$_terax_user_zdotdir/.zprofile"
 
   if [ -n "${ZDOTDIR+x}" ]; then
@@ -26,6 +31,6 @@
   else
     unset ZDOTDIR
   fi
-  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_wrapper_default_histfile _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zprofile.zsh
+++ b/src-tauri/src/modules/pty/scripts/zprofile.zsh
@@ -2,8 +2,30 @@
 #
 # See zshenv.zsh for the rationale on the trailing `:`.
 {
-  _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
+  _terax_wrapper_zdotdir="${ZDOTDIR:-}"
+  _terax_had_wrapper_zdotdir=0
+  [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+
+  if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
+    export ZDOTDIR="$TERAX_USER_ZDOTDIR"
+  else
+    unset ZDOTDIR
+  fi
+
+  _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
   [ -f "$_terax_user_zdotdir/.zprofile" ] && source "$_terax_user_zdotdir/.zprofile"
-  unset _terax_user_zdotdir
+
+  if [ -n "${ZDOTDIR+x}" ]; then
+    export TERAX_USER_ZDOTDIR="$ZDOTDIR"
+  else
+    unset TERAX_USER_ZDOTDIR
+  fi
+
+  if [ "$_terax_had_wrapper_zdotdir" = 1 ]; then
+    export ZDOTDIR="$_terax_wrapper_zdotdir"
+  else
+    unset ZDOTDIR
+  fi
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zshenv.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshenv.zsh
@@ -4,8 +4,30 @@
 # which propagates through the rest of init and ultimately into the first
 # prompt's `%?` (rendering robbyrussell's `➜` red on a clean shell start).
 {
-  _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
+  _terax_wrapper_zdotdir="${ZDOTDIR:-}"
+  _terax_had_wrapper_zdotdir=0
+  [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+
+  if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
+    export ZDOTDIR="$TERAX_USER_ZDOTDIR"
+  else
+    unset ZDOTDIR
+  fi
+
+  _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
   [ -f "$_terax_user_zdotdir/.zshenv" ] && source "$_terax_user_zdotdir/.zshenv"
-  unset _terax_user_zdotdir
+
+  if [ -n "${ZDOTDIR+x}" ]; then
+    export TERAX_USER_ZDOTDIR="$ZDOTDIR"
+  else
+    unset TERAX_USER_ZDOTDIR
+  fi
+
+  if [ "$_terax_had_wrapper_zdotdir" = 1 ]; then
+    export ZDOTDIR="$_terax_wrapper_zdotdir"
+  else
+    unset ZDOTDIR
+  fi
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zshenv.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshenv.zsh
@@ -7,6 +7,8 @@
   _terax_wrapper_zdotdir="${ZDOTDIR:-}"
   _terax_had_wrapper_zdotdir=0
   [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+  _terax_wrapper_default_histfile=""
+  [ -n "$_terax_wrapper_zdotdir" ] && _terax_wrapper_default_histfile="$_terax_wrapper_zdotdir/.zsh_history"
 
   if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
     export ZDOTDIR="$TERAX_USER_ZDOTDIR"
@@ -15,6 +17,9 @@
   fi
 
   _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
+  if [ -n "$_terax_wrapper_default_histfile" ] && [ "${HISTFILE:-}" = "$_terax_wrapper_default_histfile" ]; then
+    HISTFILE="$_terax_user_zdotdir/.zsh_history"
+  fi
   [ -f "$_terax_user_zdotdir/.zshenv" ] && source "$_terax_user_zdotdir/.zshenv"
 
   if [ -n "${ZDOTDIR+x}" ]; then
@@ -28,6 +33,6 @@
   else
     unset ZDOTDIR
   fi
-  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_wrapper_default_histfile _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -9,6 +9,8 @@
   _terax_wrapper_zdotdir="${ZDOTDIR:-}"
   _terax_had_wrapper_zdotdir=0
   [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+  _terax_wrapper_default_histfile=""
+  [ -n "$_terax_wrapper_zdotdir" ] && _terax_wrapper_default_histfile="$_terax_wrapper_zdotdir/.zsh_history"
 
   if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
     export ZDOTDIR="$TERAX_USER_ZDOTDIR"
@@ -17,11 +19,14 @@
   fi
 
   _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
+  if [ -n "$_terax_wrapper_default_histfile" ] && [ "${HISTFILE:-}" = "$_terax_wrapper_default_histfile" ]; then
+    HISTFILE="$_terax_user_zdotdir/.zsh_history"
+  fi
   [ -f "$_terax_user_zdotdir/.zshrc" ] && source "$_terax_user_zdotdir/.zshrc"
 
-  # zsh's automatic history read can miss HISTFILE when the user's real .zshrc
-  # is sourced through this wrapper. Force the same shared history file into the
-  # in-memory history list so history-backed widgets can see it immediately.
+  # zsh starts with ZDOTDIR pointed at Terax's wrapper directory. The init
+  # wrappers map the default HISTFILE back to the user's real dotfile directory;
+  # import that file now so history-backed widgets can use it at the first prompt.
   [ -n "$HISTFILE" ] && [ -r "$HISTFILE" ] && builtin fc -R "$HISTFILE" 2>/dev/null
 
   if [ -n "${ZDOTDIR+x}" ]; then
@@ -35,7 +40,7 @@
   else
     unset ZDOTDIR
   fi
-  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_wrapper_default_histfile _terax_user_zdotdir
 }
 
 # Re-source guard within a single shell (e.g. user runs `source ~/.zshrc`).

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -6,9 +6,36 @@
 # zsh, so we shadow $? into `_terax_ret`.
 
 {
-  _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
+  _terax_wrapper_zdotdir="${ZDOTDIR:-}"
+  _terax_had_wrapper_zdotdir=0
+  [ -n "${ZDOTDIR+x}" ] && _terax_had_wrapper_zdotdir=1
+
+  if [ -n "${TERAX_USER_ZDOTDIR+x}" ]; then
+    export ZDOTDIR="$TERAX_USER_ZDOTDIR"
+  else
+    unset ZDOTDIR
+  fi
+
+  _terax_user_zdotdir="${ZDOTDIR:-$HOME}"
   [ -f "$_terax_user_zdotdir/.zshrc" ] && source "$_terax_user_zdotdir/.zshrc"
-  unset _terax_user_zdotdir
+
+  # zsh's automatic history read can miss HISTFILE when the user's real .zshrc
+  # is sourced through this wrapper. Force the same shared history file into the
+  # in-memory history list so history-backed widgets can see it immediately.
+  [ -n "$HISTFILE" ] && [ -r "$HISTFILE" ] && builtin fc -R "$HISTFILE" 2>/dev/null
+
+  if [ -n "${ZDOTDIR+x}" ]; then
+    export TERAX_USER_ZDOTDIR="$ZDOTDIR"
+  else
+    unset TERAX_USER_ZDOTDIR
+  fi
+
+  if [ "$_terax_had_wrapper_zdotdir" = 1 ]; then
+    export ZDOTDIR="$_terax_wrapper_zdotdir"
+  else
+    unset ZDOTDIR
+  fi
+  unset _terax_wrapper_zdotdir _terax_had_wrapper_zdotdir _terax_user_zdotdir
 }
 
 # Re-source guard within a single shell (e.g. user runs `source ~/.zshrc`).

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -262,6 +262,173 @@ mod unix {
             format!("rename {} -> {}: {e}", tmp.display(), path.display())
         })
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::process::Command;
+
+        fn has_zsh() -> bool {
+            Command::new("zsh").arg("--version").output().is_ok()
+        }
+
+        fn quote_zsh_path(path: &Path) -> String {
+            let raw = path.to_string_lossy();
+            format!("'{}'", raw.replace('\'', "'\\''"))
+        }
+
+        fn write_zsh_wrapper(dir: &Path) {
+            fs::create_dir_all(dir).unwrap();
+            fs::write(dir.join(".zshenv"), ZSHENV).unwrap();
+            fs::write(dir.join(".zprofile"), ZPROFILE).unwrap();
+            fs::write(dir.join(".zshrc"), ZSHRC).unwrap();
+            fs::write(dir.join(".zlogin"), ZLOGIN).unwrap();
+        }
+
+        #[test]
+        fn zsh_histfile_uses_user_home_not_wrapper_zdotdir() {
+            if !has_zsh() {
+                eprintln!("skipping zsh history test: zsh not found");
+                return;
+            }
+
+            let tmp = tempfile::tempdir().unwrap();
+            let wrapper = tmp.path().join("wrapper");
+            let home = tmp.path().join("home");
+            write_zsh_wrapper(&wrapper);
+            fs::create_dir_all(&home).unwrap();
+            fs::write(
+                home.join(".zshrc"),
+                r#"HISTFILE="${ZDOTDIR:-$HOME}/.zsh_history""#,
+            )
+            .unwrap();
+
+            let out = Command::new("zsh")
+                .arg("-d")
+                .arg("-i")
+                .arg("-c")
+                .arg(r#"print -r -- "$HISTFILE""#)
+                .env("HOME", &home)
+                .env("ZDOTDIR", &wrapper)
+                .env("__TERAX_HOOKS_LOADED", "1")
+                .env_remove("HISTFILE")
+                .env_remove("TERAX_USER_ZDOTDIR")
+                .output()
+                .unwrap();
+
+            assert!(
+                out.status.success(),
+                "zsh failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&out.stdout).trim(),
+                home.join(".zsh_history").to_string_lossy()
+            );
+        }
+
+        #[test]
+        fn zsh_history_is_read_after_user_zshrc_sets_histfile() {
+            if !has_zsh() {
+                eprintln!("skipping zsh history read test: zsh not found");
+                return;
+            }
+
+            let tmp = tempfile::tempdir().unwrap();
+            let wrapper = tmp.path().join("wrapper");
+            let home = tmp.path().join("home");
+            write_zsh_wrapper(&wrapper);
+            fs::create_dir_all(&home).unwrap();
+            fs::write(
+                home.join(".zshrc"),
+                r#"HISTFILE="${ZDOTDIR:-$HOME}/.zsh_history""#,
+            )
+            .unwrap();
+            fs::write(
+                home.join(".zsh_history"),
+                ": 1:0;terax-history-regression-command\n",
+            )
+            .unwrap();
+
+            let out = Command::new("zsh")
+                .arg("-d")
+                .arg("-i")
+                .arg("-c")
+                .arg(r#"builtin fc -l 1"#)
+                .env("HOME", &home)
+                .env("ZDOTDIR", &wrapper)
+                .env("__TERAX_HOOKS_LOADED", "1")
+                .env_remove("HISTFILE")
+                .env_remove("TERAX_USER_ZDOTDIR")
+                .output()
+                .unwrap();
+
+            assert!(
+                out.status.success(),
+                "zsh failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert!(
+                String::from_utf8_lossy(&out.stdout).contains("terax-history-regression-command"),
+                "history output did not include expected command: {}",
+                String::from_utf8_lossy(&out.stdout)
+            );
+        }
+
+        #[test]
+        fn zshenv_user_zdotdir_override_controls_later_user_zshrc() {
+            if !has_zsh() {
+                eprintln!("skipping zsh ZDOTDIR override test: zsh not found");
+                return;
+            }
+
+            let tmp = tempfile::tempdir().unwrap();
+            let wrapper = tmp.path().join("wrapper");
+            let home = tmp.path().join("home");
+            let original_zdotdir = tmp.path().join("orig");
+            let alternate_zdotdir = tmp.path().join("alt");
+            let seen = tmp.path().join("seen");
+            write_zsh_wrapper(&wrapper);
+            fs::create_dir_all(&home).unwrap();
+            fs::create_dir_all(&original_zdotdir).unwrap();
+            fs::create_dir_all(&alternate_zdotdir).unwrap();
+
+            fs::write(
+                original_zdotdir.join(".zshenv"),
+                format!("export ZDOTDIR={}\n", quote_zsh_path(&alternate_zdotdir)),
+            )
+            .unwrap();
+            fs::write(
+                original_zdotdir.join(".zshrc"),
+                format!("echo orig > {}\n", quote_zsh_path(&seen)),
+            )
+            .unwrap();
+            fs::write(
+                alternate_zdotdir.join(".zshrc"),
+                format!("echo alt > {}\n", quote_zsh_path(&seen)),
+            )
+            .unwrap();
+
+            let out = Command::new("zsh")
+                .arg("-d")
+                .arg("-i")
+                .arg("-c")
+                .arg("true")
+                .env("HOME", &home)
+                .env("ZDOTDIR", &wrapper)
+                .env("TERAX_USER_ZDOTDIR", &original_zdotdir)
+                .env("__TERAX_HOOKS_LOADED", "1")
+                .output()
+                .unwrap();
+
+            assert!(
+                out.status.success(),
+                "zsh failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert_eq!(fs::read_to_string(seen).unwrap().trim(), "alt");
+        }
+    }
 }
 
 #[cfg(windows)]

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -299,12 +299,11 @@ mod unix {
             fs::create_dir_all(&home).unwrap();
             fs::write(
                 home.join(".zshrc"),
-                r#"HISTFILE="${ZDOTDIR:-$HOME}/.zsh_history""#,
+                r#"[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history""#,
             )
             .unwrap();
 
             let out = Command::new("zsh")
-                .arg("-d")
                 .arg("-i")
                 .arg("-c")
                 .arg(r#"print -r -- "$HISTFILE""#)
@@ -341,7 +340,7 @@ mod unix {
             fs::create_dir_all(&home).unwrap();
             fs::write(
                 home.join(".zshrc"),
-                r#"HISTFILE="${ZDOTDIR:-$HOME}/.zsh_history""#,
+                r#"[ -z "$HISTFILE" ] && HISTFILE="$HOME/.zsh_history""#,
             )
             .unwrap();
             fs::write(
@@ -351,7 +350,6 @@ mod unix {
             .unwrap();
 
             let out = Command::new("zsh")
-                .arg("-d")
                 .arg("-i")
                 .arg("-c")
                 .arg(r#"builtin fc -l 1"#)


### PR DESCRIPTION
## Summary
- map zsh default HISTFILE back from Terax wrapper ZDOTDIR to the user dotfile directory
- import the resolved history file before the first prompt so autosuggestion/history widgets can use existing shell history
- adjust zsh shell-integration regression tests for default-HISTFILE behavior

## Validation
- cargo test shell_init
- pnpm exec tsc --noEmit
- pnpm tauri build --bundles app produced Terax.app; updater tar.gz signing failed locally because TAURI_SIGNING_PRIVATE_KEY is not set
- manually verified the installed wrapper shows zsh-autosuggestions from ~/.zsh_history