### PR TITLE
feat: Make OpenAI-compatible model discovery durable

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,6 +52,8 @@ import {
 import { MarkdownStack } from "@/modules/markdown";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
+import { DEFAULT_MODEL_ID, getModel, type ModelId } from "@/modules/ai/config";
+import { useCompatReconciler } from "@/modules/ai/lib/useCompatReconciler";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { onKeysChanged, setThemeId as persistThemeId } from "@/modules/settings/store";
 import {
@@ -101,6 +103,20 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PanelImperativeHandle } from "react-resizable-panels";
+
+function tryStoredModelId(id: string | undefined): ModelId | null {
+  if (!id) return null;
+  try {
+    getModel(id as ModelId);
+    return id as ModelId;
+  } catch {
+    return null;
+  }
+}
+
+function resolveStoredModelId(id: string | undefined): ModelId {
+  return tryStoredModelId(id) ?? DEFAULT_MODEL_ID;
+}
 
 function dirname(path: string | null): string | null {
   if (!path) return null;
@@ -421,14 +437,40 @@ export default function App() {
   // into chatStore so the dropdown reflects what the user picked in Settings.
   const initPrefs = usePreferencesStore((s) => s.init);
   const prefDefaultModel = usePreferencesStore((s) => s.defaultModelId);
+  const prefRecentModels = usePreferencesStore((s) => s.recentModelIds);
   const prefsHydrated = usePreferencesStore((s) => s.hydrated);
   useEffect(() => {
     void initPrefs();
   }, [initPrefs]);
+  // First hydration: restore the most recently selected model so the picker
+  // shows what the user last had active — including any user-defined
+  // OpenAI-compatible models (registered in the model registry during
+  // loadPreferences). Subsequent changes to the default-model preference
+  // still flow through so updating it in Settings updates the active pick.
+  const restoredFromRecentRef = useRef(false);
+  const previousDefaultModelRef = useRef<string | null>(null);
   useEffect(() => {
     if (!prefsHydrated) return;
-    setSelectedModelId(prefDefaultModel);
-  }, [prefsHydrated, prefDefaultModel, setSelectedModelId]);
+    const defaultModel = resolveStoredModelId(prefDefaultModel);
+    if (!restoredFromRecentRef.current) {
+      restoredFromRecentRef.current = true;
+      previousDefaultModelRef.current = prefDefaultModel;
+      const lastKnown = prefRecentModels
+        .map((id) => tryStoredModelId(id))
+        .find((id): id is ModelId => id !== null);
+      setSelectedModelId(lastKnown ?? defaultModel);
+      return;
+    }
+
+    if (previousDefaultModelRef.current !== prefDefaultModel) {
+      previousDefaultModelRef.current = prefDefaultModel;
+      setSelectedModelId(defaultModel);
+    }
+  }, [prefsHydrated, prefDefaultModel, prefRecentModels, setSelectedModelId]);
+
+  // Clean up active/default/recent/favorite refs when the user removes a
+  // model from the OpenAI-compatible list, so the next render doesn't crash.
+  useCompatReconciler();
 
   const hydrateSessions = useChatStore((s) => s.hydrateSessions);
   useEffect(() => {

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -44,8 +44,8 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
 import { useMemo, useRef, useState } from "react";
 import {
-  getModel,
-  MODELS,
+  getAllModels,
+  getModelOrDefault,
   providerNeedsKey,
   PROVIDERS,
   type ModelCapabilities,
@@ -212,7 +212,10 @@ function ModelDropdown() {
   const setSelected = useChatStore((s) => s.setSelectedModelId);
   const favoriteIds = usePreferencesStore((s) => s.favoriteModelIds);
   const recentIds = usePreferencesStore((s) => s.recentModelIds);
-  const current = getModel(selected);
+  // Subscribe so the picker re-renders when user-defined compat models change.
+  const compatRaw = usePreferencesStore((s) => s.openaiCompatibleModelId);
+  const allModels = useMemo(() => getAllModels(), [compatRaw]);
+  const current = getModelOrDefault(selected);
   const [search, setSearch] = useState("");
   const [activeProvider, setActiveProvider] = useState<ProviderId | null>(null);
   const [tab, setTab] = useState<Tab>("all");
@@ -236,7 +239,7 @@ function ModelDropdown() {
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    let pool: readonly ModelInfo[] = MODELS;
+    let pool: readonly ModelInfo[] = allModels;
     if (tab === "favorites") {
       pool = pool.filter((m) => favoriteIds.includes(m.id));
     } else if (tab === "recent") {
@@ -260,7 +263,7 @@ function ModelDropdown() {
       );
     }
     return pool;
-  }, [activeProvider, favoriteIds, recentIds, search, tab]);
+  }, [activeProvider, allModels, favoriteIds, recentIds, search, tab]);
 
   return (
     <DropdownMenu>

--- a/src/modules/ai/config.test.ts
+++ b/src/modules/ai/config.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_MODEL_ID,
+  getAllModels,
+  getModel,
+  getModelOrDefault,
+  makeOpenAICompatibleId,
+  parseOpenAICompatibleModelIds,
+  serializeOpenAICompatibleModelIds,
+  setOpenAICompatibleSynthesizedModelIds,
+} from "./config";
+
+describe("OpenAI-compatible model registry", () => {
+  afterEach(() => {
+    setOpenAICompatibleSynthesizedModelIds("");
+  });
+
+  it("round-trips comma-separated upstream ids without duplicates", () => {
+    const parsed = parseOpenAICompatibleModelIds(
+      "gpt-4o, qwen/qwen3-max, gpt-4o,  , glm-4.6",
+    );
+
+    expect(parsed).toEqual(["gpt-4o", "qwen/qwen3-max", "glm-4.6"]);
+    expect(serializeOpenAICompatibleModelIds(parsed)).toBe(
+      "gpt-4o, qwen/qwen3-max, glm-4.6",
+    );
+  });
+
+  it("registers discovered upstream ids as namespaced selectable models", () => {
+    setOpenAICompatibleSynthesizedModelIds([
+      "zai/glm-4.6",
+      "openai/gpt-5.5",
+    ]);
+
+    const ids = getAllModels().map((model) => model.id);
+    expect(ids).not.toContain("openai-compatible-custom");
+    expect(ids).toContain(makeOpenAICompatibleId("zai/glm-4.6"));
+    expect(ids).toContain(makeOpenAICompatibleId("openai/gpt-5.5"));
+
+    const model = getModel(
+      makeOpenAICompatibleId("zai/glm-4.6") as Parameters<typeof getModel>[0],
+    );
+    expect(model.provider).toBe("openai-compatible");
+    expect(model.label).toBe("zai/glm-4.6");
+    expect(model.upstreamId).toBe("zai/glm-4.6");
+  });
+
+  it("falls back when a previously selected synthesized model disappears", () => {
+    const staleCompatModelId = makeOpenAICompatibleId("zai/glm-4.6");
+
+    setOpenAICompatibleSynthesizedModelIds(["zai/glm-4.6"]);
+    expect(getModelOrDefault(staleCompatModelId).id).toBe(staleCompatModelId);
+
+    setOpenAICompatibleSynthesizedModelIds([]);
+    expect(getModelOrDefault(staleCompatModelId).id).toBe(DEFAULT_MODEL_ID);
+  });
+});

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -147,6 +147,10 @@ export type ModelInfo = {
   description: string;
   capabilities: ModelCapabilities;
   tags?: readonly ModelTag[];
+  /** For synthesized entries (e.g. OpenAI-compatible aggregators): the id the
+   *  upstream API actually expects. `id` is the app-internal namespaced key
+   *  used for picker selection, recents, and `getModel` lookups. */
+  upstreamId?: string;
 };
 
 export const MODELS = [
@@ -598,13 +602,126 @@ export const MODELS = [
 
 export type ModelId = (typeof MODELS)[number]["id"];
 
-export function getModel(id: ModelId): ModelInfo {
+// ── OpenAI-compatible: multi-model support ───────────────────────────────────
+//
+// `openaiCompatibleModelId` is stored as a comma-separated list so a single
+// proxy endpoint (Vibe Proxy, OpenRouter-self-host, LiteLLM, …) can surface
+// multiple selectable models in the picker. The placeholder text in
+// `ModelsSection` already advertises this shape (`gpt-4o, qwen3-max, …`).
+//
+// Synthesized entries are kept in a runtime registry so every existing
+// `getModel(id)` callsite transparently resolves them — no caller refactor.
+// The settings store pushes the parsed id list here on load and on change.
+
+let dynamicCompatModels: readonly ModelInfo[] = [];
+
+/** App-internal id prefix that namespaces synthesized OpenAI-compatible
+ *  models. Prevents collisions with curated MODELS entries whose ids happen
+ *  to match an upstream proxy's id (e.g. `qwen/qwen3-max`, which exists as
+ *  OpenRouter in MODELS — without namespacing, selecting the compat row
+ *  would silently route through OpenRouter). */
+export const OPENAI_COMPATIBLE_ID_PREFIX = "openai-compatible:";
+
+/** True if `id` is an app-internal namespaced OpenAI-compatible model id. */
+export function isOpenAICompatibleSynthId(id: string): boolean {
+  return id.startsWith(OPENAI_COMPATIBLE_ID_PREFIX);
+}
+
+/** Build the app-internal id for a given upstream model id. */
+export function makeOpenAICompatibleId(upstreamId: string): string {
+  return `${OPENAI_COMPATIBLE_ID_PREFIX}${upstreamId}`;
+}
+
+/** Parse the comma-separated `openaiCompatibleModelId` field into a deduped,
+ *  order-preserving list of *upstream* ids (the raw API model names). */
+export function parseOpenAICompatibleModelIds(raw: string): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of raw.split(",")) {
+    const id = part.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/** Serialize a list of upstream ids back into the canonical comma-separated
+ *  form persisted in `openaiCompatibleModelId`. */
+export function serializeOpenAICompatibleModelIds(
+  ids: readonly string[],
+): string {
+  const seen = new Set<string>();
+  const cleaned: string[] = [];
+  for (const raw of ids) {
+    const id = raw.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    cleaned.push(id);
+  }
+  return cleaned.join(", ");
+}
+
+/** Build a synthetic {@link ModelInfo} for a user-configured OpenAI-compatible
+ *  upstream id. The `id` is namespaced; `upstreamId` is what's sent to the
+ *  API. The picker shows the raw upstream id as the label so users see what
+ *  they typed/picked, not the internal prefix. */
+export function synthesizeOpenAICompatibleModel(upstreamId: string): ModelInfo {
+  return {
+    id: makeOpenAICompatibleId(upstreamId),
+    provider: "openai-compatible",
+    label: upstreamId,
+    hint: "Compatible",
+    description: "User-configured OpenAI-compatible model.",
+    capabilities: { intelligence: 3, speed: 3, cost: 3 },
+    upstreamId,
+  };
+}
+
+/** Replace the runtime registry of synthesized OpenAI-compatible models.
+ *  Reconciliation of stale selections / recents / favorites is handled
+ *  separately by `useCompatReconciler`. */
+export function setOpenAICompatibleSynthesizedModelIds(
+  raw: string | readonly string[],
+): void {
+  const upstreamIds = Array.isArray(raw)
+    ? (raw as readonly string[]).filter((s) => typeof s === "string" && s.trim())
+    : parseOpenAICompatibleModelIds(raw as string);
+  dynamicCompatModels = upstreamIds.map(synthesizeOpenAICompatibleModel);
+}
+
+/** All models visible to the picker: curated + synthesized. When the user
+ *  has named at least one concrete compat model, the generic "Custom
+ *  endpoint" stub is hidden — the named ones replace it. */
+export function getAllModels(): readonly ModelInfo[] {
+  if (dynamicCompatModels.length === 0) return MODELS;
+  return [
+    ...MODELS.filter((m) => m.id !== "openai-compatible-custom"),
+    ...dynamicCompatModels,
+  ];
+}
+
+function findModel(id: string | undefined): ModelInfo | null {
+  if (!id) return null;
   const m = MODELS.find((x) => x.id === id);
-  if (!m) throw new Error(`Unknown model: ${id}`);
-  return m;
+  if (m) return m;
+  const synth = dynamicCompatModels.find((x) => x.id === id);
+  if (synth) return synth;
+  return null;
+}
+
+export function getModel(id: ModelId): ModelInfo {
+  const model = findModel(id);
+  if (model) return model;
+  throw new Error(`Unknown model: ${id}`);
 }
 
 export const DEFAULT_MODEL_ID: ModelId = "gpt-5.4-mini";
+
+export function getModelOrDefault(id: string | undefined): ModelInfo {
+  return findModel(id) ?? getModel(DEFAULT_MODEL_ID);
+}
 
 /** Approximate context window (in tokens) per model. Used for the
  *  context-usage indicator in the AI mini-window header. Conservative
@@ -664,8 +781,15 @@ export function getModelContextLimit(
   compatOverride?: number,
 ): number {
   if (!modelId) return 128_000;
-  if (modelId === "openai-compatible-custom" && compatOverride)
+  // The user's compat context-limit setting applies to the legacy "Custom
+  // endpoint" stub AND every synthesized compat model — they all share one
+  // base URL, so one limit setting covers all of them.
+  if (
+    compatOverride &&
+    (modelId === "openai-compatible-custom" || isOpenAICompatibleSynthId(modelId))
+  ) {
     return compatOverride;
+  }
   return MODEL_CONTEXT_LIMITS[modelId] ?? 128_000;
 }
 

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -15,6 +15,7 @@ import {
   MAX_AGENT_STEPS,
   MLX_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_BASE_URL,
+  parseOpenAICompatibleModelIds,
   providerNeedsKey,
   selectSystemPrompt,
   type ModelId,
@@ -229,7 +230,11 @@ export function buildConfiguredLanguageModel(
 ): Promise<LanguageModel> {
   const m = getModel(modelId);
   let resolvedId: string = m.id;
-  if (m.id === "lmstudio-local") {
+  // Synthesized compat models carry the raw upstream id on `upstreamId` —
+  // that's what the API expects. The namespaced `id` is app-internal only.
+  if (m.upstreamId) {
+    resolvedId = m.upstreamId;
+  } else if (m.id === "lmstudio-local") {
     if (!local.lmstudioModelId?.trim()) {
       throw new Error(
         "LM Studio: no model id set. Open Settings → Models and enter the model id loaded in LM Studio.",
@@ -251,12 +256,16 @@ export function buildConfiguredLanguageModel(
     }
     resolvedId = local.ollamaModelId.trim();
   } else if (m.id === "openai-compatible-custom") {
+    // Legacy "Custom endpoint" stub — predates per-model registration. Take
+    // the first parsed id from the comma list so requests go somewhere
+    // sensible instead of sending the whole literal comma-string upstream.
     if (!local.openaiCompatibleModelId?.trim()) {
       throw new Error(
         "OpenAI-compatible: no model id set. Open Settings → Models.",
       );
     }
-    resolvedId = local.openaiCompatibleModelId.trim();
+    const ids = parseOpenAICompatibleModelIds(local.openaiCompatibleModelId);
+    resolvedId = ids[0] ?? local.openaiCompatibleModelId.trim();
   }
   return buildLanguageModel(m.provider, keys, resolvedId, {
     lmstudioBaseURL: local.lmstudioBaseURL,

--- a/src/modules/ai/lib/discovery.ts
+++ b/src/modules/ai/lib/discovery.ts
@@ -1,0 +1,94 @@
+import { createProxyFetch } from "./proxyFetch";
+
+const discoveryFetch = createProxyFetch({ allowPrivateNetwork: true });
+
+export type DiscoveredModel = {
+  id: string;
+};
+
+/**
+ * GET `${baseURL}/models` against an OpenAI-compatible endpoint and return
+ * the model ids it advertises. Aggregators like Vibe Proxy, OpenRouter,
+ * LiteLLM, vLLM, LM Studio and Ollama all implement this endpoint.
+ *
+ * Goes through the Rust HTTP proxy (`ai_http_stream`) so it works under
+ * the production bundle's CORS / Mixed-Content / Private-Network policies.
+ */
+export async function fetchOpenAICompatibleModels(
+  baseURL: string,
+  apiKey: string | null,
+  signal?: AbortSignal,
+): Promise<DiscoveredModel[]> {
+  const trimmed = baseURL.trim().replace(/\/+$/, "");
+  if (!trimmed) throw new Error("Base URL is required");
+
+  const url = `${trimmed}/models`;
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (apiKey && apiKey.trim()) {
+    headers["Authorization"] = `Bearer ${apiKey.trim()}`;
+  }
+
+  const resp = await discoveryFetch(url, {
+    method: "GET",
+    headers,
+    signal,
+  });
+
+  if (!resp.ok) {
+    const detail = await safeReadShortBody(resp);
+    throw new Error(
+      `HTTP ${resp.status}${detail ? ` — ${detail}` : ""}`,
+    );
+  }
+
+  const text = await resp.text();
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error("Response was not valid JSON");
+  }
+
+  // OpenAI's canonical shape: `{ object: "list", data: [{ id, ... }] }`.
+  // Be lenient — some proxies wrap or omit the envelope.
+  const data = extractModelArray(json);
+  if (!data) {
+    throw new Error("Unexpected response shape — no `data` array of models");
+  }
+
+  const seen = new Set<string>();
+  const out: DiscoveredModel[] = [];
+  for (const entry of data) {
+    if (!entry || typeof entry !== "object") continue;
+    const id = (entry as { id?: unknown }).id;
+    if (typeof id !== "string") continue;
+    const trimmedId = id.trim();
+    if (!trimmedId || seen.has(trimmedId)) continue;
+    seen.add(trimmedId);
+    out.push({ id: trimmedId });
+  }
+
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}
+
+function extractModelArray(json: unknown): unknown[] | null {
+  if (Array.isArray(json)) return json;
+  if (json && typeof json === "object") {
+    const obj = json as Record<string, unknown>;
+    if (Array.isArray(obj.data)) return obj.data;
+    if (Array.isArray(obj.models)) return obj.models;
+  }
+  return null;
+}
+
+async function safeReadShortBody(resp: Response): Promise<string | null> {
+  try {
+    const text = await resp.text();
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    return trimmed.length > 160 ? `${trimmed.slice(0, 160)}…` : trimmed;
+  } catch {
+    return null;
+  }
+}

--- a/src/modules/ai/lib/useCompatReconciler.ts
+++ b/src/modules/ai/lib/useCompatReconciler.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from "react";
+import {
+  DEFAULT_MODEL_ID,
+  makeOpenAICompatibleId,
+  parseOpenAICompatibleModelIds,
+  type ModelId,
+} from "../config";
+import {
+  setDefaultModel,
+  setFavoriteModelIds,
+  setRecentModelIds,
+} from "@/modules/settings/store";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { useChatStore } from "../store/chatStore";
+
+/**
+ * Keep model-id references consistent when the user removes a model from the
+ * OpenAI-compatible list. Without this, `chatStore.selectedModelId` /
+ * `defaultModelId` / `recentModelIds` / `favoriteModelIds` can point at a
+ * synthesized id that no longer exists, and the next `getModel(id)` throws.
+ *
+ * The hook is a no-op until preferences hydrate, and a no-op on calls that
+ * only *add* ids — reconciliation work only happens when ids actually vanish.
+ */
+export function useCompatReconciler(): void {
+  const hydrated = usePreferencesStore((s) => s.hydrated);
+  const compatRaw = usePreferencesStore((s) => s.openaiCompatibleModelId);
+  const defaultModelId = usePreferencesStore((s) => s.defaultModelId);
+  const previousIdsRef = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    const upstreamIds = parseOpenAICompatibleModelIds(compatRaw);
+    const namespaced = new Set(upstreamIds.map(makeOpenAICompatibleId));
+
+    const previous = previousIdsRef.current;
+    previousIdsRef.current = namespaced;
+    if (previous === null) return; // First observation — nothing to reconcile.
+
+    const removed = new Set<string>();
+    for (const id of previous) if (!namespaced.has(id)) removed.add(id);
+    if (removed.size === 0) return;
+
+    const prefs = usePreferencesStore.getState();
+    const chat = useChatStore.getState();
+
+    if (removed.has(chat.selectedModelId)) {
+      const fallback = removed.has(defaultModelId)
+        ? DEFAULT_MODEL_ID
+        : (defaultModelId as ModelId);
+      chat.setSelectedModelId(fallback);
+    }
+
+    const trimmedRecents = prefs.recentModelIds.filter((id) => !removed.has(id));
+    if (trimmedRecents.length !== prefs.recentModelIds.length) {
+      void setRecentModelIds(trimmedRecents);
+    }
+
+    const trimmedFavorites = prefs.favoriteModelIds.filter(
+      (id) => !removed.has(id),
+    );
+    if (trimmedFavorites.length !== prefs.favoriteModelIds.length) {
+      void setFavoriteModelIds(trimmedFavorites);
+    }
+
+    if (removed.has(defaultModelId)) {
+      void setDefaultModel(DEFAULT_MODEL_ID);
+    }
+  }, [hydrated, compatRaw, defaultModelId]);
+}

--- a/src/modules/editor/lib/autocomplete/provider.ts
+++ b/src/modules/editor/lib/autocomplete/provider.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   LMSTUDIO_DEFAULT_BASE_URL,
+  parseOpenAICompatibleModelIds,
   type AutocompleteProviderId,
 } from "@/modules/ai/config";
 import { buildLanguageModel } from "@/modules/ai/lib/agent";
@@ -33,8 +34,15 @@ export async function requestCompletion(
   deps: CompletionDeps,
   signal: AbortSignal,
 ): Promise<string> {
+  // OpenAI-compatible stores a comma-separated list — autocomplete uses one
+  // model at a time, so pick the first parsed id. Without this the literal
+  // comma-string would be sent upstream as the model name.
+  const rawModelId =
+    deps.provider === "openai-compatible"
+      ? (parseOpenAICompatibleModelIds(deps.modelId)[0] ?? "")
+      : deps.modelId.trim();
   const modelId =
-    deps.modelId.trim() || DEFAULT_AUTOCOMPLETE_MODEL[deps.provider] || "";
+    rawModelId || DEFAULT_AUTOCOMPLETE_MODEL[deps.provider] || "";
   if (!modelId) {
     throw new Error(
       `No autocomplete model id set for ${deps.provider}.`,

--- a/src/modules/settings/preferences.ts
+++ b/src/modules/settings/preferences.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { setOpenAICompatibleSynthesizedModelIds } from "@/modules/ai/config";
 import {
   DEFAULT_PREFERENCES,
   loadPreferences,
@@ -59,6 +60,14 @@ export const usePreferencesStore = create<State>((set) => ({
       if (key === "backgroundKind" || key === "backgroundImageId") {
         const s = usePreferencesStore.getState();
         mirrorBgFastPath(s.backgroundKind, s.backgroundImageId);
+      }
+      // Cross-window writes (e.g. from the Settings window) bypass the local
+      // setter — keep the synthesized-model registry in sync so getModel()
+      // resolves user-defined OpenAI-compatible ids in every window.
+      if (key === "openaiCompatibleModelId") {
+        setOpenAICompatibleSynthesizedModelIds(
+          typeof value === "string" ? value : "",
+        );
       }
     });
   },

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -5,6 +5,7 @@ import {
   MLX_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_BASE_URL,
   OPENAI_COMPATIBLE_DEFAULT_BASE_URL,
+  setOpenAICompatibleSynthesizedModelIds,
   type AutocompleteProviderId,
   type ModelId,
 } from "@/modules/ai/config";
@@ -195,6 +196,12 @@ export async function loadPreferences(): Promise<Preferences> {
   const entries = await store.entries();
   const map = new Map<string, unknown>(entries);
   const get = <T>(k: string): T | undefined => map.get(k) as T | undefined;
+  // Push synthesized OpenAI-compatible model ids into the AI config registry
+  // so `getModel(id)` resolves them everywhere from the very first tick.
+  setOpenAICompatibleSynthesizedModelIds(
+    get<string>(KEY_OPENAI_COMPAT_MODEL_ID) ??
+      DEFAULT_PREFERENCES.openaiCompatibleModelId,
+  );
   return {
     theme: get<ThemePref>(KEY_THEME) ?? DEFAULT_PREFERENCES.theme,
     themeId: get<string>(KEY_THEME_ID) ?? DEFAULT_PREFERENCES.themeId,
@@ -388,6 +395,7 @@ export async function setOpenaiCompatibleBaseURL(value: string): Promise<void> {
 }
 
 export async function setOpenaiCompatibleModelId(value: string): Promise<void> {
+  setOpenAICompatibleSynthesizedModelIds(value);
   await writePref(KEY_OPENAI_COMPAT_MODEL_ID, value);
 }
 

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -6,7 +6,7 @@ import {
   type GitStatusSnapshot,
 } from "@/modules/ai/lib/native";
 import { useChatStore } from "@/modules/ai/store/chatStore";
-import { getModel, providerNeedsKey } from "@/modules/ai/config";
+import { getModelOrDefault, providerNeedsKey } from "@/modules/ai/config";
 import {
   invalidateDiff,
   invalidateRepoDiffs,
@@ -369,7 +369,7 @@ export function useSourceControlPanel(
   const selectedModelId = useChatStore((state) => state.selectedModelId);
   const agentStatus = useChatStore((state) => state.agentMeta.status);
   const hasApiKeyForSelected = useChatStore((state) => {
-    const model = getModel(state.selectedModelId);
+    const model = getModelOrDefault(state.selectedModelId);
     return !providerNeedsKey(model.provider) || !!state.apiKeys[model.provider];
   });
   const lmstudioModelId = usePreferencesStore((state) => state.lmstudioModelId);
@@ -459,7 +459,7 @@ export function useSourceControlPanel(
 
   const allClean = stagedEntries.length === 0 && unstagedEntries.length === 0;
   const canPush = !!status?.upstream && status.behind === 0;
-  const selectedModel = getModel(selectedModelId);
+  const selectedModel = getModelOrDefault(selectedModelId);
   const aiBusy = agentStatus !== "idle" && agentStatus !== "error";
   const anyActionBusy = localActionBusy !== null || summary.busyAction !== null;
   const aiUnavailableReason = useMemo(() => {

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -13,15 +13,19 @@ import { cn } from "@/lib/utils";
 import {
   MODELS,
   PROVIDERS,
+  getAllModels,
   getAutocompleteEligibleModels,
-  getModel,
+  getModelOrDefault,
   getProvider,
+  parseOpenAICompatibleModelIds,
   providerNeedsKey,
+  serializeOpenAICompatibleModelIds,
   type ModelId,
   type ProviderId,
   type ProviderInfo,
 } from "@/modules/ai/config";
 import { clearKey, getAllKeys, setKey } from "@/modules/ai/lib/keyring";
+import { fetchOpenAICompatibleModels } from "@/modules/ai/lib/discovery";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   emitKeysChanged,
@@ -45,11 +49,13 @@ import {
   ArrowUpRight01Icon,
   Cancel01Icon,
   CheckmarkCircle02Icon,
+  RefreshIcon,
+  Tick01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ProviderIcon } from "../components/ProviderIcon";
 import { ProviderKeyCard } from "../components/ProviderKeyCard";
 import { SectionHeader } from "../components/SectionHeader";
@@ -387,7 +393,10 @@ function DefaultModelPicker({
   defaultModel: ModelId;
   configuredIds: Set<ProviderId>;
 }) {
-  const m = getModel(defaultModel);
+  // Re-render when user-defined OpenAI-compatible models change.
+  const compatRaw = usePreferencesStore((s) => s.openaiCompatibleModelId);
+  const allModels = useMemo(() => getAllModels(), [compatRaw]);
+  const m = getModelOrDefault(defaultModel);
   const hasAny = configuredIds.size > 0;
 
   return (
@@ -420,7 +429,7 @@ function DefaultModelPicker({
       >
         <div className="max-h-72 overflow-y-auto overscroll-contain pr-1">
           {PROVIDERS.filter((p) => configuredIds.has(p.id)).map((p) => {
-            const models = MODELS.filter((x) => x.provider === p.id);
+            const models = allModels.filter((x) => x.provider === p.id);
             if (models.length === 0) return null;
             return (
               <div key={p.id} className="px-1 pt-1.5 first:pt-1">
@@ -617,12 +626,27 @@ function LocalProviderCard({
   const [testStatus, setTestStatus] = useState<
     "idle" | "testing" | "ok" | "fail"
   >("idle");
+  // Discovery state — only used by the openai-compatible card.
+  const [discovered, setDiscovered] = useState<string[] | null>(null);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
+  const discoverAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => setUrlDraft(baseURL), [baseURL]);
   useEffect(() => setModelDraft(modelId), [modelId]);
   useEffect(() => setContextDraft(String(contextLimit ?? "")), [contextLimit]);
+  // Editing the base URL invalidates any in-flight or stale discovery result.
+  useEffect(() => {
+    discoverAbortRef.current?.abort();
+    discoverAbortRef.current = null;
+    setDiscovering(false);
+    setDiscovered(null);
+    setDiscoverError(null);
+  }, [urlDraft]);
+  useEffect(() => () => discoverAbortRef.current?.abort(), []);
 
   const supportsKey = provider.id === "openai-compatible";
+  const supportsDiscovery = provider.id === "openai-compatible";
 
   const test = async () => {
     setTestStatus("testing");
@@ -632,6 +656,56 @@ function LocalProviderCard({
     } catch {
       setTestStatus("fail");
     }
+  };
+
+  const discover = async () => {
+    discoverAbortRef.current?.abort();
+    const controller = new AbortController();
+    discoverAbortRef.current = controller;
+    setDiscovering(true);
+    setDiscoverError(null);
+    try {
+      const url = urlDraft.trim();
+      if (!url) throw new Error("Base URL is required");
+      if (url !== baseURL) await setBaseURL(url);
+      const apiKey = compatKey ?? null;
+      const list = await fetchOpenAICompatibleModels(
+        url,
+        apiKey,
+        controller.signal,
+      );
+      if (controller.signal.aborted) return;
+      const ids = list.map((m) => m.id);
+      setDiscovered(ids);
+      if (ids.length > 0) {
+        const serialized = serializeOpenAICompatibleModelIds(ids);
+        setModelDraft(serialized);
+        if (serialized !== modelId) await setModelId(serialized);
+      }
+    } catch (e) {
+      if (controller.signal.aborted) return; // user moved on; ignore.
+      setDiscovered(null);
+      setDiscoverError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (discoverAbortRef.current === controller) {
+        discoverAbortRef.current = null;
+        setDiscovering(false);
+      }
+    }
+  };
+
+  const selectedSet = useMemo(
+    () => new Set(parseOpenAICompatibleModelIds(modelDraft)),
+    [modelDraft],
+  );
+
+  const toggleModel = (id: string) => {
+    const next = new Set(selectedSet);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    const serialized = serializeOpenAICompatibleModelIds([...next]);
+    setModelDraft(serialized);
+    if (serialized !== modelId) void setModelId(serialized);
   };
 
   return (
@@ -694,15 +768,38 @@ function LocalProviderCard({
             >
               Test
             </Button>
+            {supportsDiscovery ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void discover()}
+                disabled={!urlDraft.trim() || discovering}
+                className="h-8 gap-1.5 px-3 text-[11px]"
+                title="Fetch model list from /v1/models"
+              >
+                <HugeiconsIcon
+                  icon={RefreshIcon}
+                  size={11}
+                  strokeWidth={1.75}
+                  className={discovering ? "animate-spin" : undefined}
+                />
+                {discovering ? "Loading…" : "Refresh"}
+              </Button>
+            ) : null}
           </div>
         </FieldRow>
 
-        <FieldRow label="Model ID">
+        <FieldRow label={supportsDiscovery ? "Model IDs" : "Model ID"}>
           <Input
             value={modelDraft}
             onChange={(e) => setModelDraft(e.target.value)}
             onBlur={() => {
-              const v = modelDraft.trim();
+              const v = supportsDiscovery
+                ? serializeOpenAICompatibleModelIds(
+                    parseOpenAICompatibleModelIds(modelDraft),
+                  )
+                : modelDraft.trim();
+              if (v !== modelDraft) setModelDraft(v);
               if (v !== modelId) void setModelId(v);
             }}
             placeholder={meta.modelPlaceholder}
@@ -710,6 +807,37 @@ function LocalProviderCard({
             className="h-8 font-mono text-[11.5px]"
           />
         </FieldRow>
+
+        {supportsDiscovery && (discovered || discoverError) ? (
+          <FieldRow label="Available">
+            <div className="flex flex-1 flex-col gap-1">
+              {discoverError ? (
+                <p className="text-[10.5px] text-destructive">
+                  Couldn't load models: {discoverError}
+                </p>
+              ) : discovered && discovered.length === 0 ? (
+                <p className="text-[10.5px] text-muted-foreground">
+                  Endpoint returned an empty model list.
+                </p>
+              ) : discovered ? (
+                <DiscoveredModelsList
+                  models={discovered}
+                  selected={selectedSet}
+                  onToggle={toggleModel}
+                  onSelectAll={() => {
+                    const next = serializeOpenAICompatibleModelIds(discovered);
+                    setModelDraft(next);
+                    if (next !== modelId) void setModelId(next);
+                  }}
+                  onClear={() => {
+                    setModelDraft("");
+                    if (modelId !== "") void setModelId("");
+                  }}
+                />
+              ) : null}
+            </div>
+          </FieldRow>
+        ) : null}
 
         {setContextLimit ? (
           <FieldRow label="Context">
@@ -836,5 +964,105 @@ function Label({ children }: { children: React.ReactNode }) {
     <span className="text-[11px] font-medium tracking-tight text-muted-foreground">
       {children}
     </span>
+  );
+}
+
+function DiscoveredModelsList({
+  models,
+  selected,
+  onToggle,
+  onSelectAll,
+  onClear,
+}: {
+  models: readonly string[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  onSelectAll: () => void;
+  onClear: () => void;
+}) {
+  const [filter, setFilter] = useState("");
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return models;
+    return models.filter((id) => id.toLowerCase().includes(q));
+  }, [filter, models]);
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-border/60 bg-muted/20 p-1.5">
+      <div className="flex items-center gap-1.5">
+        <Input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder={`Filter ${models.length} models…`}
+          spellCheck={false}
+          className="h-7 flex-1 text-[11px]"
+        />
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onSelectAll}
+          className="h-7 px-2 text-[10.5px] text-muted-foreground"
+        >
+          All
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onClear}
+          disabled={selected.size === 0}
+          className="h-7 px-2 text-[10.5px] text-muted-foreground"
+        >
+          None
+        </Button>
+      </div>
+      <ul className="max-h-44 overflow-y-auto rounded-sm">
+        {filtered.length === 0 ? (
+          <li className="px-2 py-1.5 text-[10.5px] text-muted-foreground">
+            No matches.
+          </li>
+        ) : (
+          filtered.map((id) => {
+            const isSelected = selected.has(id);
+            return (
+              <li key={id}>
+                <button
+                  type="button"
+                  onClick={() => onToggle(id)}
+                  className={cn(
+                    "flex w-full items-center gap-1.5 rounded-sm px-2 py-1 text-left font-mono text-[11px] transition-colors",
+                    isSelected
+                      ? "bg-accent/60 text-foreground"
+                      : "text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex size-3.5 shrink-0 items-center justify-center rounded-sm border",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border/70 bg-transparent",
+                    )}
+                  >
+                    {isSelected ? (
+                      <HugeiconsIcon
+                        icon={Tick01Icon}
+                        size={9}
+                        strokeWidth={2.5}
+                      />
+                    ) : null}
+                  </span>
+                  <span className="truncate">{id}</span>
+                </button>
+              </li>
+            );
+          })
+        )}
+      </ul>
+      <p className="px-1 text-[10px] text-muted-foreground">
+        {selected.size} of {models.length} selected.
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Register every OpenAI-compatible /models result as a namespaced selectable model id and persist refreshed discoveries.
- Reconcile default, recent, and favorite model prefs across windows and route synthesized ids back to upstream model ids.
- Keep this scoped to model discovery and selection; the Tauri startup command-pruning repair is intentionally not included.

## Verification
- `npm test -- src/modules/ai/config.test.ts`
- `git diff --check`
- `npm run build`
- Direct diff review passed with no blocking findings; it confirmed stale synthesized model ids fall back safely during render and `src-tauri/tauri.conf.json` is not part of this PR.