### PR TITLE
feat(ai): conversation panel toggle (Cmd+I) + new-thread shortcut (Cmd+N)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -371,6 +371,7 @@ export default function App() {
   const [newEditorOpen, setNewEditorOpen] = useState(false);
   const miniOpen = useChatStore((s) => s.mini.open);
   const openMini = useChatStore((s) => s.openMini);
+  const newSession = useChatStore((s) => s.newSession);
   const focusInput = useChatStore((s) => s.focusInput);
   const openPanel = useChatStore((s) => s.openPanel);
   const panelOpen = useChatStore((s) => s.panelOpen);
@@ -652,13 +653,16 @@ export default function App() {
       void openSettingsWindow("models");
       return;
     }
-    if (panelOpen) {
-      useChatStore.getState().closePanel();
+    const store = useChatStore.getState();
+    if (panelOpen || miniOpen) {
+      store.closePanel();
+      store.closeMini();
     } else {
       openPanel();
+      store.openMini();
       focusInput(null);
     }
-  }, [hasComposer, panelOpen, openPanel, focusInput]);
+  }, [hasComposer, panelOpen, miniOpen, openPanel, focusInput]);
 
   const attachSelection = useChatStore((s) => s.attachSelection);
 
@@ -982,6 +986,10 @@ export default function App() {
       "pane.source": toggleSourceControl,
       "search.focus": () => searchInlineRef.current?.focus(),
       "ai.toggle": togglePanelAndFocus,
+      "ai.newThread": () => {
+        newSession();
+        focusInput(null);
+      },
       "ai.askSelection": askFromSelection,
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
       "settings.open": () => void openSettingsWindow(),
@@ -1005,6 +1013,8 @@ export default function App() {
       focusNextPaneInTab,
       toggleSourceControl,
       togglePanelAndFocus,
+      newSession,
+      focusInput,
       askFromSelection,
       toggleSidebar,
       toggleExplorerFocus,
@@ -1018,6 +1028,15 @@ export default function App() {
     (id: ShortcutId, e: KeyboardEvent) => {
       if (id === "editor.undo" || id === "editor.redo") {
         return activeTab?.kind !== "editor";
+      }
+      if (id === "ai.newThread") {
+        // Only when focus is inside the AI surface (conversation popup or
+        // the docked input bar) — otherwise Cmd+N falls through.
+        const target =
+          (e.target as HTMLElement | null) ?? document.activeElement;
+        return !(target as HTMLElement | null)?.closest?.(
+          "[data-ai-mini-window], [data-ai-input-bar]",
+        );
       }
       if (id === "ai.askSelection") {
         const target =

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -25,6 +25,7 @@ export type ShortcutId =
   | "view.zoomOut"
   | "view.zoomReset"
   | "ai.toggle"
+  | "ai.newThread"
   | "ai.askSelection"
   | "shortcuts.open"
   | "settings.open"
@@ -165,6 +166,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Toggle AI agent",
     group: "AI",
     defaultBindings: [{ [MOD_PROP]: true, key: "i" }],
+  },
+  {
+    id: "ai.newThread",
+    label: "New AI conversation",
+    group: "AI",
+    defaultBindings: [{ [MOD_PROP]: true, key: "n" }],
   },
   {
     id: "ai.askSelection",


### PR DESCRIPTION
## What

Two AI keyboard shortcuts:

- **Cmd+I** — toggles the AI surface. Opens the docked input bar **and** the conversation popup together (and focuses the input); pressing again closes both. Previously it only toggled the docked input bar, so the conversation popup had no keyboard shortcut.
- **Cmd+N** — starts a new conversation thread and switches to it. Gated to fire **only when focus is within the AI surface** (`[data-ai-mini-window]` or `[data-ai-input-bar]`); otherwise the keypress falls through.

Both are user-rebindable via Settings → Shortcuts.

## Changes

- `src/app/App.tsx` — `togglePanelAndFocus` now drives both panel + mini; `ai.newThread` handler + focus gate.
- `src/modules/shortcuts/shortcuts.ts` — register `ai.newThread` (default Cmd+N).

## Testing

Manually verified in the running app:
- Cmd+I opens input bar + conversation popup, re-press closes both.
- Cmd+N from inside the AI surface creates a new thread and switches to it; from terminal/editor it does nothing.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)