### PR TITLE
fix: make settings window resizable and increase default size

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,10 +49,9 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
 
     let mut builder = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(url_path.into()))
         .title("Settings")
-        .inner_size(820.0, 620.0)
+        .inner_size(900.0, 700.0)
         .min_inner_size(820.0, 620.0)
-        .max_inner_size(820.0, 620.0)
-        .resizable(false)
+        .resizable(true)
         .visible(false)
         // Keep settings above the main app window so it doesn't get hidden
         // when the user clicks back into the editor or terminal (#33).


### PR DESCRIPTION
## Description
This PR fixes issue #415 by making the settings window resizable and increasing its default size.

## Changes
- Increased default window size from 820x620 to 900x700 pixels for better visibility
- Made window resizable by setting `resizable(true)`
- Removed `max_inner_size` constraint to allow unlimited expansion
- Kept `min_inner_size` at 820x620 to maintain usability


Fixes #416


## Screenshots / GIFs
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a45638d2-9f94-47b7-8a85-76f87f81c02c" />
