### PR TITLE
docs: prevent code and utility duplication

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ Examples: feat(terminal): add split panes / fix(explorer): close button alignmen
 - [ ] Manual smoke-test of the affected feature
 - [ ] (If you touched `src-tauri/`) `cargo check` clean
 - [ ] (If UI) tested in `pnpm tauri dev`
+- [ ] No duplicate/redundant code introduced
 
 ## Screenshots / GIFs
 <!-- Required for any UI change. Before / after if applicable. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,7 @@ Within a PR, individual commit messages can be free-form (they get squashed or g
 ## Code style
 
 - Follow existing patterns. Read 2-3 adjacent files before adding new ones.
+- **Avoid duplicating code**: Do not copy-paste helpers or utilities. Reuse existing code or extract it to a shared module (such as `src/lib/utils.ts` or designated shared components).
 - TypeScript: no `any` unless you really mean it. Strict mode is on.
 - Rust: `cargo fmt` + `clippy` clean.
 - Comments: only for *why*, not *what*. Code should explain itself. No multi-paragraph docstrings.

--- a/TERAX.md
+++ b/TERAX.md
@@ -48,6 +48,8 @@ Single-window React app. Path alias `@/*` → `src/*`. Tabs are tagged-union (`{
 
 `App.tsx` wires modules together — keep it a coordinator. New features go inside the appropriate `modules/<area>/`.
 
+**Avoid Duplicating Code**: Do not copy-paste helpers or utilities. Reuse existing code or export/import it from shared modules (such as `src/lib/utils.ts` or designated shared components).
+
 ### Module layout (`src/modules/`)
 
 Each module is self-contained, exports a thin barrel via `index.ts`, and owns its hooks under `lib/`.


### PR DESCRIPTION
## What
Added clear, generic, and evergreen guidelines to avoid duplicating code, helper functions, and utilities across modules.

## Why
Multiple duplicate implementations of basic utilities (such as `basename`, `dirname`, backslash path normalization, `formatBytes`, `joinPath`, and `localhost` loopback checks) were discovered across different files in `src/`. Documenting this standard keeps the codebase DRY and guides future contributors (and AI agents) to reuse or centralize shared logic.

## How
Updated three documentation files with short, generic guidelines:
- **`CONTRIBUTING.md`**: Added a rule under Code Style requesting contributors to reuse code/utilities rather than copy-pasting.
- **`TERAX.md`**: Added a rule under Frontend (`src/`) to prevent duplicate helper or utility logic.
- **`.github/PULL_REQUEST_TEMPLATE.md`**: Added a checklist item to verify that no duplicate/redundant code was introduced.

## Testing
- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [ ] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs
N/A (Docs-only change)

## Notes for reviewer
basename, formatBytes, normalize, dirname and many more functions were duplicated across modules. 
