### PR TITLE
feat: implement native API Tester (like Bruno/Postman)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "~2.5.1",
+    "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-log": "~2.8.0",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-os": "~2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@tauri-apps/plugin-autostart':
         specifier: ~2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-http':
+        specifier: ^2.5.9
+        version: 2.5.9
       '@tauri-apps/plugin-log':
         specifier: ~2.8.0
         version: 2.8.0
@@ -1883,6 +1886,9 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
     engines: {node: '>= 10'}
@@ -1961,6 +1967,9 @@ packages:
 
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-http@2.5.9':
+    resolution: {integrity: sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==}
 
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
@@ -6028,6 +6037,8 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
+  '@tauri-apps/api@2.11.0': {}
+
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     optional: true
 
@@ -6078,6 +6089,10 @@ snapshots:
   '@tauri-apps/plugin-autostart@2.5.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-http@2.5.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-log@2.8.0':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -634,8 +634,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -835,6 +854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1030,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1791,6 +1825,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +1962,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1953,9 +2007,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2409,6 +2465,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3412,6 +3474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3497,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -3492,7 +3570,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3744,8 +3822,12 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3754,6 +3836,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4643,6 +4726,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4974,54 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
 ]
 
 [[package]]
@@ -5165,6 +5317,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-http",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-os",
@@ -5348,6 +5501,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -6154,6 +6322,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 bytes = "1"
 futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
+tauri-plugin-http = "2.5.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -24,6 +24,14 @@
     "store:default",
     "autostart:allow-enable",
     "autostart:allow-disable",
