### PR TITLE
feat(windows): expand 'Open in Terax' context menu and load files on startup

### DIFF
--- a/src-tauri/installer-hooks.nsh
+++ b/src-tauri/installer-hooks.nsh
@@ -2,25 +2,34 @@
 ; HKCU matches installer currentUser scope. %V = clicked path.
 ; NoWorkingDirectory keeps Explorer from overriding %V (System32 on Drive).
 
+  !macro REGISTER_SHELL_VERB CLASS PARAM
+    WriteRegStr HKCU "Software\Classes\${CLASS}\shell\OpenInTerax" "" "Open in Terax"
+    WriteRegStr HKCU "Software\Classes\${CLASS}\shell\OpenInTerax" "Icon" '"$INSTDIR\terax.exe",0'
+    WriteRegStr HKCU "Software\Classes\${CLASS}\shell\OpenInTerax" "NoWorkingDirectory" ""
+    WriteRegStr HKCU "Software\Classes\${CLASS}\shell\OpenInTerax\command" "" '"$INSTDIR\terax.exe" "${PARAM}"'
+  !macroend
+
+  !macro UNREGISTER_SHELL_VERB CLASS
+    DeleteRegKey HKCU "Software\Classes\${CLASS}\shell\OpenInTerax"
+  !macroend
+
 !macro NSIS_HOOK_POSTINSTALL
-  WriteRegStr HKCU "Software\Classes\Directory\shell\OpenInTerax" "" "Open in Terax"
-  WriteRegStr HKCU "Software\Classes\Directory\shell\OpenInTerax" "Icon" '"$INSTDIR\terax.exe",0'
-  WriteRegStr HKCU "Software\Classes\Directory\shell\OpenInTerax" "NoWorkingDirectory" ""
-  WriteRegStr HKCU "Software\Classes\Directory\shell\OpenInTerax\command" "" '"$INSTDIR\terax.exe" "%V"'
+  !insertmacro REGISTER_SHELL_VERB "Directory" "%V"
+  !insertmacro REGISTER_SHELL_VERB "Directory\Background" "%V"
+  !insertmacro REGISTER_SHELL_VERB "Drive" "%V"
+  !insertmacro REGISTER_SHELL_VERB "*" "%1"
 
-  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\OpenInTerax" "" "Open in Terax"
-  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\OpenInTerax" "Icon" '"$INSTDIR\terax.exe",0'
-  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\OpenInTerax" "NoWorkingDirectory" ""
-  WriteRegStr HKCU "Software\Classes\Directory\Background\shell\OpenInTerax\command" "" '"$INSTDIR\terax.exe" "%V"'
-
-  WriteRegStr HKCU "Software\Classes\Drive\shell\OpenInTerax" "" "Open in Terax"
-  WriteRegStr HKCU "Software\Classes\Drive\shell\OpenInTerax" "Icon" '"$INSTDIR\terax.exe",0'
-  WriteRegStr HKCU "Software\Classes\Drive\shell\OpenInTerax" "NoWorkingDirectory" ""
-  WriteRegStr HKCU "Software\Classes\Drive\shell\OpenInTerax\command" "" '"$INSTDIR\terax.exe" "%V"'
+  ; Register Terax as a known application for the "Open with..." menu
+  WriteRegStr HKCU "Software\Classes\Applications\terax.exe" "" "Terax"
+  WriteRegStr HKCU "Software\Classes\Applications\terax.exe" "FriendlyAppName" "Terax"
+  WriteRegStr HKCU "Software\Classes\Applications\terax.exe\shell\open" "" "Open in Terax"
+  WriteRegStr HKCU "Software\Classes\Applications\terax.exe\shell\open\command" "" '"$INSTDIR\terax.exe" "%1"'
 !macroend
 
 !macro NSIS_HOOK_POSTUNINSTALL
