### PR TITLE
fix(ci): strip bundled wayland libs from appimage to fix egl crash on newer mesa

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
           printf '%s' "$KEY_CONTENT" > "$HOME/private_keys/AuthKey.p8"
           echo "APPLE_API_KEY_PATH=$HOME/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
 
-      - uses: tauri-apps/tauri-action@v0
+      - id: tauri
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -94,3 +95,59 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}
+
+      # Strip outdated bundled libwayland-* libs from the AppImage so it loads
+      # the host's libs at runtime. The Ubuntu 22.04 build host ships
+      # libwayland 1.20, but recent Mesa (e.g. Fedora 43 / Mesa 25.3) expects
+      # 1.22+ symbols; the loader's lib-search-path preference makes the
+      # bundled copy win, breaking EGL with EGL_BAD_PARAMETER. These libs are
+      # on the AppImage project's standard excludelist for exactly this
+      # reason — host copies are ABI-stable and always preferred.
+      - name: Fix AppImage wayland libs and re-sign
+        if: matrix.platform == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          APPIMAGE=$(ls src-tauri/target/release/bundle/appimage/*.AppImage | head -n1)
+          BASENAME=$(basename "$APPIMAGE")
+          LATEST=src-tauri/target/release/bundle/latest.json
+          echo "Patching: $APPIMAGE"
+
+          WORK=$(mktemp -d)
+          cp "$APPIMAGE" "$WORK/"
+          pushd "$WORK" >/dev/null
+          chmod +x "./$BASENAME"
+          "./$BASENAME" --appimage-extract >/dev/null
+
+          rm -f squashfs-root/usr/lib/libwayland-client.so.0 \
+                squashfs-root/usr/lib/libwayland-egl.so.1 \
+                squashfs-root/usr/lib/libwayland-cursor.so.0
+
+          curl -fsSL -o appimagetool.AppImage \
+            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x appimagetool.AppImage
+          ARCH=x86_64 ./appimagetool.AppImage --appimage-extract-and-run squashfs-root "$BASENAME"
+          popd >/dev/null
+
+          cp "$WORK/$BASENAME" "$APPIMAGE"
+
+          rm -f "$APPIMAGE.sig"
+          pnpm tauri signer sign "$APPIMAGE"
+
+          if [ -f "$LATEST" ]; then
+            NEW_SIG=$(cat "$APPIMAGE.sig")
+            jq --arg sig "$NEW_SIG" '.platforms["linux-x86_64"].signature = $sig' "$LATEST" > "$LATEST.tmp"
+            mv "$LATEST.tmp" "$LATEST"
+          fi
+
+          TAG="${GITHUB_REF_NAME}"
+          gh release upload "$TAG" "$APPIMAGE" "$APPIMAGE.sig" \
+            --clobber --repo "$GITHUB_REPOSITORY"
+          if [ -f "$LATEST" ]; then
+            gh release upload "$TAG" "$LATEST" \
+              --clobber --repo "$GITHUB_REPOSITORY"
+          fi


### PR DESCRIPTION
## What

Post-process the AppImage in CI to remove the three bundled `libwayland-*` libs that ship with Tauri's `linuxdeploy-plugin-gtk` output, then re-sign it for the updater.

## Why

Closes #295.

The AppImage built on the `ubuntu-22.04` runner bundles `libwayland-client.so.0`, `libwayland-egl.so.1`, and `libwayland-cursor.so.0` from libwayland 1.20. On systems with recent Mesa — Fedora 43 / Mesa 25.3, Arch, Bazzite, etc. — the dynamic loader prefers these bundled copies over the host's, but Mesa was built against libwayland 1.22+ and uses symbols the older bundled libs don't have. `eglGetDisplay()` then returns an invalid display:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

These libs are on the official AppImage [excludelist](https://github.com/AppImageCommunity/pkg2appimage/blob/master/excludelist) for exactly this reason — they have stable ABI and the host copy is always safe to use. `linuxdeploy-plugin-gtk` bundles them anyway, and Tauri 2 exposes no config to exclude libraries from the AppImage (`bundle.linux.appimage` only supports `bundleMediaFramework` and `files`).

Verified manually on Fedora 43 (Intel iGPU, Wayland, Mesa 25.3.6): extracting the released 0.7.1 AppImage, deleting the three libs, and running `AppRun` again — the app launches cleanly with full GPU acceleration.

## How

New CI step after `tauri-action`, gated on `ubuntu-22.04` and tag pushes:

1. Extract the produced `.AppImage` with `--appimage-extract`.
2. `rm` the three offending libs from `squashfs-root/usr/lib/`.
3. Repack with `appimagetool` (`--appimage-extract-and-run`, no FUSE needed on runners).
4. Re-sign with `pnpm tauri signer sign` — the existing `.sig` is invalidated by the repack.
5. Patch `latest.json` with the new signature via `jq` so the updater endpoint keeps working.
6. Re-upload the patched `.AppImage`, `.sig`, and `latest.json` to the draft release with `gh release upload --clobber`.

No change to `tauri.conf.json` or app source.

## Testing

- [x] `pnpm exec tsc --noEmit` clean — no app code touched
- [x] Manual smoke-test of the fix on the failing environment: extracted the released 0.7.1 AppImage, removed the three libs, repacked, launched on Fedora 43 / Wayland / Mesa 25.3 — app starts, no EGL error, hardware GPU in use.
- [ ] (If you touched `src-tauri/`) `cargo check` clean — N/A, no Rust changes
- [ ] (If UI) tested in `pnpm tauri dev` — N/A, CI-only change

CI-side verification will happen on the next tag push. Suggested check before tagging a release: dispatch the workflow against a throwaway tag (e.g. `v0.7.2-rc1`), download the produced `.AppImage` + `.sig`, run on Fedora 43 / Bazzite / Arch (Wayland), and confirm the previous 0.7.1 can self-update to it via the regenerated `latest.json` signature.

## Notes for reviewer

- Signing relies on the Tauri CLI honoring the existing `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` env vars during `signer sign`. If a future Tauri CLI version drops env-var support, pass them explicitly: `pnpm tauri signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$APPIMAGE"`.
- The step is gated `if: matrix.platform == 'ubuntu-22.04' && startsWith(github.ref, 'refs/tags/')` so `workflow_dispatch` runs from a branch don't try to upload to a non-existent release.
- macOS / Windows artifacts are untouched.
- Long-term, the cleanest fix would be upstream — either `linuxdeploy-plugin-gtk` respecting the AppImage excludelist, or Tauri exposing an `excludedLibs` option. This patch is a contained workaround until then.