-    "autostart:allow-is-enabled"
+    "autostart:allow-is-enabled",
+    "http:default",
+    {
+      "identifier": "http:allow-fetch",
+      "allow": [
+        { "url": "http://**" },
+        { "url": "https://**" }
+      ]
+    }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,7 @@ pub fn run() {
         .plugin(tauri_plugin_autostart::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_os::init())
+        .plugin(tauri_plugin_http::init())
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(tauri_plugin_log::log::LevelFilter::Info)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -37,6 +37,7 @@ import {
   NewEditorDialog,
   type EditorPaneHandle,
 } from "@/modules/editor";
+import { ApiTesterView } from "@/modules/api-tester";
 import { GitHistoryStack } from "@/modules/git-history";
 import { useZoom } from "@/lib/useZoom";
 import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
@@ -151,6 +152,7 @@ export default function App() {
     openGitDiffTab,
     openCommitHistoryTab,
     openCommitFileDiffTab,
+    openApiTesterTab,
     closeTab,
     updateTab,
     selectByIndex,
@@ -426,6 +428,7 @@ export default function App() {
   const isGitDiffTab =
     activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
   const isGitHistoryTab = activeTab?.kind === "git-history";
+  const isApiTesterTab = activeTab?.kind === "api-tester";
 
   // When an AI diff is approved (write_file applied to disk), reload any
   // open editor tabs for that path so the user sees the new content. We
@@ -861,6 +864,7 @@ export default function App() {
       "tab.newPrivate": openNewPrivateTab,
       "tab.newPreview": () => openPreviewTab(""),
       "tab.newEditor": () => setNewEditorOpen(true),
+      "tab.newApiTester": openApiTesterTab,
       "tab.close": handleCloseTabOrPane,
       "tab.next": () => cycleTab(1),
       "tab.prev": () => cycleTab(-1),
@@ -888,6 +892,7 @@ export default function App() {
       openNewTab,
       openNewPrivateTab,
       openPreviewTab,
+      openApiTesterTab,
       selectByIndex,
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
@@ -1119,6 +1124,15 @@ export default function App() {
           onOpenCommitFile={openCommitFileDiffTab}
         />
       </div>
+      <div
+        className={cn(
+          "absolute inset-0",
+          !isApiTesterTab && "invisible pointer-events-none",
+        )}
+        aria-hidden={!isApiTesterTab}
+      >
+        {isApiTesterTab && <ApiTesterView />}
+      </div>
     </div>
   );
 
@@ -1134,6 +1148,7 @@ export default function App() {
             onNewPrivate={openNewPrivateTab}
             onNewPreview={() => openPreviewTab("")}
             onNewEditor={() => setNewEditorOpen(true)}
+            onNewApiTester={openApiTesterTab}
             onClose={handleClose}
             onPin={pinTab}
             onToggleSidebar={toggleSidebar}

--- a/src/modules/api-tester/components/ApiTesterView.tsx
+++ b/src/modules/api-tester/components/ApiTesterView.tsx
@@ -1,0 +1,370 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useApiTesterStore } from "../store/apiTesterStore";
+import { Sidebar } from "./Sidebar";
+import { RequestEditor } from "./RequestEditor";
+import { ResponsePane } from "./ResponsePane";
+import type { ApiResponse } from "../types";
+import { parseCurl } from "../lib/parseCurl";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ComputerTerminal02Icon } from "@hugeicons/core-free-icons";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { createProxyFetch } from "@/modules/ai/lib/proxyFetch";
+
+export function ApiTesterView() {
+  const { collections, activeRequestId, updateRequest, createRequest } = useApiTesterStore();
+  const [response, setResponse] = useState<ApiResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [curlInput, setCurlInput] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+  const proxyFetch = useMemo(
+    () => createProxyFetch({ allowPrivateNetwork: true }),
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, []);
+
+  const setResponseSafe = (
+    value: ApiResponse | null | ((prev: ApiResponse | null) => ApiResponse | null)
+  ) => {
+    if (!isMountedRef.current) return;
+    setResponse(value);
+  };
+
+  const setLoadingSafe = (value: boolean) => {
+    if (!isMountedRef.current) return;
+    setLoading(value);
+  };
+
+  const activeRequest = collections
+    .flatMap((c) => c.requests)
+    .find((r) => r.id === activeRequestId);
+
+  const handleSend = async () => {
+    if (!activeRequest || loading) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoadingSafe(true);
+    setResponseSafe(null);
+    const start = performance.now();
+
+    try {
+      const headersMap: Record<string, string> = {};
+      activeRequest.headers
+        .filter((h) => h.enabled && h.key)
+        .forEach((h) => {
+          headersMap[h.key] = h.value;
+        });
+
+      let finalUrl = activeRequest.url;
+      try {
+        const urlObj = new URL(activeRequest.url);
+        activeRequest.queryParams
+          .filter((q) => q.enabled && q.key)
+          .forEach((q) => {
+            urlObj.searchParams.set(q.key, q.value);
+          });
+        finalUrl = urlObj.toString();
+      } catch (e) {
+        // Fallback for invalid URLs or relative paths during test
+      }
+
+      let bodyData: string | undefined = undefined;
+      if (activeRequest.body.type === "raw" && activeRequest.body.content) {
+        if (!headersMap["Content-Type"] && !headersMap["content-type"]) {
+          headersMap["Content-Type"] =
+            activeRequest.body.rawType === "json" ? "application/json" : "text/plain";
+        }
+        bodyData = activeRequest.body.content;
+      }
+
+      const res = await proxyFetch(finalUrl, {
+        method: activeRequest.method,
+        headers: headersMap,
+        body: bodyData,
+        signal: controller.signal,
+      });
+      const responseHeaders: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+
+      let accumulatedBody = "";
+      let sizeBytes = 0;
+      setResponseSafe({
+        status: res.status,
+        statusText: res.statusText,
+        headers: responseHeaders,
+        body: accumulatedBody,
+        timeMs: 0,
+        sizeBytes,
+        isError: false,
+      });
+
+      if (res.body) {
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done || controller.signal.aborted) break;
+          sizeBytes += value.length;
+          accumulatedBody += decoder.decode(value, { stream: true });
+          setResponseSafe((prev) => prev ? {
+            ...prev,
+            body: accumulatedBody,
+            sizeBytes,
+          } : prev);
+        }
+        accumulatedBody += decoder.decode();
+        setResponseSafe((prev) => prev ? {
+          ...prev,
+          body: accumulatedBody,
+          sizeBytes,
+        } : prev);
+      } else {
+        const text = await res.text();
+        accumulatedBody = text;
+        sizeBytes = new TextEncoder().encode(text).length;
+        setResponseSafe((prev) => prev ? {
+          ...prev,
+          body: accumulatedBody,
+          sizeBytes,
+        } : prev);
+      }
+
+      const end = performance.now();
+      setResponseSafe((prev) => prev ? {
+        ...prev,
+        timeMs: Math.round(end - start),
+        sizeBytes,
+      } : prev);
+
+    } catch (e: any) {
+      if (e?.name === "AbortError") {
+        return;
+      }
+      const end = performance.now();
+      setResponseSafe({
+        status: 0,
+        statusText: "Error",
+        headers: {},
+        body: "",
+        timeMs: Math.round(end - start),
+        sizeBytes: 0,
+        isError: true,
+        errorMsg: e.toString(),
+      });
+    } finally {
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+      setLoadingSafe(false);
+    }
+  };
+
+  const handleStop = () => {
+    abortRef.current?.abort();
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Enter") return;
+      const isMod = e.metaKey || e.ctrlKey;
+      if (!isMod) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (loading) {
+        handleStop();
+      } else {
+        void handleSend();
+      }
+    };
+
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
+  }, [loading, handleSend, handleStop]);
+
+  const handleImportCurl = () => {
+    if (!curlInput.trim()) return;
+    const req = parseCurl(curlInput);
+    if (req) {
+      // Find default collection or uncategorized
+      const defaultCol = collections.find((c) => c.name === "Uncategorized") || collections[0];
+      const colId = defaultCol ? defaultCol.id : null;
+      createRequest(colId, req);
+      setCurlInput("");
+    } else {
+      alert("Failed to parse cURL command");
+    }
+  };
+
+  return (
+    <div className="flex h-full w-full bg-background text-foreground overflow-hidden">
+      <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+        <ResizablePanel
+          id="api-tester-collections"
+          defaultSize="240px"
+          minSize="180px"
+          maxSize="420px"
+        >
+          <div className="h-full">
+            <Sidebar />
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel id="api-tester-main" minSize="320px">
+          <div className="flex h-full flex-col overflow-hidden">
+            {activeRequest ? (
+              <>
+                <div className="flex items-center gap-2 border-b border-border p-4 bg-card shrink-0">
+                  <select
+                    value={activeRequest.method}
+                    onChange={(e) => updateRequest(activeRequest.id, { method: e.target.value as any })}
+                    className="bg-transparent text-sm font-bold outline-none text-muted-foreground w-24"
+                  >
+                    {[
+                      "GET",
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE",
+                      "OPTIONS",
+                      "HEAD",
+                    ].map((m) => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    value={activeRequest.url}
+                    onChange={(e) => updateRequest(activeRequest.id, { url: e.target.value })}
+                    placeholder="Enter URL or paste cURL here"
+                    onPaste={(e) => {
+                      const text = e.clipboardData.getData("Text");
+                      if (text.trim().startsWith("curl ")) {
+                        e.preventDefault();
+                        const req = parseCurl(text);
+                        if (req) {
+                          updateRequest(activeRequest.id, req);
+                        }
+                      }
+                    }}
+                    className="flex-1 bg-transparent px-2 py-1 outline-none font-mono text-sm border border-transparent focus:border-border rounded"
+                  />
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={handleSend}
+                      disabled={loading}
+                      className="bg-primary text-primary-foreground hover:bg-primary/90 px-6 py-1.5 rounded text-sm font-medium disabled:opacity-50"
+                    >
+                      Send
+                    </button>
+                    {loading && (
+                      <button
+                        onClick={handleStop}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90 px-4 py-1.5 rounded text-sm font-medium"
+                      >
+                        Stop
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <ResizablePanelGroup orientation="vertical" className="flex-1 min-h-0">
+                  <ResizablePanel
+                    id="api-tester-request"
+                    defaultSize="55%"
+                    minSize="20%"
+                  >
+                    <div className="h-full min-h-0 overflow-y-auto">
+                      <RequestEditor
+                        request={activeRequest}
+                        onChange={(updates) => updateRequest(activeRequest.id, updates)}
+                      />
+                    </div>
+                  </ResizablePanel>
+                  <ResizableHandle withHandle />
+                  <ResizablePanel
+                    id="api-tester-response"
+                    defaultSize="45%"
+                    minSize="20%"
+                  >
+                    <div className="h-full">
+                      <ResponsePane response={response} loading={loading} />
+                    </div>
+                  </ResizablePanel>
+                </ResizablePanelGroup>
+              </>
+            ) : (
+              <div className="flex flex-1 items-center justify-center flex-col text-muted-foreground">
+                <HugeiconsIcon icon={ComputerTerminal02Icon} size={48} className="mb-4 opacity-20" />
+                <p className="mb-8">Select a request from the sidebar or create a new one.</p>
+
+                <div className="w-full max-w-4xl bg-card border border-border rounded-lg shadow-lg p-8">
+                  <div className="flex items-start gap-6">
+                    <HugeiconsIcon icon={ComputerTerminal02Icon} size={24} className="mt-1 opacity-90" />
+
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <div className="text-lg font-semibold text-foreground">Quick Import cURL</div>
+                          <div className="text-sm text-muted-foreground">Paste a cURL command to create a request</div>
+                        </div>
+                        <div className="text-sm text-muted-foreground hidden sm:block">Tip: Paste a curl command or the raw URL above</div>
+                      </div>
+
+                      <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <textarea
+                          value={curlInput}
+                          onChange={(e) => setCurlInput(e.target.value)}
+                          placeholder={`curl -X POST https://httpbin.org/post -H 'Content-Type: application/json' -d '{"name":"Jane"}'`}
+                          className="col-span-2 w-full bg-background border border-border rounded-md p-4 text-sm font-mono h-44 outline-none resize-none placeholder:text-muted-foreground"
+                        />
+
+                        <div className="col-span-1 bg-background/50 border border-border rounded-md p-3 text-sm text-muted-foreground">
+                          <div className="font-medium text-foreground mb-2">Preview</div>
+                          <div className="text-xs font-mono break-words">Paste a curl command to see a quick parse preview here.</div>
+                        </div>
+                      </div>
+
+                      <div className="mt-4 flex items-center gap-3">
+                        <button
+                          onClick={handleImportCurl}
+                          className="bg-primary text-primary-foreground hover:bg-primary/95 px-4 py-2 rounded-md text-sm font-medium transition-colors"
+                        >
+                          Import
+                        </button>
+                        <button
+                          onClick={() => setCurlInput("")}
+                          className="bg-transparent border border-border text-sm px-3 py-2 rounded-md text-muted-foreground"
+                        >
+                          Clear
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}

--- a/src/modules/api-tester/components/KeyValueTable.tsx
+++ b/src/modules/api-tester/components/KeyValueTable.tsx
@@ -1,0 +1,92 @@
+import type { KeyValuePair } from "../types";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Delete01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+
+function generateId() {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function KeyValueTable({
+  items,
+  onChange,
+}: {
+  items: KeyValuePair[];
+  onChange: (items: KeyValuePair[]) => void;
+}) {
+  const handleChange = (id: string, field: keyof KeyValuePair, value: any) => {
+    onChange(items.map((item) => (item.id === id ? { ...item, [field]: value } : item)));
+  };
+
+  const handleAdd = () => {
+    onChange([...items, { id: generateId(), key: "", value: "", enabled: true }]);
+  };
+
+  const handleRemove = (id: string) => {
+    onChange(items.filter((item) => item.id !== id));
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="rounded border border-border overflow-hidden">
+        <table className="w-full text-sm text-left">
+          <thead className="bg-muted/50 text-muted-foreground border-b border-border">
+            <tr>
+              <th className="w-8 p-2"></th>
+              <th className="p-2 border-l border-border">Key</th>
+              <th className="p-2 border-l border-border">Value</th>
+              <th className="w-8 p-2 border-l border-border"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id} className="border-b border-border last:border-0 group">
+                <td className="p-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={item.enabled}
+                    onChange={(e) => handleChange(item.id, "enabled", e.target.checked)}
+                    className="cursor-pointer"
+                  />
+                </td>
+                <td className="p-0 border-l border-border relative">
+                  <input
+                    type="text"
+                    value={item.key}
+                    onChange={(e) => handleChange(item.id, "key", e.target.value)}
+                    placeholder="Key"
+                    className="w-full bg-transparent p-2 outline-none placeholder:text-muted-foreground/50"
+                  />
+                </td>
+                <td className="p-0 border-l border-border relative">
+                  <input
+                    type="text"
+                    value={item.value}
+                    onChange={(e) => handleChange(item.id, "value", e.target.value)}
+                    placeholder="Value"
+                    className="w-full bg-transparent p-2 outline-none placeholder:text-muted-foreground/50"
+                  />
+                </td>
+                <td className="p-2 border-l border-border text-center">
+                  <button
+                    onClick={() => handleRemove(item.id)}
+                    className="text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-red-500"
+                  >
+                    <HugeiconsIcon icon={Delete01Icon} size={14} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <button
+          onClick={handleAdd}
+          className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 px-2 py-1"
+        >
+          <HugeiconsIcon icon={PlusSignIcon} size={12} /> Add Row
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/api-tester/components/RequestEditor.tsx
+++ b/src/modules/api-tester/components/RequestEditor.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import type { ApiRequest } from "../types";
+import { KeyValueTable } from "./KeyValueTable";
+import { cn } from "@/lib/utils";
+import CodeMirror from "@uiw/react-codemirror";
+import { json } from "@codemirror/lang-json";
+import { tokyoNight } from "@uiw/codemirror-theme-tokyo-night";
+
+export function RequestEditor({
+  request,
+  onChange,
+}: {
+  request: ApiRequest;
+  onChange: (updates: Partial<ApiRequest>) => void;
+}) {
+  const [tab, setTab] = useState<"params" | "headers" | "body">("params");
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-4 border-b border-border px-4 py-2">
+        <button
+          onClick={() => setTab("params")}
+          className={cn(
+            "text-sm font-medium pb-1 border-b-2",
+            tab === "params" ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+          )}
+        >
+          Params
+        </button>
+        <button
+          onClick={() => setTab("headers")}
+          className={cn(
+            "text-sm font-medium pb-1 border-b-2",
+            tab === "headers" ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+          )}
+        >
+          Headers
+        </button>
+        <button
+          onClick={() => setTab("body")}
+          className={cn(
+            "text-sm font-medium pb-1 border-b-2",
+            tab === "body" ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+          )}
+        >
+          Body
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {tab === "params" && (
+          <KeyValueTable
+            items={request.queryParams}
+            onChange={(items) => onChange({ queryParams: items })}
+          />
+        )}
+
+        {tab === "headers" && (
+          <KeyValueTable
+            items={request.headers}
+            onChange={(items) => onChange({ headers: items })}
+          />
+        )}
+
+        {tab === "body" && (
+          <div className="flex h-full flex-col gap-2">
+            <div className="flex gap-2 mb-2">
+              <select
+                value={request.body.type}
+                onChange={(e) =>
+                  onChange({
+                    body: { ...request.body, type: e.target.value as "none" | "raw" },
+                  })
+                }
+                className="bg-transparent border border-border rounded px-2 py-1 text-sm outline-none"
+              >
+                <option value="none">None</option>
+                <option value="raw">Raw</option>
+              </select>
+
+              {request.body.type === "raw" && (
+                <select
+                  value={request.body.rawType}
+                  onChange={(e) =>
+                    onChange({
+                      body: { ...request.body, rawType: e.target.value as "json" | "text" },
+                    })
+                  }
+                  className="bg-transparent border border-border rounded px-2 py-1 text-sm outline-none"
+                >
+                  <option value="json">JSON</option>
+                  <option value="text">Text</option>
+                </select>
+              )}
+            </div>
+
+            {request.body.type === "raw" && (
+              <div className="flex-1 border border-border rounded overflow-hidden">
+                <CodeMirror
+                  value={request.body.content}
+                  height="100%"
+                  extensions={request.body.rawType === "json" ? [json()] : []}
+                  theme={tokyoNight}
+                  onChange={(value) => onChange({ body: { ...request.body, content: value } })}
+                  className="h-full text-sm"
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/api-tester/components/ResponsePane.tsx
+++ b/src/modules/api-tester/components/ResponsePane.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useRef } from "react";
+import type { ApiResponse } from "../types";
+import { cn } from "@/lib/utils";
+import CodeMirror from "@uiw/react-codemirror";
+import { json } from "@codemirror/lang-json";
+import { tokyoNight } from "@uiw/codemirror-theme-tokyo-night";
+import type { EditorView } from "@codemirror/view";
+
+export function ResponsePane({
+  response,
+  loading,
+}: {
+  response: ApiResponse | null;
+  loading: boolean;
+}) {
+  const [tab, setTab] = useState<"body" | "headers">("body");
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const editorViewRef = useRef<EditorView | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+
+  const contentType = response?.headers?.["content-type"] ?? response?.headers?.["Content-Type"] ?? "";
+  const isEventStream = contentType.includes("text/event-stream");
+
+  useEffect(() => {
+    if (tab !== "body") return;
+    if (isEventStream && bodyRef.current) {
+      // scroll to bottom as new chunks arrive (event-stream view)
+      bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+      return;
+    }
+    if (editorViewRef.current) {
+      // scroll to bottom for CodeMirror view
+      const scrollDom = editorViewRef.current.scrollDOM;
+      scrollDom.scrollTop = scrollDom.scrollHeight;
+    }
+  }, [response?.body, tab, isEventStream]);
+
+  if (!response) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <span className={cn("text-sm", loading && "animate-pulse")}>
+          {loading ? "Sending request..." : "No response yet"}
+        </span>
+      </div>
+    );
+  }
+
+  const isSuccess = response.status >= 200 && response.status < 300;
+
+  let formattedBody = response.body;
+  let isJson = false;
+
+  if (contentType.includes("application/json")) {
+    try {
+      formattedBody = JSON.stringify(JSON.parse(response.body), null, 2);
+      isJson = true;
+    } catch {
+      // ignore
+    }
+  }
+
+  const handleCopy = async () => {
+    const textToCopy = tab === "headers"
+      ? Object.entries(response.headers)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join("\n")
+      : formattedBody;
+
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    }
+
+    window.setTimeout(() => setCopyState("idle"), 1500);
+  };
+
+  return (
+    <div className="flex h-full flex-col border-t border-border bg-card">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => setTab("body")}
+            className={cn(
+              "text-sm font-medium pb-1 border-b-2",
+              tab === "body" ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Body
+          </button>
+          <button
+            onClick={() => setTab("headers")}
+            className={cn(
+              "text-sm font-medium pb-1 border-b-2",
+              tab === "headers" ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Headers
+          </button>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleCopy}
+            className={cn(
+              "rounded border border-border px-2 py-1 text-xs",
+              copyState === "copied" && "border-green-500 text-green-500",
+              copyState === "error" && "border-red-500 text-red-500"
+            )}
+          >
+            {copyState === "copied"
+              ? "Copied"
+              : copyState === "error"
+                ? "Copy failed"
+                : tab === "headers"
+                  ? "Copy headers"
+                  : "Copy body"}
+          </button>
+          <div className="flex items-center gap-4 text-xs">
+            <span className={cn("font-bold", isSuccess ? "text-green-500" : "text-red-500")}>
+              {response.status} {response.statusText}
+            </span>
+            {loading && <span className="text-muted-foreground animate-pulse">Streaming...</span>}
+            <span className="text-muted-foreground">{response.timeMs} ms</span>
+            <span className="text-muted-foreground">{(response.sizeBytes / 1024).toFixed(2)} KB</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {response.isError && (
+          <div className="mb-4 text-red-500 text-sm">
+            Error: {response.errorMsg}
+          </div>
+        )}
+
+        {tab === "body" && (
+          <div
+            ref={bodyRef}
+            className={cn(
+              "h-full border border-border rounded",
+              isEventStream ? "overflow-y-auto" : "overflow-hidden"
+            )}
+          >
+            {isEventStream ? (
+              <pre className="p-3 text-sm font-mono whitespace-pre-wrap break-words">
+                {formattedBody || ""}
+              </pre>
+            ) : (
+              <CodeMirror
+                value={formattedBody}
+                height="100%"
+                extensions={isJson ? [json()] : []}
+                theme={tokyoNight}
+                readOnly
+                editable={false}
+                className="h-full text-sm"
+                onCreateEditor={(view) => {
+                  editorViewRef.current = view;
+                }}
+              />
+            )}
+          </div>
+        )}
+
+        {tab === "headers" && (
+          <div className="rounded border border-border overflow-hidden">
+            <table className="w-full text-sm text-left">
+              <thead className="bg-muted/50 text-muted-foreground border-b border-border">
+                <tr>
+                  <th className="p-2 border-r border-border">Key</th>
+                  <th className="p-2">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(response.headers).map(([key, value]) => (
+                  <tr key={key} className="border-b border-border last:border-0">
+                    <td className="p-2 border-r border-border font-medium">{key}</td>
+                    <td className="p-2 break-all">{value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/api-tester/components/Sidebar.tsx
+++ b/src/modules/api-tester/components/Sidebar.tsx
@@ -1,0 +1,195 @@
+import { useState } from "react";
+import { useApiTesterStore } from "../store/apiTesterStore";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FolderGitTwoIcon, PlusSignIcon, Delete01Icon, FileImportIcon } from "@hugeicons/core-free-icons";
+import { cn } from "@/lib/utils";
+import { importPostmanCollection } from "../lib/importPostman";
+
+export function Sidebar() {
+  const { collections, activeRequestId, setActiveRequest, createCollection, updateCollection, createRequest, updateRequest, deleteCollection, deleteRequest, importCollection } = useApiTesterStore();
+  const [editingCollectionId, setEditingCollectionId] = useState<string | null>(null);
+  const [editingRequestId, setEditingRequestId] = useState<string | null>(null);
+  const [nameDraft, setNameDraft] = useState("");
+
+  const startEditCollection = (id: string, currentName: string) => {
+    setEditingCollectionId(id);
+    setEditingRequestId(null);
+    setNameDraft(currentName);
+  };
+
+  const startEditRequest = (id: string, currentName: string) => {
+    setEditingRequestId(id);
+    setEditingCollectionId(null);
+    setNameDraft(currentName);
+  };
+
+  const finishEdit = () => {
+    if (editingCollectionId) {
+      const trimmed = nameDraft.trim();
+      if (trimmed) updateCollection(editingCollectionId, { name: trimmed });
+    }
+    if (editingRequestId) {
+      const trimmed = nameDraft.trim();
+      if (trimmed) updateRequest(editingRequestId, { name: trimmed });
+    }
+    setEditingCollectionId(null);
+    setEditingRequestId(null);
+    setNameDraft("");
+  };
+
+  const cancelEdit = () => {
+    setEditingCollectionId(null);
+    setEditingRequestId(null);
+    setNameDraft("");
+  };
+
+  const handleImport = () => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const text = await file.text();
+      const coll = importPostmanCollection(text);
+      if (coll) {
+        importCollection(coll);
+      } else {
+        alert("Failed to import Postman collection. Ensure it is a valid v2/v2.1 JSON format.");
+      }
+    };
+    input.click();
+  };
+
+  return (
+    <div className="flex h-full flex-col border-r border-border bg-card">
+      <div className="flex items-center justify-between border-b border-border p-2">
+        <span className="text-xs font-semibold uppercase text-muted-foreground">Collections</span>
+        <div className="flex gap-1">
+           <button
+            onClick={handleImport}
+            className="p-1 text-muted-foreground hover:text-foreground rounded hover:bg-accent"
+            title="Import Postman Collection"
+          >
+            <HugeiconsIcon icon={FileImportIcon} size={14} />
+          </button>
+          <button
+            onClick={() => createCollection("New Collection")}
+            className="p-1 text-muted-foreground hover:text-foreground rounded hover:bg-accent"
+            title="New Collection"
+          >
+            <HugeiconsIcon icon={PlusSignIcon} size={14} />
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2">
+        {collections.map((col) => (
+          <div key={col.id} className="mb-4">
+            <div className="group flex items-center justify-between rounded px-2 py-1 hover:bg-accent">
+              <div className="flex items-center gap-2 min-w-0">
+                <HugeiconsIcon icon={FolderGitTwoIcon} size={14} className="text-muted-foreground" />
+                {editingCollectionId === col.id ? (
+                  <input
+                    value={nameDraft}
+                    onChange={(e) => setNameDraft(e.target.value)}
+                    onBlur={finishEdit}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") finishEdit();
+                      if (e.key === "Escape") cancelEdit();
+                    }}
+                    className="bg-transparent text-sm font-medium outline-none border-b border-border"
+                    autoFocus
+                  />
+                ) : (
+                  <span
+                    className="text-sm font-medium truncate"
+                    onDoubleClick={() => startEditCollection(col.id, col.name)}
+                  >
+                    {col.name}
+                  </span>
+                )}
+              </div>
+              <div className="flex opacity-0 group-hover:opacity-100">
+                <button
+                  onClick={() => createRequest(col.id)}
+                  className="p-1 text-muted-foreground hover:text-foreground"
+                  title="New Request"
+                >
+                  <HugeiconsIcon icon={PlusSignIcon} size={12} />
+                </button>
+                <button
+                  onClick={() => deleteCollection(col.id)}
+                  className="p-1 text-muted-foreground hover:text-red-500"
+                  title="Delete Collection"
+                >
+                  <HugeiconsIcon icon={Delete01Icon} size={12} />
+                </button>
+              </div>
+            </div>
+            <div className="ml-4 mt-1 space-y-1">
+              {col.requests.map((req) => (
+                <div
+                  key={req.id}
+                  onClick={() => {
+                    if (editingRequestId !== req.id) setActiveRequest(req.id);
+                  }}
+                  className={cn(
+                    "group flex cursor-pointer items-center justify-between rounded px-2 py-1 text-sm",
+                    activeRequestId === req.id
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  )}
+                >
+                  <div className="flex items-center gap-2 overflow-hidden min-w-0">
+                    <span className={cn("text-[10px] font-bold",
+                      req.method === "GET" && "text-green-500",
+                      req.method === "POST" && "text-blue-500",
+                      req.method === "PUT" && "text-orange-500",
+                      req.method === "DELETE" && "text-red-500",
+                    )}>
+                      {req.method}
+                    </span>
+                    {editingRequestId === req.id ? (
+                      <input
+                        value={nameDraft}
+                        onChange={(e) => setNameDraft(e.target.value)}
+                        onBlur={finishEdit}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") finishEdit();
+                          if (e.key === "Escape") cancelEdit();
+                        }}
+                        className="bg-transparent text-sm outline-none border-b border-border flex-1 min-w-0"
+                        autoFocus
+                      />
+                    ) : (
+                      <span
+                        className="truncate"
+                        onDoubleClick={() => startEditRequest(req.id, req.name)}
+                      >
+                        {req.name}
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteRequest(req.id);
+                    }}
+                    className="p-1 opacity-0 group-hover:opacity-100 hover:text-red-500"
+                  >
+                    <HugeiconsIcon icon={Delete01Icon} size={12} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+        {collections.length === 0 && (
+          <div className="text-center text-xs text-muted-foreground mt-4">
+            No collections yet.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/api-tester/index.ts
+++ b/src/modules/api-tester/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./store/apiTesterStore";
+export * from "./components/ApiTesterView";

--- a/src/modules/api-tester/lib/importPostman.ts
+++ b/src/modules/api-tester/lib/importPostman.ts
@@ -1,0 +1,97 @@
+import type { ApiCollection, ApiRequest, HttpMethod, KeyValuePair } from "../types";
+
+function generateId() {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function importPostmanCollection(jsonString: string): ApiCollection | null {
+  try {
+    const data = JSON.parse(jsonString);
+
+    // Very basic Postman v2/v2.1 validation
+    if (!data.info || !data.item) {
+      return null;
+    }
+
+    const collectionName = data.info.name || "Imported Collection";
+    const requests: ApiRequest[] = [];
+
+    // Helper to recursively extract items
+    function extractItems(items: any[]) {
+      for (const item of items) {
+        if (item.item) {
+          // It's a folder, extract its items
+          extractItems(item.item);
+        } else if (item.request) {
+          // It's a request
+          const req = item.request;
+
+          let url = "";
+          if (typeof req.url === "string") {
+            url = req.url;
+          } else if (req.url && req.url.raw) {
+            url = req.url.raw;
+          }
+
+          const headers: KeyValuePair[] = (req.header || []).map((h: any) => ({
+            id: generateId(),
+            key: h.key || "",
+            value: h.value || "",
+            enabled: h.disabled !== true,
+          }));
+
+          const queryParams: KeyValuePair[] = [];
+          if (req.url && Array.isArray(req.url.query)) {
+            for (const q of req.url.query) {
+              queryParams.push({
+                id: generateId(),
+                key: q.key || "",
+                value: q.value || "",
+                enabled: q.disabled !== true,
+              });
+            }
+          }
+
+          let bodyType: "none" | "raw" = "none";
+          let rawType: "json" | "text" = "text";
+          let content = "";
+
+          if (req.body) {
+            if (req.body.mode === "raw") {
+              bodyType = "raw";
+              content = req.body.raw || "";
+              if (req.body.options && req.body.options.raw && req.body.options.raw.language === "json") {
+                rawType = "json";
+              }
+            }
+          }
+
+          requests.push({
+            id: generateId(),
+            name: item.name || "Untitled Request",
+            method: (req.method || "GET").toUpperCase() as HttpMethod,
+            url,
+            headers,
+            queryParams,
+            body: {
+              type: bodyType,
+              rawType,
+              content,
+            },
+          });
+        }
+      }
+    }
+
+    extractItems(data.item);
+
+    return {
+      id: generateId(),
+      name: collectionName,
+      requests,
+    };
+  } catch (e) {
+    console.error("Failed to parse Postman collection", e);
+    return null;
+  }
+}

--- a/src/modules/api-tester/lib/parseCurl.ts
+++ b/src/modules/api-tester/lib/parseCurl.ts
@@ -1,0 +1,94 @@
+import type { ApiRequest, HttpMethod } from "../types";
+import { createDefaultRequest } from "../store/apiTesterStore";
+
+function generateId() {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function parseCurl(curlString: string): Partial<ApiRequest> | null {
+  const cmd = curlString.trim();
+  if (!cmd.startsWith("curl ")) return null;
+
+  const req = createDefaultRequest();
+
+  // A very basic parser. Split by spaces, respecting quotes.
+  const regex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
+  const tokens: string[] = [];
+  let match;
+  while ((match = regex.exec(cmd)) !== null) {
+    tokens.push(match[1] || match[2] || match[0]);
+  }
+
+  let methodSet = false;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (token === "-X" || token === "--request") {
+      if (i + 1 < tokens.length) {
+        req.method = tokens[++i].toUpperCase() as HttpMethod;
+        methodSet = true;
+      }
+    } else if (token === "-H" || token === "--header") {
+      if (i + 1 < tokens.length) {
+        const headerStr = tokens[++i];
+        const colonIndex = headerStr.indexOf(":");
+        if (colonIndex !== -1) {
+          req.headers.push({
+            id: generateId(),
+            key: headerStr.substring(0, colonIndex).trim(),
+            value: headerStr.substring(colonIndex + 1).trim(),
+            enabled: true,
+          });
+        }
+      }
+    } else if (token === "-d" || token === "--data" || token === "--data-raw") {
+      if (i + 1 < tokens.length) {
+        req.body.type = "raw";
+        let content = tokens[++i];
+
+        // Try to prettify if it's JSON
+        try {
+          const parsedJson = JSON.parse(content);
+          content = JSON.stringify(parsedJson, null, 2);
+          req.body.rawType = "json";
+        } catch (e) {
+          // not json, leave as is
+        }
+
+        req.body.content = content;
+        if (!methodSet) {
+          req.method = "POST";
+          methodSet = true;
+        }
+      }
+    } else if (!token.startsWith("-") && req.url === "") {
+      // Treat the first non-flag argument as the URL
+      // Strip outer quotes if present
+      let url = token;
+      if ((url.startsWith("'") && url.endsWith("'")) || (url.startsWith('"') && url.endsWith('"'))) {
+        url = url.substring(1, url.length - 1);
+      }
+      req.url = url;
+    }
+  }
+
+  // Try to parse query params from URL
+  try {
+    const parsedUrl = new URL(req.url);
+    parsedUrl.searchParams.forEach((value, key) => {
+      req.queryParams.push({
+        id: generateId(),
+        key,
+        value,
+        enabled: true,
+      });
+    });
+    // Optional: strip query string from url so it can be managed by the UI entirely
+    // req.url = req.url.split('?')[0];
+  } catch (e) {
+    // Ignore invalid URL
+  }
+
+  return req;
+}

--- a/src/modules/api-tester/store/apiTesterStore.ts
+++ b/src/modules/api-tester/store/apiTesterStore.ts
@@ -1,0 +1,168 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { ApiCollection, ApiRequest } from "../types";
+
+function generateId() {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function createDefaultRequest(): ApiRequest {
+  return {
+    id: generateId(),
+    name: "New Request",
+    method: "GET",
+    url: "",
+    headers: [],
+    queryParams: [],
+    body: { type: "none", rawType: "json", content: "" },
+  };
+}
+
+const apiTesterStorage = createJSONStorage(() => {
+  if (typeof window === "undefined") {
+    return {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+  }
+
+  let pending: { name: string; value: string } | null = null;
+  let timer: number | null = null;
+
+  return {
+    getItem: (name) => window.localStorage.getItem(name),
+    setItem: (name, value) => {
+      pending = { name, value };
+      if (timer) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        if (!pending) return;
+        window.localStorage.setItem(pending.name, pending.value);
+        pending = null;
+        timer = null;
+      }, 300);
+    },
+    removeItem: (name) => {
+      if (timer) {
+        window.clearTimeout(timer);
+        timer = null;
+        pending = null;
+      }
+      window.localStorage.removeItem(name);
+    },
+  };
+});
+
+type ApiTesterState = {
+  collections: ApiCollection[];
+  activeRequestId: string | null;
+
+  createCollection: (name: string) => string;
+  updateCollection: (id: string, updates: Partial<ApiCollection>) => void;
+  deleteCollection: (id: string) => void;
+  importCollection: (collection: ApiCollection) => void;
+
+  createRequest: (collectionId: string | null, overrides?: Partial<ApiRequest>) => string;
+  updateRequest: (id: string, updates: Partial<ApiRequest>) => void;
+  deleteRequest: (id: string) => void;
+
+  setActiveRequest: (id: string | null) => void;
+};
+
+export const useApiTesterStore = create<ApiTesterState>()(
+  persist(
+    (set) => ({
+      collections: [],
+      activeRequestId: null,
+
+      createCollection: (name) => {
+        const id = generateId();
+        set((state) => ({
+          collections: [...state.collections, { id, name, requests: [] }],
+        }));
+        return id;
+      },
+
+      updateCollection: (id, updates) => {
+        set((state) => ({
+          collections: state.collections.map((c) => (c.id === id ? { ...c, ...updates } : c)),
+        }));
+      },
+
+      deleteCollection: (id) => {
+        set((state) => {
+          const newCollections = state.collections.filter((c) => c.id !== id);
+          // if active request was in this collection, clear it
+          const isActiveDeleted = state.collections
+            .find((c) => c.id === id)
+            ?.requests.some((r) => r.id === state.activeRequestId);
+          return {
+            collections: newCollections,
+            activeRequestId: isActiveDeleted ? null : state.activeRequestId,
+          };
+        });
+      },
+
+      importCollection: (collection) => {
+        set((state) => ({
+          collections: [...state.collections, collection],
+        }));
+      },
+
+      createRequest: (collectionId, overrides) => {
+        const req = { ...createDefaultRequest(), ...overrides };
+        set((state) => {
+          if (!collectionId) {
+            // Put it in an "Uncategorized" collection if none exists, or just the first one
+            let defaultCol = state.collections.find((c) => c.name === "Uncategorized");
+            let collections = state.collections;
+            if (!defaultCol) {
+              defaultCol = { id: generateId(), name: "Uncategorized", requests: [] };
+              collections = [...collections, defaultCol];
+            }
+            return {
+              collections: collections.map((c) =>
+                c.id === defaultCol!.id ? { ...c, requests: [...c.requests, req] } : c
+              ),
+              activeRequestId: req.id,
+            };
+          }
+          return {
+            collections: state.collections.map((c) =>
+              c.id === collectionId ? { ...c, requests: [...c.requests, req] } : c
+            ),
+            activeRequestId: req.id,
+          };
+        });
+        return req.id;
+      },
+
+      updateRequest: (id, updates) => {
+        set((state) => ({
+          collections: state.collections.map((c) => ({
+            ...c,
+            requests: c.requests.map((r) => (r.id === id ? { ...r, ...updates } : r)),
+          })),
+        }));
+      },
+
+      deleteRequest: (id) => {
+        set((state) => ({
+          collections: state.collections.map((c) => ({
+            ...c,
+            requests: c.requests.filter((r) => r.id !== id),
+          })),
+          activeRequestId: state.activeRequestId === id ? null : state.activeRequestId,
+        }));
+      },
+
+      setActiveRequest: (id) => {
+        set({ activeRequestId: id });
+      },
+    }),
+    {
+      name: "terax-api-tester-storage",
+      storage: apiTesterStorage,
+    }
+  )
+);

--- a/src/modules/api-tester/types.ts
+++ b/src/modules/api-tester/types.ts
@@ -1,0 +1,39 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
+
+export type KeyValuePair = {
+  id: string;
+  key: string;
+  value: string;
+  enabled: boolean;
+};
+
+export type ApiRequest = {
+  id: string;
+  name: string;
+  method: HttpMethod;
+  url: string;
+  headers: KeyValuePair[];
+  queryParams: KeyValuePair[];
+  body: {
+    type: "none" | "raw";
+    rawType: "json" | "text" | "html" | "xml";
+    content: string;
+  };
+};
+
+export type ApiCollection = {
+  id: string;
+  name: string;
+  requests: ApiRequest[];
+};
+
+export type ApiResponse = {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  timeMs: number;
+  sizeBytes: number;
+  isError: boolean;
+  errorMsg?: string;
+};

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -39,6 +39,7 @@ type Props = {
   onNewPrivate: () => void;
   onNewPreview: () => void;
   onNewEditor: () => void;
+  onNewApiTester: () => void;
   onClose: (id: number) => void;
   /** Promote a preview (transient) tab to persistent. */
   onPin: (id: number) => void;
@@ -62,6 +63,7 @@ export function Header({
   onNewPrivate,
   onNewPreview,
   onNewEditor,
+  onNewApiTester,
   onClose,
   onPin,
   onToggleSidebar,
@@ -208,6 +210,7 @@ export function Header({
           onNewPrivate={onNewPrivate}
           onNewPreview={onNewPreview}
           onNewEditor={onNewEditor}
+          onNewApiTester={onNewApiTester}
           onClose={onClose}
           onPin={onPin}
           compact={compact}

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -9,6 +9,7 @@ export type ShortcutId =
   | "tab.newPrivate"
   | "tab.newPreview"
   | "tab.newEditor"
+  | "tab.newApiTester"
   | "tab.close"
   | "tab.next"
   | "tab.prev"
@@ -90,6 +91,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "New editor tab",
     group: "Tabs",
     defaultBindings: [{ [MOD_PROP]: true, key: "e" }],
+  },
+  {
+    id: "tab.newApiTester",
+    label: "Open API tester",
+    group: "Tabs",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "y" }],
   },
   {
     id: "tab.close",

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -31,6 +31,7 @@ type Props = {
   onNewPrivate: () => void;
   onNewPreview: () => void;
   onNewEditor: () => void;
+  onNewApiTester: () => void;
   onClose: (id: number) => void;
   /** Pin (promote) a preview tab to persistent on double-click. */
   onPin: (id: number) => void;
@@ -45,6 +46,7 @@ export function TabBar({
   onNewPrivate,
   onNewPreview,
   onNewEditor,
+  onNewApiTester,
   onClose,
   onPin,
   compact,
@@ -195,6 +197,10 @@ export function TabBar({
                 {fmtShortcut(MOD_KEY, "P")}
               </span>
             </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onNewApiTester()}>
+              <HugeiconsIcon icon={Globe02Icon} size={14} strokeWidth={1.75} />
+              <span className="flex-1">API Tester</span>
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -203,6 +209,16 @@ export function TabBar({
 }
 
 function TabIcon({ tab }: { tab: Tab }) {
+  if (tab.kind === "api-tester") {
+    return (
+      <HugeiconsIcon
+        icon={Globe02Icon}
+        size={14}
+        strokeWidth={2}
+        className="shrink-0 text-indigo-500"
+      />
+    );
+  }
   if (tab.kind === "editor") {
     const url = fileIconUrl(tab.title);
     return url ? <img src={url} alt="" className="size-3.5 shrink-0" /> : null;
@@ -268,13 +284,14 @@ function TabIcon({ tab }: { tab: Tab }) {
 }
 
 function labelFor(t: Tab): string {
+  if (t.kind === "api-tester") return t.title;
   if (t.kind === "editor") return t.title;
   if (t.kind === "preview") return t.title;
   if (t.kind === "ai-diff") return t.title;
   if (t.kind === "git-diff") return t.title;
   if (t.kind === "git-history") return t.title;
   if (t.kind === "git-commit-file") return t.title;
-  if (!t.cwd) return t.title;
+  if (!("cwd" in t) || !t.cwd) return t.title;
   const parts = t.cwd.split(/[\\/]/).filter(Boolean);
   return parts.length ? parts[parts.length - 1] : "/";
 }

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -10,6 +10,7 @@ export {
   type GitDiffTab,
   type GitHistoryTab,
   type GitCommitFileDiffTab,
+  type ApiTesterTab,
   type AiDiffStatus,
   type TabPatch,
 } from "./lib/useTabs";

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -93,6 +93,12 @@ export type GitCommitFileDiffTab = {
   originalPath: string | null;
 };
 
+export type ApiTesterTab = {
+  id: number;
+  kind: "api-tester";
+  title: string;
+};
+
 export type Tab =
   | TerminalTab
   | EditorTab
@@ -100,7 +106,8 @@ export type Tab =
   | AiDiffTab
   | GitDiffTab
   | GitHistoryTab
-  | GitCommitFileDiffTab;
+  | GitCommitFileDiffTab
+  | ApiTesterTab;
 
 export type TabPatch = Partial<{
   title: string;
@@ -511,6 +518,28 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     [],
   );
 
+  const openApiTesterTab = useCallback(() => {
+    const existing = tabsRef.current.find((t) => t.kind === "api-tester");
+    if (existing) {
+      setActiveId(existing.id);
+      return existing.id;
+    }
+
+    const id = nextIdRef.current++;
+    const nextTabs = [
+      ...tabsRef.current,
+      {
+        id,
+        kind: "api-tester",
+        title: "API Tester",
+      } satisfies ApiTesterTab,
+    ];
+    tabsRef.current = nextTabs;
+    setTabs(nextTabs);
+    setActiveId(id);
+    return id;
+  }, []);
+
   const closeTab = useCallback((id: number) => {
     let toDispose: number[] = [];
     setTabs((curr) => {
@@ -754,6 +783,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     openGitDiffTab,
     openCommitHistoryTab,
     openCommitFileDiffTab,
+    openApiTesterTab,
     setAiDiffStatus,
     closeAiDiffTab,
     closeTab,


### PR DESCRIPTION
## What

Introduces a Postman-like native API Tester feature to the app: a full UI for collections/requests, request editor, streaming response viewer, Postman collection import, cURL parsing, and a native proxy to bypass webview CORS. Also includes streaming optimizations and debounced persistence.

## Why
Users need a reliable, desktop-capable API testing tool inside the Terax that eases the workflow instead of having to juggle between apps.

## How
- Frontend UI: `ApiTesterView` with `Sidebar`, `RequestEditor`, and `ResponsePane` for collections, request editing, and streaming responses.
- Native proxy: uses existing `ai_http_stream` / `ai_http_request` via `createProxyFetch` (proxyFetch.ts) so requests originate from the native layer and bypass CORS.
- Streaming: incremental `sizeBytes` updates per chunk and `timeMs` set after stream completion to avoid O(n^2) re-encoding.
- Persistence: debounced `createJSONStorage` wrapper (300ms) for apiTesterStore.ts to batch localStorage writes.
- Import & parsing: lightweight Postman v2/v2.1 importer and basic cURL parser to seed requests.

## Testing
- In-app: setup a local streaming response server and tested via the API Tester and observed streaming body updates, incremental `sizeBytes`, and final `timeMs`.
- Also tested & Verified on publically availble APIs.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
<img width="1920" height="1080" alt="api_tester(1)" src="https://github.com/user-attachments/assets/0d4545f6-934d-411b-a2b9-c5d4375f624c" />
