### PR TITLE
feat(terminal): add configurable default working directory

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -146,6 +146,12 @@ function readSidebarView(): SidebarViewId {
 }
 
 export default function App() {
+  const defaultTerminalCwd = usePreferencesStore(
+    (s) => s.defaultTerminalCwd,
+  );
+  const initialCwd =
+    getLaunchDir() || defaultTerminalCwd || undefined;
+
   const {
     tabs,
     activeId,
@@ -171,7 +177,7 @@ export default function App() {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
-  } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
+  } = useTabs(initialCwd ? { cwd: initialCwd } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
   // (e.g. cdInNewTab) read the latest pane state instead of a stale closure.
@@ -552,6 +558,7 @@ export default function App() {
     activeTab,
     tabs,
     launchCwd ?? home,
+    defaultTerminalCwd || null,
   );
 
   useEffect(() => {

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -79,6 +79,7 @@ export type Preferences = {
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  defaultTerminalCwd: string;
   lastWslDistro: string | null;
   zoomLevel: number;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
@@ -118,6 +119,7 @@ const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_DEFAULT_TERMINAL_CWD = "defaultTerminalCwd";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_SHORTCUTS = "shortcuts";
@@ -170,6 +172,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  defaultTerminalCwd: "",
   lastWslDistro: null,
   zoomLevel: 1.0,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
@@ -276,6 +279,9 @@ export async function loadPreferences(): Promise<Preferences> {
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
     ),
+    defaultTerminalCwd:
+      get<string>(KEY_DEFAULT_TERMINAL_CWD) ??
+      DEFAULT_PREFERENCES.defaultTerminalCwd,
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
@@ -451,6 +457,10 @@ export async function setTerminalScrollback(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_SCROLLBACK, clampScrollback(value));
 }
 
+export async function setDefaultTerminalCwd(value: string): Promise<void> {
+  await writePref(KEY_DEFAULT_TERMINAL_CWD, value.trim());
+}
+
 export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
@@ -508,6 +518,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_DEFAULT_TERMINAL_CWD]: "defaultTerminalCwd",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_SHORTCUTS]: "shortcuts",

--- a/src/modules/tabs/lib/resolveCwd.test.ts
+++ b/src/modules/tabs/lib/resolveCwd.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { resolveInheritedCwd } from "./resolveCwd";
+import type { Tab, TerminalTab } from "./useTabs";
+
+const home = "/home/user";
+const defaultCwd = "/home/user/projects";
+const lastCwd = "/home/user/work";
+
+function termTab(cwd: string): Tab {
+  return {
+    kind: "terminal",
+    id: 1,
+    title: "Terminal",
+    cwd,
+    paneTree: {} as TerminalTab["paneTree"],
+    activeLeafId: 1,
+  } satisfies TerminalTab;
+}
+
+function editorTab(): Tab {
+  return {
+    kind: "editor",
+    id: 2,
+    title: "Editor",
+    path: "/file.ts",
+    dirty: false,
+    preview: false,
+  };
+}
+
+describe("resolveInheritedCwd — priority chain", () => {
+  it("returns active terminal cwd first", () => {
+    expect(
+      resolveInheritedCwd(termTab("/active"), lastCwd, defaultCwd, home),
+    ).toBe("/active");
+  });
+
+  it("falls back to lastTerminalCwd when active tab is an editor", () => {
+    expect(
+      resolveInheritedCwd(editorTab(), lastCwd, defaultCwd, home),
+    ).toBe(lastCwd);
+  });
+
+  it("falls back to defaultCwd when lastTerminalCwd is null", () => {
+    expect(
+      resolveInheritedCwd(editorTab(), null, defaultCwd, home),
+    ).toBe(defaultCwd);
+  });
+
+  it("falls back to home when both lastTerminalCwd and defaultCwd are absent", () => {
+    expect(
+      resolveInheritedCwd(editorTab(), null, null, home),
+    ).toBe(home);
+  });
+
+  it("returns undefined when all sources are absent", () => {
+    expect(
+      resolveInheritedCwd(undefined, null, null, null),
+    ).toBeUndefined();
+  });
+
+  it("treats empty string defaultCwd as absent (falls through to home)", () => {
+    expect(
+      resolveInheritedCwd(editorTab(), null, "", home),
+    ).toBe(home);
+  });
+
+  it("treats empty string lastTerminalCwd as absent (falls through to defaultCwd)", () => {
+    expect(
+      resolveInheritedCwd(editorTab(), "", defaultCwd, home),
+    ).toBe(defaultCwd);
+  });
+
+  it("returns undefined when active tab is undefined and all sources are null", () => {
+    expect(
+      resolveInheritedCwd(undefined, null, undefined, null),
+    ).toBeUndefined();
+  });
+});

--- a/src/modules/tabs/lib/resolveCwd.ts
+++ b/src/modules/tabs/lib/resolveCwd.ts
@@ -1,0 +1,23 @@
+import type { Tab } from "./useTabs";
+
+/**
+ * Resolve the cwd a new terminal tab should inherit.
+ *
+ * Priority (highest → lowest):
+ *   1. Active terminal tab's live cwd
+ *   2. Last cwd seen from any terminal (tracked by the caller)
+ *   3. User-configured default directory (Settings → General → Default directory)
+ *   4. Workspace home directory
+ *   5. undefined (caller decides)
+ */
+export function resolveInheritedCwd(
+  activeTab: Tab | undefined,
+  lastTerminalCwd: string | null,
+  defaultCwd: string | null | undefined,
+  home: string | null,
+): string | undefined {
+  if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
+  // Use || not ?? so that empty strings (the store default for an unconfigured
+  // defaultCwd) are treated the same as null/undefined and fall through.
+  return lastTerminalCwd || defaultCwd || home || undefined;
+}

--- a/src/modules/tabs/lib/useWorkspaceCwd.ts
+++ b/src/modules/tabs/lib/useWorkspaceCwd.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { resolveInheritedCwd } from "./resolveCwd";
 import type { Tab } from "./useTabs";
 
 type Result = {
@@ -10,6 +11,7 @@ export function useWorkspaceCwd(
   activeTab: Tab | undefined,
   tabs: Tab[],
   home: string | null,
+  defaultCwd?: string | null,
 ): Result {
   const lastTerminalCwd = useRef<string | null>(null);
 
@@ -28,12 +30,11 @@ export function useWorkspaceCwd(
   }, [activeTab, tabs, home]);
 
   const inheritedCwdForNewTab = useCallback((): string | undefined => {
-    if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
     // Editor tabs inherit the last terminal's cwd (or workspace home), not
     // the file's folder — opening a new terminal from a file shouldn't
     // hijack the user's working directory context.
-    return lastTerminalCwd.current ?? home ?? undefined;
-  }, [activeTab, home]);
+    return resolveInheritedCwd(activeTab, lastTerminalCwd.current, defaultCwd, home);
+  }, [activeTab, defaultCwd, home]);
 
   return { explorerRoot, inheritedCwdForNewTab };
 }

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -20,6 +20,7 @@ import {
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAutostart,
+  setDefaultTerminalCwd,
   setRestoreWindowState,
   setShowHidden,
   setTerminalFontFamily,
@@ -73,6 +74,7 @@ export function GeneralSection() {
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
+  const defaultTerminalCwd = usePreferencesStore((s) => s.defaultTerminalCwd);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
 
   useEffect(() => {
@@ -289,6 +291,18 @@ export function GeneralSection() {
               ))}
             </SelectContent>
           </Select>
+        </SettingRow>
+        <SettingRow
+          title="Default directory"
+          description='Path for new terminals when no workspace is active. Leave blank to use the launch directory or home.'
+        >
+          <input
+            type="text"
+            value={defaultTerminalCwd}
+            placeholder="Inherited"
+            onChange={(e) => void setDefaultTerminalCwd(e.target.value)}
+            className="h-8 w-48 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+          />
         </SettingRow>
       </div>
 


### PR DESCRIPTION
## What

Adds a **Default directory** field to Settings → General. New terminals open
in this directory when no workspace is active and no prior terminal cwd exists
in the session.

## Why

When Terax is launched without a folder argument (e.g. from the app icon or
dock), new terminals fall back to the OS home directory. Users who always work
in a specific root (e.g. `~/projects`) had no way to configure this without
passing a CLI argument every time.

## How

Priority chain for new-tab cwd resolution (highest → lowest):
1. Active terminal tab's live cwd
2. Last cwd seen from any terminal in the session
3. **User-configured default directory** ← new
4. Workspace home / launch directory
5. OS home

The priority logic is extracted into `src/modules/tabs/lib/resolveCwd.ts` as
a pure function so it can be tested independently of the React hook.

Also fixes a latent bug in the original `??` chain: the store defaults
`defaultTerminalCwd` to `""`, which `??` treats as a present value and returns
an empty string instead of falling through to home. Changed to `||` to match
the existing `App.tsx` pattern for the same value.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 8 new tests added for `resolveInheritedCwd`, all passing
- [x] Manual smoke-test of the affected feature
- [x] Tested in `pnpm tauri dev`

Tested manually:
1. Set Default directory to `~/projects` in Settings → General.
2. Closed all terminal tabs. Opened a new terminal → opened in `~/projects`.
3. Navigated to a subdirectory in the terminal. Opened a new terminal →
   inherited the active terminal's cwd, not the default.
4. Cleared the Default directory field. New terminals fell back to home.
5. Launched with a folder argument — launch directory still takes precedence.

## Screenshots / GIFs

New **Default directory** field in the Terminal section of General settings.

## Notes for reviewer

Only frontend files changed (`store.ts`, `App.tsx`, `GeneralSection.tsx`,
`useWorkspaceCwd.ts`, plus two new files for the extracted pure function and
its tests). No Rust/IPC changes. The setting persists via `tauri-plugin-store`
using the existing `writePref` pattern.