### PR TITLE
feat: Attach pasted chat images

### DIFF
--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -12,7 +12,11 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useMemo, useState } from "react";
-import { useComposer, type FileAttachment } from "../lib/composer";
+import {
+  collectClipboardImageFiles,
+  useComposer,
+  type FileAttachment,
+} from "../lib/composer";
 import { useWorkspaceFiles } from "../hooks/useWorkspaceFiles";
 import { SLASH_COMMANDS } from "../lib/slashCommands";
 import type { Snippet } from "../lib/snippets";
@@ -213,6 +217,13 @@ export function AiInputBar() {
       ? "Transcribing…"
       : null;
 
+  const onPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const files = collectClipboardImageFiles(e.clipboardData?.items);
+    if (files.length === 0) return;
+    e.preventDefault();
+    void c.addFiles(files);
+  };
+
   return (
     <div className="shrink-0 border-t border-border/60 bg-card/40 px-3 py-2">
       <div
@@ -243,6 +254,7 @@ export function AiInputBar() {
                 ref={c.textareaRef}
                 value={c.value}
                 onChange={(e) => c.setValue(e.target.value)}
+                onPaste={onPaste}
                 onKeyUp={updateTrigger}
                 onClick={updateTrigger}
                 onSelect={updateTrigger}

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -23,6 +23,7 @@ import {
 import { buildTools, type ToolContext } from "../tools/tools";
 import { compactModelMessagesDetailed } from "./compact";
 import type { ProviderKeys } from "./keyring";
+import { normalizeDataUrlFileParts } from "./messageParts";
 import { createProxyFetch } from "./proxyFetch";
 
 const localProxyFetch = createProxyFetch({ allowPrivateNetwork: true });
@@ -374,7 +375,9 @@ export async function runAgentStream(opts: RunAgentOptions) {
     opts.projectMemory ?? null,
   );
 
-  const history = await convertToModelMessages(opts.uiMessages);
+  const history = normalizeDataUrlFileParts(
+    await convertToModelMessages(opts.uiMessages),
+  );
   const prunedHistory = pruneMessages({
     messages: history,
     reasoning: "all",

--- a/src/modules/ai/lib/composer.test.ts
+++ b/src/modules/ai/lib/composer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectClipboardImageFiles,
+  isAcceptedAttachmentFile,
+} from "./composer";
+
+describe("composer attachment helpers", () => {
+  it("collects only usable image files from clipboard items", () => {
+    const image = new File(["image"], "image.png", { type: "image/png" });
+    const text = new File(["/tmp/image.png"], "image-path.txt", {
+      type: "text/plain",
+    });
+
+    const items = [
+      { kind: "string", type: "text/plain", getAsFile: () => null },
+      { kind: "file", type: "text/plain", getAsFile: () => text },
+      { kind: "file", type: "image/png", getAsFile: () => image },
+      { kind: "file", type: "image/png", getAsFile: () => null },
+    ] as unknown as DataTransferItem[];
+
+    expect(collectClipboardImageFiles(items)).toEqual([image]);
+  });
+
+  it("accepts images and known text-like files while rejecting binary files", () => {
+    expect(
+      isAcceptedAttachmentFile({ name: "screenshot.png", type: "image/png" }),
+    ).toBe(true);
+    expect(isAcceptedAttachmentFile({ name: "notes.md", type: "" })).toBe(
+      true,
+    );
+    expect(isAcceptedAttachmentFile({ name: "Dockerfile", type: "" })).toBe(
+      true,
+    );
+    expect(
+      isAcceptedAttachmentFile({ name: "archive.pdf", type: "application/pdf" }),
+    ).toBe(false);
+  });
+});

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -33,6 +33,37 @@ export const MAX_TEXT_INLINE = 200_000;
 export const ACCEPTED_FILES =
   "image/*,.txt,.md,.json,.yaml,.yml,.toml,.sh,.zsh,.bash,.py,.js,.jsx,.ts,.tsx,.rs,.go,.java,.c,.cpp,.h,.hpp,.html,.css,.csv,.log,.env,.config,.conf,.ini,Dockerfile,.dockerfile";
 
+const ACCEPTED_TEXT_EXTENSIONS = new Set<string>(
+  ".txt,.md,.json,.yaml,.yml,.toml,.sh,.zsh,.bash,.py,.js,.jsx,.ts,.tsx,.rs,.go,.java,.c,.cpp,.h,.hpp,.html,.css,.csv,.log,.env,.config,.conf,.ini,.dockerfile"
+    .split(","),
+);
+const ACCEPTED_FILENAMES = new Set<string>(["dockerfile"]);
+
+export function isAcceptedAttachmentFile(
+  file: Pick<File, "name" | "type">,
+): boolean {
+  if (file.type.startsWith("image/")) return true;
+  if (file.type.startsWith("text/")) return true;
+  if (ACCEPTED_FILENAMES.has(file.name.toLowerCase())) return true;
+  const dotIdx = file.name.lastIndexOf(".");
+  if (dotIdx < 0) return false;
+  return ACCEPTED_TEXT_EXTENSIONS.has(file.name.slice(dotIdx).toLowerCase());
+}
+
+export function collectClipboardImageFiles(
+  items: DataTransferItemList | readonly DataTransferItem[] | null | undefined,
+): File[] {
+  if (!items || items.length === 0) return [];
+  const files: File[] = [];
+  for (const item of Array.from(items)) {
+    if (item.kind !== "file") continue;
+    if (!item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (file) files.push(file);
+  }
+  return files;
+}
+
 type Voice = ReturnType<typeof useWhisperRecording>;
 
 type ComposerCtx = {
@@ -40,7 +71,7 @@ type ComposerCtx = {
   value: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;
   files: FileAttachment[];
-  addFiles: (list: FileList | null) => Promise<void>;
+  addFiles: (source: FileList | readonly File[] | null) => Promise<void>;
   /** Attach a file by absolute path — used by the file explorer's "Attach to Agent". */
   attachFileByPath: (path: string) => Promise<void>;
   removeFile: (id: string) => void;
@@ -152,10 +183,12 @@ export function AiComposerProvider({ children }: ProviderProps) {
     },
   });
 
-  const addFiles = async (list: FileList | null) => {
-    if (!list) return;
+  const addFiles = async (source: FileList | readonly File[] | null) => {
+    if (!source) return;
+    const items = Array.isArray(source) ? source.slice() : Array.from(source);
+    if (items.length === 0) return;
     const next: FileAttachment[] = [];
-    for (const f of Array.from(list)) {
+    for (const f of items) {
       const att = await readAttachment(f);
       if (att) next.push(att);
     }
@@ -357,6 +390,7 @@ export function AiComposerProvider({ children }: ProviderProps) {
 
 async function readAttachment(file: File): Promise<FileAttachment | null> {
   const id = `${file.name}-${file.size}-${file.lastModified}`;
+  if (!isAcceptedAttachmentFile(file)) return null;
   if (file.type.startsWith("image/")) {
     const url = await readAsDataURL(file);
     return {

--- a/src/modules/ai/lib/messageParts.test.ts
+++ b/src/modules/ai/lib/messageParts.test.ts
@@ -1,0 +1,48 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { normalizeDataUrlFileParts } from "./messageParts";
+
+describe("normalizeDataUrlFileParts", () => {
+  it("converts base64 data-url file parts before model prompting", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "can you see this?" },
+          {
+            type: "file",
+            data: "data:image/png;base64,aGVsbG8=",
+            mediaType: "application/octet-stream",
+            filename: "screenshot.png",
+          },
+        ],
+      },
+    ];
+
+    const normalized = normalizeDataUrlFileParts(messages);
+    const filePart = (normalized[0].content as unknown[])[1] as {
+      data: string;
+      mediaType: string;
+    };
+
+    expect(filePart.data).toBe("aGVsbG8=");
+    expect(filePart.mediaType).toBe("image/png");
+  });
+
+  it("leaves hosted file urls untouched", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            data: "https://example.com/screenshot.png",
+            mediaType: "image/png",
+          },
+        ],
+      },
+    ];
+
+    expect(normalizeDataUrlFileParts(messages)).toEqual(messages);
+  });
+});

--- a/src/modules/ai/lib/messageParts.ts
+++ b/src/modules/ai/lib/messageParts.ts
@@ -1,0 +1,49 @@
+import type { ModelMessage } from "ai";
+
+type FileLikePart = {
+  type: string;
+  data?: unknown;
+  mediaType?: string;
+};
+
+type ParsedDataUrl = {
+  mediaType: string | undefined;
+  base64: string;
+};
+
+function parseBase64DataUrl(value: string): ParsedDataUrl | null {
+  if (!value.startsWith("data:")) return null;
+  const comma = value.indexOf(",");
+  if (comma === -1) return null;
+  const header = value.slice(5, comma);
+  if (!/(^|;)base64($|;)/i.test(header)) return null;
+  const mediaType = header.split(";")[0] || undefined;
+  const base64 = value.slice(comma + 1);
+  return base64 ? { mediaType, base64 } : null;
+}
+
+function normalizeFilePart(part: unknown): unknown {
+  const candidate = part as FileLikePart;
+  if (candidate?.type !== "file" || typeof candidate.data !== "string") {
+    return part;
+  }
+  const parsed = parseBase64DataUrl(candidate.data);
+  if (!parsed) return part;
+  return {
+    ...candidate,
+    data: parsed.base64,
+    mediaType: parsed.mediaType ?? candidate.mediaType,
+  };
+}
+
+export function normalizeDataUrlFileParts(
+  messages: ModelMessage[],
+): ModelMessage[] {
+  return messages.map((message) => {
+    if (!Array.isArray(message.content)) return message;
+    return {
+      ...message,
+      content: message.content.map(normalizeFilePart),
+    } as ModelMessage;
+  });
+}


### PR DESCRIPTION
## Summary
- Collect pasted image File objects from the chat textarea and attach them through the existing composer file pipeline.
- Accept the same image and text-like files for non-picker sources while rejecting unsupported binary files.
- Normalize data:image model file parts before streamText so pasted screenshots are sent as inline file data instead of being downloaded as URLs.

## Verification
- `npm test -- src/modules/ai/lib/composer.test.ts src/modules/ai/lib/messageParts.test.ts`
- `git diff --check`
- `npm run build`
- Direct diff review passed with no blocking findings.