### PR TITLE
feat(terminal,ai): add configurable shell overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,20 +104,20 @@ Latest installers are on the [Releases](https://github.com/crynta/terax-ai/relea
 2. Pick a provider and paste your API key. For local inference, point Terax at your LM Studio / MLX / Ollama endpoint.
 3. Keys are written to the OS keychain via `keyring`. They never touch disk or localStorage.
 
-## Shell command overrides
+## Shell executable overrides
 
-You can now configure shell commands used by both the built-in terminal and AI tool execution:
+You can now configure shell executables used by both the built-in terminal and AI tool execution:
 
-- **Settings -> General → Terminal shell command**
+- **Settings -> General -> Terminal shell executable**
   - Controls which shell binary opens interactive terminal tabs.
   - Leave empty to auto-detect based on your platform and default behavior.
-  - Supports presets like `bash`, `zsh`, `fish`, `cmd`, `powershell`, `pwsh`, or any absolute shell command.
+  - Supports presets like `bash`, `zsh`, `fish`, `cmd`, `powershell`, `pwsh`, or any absolute shell executable.
 
-- **Settings -> General → Agent shell command**
-  - Controls the shell used by AI tools that execute commands (`run_command`, `shell_session_run`, `shell_bg_spawn`).
+- **Settings -> General -> Agent shell executable**
+  - Controls the shell executable used by AI command tools (`bash_run`, `bash_background`).
   - Leave empty to keep platform defaults.
 
-Both fields are trimmed before use and applied to the backend shell launcher. If a custom command is invalid or unavailable, shell startup/execution will fail and the normal UI error path is used.
+Both fields are trimmed before use and applied to the backend shell launcher. If a custom executable is invalid or unavailable, shell startup/execution will fail and the normal UI error path is used.
 
 ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ Latest installers are on the [Releases](https://github.com/crynta/terax-ai/relea
 2. Pick a provider and paste your API key. For local inference, point Terax at your LM Studio / MLX / Ollama endpoint.
 3. Keys are written to the OS keychain via `keyring`. They never touch disk or localStorage.
 
+## Shell command overrides
+
+You can now configure shell commands used by both the built-in terminal and AI tool execution:
+
+- **Settings -> General → Terminal shell command**
+  - Controls which shell binary opens interactive terminal tabs.
+  - Leave empty to auto-detect based on your platform and default behavior.
+  - Supports presets like `bash`, `zsh`, `fish`, `cmd`, `powershell`, `pwsh`, or any absolute shell command.
+
+- **Settings -> General → Agent shell command**
+  - Controls the shell used by AI tools that execute commands (`run_command`, `shell_session_run`, `shell_bg_spawn`).
+  - Leave empty to keep platform defaults.
+
+Both fields are trimmed before use and applied to the backend shell launcher. If a custom command is invalid or unavailable, shell startup/execution will fail and the normal UI error path is used.
+
 ## Build from source
 
 **Prerequisites**

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -41,6 +41,7 @@ pub async fn pty_open(
     rows: u16,
     cwd: Option<String>,
     workspace: Option<WorkspaceEnv>,
+    shell_override: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
@@ -50,7 +51,8 @@ pub async fn pty_open(
         e
     })?;
     let session = tauri::async_runtime::spawn_blocking(move || {
-        session::spawn(cols, rows, cwd, workspace, on_data, on_exit).map(|(s, _)| s)
+        session::spawn(cols, rows, cwd, workspace, shell_override, on_data, on_exit)
+            .map(|(s, _)| s)
     })
     .await
     .map_err(|e| {

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -94,6 +94,7 @@ pub fn spawn(
     rows: u16,
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    shell_override: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<(Arc<Session>, PtySize), String> {
@@ -109,7 +110,7 @@ pub fn spawn(
     };
     let pair = pty_system.openpty(size).map_err(|e| e.to_string())?;
 
-    let cmd = shell_init::build_command(cwd, workspace)?;
+    let cmd = shell_init::build_command(cwd, workspace, shell_override)?;
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -50,15 +50,17 @@ fn fish_init_script() -> &'static str {
 pub fn build_command(
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    shell_override: Option<String>,
 ) -> Result<CommandBuilder, String> {
+    let shell_override = shell_override.as_deref().map(str::trim).filter(|s| !s.is_empty());
     #[cfg(unix)]
     {
         let _ = workspace;
-        unix::build(cwd)
+        unix::build(cwd, shell_override)
     }
     #[cfg(windows)]
     {
-        windows::build(cwd, workspace)
+        windows::build(cwd, workspace, shell_override)
     }
 }
 
@@ -126,8 +128,10 @@ mod unix {
     }
 
     impl Shell {
-        pub fn detect() -> (Shell, String) {
-            let path = login_shell()
+        pub fn detect(override_path: Option<&str>) -> (Shell, String) {
+            let path = override_path
+                .map(String::from)
+                .or_else(login_shell)
                 .or_else(|| std::env::var("SHELL").ok())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "/bin/zsh".into());
@@ -158,8 +162,8 @@ mod unix {
         }
     }
 
-    pub fn build(cwd: Option<String>) -> Result<CommandBuilder, String> {
-        let (shell, shell_path) = Shell::detect();
+    pub fn build(cwd: Option<String>, shell_override: Option<&str>) -> Result<CommandBuilder, String> {
+        let (shell, shell_path) = Shell::detect(shell_override);
         let mut cmd = CommandBuilder::new(&shell_path);
         super::apply_common(&mut cmd, cwd);
 
@@ -310,12 +314,18 @@ mod windows {
         args: Vec<String>,
     }
 
-    pub fn build(cwd: Option<String>, workspace: WorkspaceEnv) -> Result<CommandBuilder, String> {
+    pub fn build(
+        cwd: Option<String>,
+        workspace: WorkspaceEnv,
+        shell_override: Option<&str>,
+    ) -> Result<CommandBuilder, String> {
         if let WorkspaceEnv::Wsl { distro } = workspace {
-            return build_wsl(cwd, distro);
+            return build_wsl(cwd, distro, shell_override);
         }
-        let shell_path = super::windows_shell_path();
-        let shell_name = shell_path
+        let shell_path = shell_override
+            .map(String::from)
+            .unwrap_or_else(|| super::windows_shell_path().to_string_lossy().into_owned());
+        let shell_name = std::path::Path::new(&shell_path)
             .file_name()
             .and_then(|s| s.to_str())
             .map(|s| s.to_ascii_lowercase())
@@ -343,13 +353,20 @@ mod windows {
             log::info!("spawning {} without shell integration", shell_name);
         }
 
-        log::info!("spawning Windows shell: {}", shell_path.display());
+        log::info!("spawning Windows shell: {shell_path}");
         Ok(cmd)
     }
 
-    fn build_wsl(cwd: Option<String>, distro: String) -> Result<CommandBuilder, String> {
+    fn build_wsl(
+        cwd: Option<String>,
+        distro: String,
+        shell_override: Option<&str>,
+    ) -> Result<CommandBuilder, String> {
         crate::modules::workspace::validate_wsl_distro_name(&distro)?;
-        let shell_path = crate::modules::workspace::wsl_login_shell(distro.clone())?;
+        let shell_path = match shell_override {
+            Some(s) if !s.trim().is_empty() => s.to_string(),
+            _ => crate::modules::workspace::wsl_login_shell(distro.clone())?,
+        };
         let shell_kind = ShellKind::from_path(&shell_path);
         let integration = match shell_kind {
             ShellKind::Zsh => match prepare_wsl_zdotdir(&distro) {

--- a/src-tauri/src/modules/shell/background.rs
+++ b/src-tauri/src/modules/shell/background.rs
@@ -92,6 +92,7 @@ impl Drop for BackgroundProc {
 pub fn spawn(
     command: String,
     cwd: Option<String>,
+    shell_override: Option<String>,
     workspace: WorkspaceEnv,
 ) -> Result<Arc<BackgroundProc>, String> {
     let trimmed = command.trim().to_string();
@@ -104,7 +105,12 @@ pub fn spawn(
         }
     }
 
-    let mut cmd = super::build_oneshot_command(&trimmed, &workspace, cwd.as_deref())?;
+    let mut cmd = super::build_oneshot_command(
+        &trimmed,
+        &workspace,
+        cwd.as_deref(),
+        shell_override.as_deref(),
+    )?;
     if let (WorkspaceEnv::Local, Some(ref dir)) = (&workspace, &cwd) {
         cmd.current_dir(dir);
     }

--- a/src-tauri/src/modules/shell/mod.rs
+++ b/src-tauri/src/modules/shell/mod.rs
@@ -4,7 +4,7 @@ pub mod session;
 
 use std::collections::HashMap;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{mpsc, Arc, RwLock};
@@ -43,6 +43,7 @@ pub async fn shell_run_command(
     command: String,
     cwd: Option<String>,
     timeout_secs: Option<u64>,
+    shell_override: Option<String>,
     workspace: Option<WorkspaceEnv>,
     registry: tauri::State<'_, WorkspaceRegistry>,
 ) -> Result<CommandOutput, String> {
@@ -69,7 +70,13 @@ pub async fn shell_run_command(
     // runtime stays unblocked.
     let (tx, rx) = mpsc::channel::<Result<CommandOutput, String>>();
     thread::spawn(move || {
-        let _ = tx.send(run_blocking(trimmed, cwd_path, workspace, dur));
+        let _ = tx.send(run_blocking(
+            trimmed,
+            cwd_path,
+            workspace,
+            shell_override.as_deref(),
+            dur,
+        ));
     });
 
     rx.recv().map_err(|e| e.to_string())?
@@ -79,18 +86,25 @@ pub(crate) fn run_blocking_inner(
     command: String,
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    shell_override: Option<&str>,
     dur: Duration,
 ) -> Result<CommandOutput, String> {
-    run_blocking(command, cwd, workspace, dur)
+    run_blocking(command, cwd, workspace, shell_override, dur)
 }
 
 fn run_blocking(
     command: String,
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    shell_override: Option<&str>,
     dur: Duration,
 ) -> Result<CommandOutput, String> {
-    let mut cmd = build_oneshot_command(&command, &workspace, cwd.as_deref())?;
+    let mut cmd = build_oneshot_command(
+        &command,
+        &workspace,
+        cwd.as_deref(),
+        shell_override,
+    )?;
     if let (WorkspaceEnv::Local, Some(dir)) = (&workspace, cwd) {
         cmd.current_dir(dir);
     }
@@ -173,6 +187,7 @@ pub fn shell_session_open(
     state: tauri::State<ShellState>,
     registry: tauri::State<WorkspaceRegistry>,
     cwd: Option<String>,
+    shell_override: Option<String>,
     workspace: Option<WorkspaceEnv>,
 ) -> Result<u32, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
@@ -187,7 +202,11 @@ pub fn shell_session_open(
             }
         }
     };
-    let session = Arc::new(ShellSession::new(initial, workspace));
+    let session = Arc::new(ShellSession::new_with_shell(
+        initial,
+        workspace,
+        shell_override,
+    ));
     let id = state.next_session_id.fetch_add(1, Ordering::Relaxed);
     state.sessions.write().unwrap().insert(id, session);
     Ok(id)
@@ -236,11 +255,12 @@ pub fn shell_bg_spawn(
     registry: tauri::State<WorkspaceRegistry>,
     command: String,
     cwd: Option<String>,
+    shell_override: Option<String>,
     workspace: Option<WorkspaceEnv>,
 ) -> Result<u32, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
     authorize_spawn_cwd(&registry, cwd.as_deref(), &workspace)?;
-    let proc = background::spawn(command, cwd, workspace)?;
+    let proc = background::spawn(command, cwd, shell_override, workspace)?;
     let id = state.next_bg_id.fetch_add(1, Ordering::Relaxed);
     state.bg.write().unwrap().insert(id, proc);
     Ok(id)
@@ -285,29 +305,55 @@ pub(crate) fn build_oneshot_command(
     command: &str,
     #[cfg_attr(not(windows), allow(unused_variables))] workspace: &WorkspaceEnv,
     #[cfg_attr(not(windows), allow(unused_variables))] cwd: Option<&str>,
+    shell_override: Option<&str>,
 ) -> Result<Command, String> {
     #[cfg(windows)]
     if let WorkspaceEnv::Wsl { distro } = workspace {
         validate_wsl_distro_name(distro)?;
+        let shell = shell_override
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("sh");
         let mut cmd = Command::new("wsl.exe");
         cmd.arg("-d").arg(distro);
         if let Some(cwd) = cwd.filter(|s| !s.is_empty()) {
             cmd.arg("--cd").arg(cwd);
         }
-        cmd.arg("--exec").arg("sh").arg("-lc").arg(command);
+        cmd.arg("--exec").arg(shell).arg("-lc").arg(command);
         return Ok(cmd);
     }
     #[cfg(unix)]
     {
-        let mut cmd = Command::new("/bin/sh");
-        cmd.arg("-c").arg(command);
+        let shell = shell_override
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("/bin/sh");
+        let mut cmd = Command::new(shell);
+        let shell_name = Path::new(shell)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_ascii_lowercase())
+            .unwrap_or_default();
+        if shell_name == "cmd" || shell_name == "cmd.exe" {
+            cmd.arg("/C").arg(command);
+        } else {
+            cmd.arg("-lc").arg(command);
+        }
         Ok(cmd)
     }
     #[cfg(windows)]
     {
-        let shell = crate::modules::pty::shell_init::windows_shell_path();
+        let shell = shell_override
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| {
+                crate::modules::pty::shell_init::windows_shell_path()
+                    .to_string_lossy()
+                    .into_owned()
+            });
         let mut cmd = Command::new(&shell);
-        let is_cmd = shell
+        let is_cmd = std::path::Path::new(&shell)
             .file_name()
             .and_then(|s| s.to_str())
             .map(|s| s.eq_ignore_ascii_case("cmd.exe"))

--- a/src-tauri/src/modules/shell/session.rs
+++ b/src-tauri/src/modules/shell/session.rs
@@ -16,6 +16,7 @@ pub struct ShellSession {
     #[allow(dead_code)]
     pub started_at_ms: u64,
     sentinel: String,
+    shell_override: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -45,6 +46,14 @@ fn generate_sentinel() -> String {
 
 impl ShellSession {
     pub fn new(initial_cwd: String, workspace: WorkspaceEnv) -> Self {
+        Self::new_with_shell(initial_cwd, workspace, None)
+    }
+
+    pub fn new_with_shell(
+        initial_cwd: String,
+        workspace: WorkspaceEnv,
+        shell_override: Option<String>,
+    ) -> Self {
         let started_at_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
@@ -55,6 +64,7 @@ impl ShellSession {
             pristine: AtomicBool::new(true),
             started_at_ms,
             sentinel: generate_sentinel(),
+            shell_override,
         }
     }
 
@@ -88,11 +98,13 @@ impl ShellSession {
 
         let (tx, rx) = mpsc::channel::<Result<super::CommandOutput, String>>();
         let cwd_for_thread = cwd.clone();
+        let shell_override = self.shell_override.clone();
         thread::spawn(move || {
             let _ = tx.send(run_blocking_inner(
                 wrapped,
                 Some(cwd_for_thread),
                 effective_workspace,
+                shell_override.as_deref(),
                 timeout,
             ));
         });

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -184,17 +184,20 @@ export const native = {
     command: string,
     cwd?: string | null,
     timeoutSecs?: number,
+    shellOverride?: string | null,
   ) =>
     invoke<CommandOutput>("shell_run_command", {
       command,
       cwd: cwd ?? null,
       timeoutSecs: timeoutSecs ?? null,
+      shellOverride: shellOverride ?? null,
       workspace: currentWorkspaceEnv(),
     }),
 
-  shellSessionOpen: (cwd?: string | null) =>
+  shellSessionOpen: (cwd?: string | null, shellOverride?: string | null) =>
     invoke<number>("shell_session_open", {
       cwd: cwd ?? null,
+      shellOverride: shellOverride ?? null,
       workspace: currentWorkspaceEnv(),
     }),
   shellSessionRun: (
@@ -219,10 +222,15 @@ export const native = {
     }),
   shellSessionClose: (id: number) =>
     invoke<void>("shell_session_close", { id }),
-  shellBgSpawn: (command: string, cwd?: string | null) =>
+  shellBgSpawn: (
+    command: string,
+    cwd?: string | null,
+    shellOverride?: string | null,
+  ) =>
     invoke<number>("shell_bg_spawn", {
       command,
       cwd: cwd ?? null,
+      shellOverride: shellOverride ?? null,
       workspace: currentWorkspaceEnv(),
     }),
   shellBgLogs: (handle: number, sinceOffset?: number) =>

--- a/src/modules/ai/tools/shell.ts
+++ b/src/modules/ai/tools/shell.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { native } from "../lib/native";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { checkShellCommand } from "../lib/security";
 import type { ToolContext } from "./context";
 import { currentWorkspaceEnv, workspaceScopeKey } from "@/modules/workspace";
@@ -11,20 +12,25 @@ import { currentWorkspaceEnv, workspaceScopeKey } from "@/modules/workspace";
  */
 const sessionShells = new Map<string, Promise<number>>();
 
+function getAgentShellCommand(): string {
+  return usePreferencesStore.getState().agentShellCommand.trim();
+}
+
+function agentShellSessionKey(sessionId: string): string {
+  const shell = getAgentShellCommand() || "auto";
+  return `${sessionId}:${workspaceScopeKey(currentWorkspaceEnv())}:${shell}`;
+}
+
 async function getSessionShell(
   sessionId: string,
   cwd: string | null,
 ): Promise<number> {
   let p = sessionShells.get(sessionId);
   if (!p) {
-    p = native.shellSessionOpen(cwd);
+    p = native.shellSessionOpen(cwd, getAgentShellCommand());
     sessionShells.set(sessionId, p);
   }
   return p;
-}
-
-function workspaceSessionKey(sessionId: string): string {
-  return `${sessionId}:${workspaceScopeKey(currentWorkspaceEnv())}`;
 }
 
 export function buildShellTools(ctx: ToolContext) {
@@ -44,7 +50,7 @@ export function buildShellTools(ctx: ToolContext) {
         if (!sid) return { error: "no active chat session" };
         try {
           const cwd = ctx.getCwd();
-          const shellId = await getSessionShell(workspaceSessionKey(sid), cwd);
+          const shellId = await getSessionShell(agentShellSessionKey(sid), cwd);
           const r = await native.shellSessionRun(
             shellId,
             command,
@@ -79,7 +85,11 @@ export function buildShellTools(ctx: ToolContext) {
         if (!safety.ok) return { error: safety.reason };
         const effectiveCwd = cwd ?? ctx.getCwd();
         try {
-          const handle = await native.shellBgSpawn(command, effectiveCwd);
+          const handle = await native.shellBgSpawn(
+            command,
+            effectiveCwd,
+            getAgentShellCommand(),
+          );
           return { handle, command, cwd: effectiveCwd, ok: true };
         } catch (e) {
           return { error: String(e) };

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -79,6 +79,8 @@ export type Preferences = {
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  terminalShellCommand: string;
+  agentShellCommand: string;
   lastWslDistro: string | null;
   zoomLevel: number;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
@@ -118,6 +120,8 @@ const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_TERMINAL_SHELL_COMMAND = "terminalShellCommand";
+const KEY_AGENT_SHELL_COMMAND = "agentShellCommand";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_SHORTCUTS = "shortcuts";
@@ -170,6 +174,8 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  terminalShellCommand: "",
+  agentShellCommand: "",
   lastWslDistro: null,
   zoomLevel: 1.0,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
@@ -276,6 +282,12 @@ export async function loadPreferences(): Promise<Preferences> {
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
     ),
+    terminalShellCommand:
+      get<string>(KEY_TERMINAL_SHELL_COMMAND)?.trim() ??
+      DEFAULT_PREFERENCES.terminalShellCommand,
+    agentShellCommand:
+      get<string>(KEY_AGENT_SHELL_COMMAND)?.trim() ??
+      DEFAULT_PREFERENCES.agentShellCommand,
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
@@ -451,6 +463,18 @@ export async function setTerminalScrollback(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_SCROLLBACK, clampScrollback(value));
 }
 
+function normalizeShellCommand(value: string): string {
+  return value.trim();
+}
+
+export async function setTerminalShellCommand(value: string): Promise<void> {
+  await writePref(KEY_TERMINAL_SHELL_COMMAND, normalizeShellCommand(value));
+}
+
+export async function setAgentShellCommand(value: string): Promise<void> {
+  await writePref(KEY_AGENT_SHELL_COMMAND, normalizeShellCommand(value));
+}
+
 export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
@@ -508,6 +532,8 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_TERMINAL_SHELL_COMMAND]: "terminalShellCommand",
+    [KEY_AGENT_SHELL_COMMAND]: "agentShellCommand",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_SHORTCUTS]: "shortcuts",

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -18,6 +18,7 @@ export async function openPty(
   rows: number,
   handlers: PtyHandlers,
   cwd?: string,
+  shellOverride?: string | null,
 ): Promise<PtySession> {
   // Raw bytes — no base64/JSON round-trip; messages arrive as ArrayBuffer.
   const onData = new Channel<ArrayBuffer>();
@@ -42,6 +43,7 @@ export async function openPty(
     cols,
     rows,
     cwd: cwd ?? null,
+    shellOverride: shellOverride?.trim() || null,
     workspace: currentWorkspaceEnv(),
     onData,
     onExit,

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -145,6 +145,7 @@ async function openPtyForSession(
 ): Promise<PtySession> {
   const startCols = s.cols > 0 ? s.cols : 80;
   const startRows = s.rows > 0 ? s.rows : 24;
+  const shellOverride = usePreferencesStore.getState().terminalShellCommand;
   return openPty(
     startCols,
     startRows,
@@ -160,6 +161,7 @@ async function openPtyForSession(
       },
     },
     cwd,
+    shellOverride,
   );
 }
 

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -58,7 +58,15 @@ const LETTER_SPACINGS = [-4, -3, -2, -1, 0, 1, 2, 3, 4] as const;
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 2.0;
 const ZOOM_STEP = 0.05;
-const SHELL_PRESETS = ["bash", "zsh", "fish", "sh", "cmd", "powershell", "pwsh"] as const;
+const SHELL_PRESETS = [
+  "bash",
+  "zsh",
+  "fish",
+  "sh",
+  "cmd",
+  "powershell",
+  "pwsh",
+] as const;
 const CUSTOM_SHELL_VALUE = "__custom__";
 
 function shellPresetFromValue(value: string): string {
@@ -90,12 +98,13 @@ function ShellCommandField({
   useEffect(() => {
     setIsCustom(selected === CUSTOM_SHELL_VALUE);
   }, [selected]);
+  const selectValue = isCustom ? CUSTOM_SHELL_VALUE : selected;
 
   return (
     <div className="flex flex-col gap-2">
       <SettingRow title={title} description={description}>
         <Select
-          value={selected}
+          value={selectValue}
           onValueChange={(v) => {
             setIsCustom(v === CUSTOM_SHELL_VALUE);
             if (v === "auto") onChange("");
@@ -128,7 +137,7 @@ function ShellCommandField({
         <input
           type="text"
           value={value}
-          placeholder="Type custom shell command"
+          placeholder="Type custom shell executable"
           onChange={(e) => onChange(e.target.value)}
           className="h-8 w-64 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
         />
@@ -373,14 +382,14 @@ export function GeneralSection() {
           </Select>
         </SettingRow>
         <ShellCommandField
-          title="Terminal shell command"
-          description="Shell command for the built-in terminal PTY session."
+          title="Terminal shell executable"
+          description="Shell executable for built-in terminal PTY sessions."
           value={terminalShellCommand}
           onChange={(value) => void setTerminalShellCommand(value)}
         />
         <ShellCommandField
-          title="Agent shell command"
-          description="Shell command used by AI tools (`run`, `background`)."
+          title="Agent shell executable"
+          description="Shell executable used by AI command tools."
           value={agentShellCommand}
           onChange={(value) => void setAgentShellCommand(value)}
         />

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -25,8 +25,10 @@ import {
   setTerminalFontFamily,
   setTerminalLetterSpacing,
   setTerminalFontSize,
+  setTerminalShellCommand,
   setTerminalScrollback,
   setTerminalWebglEnabled,
+  setAgentShellCommand,
   setVimMode,
   setZoomLevel,
 } from "@/modules/settings/store";
@@ -38,7 +40,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SectionHeader } from "../components/SectionHeader";
 import { SettingRow } from "../components/SettingRow";
 
@@ -56,6 +58,84 @@ const LETTER_SPACINGS = [-4, -3, -2, -1, 0, 1, 2, 3, 4] as const;
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 2.0;
 const ZOOM_STEP = 0.05;
+const SHELL_PRESETS = ["bash", "zsh", "fish", "sh", "cmd", "powershell", "pwsh"] as const;
+const CUSTOM_SHELL_VALUE = "__custom__";
+
+function shellPresetFromValue(value: string): string {
+  if (!value) return "auto";
+  return SHELL_PRESETS.includes(value as (typeof SHELL_PRESETS)[number])
+    ? value
+    : CUSTOM_SHELL_VALUE;
+}
+
+function shellPresetLabel(value: string): string {
+  return value === "auto" ? "Auto-detect" : value;
+}
+
+type ShellCommandFieldProps = {
+  title: string;
+  description: string;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+function ShellCommandField({
+  title,
+  description,
+  value,
+  onChange,
+}: ShellCommandFieldProps) {
+  const selected = useMemo(() => shellPresetFromValue(value), [value]);
+  const [isCustom, setIsCustom] = useState(selected === CUSTOM_SHELL_VALUE);
+  useEffect(() => {
+    setIsCustom(selected === CUSTOM_SHELL_VALUE);
+  }, [selected]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <SettingRow title={title} description={description}>
+        <Select
+          value={selected}
+          onValueChange={(v) => {
+            setIsCustom(v === CUSTOM_SHELL_VALUE);
+            if (v === "auto") onChange("");
+            else if (v !== CUSTOM_SHELL_VALUE) onChange(v);
+          }}
+        >
+          <SelectTrigger size="sm" className="h-8 w-40 text-[12px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="auto" className="text-[12px]">
+              Auto-detect
+            </SelectItem>
+            {SHELL_PRESETS.map((shell) => (
+              <SelectItem
+                key={shell}
+                value={shell}
+                className="text-[12px]"
+              >
+                {shellPresetLabel(shell)}
+              </SelectItem>
+            ))}
+            <SelectItem value={CUSTOM_SHELL_VALUE} className="text-[12px]">
+              Custom
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </SettingRow>
+      {isCustom && (
+        <input
+          type="text"
+          value={value}
+          placeholder="Type custom shell command"
+          onChange={(e) => onChange(e.target.value)}
+          className="h-8 w-64 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+        />
+      )}
+    </div>
+  );
+}
 
 export function GeneralSection() {
   const { mode, setMode } = useTheme();
@@ -73,6 +153,8 @@ export function GeneralSection() {
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
+  const terminalShellCommand = usePreferencesStore((s) => s.terminalShellCommand);
+  const agentShellCommand = usePreferencesStore((s) => s.agentShellCommand);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
 
   useEffect(() => {
@@ -290,6 +372,18 @@ export function GeneralSection() {
             </SelectContent>
           </Select>
         </SettingRow>
+        <ShellCommandField
+          title="Terminal shell command"
+          description="Shell command for the built-in terminal PTY session."
+          value={terminalShellCommand}
+          onChange={(value) => void setTerminalShellCommand(value)}
+        />
+        <ShellCommandField
+          title="Agent shell command"
+          description="Shell command used by AI tools (`run`, `background`)."
+          value={agentShellCommand}
+          onChange={(value) => void setAgentShellCommand(value)}
+        />
       </div>
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
Add configurable shell executable overrides for both interactive terminals and AI-backed shell execution.

## What changed
- Added `terminalShellCommand` and `agentShellCommand` preferences with persistence.
- Added Settings -> General controls for terminal and agent shell executables, with presets plus a custom executable field.
- Passed the terminal override into PTY session startup.
- Passed the agent override into persistent AI shell sessions and background command spawns.
- Documented shell executable overrides in `README.md`.

## Notes
- Empty values keep existing auto-detect/default behavior.
- Custom values are treated as shell executables, not full shell command lines with arguments.
- Invalid or unavailable custom executables fail through the existing shell startup/execution error path.

## Validation
- `pnpm exec tsc --noEmit` passes

## Suggested additional maintainer checks
- `cd src-tauri && cargo fmt --check && cargo clippy`
- Manual smoke test: default terminal launch, preset terminal launch, custom executable terminal launch, agent `bash_run`, and agent `bash_background`.