### PR TITLE
feat: added Terminal group w/ terminal.clear shortcut

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -992,9 +992,14 @@ export default function App() {
       "view.zoomReset": zoomReset,
       "editor.undo": () => editorRefs.current.get(activeId)?.undo(),
       "editor.redo": () => editorRefs.current.get(activeId)?.redo(),
+      "terminal.clear": () => {
+        if (activeLeafId !== null)
+          terminalRefs.current.get(activeLeafId)?.clear();
+      },
     }),
     [
       activeId,
+      activeLeafId,
       cycleTab,
       handleCloseTabOrPane,
       openNewTab,

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -30,7 +30,8 @@ export type ShortcutId =
   | "settings.open"
   | "sidebar.toggle"
   | "editor.undo"
-  | "editor.redo";
+  | "editor.redo"
+  | "terminal.clear";
 
 export type ShortcutGroup =
   | "General"
@@ -39,7 +40,8 @@ export type ShortcutGroup =
   | "Search"
   | "AI"
   | "View"
-  | "Editor";
+  | "Editor"
+  | "Terminal";
 
 export type KeyBinding = {
   key: string;
@@ -227,6 +229,12 @@ export const SHORTCUTS: Shortcut[] = [
     group: "Editor",
     defaultBindings: [{ [MOD_PROP]: true, key: "y" }],
   },
+  {
+    id: "terminal.clear",
+    label: "Clear terminal",
+    group: "Terminal",
+    defaultBindings: [],
+  },
 ];
 
 export const SHORTCUT_GROUPS: ShortcutGroup[] = [
@@ -237,6 +245,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   "Search",
   "AI",
   "Editor",
+  "Terminal",
 ];
 
 /**

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -8,6 +8,7 @@ export type TerminalPaneHandle = {
   focus: () => void;
   getBuffer: (maxLines?: number) => string | null;
   getSelection: () => string | null;
+  clear: () => void;
 };
 
 type Props = {
@@ -63,6 +64,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
         focus: () => session.focus(),
         getBuffer: (max?: number) => session.getBuffer(max),
         getSelection: () => session.getSelection(),
+        clear: () => session.clear(),
       }),
       [session],
     );

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -438,13 +438,17 @@ export function useTerminalSession({
     return sel.length > 0 ? sel : null;
   }, [leafId]);
 
+  const clear = useCallback(() => {
+    getSlotForLeaf(leafId)?.term.clear();
+  }, [leafId]);
+
   const applyTheme = useCallback(() => {
     applyPoolTheme();
   }, []);
 
   return useMemo(
-    () => ({ write, focus, getBuffer, getSelection, applyTheme }),
-    [write, focus, getBuffer, getSelection, applyTheme],
+    () => ({ write, focus, getBuffer, getSelection, clear, applyTheme }),
+    [write, focus, getBuffer, getSelection, clear, applyTheme],
   );
 }
 


### PR DESCRIPTION
## What
This PR adds a) a Terminal section in the keyboard shortcuts b) the ability to clear the terminal. By default, it's left empty.

Would close [this issue](https://github.com/crynta/terax-ai/issues/404)

## Why
Native MacOS users can't clear the terminal using Cmd + K. That's currently used for showing the shortcuts themselves, so for now just adding an un-mapped shortcut preserves current behavior and lets the user customize.

## How


## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
See below

## Notes for reviewer
This doesn't add any fix for the bug where clashing commands = first one (in order) wins.

https://github.com/user-attachments/assets/bac0f7fa-791f-44de-8cb9-1778dd142b1b


