### PR TITLE
fix(ai): keep reasoning in history so thinking models accept tool-call turns

### DIFF
--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -377,7 +377,10 @@ export async function runAgentStream(opts: RunAgentOptions) {
   const history = await convertToModelMessages(opts.uiMessages);
   const prunedHistory = pruneMessages({
     messages: history,
-    reasoning: "all",
+    // Keep reasoning in history: thinking models (DeepSeek Reasoner, GLM, Kimi)
+    // reject assistant tool-call turns whose reasoning_content was stripped, and
+    // Anthropic extended thinking needs the signed thinking block passed back.
+    reasoning: "none",
     emptyMessages: "remove",
   });
   const compact = compactModelMessagesDetailed(


### PR DESCRIPTION
## Problem

Thinking models surfaced a runtime error mid-conversation:

> The `reasoning_content` in the thinking mode must be passed back to the API.

`runAgentStream` ran `pruneMessages({ reasoning: "all" })` on the history before every request, deleting the `reasoning` part from every assistant message. On a continuation turn this stripped the reasoning from a prior assistant **tool-call** turn — which thinking models (DeepSeek Reasoner, GLM-4.6, Kimi K2) require to be passed back, and which Anthropic extended thinking needs (the signed thinking block) for tool use.

## Fix

Switch the prune to `reasoning: "none"` so reasoning is preserved in history.

- One line in `src/modules/ai/lib/agent.ts` (+ explanatory comment).
- Trade-off: providers that don't need reasoning back (OpenAI/Gemini) carry a few extra tokens. Acceptable; a future provider-conditional prune can optimize this alongside the planned deep-thinking toggle.

## Testing

Reproduced the error before the change with a thinking model over a multi-turn, tool-calling conversation; after the change the error is gone. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)