-  DeleteRegKey HKCU "Software\Classes\Directory\shell\OpenInTerax"
-  DeleteRegKey HKCU "Software\Classes\Directory\Background\shell\OpenInTerax"
-  DeleteRegKey HKCU "Software\Classes\Drive\shell\OpenInTerax"
+  !insertmacro UNREGISTER_SHELL_VERB "Directory"
+  !insertmacro UNREGISTER_SHELL_VERB "Directory\Background"
+  !insertmacro UNREGISTER_SHELL_VERB "Drive"
+  !insertmacro UNREGISTER_SHELL_VERB "*"
+  DeleteRegKey HKCU "Software\Classes\Applications\terax.exe"
 !macroend

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,9 +134,6 @@ pub fn run() {
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
-            if let Some(ref dir) = launch_dir {
-                let _ = registry.authorize(dir);
-            }
             registry
         })
         .manage(LaunchDir(Mutex::new(launch_dir)))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,8 +133,8 @@ pub fn run() {
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
-            if let Some(launch_dir) = parse_launch_dir() {
-                let _ = registry.authorize(&launch_dir);
+            if let Some(ref launch_dir) = launch_dir {
+                let _ = registry.authorize(launch_dir);
             }
             registry
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,24 +9,42 @@ use tauri_plugin_window_state::StateFlags;
 #[derive(Default)]
 struct LaunchDir(Mutex<Option<String>>);
 
+/// Drained on first read so HMR / re-mounts can't replay the launch file.
+#[derive(Default)]
+struct LaunchFile(Mutex<Option<String>>);
+
 #[tauri::command]
 fn get_launch_dir(state: State<'_, LaunchDir>) -> Option<String> {
     state.0.lock().expect("LaunchDir mutex poisoned").take()
 }
 
-fn parse_launch_dir() -> Option<String> {
+#[tauri::command]
+fn get_launch_file(state: State<'_, LaunchFile>) -> Option<String> {
+    state.0.lock().expect("LaunchFile mutex poisoned").take()
+}
+
+fn parse_launch_args() -> (Option<String>, Option<String>) {
     for arg in std::env::args().skip(1) {
         if arg.starts_with('-') {
             continue;
         }
         let Ok(canon) = std::fs::canonicalize(&arg) else { continue };
-        if !canon.is_dir() {
-            continue;
+        if canon.is_dir() {
+            let s = canon.to_string_lossy();
+            let dir = s.strip_prefix(r"\\?\").unwrap_or(&s).to_string();
+            return (Some(dir), None);
+        } else if canon.is_file() {
+            let s = canon.to_string_lossy();
+            let file = s.strip_prefix(r"\\?\").unwrap_or(&s).to_string();
+            if let Some(parent) = canon.parent() {
+                let ps = parent.to_string_lossy();
+                let dir = ps.strip_prefix(r"\\?\").unwrap_or(&ps).to_string();
+                return (Some(dir), Some(file));
+            }
+            return (None, Some(file));
         }
-        let s = canon.to_string_lossy();
-        return Some(s.strip_prefix(r"\\?\").unwrap_or(&s).to_string());
     }
-    None
+    (None, None)
 }
 
 #[tauri::command]
@@ -88,6 +106,7 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     workspace::init_launch_cwd();
+    let (launch_dir, launch_file) = parse_launch_args();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
@@ -115,9 +134,13 @@ pub fn run() {
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
+            if let Some(ref dir) = launch_dir {
+                let _ = registry.authorize(dir);
+            }
             registry
         })
-        .manage(LaunchDir(Mutex::new(parse_launch_dir())))
+        .manage(LaunchDir(Mutex::new(launch_dir)))
+        .manage(LaunchFile(Mutex::new(launch_file)))
         .invoke_handler(tauri::generate_handler![
             pty::pty_open,
             pty::pty_write,
@@ -168,6 +191,7 @@ pub fn run() {
             workspace::workspace_authorize,
             workspace::workspace_current_dir,
             get_launch_dir,
+            get_launch_file,
             open_settings_window,
             secrets::secrets_get,
             secrets::secrets_set,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,7 +41,7 @@ import {
   GitHistoryStack,
   type GitHistorySearchHandle,
 } from "@/modules/git-history";
-import { getLaunchDir } from "@/lib/launchDir";
+import { getLaunchDir, getLaunchFile } from "@/lib/launchDir";
 import { useZoom } from "@/lib/useZoom";
 import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
 import {
@@ -436,6 +436,13 @@ export default function App() {
     void useAgentsStore.getState().hydrate();
     void useSnippetsStore.getState().hydrate();
   }, [hydrateSessions]);
+
+  useEffect(() => {
+    const launchFile = getLaunchFile();
+    if (launchFile) {
+      openFileTab(launchFile);
+    }
+  }, [openFileTab]);
 
   const activeTab = tabs.find((t) => t.id === activeId);
   const isTerminalTab = activeTab?.kind === "terminal";

--- a/src/lib/launchDir.ts
+++ b/src/lib/launchDir.ts
@@ -1,12 +1,21 @@
 import { invoke } from "@tauri-apps/api/core";
 
-let cached: string | undefined;
+let cachedDir: string | undefined;
+let cachedFile: string | undefined;
 
 export async function initLaunchDir(): Promise<void> {
-  const dir = await invoke<string | null>("get_launch_dir").catch(() => null);
-  cached = dir ? dir.replace(/\\/g, "/") : undefined;
+  const [dir, file] = await Promise.all([
+    invoke<string | null>("get_launch_dir").catch(() => null),
+    invoke<string | null>("get_launch_file").catch(() => null),
+  ]);
+  cachedDir = dir ? dir.replace(/\\/g, "/") : undefined;
+  cachedFile = file ? file.replace(/\\/g, "/") : undefined;
 }
 
 export function getLaunchDir(): string | undefined {
-  return cached;
+  return cachedDir;
+}
+
+export function getLaunchFile(): string | undefined {
+  return cachedFile;
 }


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Expands the **"Open in Terax"** Windows context menu integration to cover directories, backgrounds, drives, and all files (`*`), and enables opening the targeted file directly in a CodeMirror editor tab on startup.

## Why
1. Previously, the installer hooks only registered context menu items for directories. The right-click context menu did not support files, and Terax was not selectable in the Windows system "Open with..." applications menu.
2. Clicked files were not automatically loaded in the editor tab on startup.

## How
1. **Installer Associations (`src-tauri/installer-hooks.nsh`)**:
   - Refactored registry key writes into reusable NSIS macros: `REGISTER_SHELL_VERB` and `UNREGISTER_SHELL_VERB`.
   - Added context verbs for: `Directory`, `Directory\Background`, `Drive`, and `*` (all files).
   - Registered Terax under `Applications\terax.exe` to register it as a known option for the Windows "Open with..." applications menu.
   - Cleaned up uninstallation hooks to fully delete all newly created keys.

2. **Rust Backend (`src-tauri/src/lib.rs`)**:
   - Finalized `parse_launch_args` returning `(Option<String>, Option<String>)` to differentiate files from directories, normalise paths (removes Windows `\\?\` prefix), and resolve parent directories.
   - Implemented `LaunchFile` state wrapper and `get_launch_file` command.
   - Registered `get_launch_file` in the Tauri builder handlers.

3. **React Frontend (`src/lib/launchDir.ts`, `src/app/App.tsx`)**:
   - Refactored `initLaunchDir()` to concurrently call `get_launch_dir` and `get_launch_file` via `Promise.all`.
   - Added a mounting `useEffect` in `App.tsx` to read `getLaunchFile()` and open it in an editor tab on startup using `openFileTab()`.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

*Manual testing flows exercised:*
1. Ran `pnpm exec tsc --noEmit` to ensure all frontend changes compile with 0 type errors.
2. Ran `cargo check` inside `src-tauri/` to ensure all backend changes compile cleanly.
3. Verified path normalisation logic: when Terax is launched with a file argument, the file is parsed, separators are normalised, and the file is successfully loaded into the editor tab on startup.

## Screenshots / GIFs
<img width="1012" height="852" alt="image" src="https://github.com/user-attachments/assets/7831febd-a4bc-4f5d-9d32-eaa4fa3a966d" />

## Notes for reviewer
None.
