### PR TITLE
fix(settings): settings window hidden behind main window on macOS

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,9 @@ mod modules;
 
 use modules::{fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
-use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{
+    Emitter, Manager, PhysicalPosition, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+};
 use tauri_plugin_window_state::StateFlags;
 
 /// Drained on first read so HMR / re-mounts can't replay the launch dir.
@@ -19,7 +21,9 @@ fn parse_launch_dir() -> Option<String> {
         if arg.starts_with('-') {
             continue;
         }
-        let Ok(canon) = std::fs::canonicalize(&arg) else { continue };
+        let Ok(canon) = std::fs::canonicalize(&arg) else {
+            continue;
+        };
         if !canon.is_dir() {
             continue;
         }
@@ -37,6 +41,7 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     };
 
     if let Some(window) = app.get_webview_window("settings") {
+        let _ = window.set_always_on_top(true);
         let _ = window.show();
         let _ = window.set_focus();
         if let Some(t) = tab.as_deref().filter(|s| !s.is_empty()) {
@@ -47,7 +52,7 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         return Ok(());
     }
 
-    let mut builder = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(url_path.into()))
+    let builder = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(url_path.into()))
         .title("Settings")
         .inner_size(820.0, 620.0)
         .min_inner_size(820.0, 620.0)
@@ -59,9 +64,14 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         .always_on_top(true);
 
     // Tie lifecycle to the main window so settings minimizes/closes with it.
-    if let Some(main) = app.get_webview_window("main") {
-        builder = builder.parent(&main).map_err(|e| e.to_string())?;
-    }
+    // macOS: skip parent() — child + always_on_top leaves the settings webview
+    // behind the main window except while the parent is being dragged (#33).
+    #[cfg(not(target_os = "macos"))]
+    let builder = if let Some(main) = app.get_webview_window("main") {
+        builder.parent(&main).map_err(|e| e.to_string())?
+    } else {
+        builder
+    };
 
     #[cfg(target_os = "macos")]
     let builder = builder
@@ -81,7 +91,24 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     {
         let _ = window.set_decorations(false);
     }
-    let _ = window;
+
+    #[cfg(target_os = "macos")]
+    if let Some(main) = app.get_webview_window("main") {
+        if let (Ok(main_pos), Ok(main_size), Ok(settings_size)) = (
+            main.outer_position(),
+            main.outer_size(),
+            window.outer_size(),
+        ) {
+            let x = main_pos.x
+                + ((main_size.width as i32).saturating_sub(settings_size.width as i32)) / 2;
+            let y = main_pos.y
+                + ((main_size.height as i32).saturating_sub(settings_size.height as i32)) / 2;
+            let _ = window.set_position(PhysicalPosition::new(x, y));
+        } else {
+            let _ = window.center();
+        }
+    }
+
     Ok(())
 }
 
@@ -109,6 +136,24 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .setup(|app| {
+            // Without parent() on macOS, close settings when the main window goes away.
+            let Some(main) = app.get_webview_window("main") else {
+                return Ok(());
+            };
+            let handle = app.handle().clone();
+            main.on_window_event(move |event| {
+                if matches!(
+                    event,
+                    WindowEvent::CloseRequested { .. } | WindowEvent::Destroyed
+                ) {
+                    if let Some(settings) = handle.get_webview_window("settings") {
+                        let _ = settings.close();
+                    }
+                }
+            });
+            Ok(())
+        })
         .manage(pty::PtyState::default())
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())


### PR DESCRIPTION
## What

Fix the settings window being invisible on macOS — it was hidden behind the
main window and only appeared briefly while the main window was being dragged.

## Why

The settings window was created as a child of `main` (`.parent()`) while also
having `.always_on_top(true)`. On macOS, `addChildWindow:ordered:Above` and
`NSFloatingWindowLevel` interact poorly with wry's webview surface layering —
the webview content ends up rendered *behind* the parent window's content
despite the NSWindow ordering being correct. The drag behaviour revealed it
because macOS briefly re-composites the window stack during a window move.

Closes #33

## How

- Skip `.parent(&main)` on macOS only (`#[cfg(not(target_os = "macos"))]`).
- Add a `.setup()` hook that watches `main` for `CloseRequested`/`Destroyed`
  and closes settings — replacing the lifecycle tie that `.parent()` gave for
  free on other platforms.
- Center settings over the main window on first open (fallback: screen center),
  since macOS no longer auto-positions a non-child window relative to its
  logical owner.
- Re-apply `set_always_on_top(true)` when re-focusing an already-open settings
  window so it reliably surfaces after being hidden.

Windows and Linux are unchanged — both still use `.parent()`.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] Manual smoke-test of the affected feature
- [x] Tested in `pnpm tauri dev`

Tested on macOS (Apple Silicon):
1. Launched `pnpm tauri dev`, opened Settings via the gear icon → window
   appeared immediately above the main window.
2. Clicked back into the terminal, then reopened Settings → stayed on top.
3. Opened Settings via the Models deep-link from the AI panel → correct tab,
   window visible.
4. Closed the main window → settings window closed with it.
5. Used Themes → Edit to hide the settings window, reopened → window
   resurfaced correctly.

## Screenshots / GIFs

Before: settings window invisible until main window was dragged.
After: settings window opens normally and stays above the main window.

## Notes for reviewer

Only `src-tauri/src/lib.rs` is changed. The fix is platform-gated so
Windows/Linux behaviour is byte-for-byte identical to before.