### PR TITLE
fix(fs): Enforce workspace authorization for native IPC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,9 @@ The most common way a PR breaks Terax is a **local fix with global blast radius*
 So if your change touches behavior in any of these load-bearing paths, the PR must add or extend a test that locks the invariant you're relying on:
 
 - **Shell/terminal spawn**: what shell launches, with which cwd, env, and login flags. A "fix" here can stop terminals from starting entirely.
-- **Workspace authorization**: which directories spawns, git, and AI tools may operate in. Both the allow and the deny side.
+- **Workspace authorization**: which directories native fs IPC, spawns, git, and AI tools may operate in. Both the allow and the deny side. The home directory is not automatically authorized unless it is the deliberate active workspace root.
 - **Git command layer**: repo-root resolution, pathspec/argument guards, status parsing.
-- **Filesystem mutation**: atomic writes, symlink handling, no-data-loss on partial failure.
+- **Filesystem mutation**: atomic writes, symlink handling, no-data-loss on partial failure, and rejection of create/write/rename/delete targets outside authorized workspace roots.
 - **IPC command surface and AI tool surface**: anything the webview or the agent can invoke.
 - **Pure logic with wide reach**: cwd inheritance, tab/split tree transforms, OSC/prompt parsing, the command guard.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,9 @@ Until `1.0.0`, only the latest minor gets security fixes. Right now that's `0.5.
 - **No telemetry.** Terax only talks to the network when you ask it to (AI requests, update checks, web preview).
 - **AI tool approval.** File writes and shell commands from the agent need your OK before they run.
 - **No Node in the renderer.** The frontend only reaches the host through the allow-listed Tauri commands.
+- **Workspace-scoped native filesystem access.** Rust filesystem IPC rejects reads, writes, search, rename, and delete operations outside explicitly authorized workspace roots. `$HOME` is not implicitly authorized unless it is the selected workspace.
+- **Symlink escape protection.** Reads, writes, stats, canonicalization, and recursive search operations resolve paths before authorization. Deleting or renaming a symlink inside an authorized workspace affects the link entry itself, not the outside target.
+- **AI sensitive-path guard.** The agent also refuses obvious secret paths such as `.env*`, `.ssh/`, credentials, and keychain directories before native IPC runs. This is defense-in-depth for AI tools, while normal editor and explorer access is governed by workspace authorization.
 - **Signed releases.** Updates are verified before they're applied.
 
 ## What we can't promise

--- a/TERAX.md
+++ b/TERAX.md
@@ -18,7 +18,7 @@ Production-grade or it does not ship. Every change is judged against all of thes
 
 - **Correctness**: edge cases, failure modes, concurrent access. No "works for now".
 - **Performance**: ultra-lightweight is the product. ~7-8 MB bundle, high-performance terminal. For every change ask: how much RAM it costs, whether it adds IPC round-trips or redundant requests, whether it triggers extra re-renders or wasted work, whether it pulls a heavy dependency. Unused features consume zero resources.
-- **Security**: no critical security holes. Validate at every boundary (IPC, fs, network, AI tool surface). The secret-path deny-list applies on both read and write and is never bypassed.
+- **Security**: no critical security holes. Validate at every boundary (IPC, fs, network, AI tool surface). Native file IPC is workspace-authorized, and AI tools add their own sensitive-path deny-list on top.
 - **UI/UX**: polished, professional, premium. Every state and detail considered.
 - **Architecture**: new or changed logic lives in pure, dependency-light functions (functional core); tauri commands and React components stay thin (imperative shell). Keeps it testable without a later rewrite.
 
@@ -39,15 +39,23 @@ Verify before claiming done: `pnpm exec tsc --noEmit`, `pnpm test`, `cargo clipp
 **Rust (`src-tauri/`)** owns all OS access. The webview never touches the FS, processes, or shells directly — everything goes through `invoke()` calls to commands registered in `src-tauri/src/lib.rs`:
 
 - `pty::pty_*` — long-lived interactive PTY sessions (xterm ↔ portable-pty), managed by `PtyState` (`RwLock<HashMap<id, Session>>`). Output streams via a Tauri `Channel<PtyEvent>`.
-- `fs::tree::*` (`fs_read_dir`, `list_subdirs`), `fs::file::*` (`fs_read_file`, `fs_write_file`, `fs_stat`, `fs_canonicalize`), `fs::mutate::*` (`fs_create_file`, `fs_create_dir`, `fs_rename`, `fs_delete`): file explorer + editor IO.
-- `fs::search::*` (`fs_search`, `fs_list_files`), `fs::grep::*` (`fs_grep`, `fs_glob`): fuzzy file finder + content search (powered by `ignore` + `grep-*` crates).
+- `fs::tree::*` (`fs_read_dir`, `list_subdirs`), `fs::file::*` (`fs_read_file`, `fs_write_file`, `fs_stat`, `fs_canonicalize`), `fs::mutate::*` (`fs_create_file`, `fs_create_dir`, `fs_rename`, `fs_delete`): file explorer + editor IO. All native fs commands require `WorkspaceRegistry` authorization.
+- `fs::search::*` (`fs_search`, `fs_list_files`), `fs::grep::*` (`fs_grep`, `fs_glob`): fuzzy file finder + content search (powered by `ignore` + `grep-*` crates). Search roots are also workspace-authorized before walking.
 - `git::commands::*`: full source-control surface (`git_status`, `git_diff`, `git_diff_content`, `git_stage`, `git_unstage`, `git_discard`, `git_commit`, `git_fetch`, `git_pull_ff_only`, `git_push`, `git_log`, `git_show_commit`, `git_commit_files`, `git_commit_file_diff`, `git_panel_snapshot`, `git_resolve_repo`, `git_remote_url`). All gated through the workspace authorization registry.
 - `shell::shell_run_command`: one-shot subshell exec used by AI tools. Distinct from PTY sessions; not the user's interactive terminal. On Windows via PowerShell (`-NoProfile -Command`), on Unix via `$SHELL -lc`. Shared helper `build_oneshot_command`.
 - `shell::shell_session_*`: persistent agent shell with state across calls. `shell::shell_bg_*` (`spawn`, `logs`, `kill`, `list`): long-running background processes (dev servers etc.) with bounded ring-buffer log capture.
-- `workspace::*`: `workspace_authorize` / `workspace_current_dir` (the spawn/git/AI cwd authorization registry) plus the WSL bridge (`wsl_list_distros`, `wsl_default_distro`, `wsl_home`).
+- `workspace::*`: `workspace_authorize` / `workspace_current_dir` (the fs/spawn/git/AI cwd authorization registry) plus the WSL bridge (`wsl_list_distros`, `wsl_default_distro`, `wsl_home`).
 - `net::*` (`ai_http_request`, `ai_http_stream`, `lm_ping`): AI HTTP proxy with SSRF guard; keeps provider calls and local-model pings off the webview.
 - `secrets::secrets_*`: OS keychain via the `keyring` crate. Service constant `terax-ai`. Linux uses a file-based fallback gated behind `#[cfg(target_os = "linux")]`.
 - `open_settings_window`: separate webview window for Settings (optional `tab` arg deep-links a section).
+
+### Workspace authorization
+
+`WorkspaceRegistry` is the native trust boundary for filesystem, shell cwd, git, and AI tool cwd operations. Rust bootstraps the launch/current workspace root and explicitly selected workspace roots only. Do not authorize `$HOME` just because it is the user's home directory. Home is authorized only when it is the deliberate active workspace root, such as a local workspace fallback or user-selected workspace switch.
+
+Native filesystem IPC policy is workspace authorization, not sensitive-file filtering. Editor and explorer workflows must be able to open files such as `.env` when those files are inside an authorized workspace. AI tools are different: `src/modules/ai/lib/security.ts` keeps a sensitive-path deny-list as defense-in-depth before and after canonicalization.
+
+For fs commands, existing targets are canonicalized and must resolve under an authorized root. Create/write-to-missing-target operations authorize the nearest existing ancestor and reject traversal outside the authorized root. Delete and rename preserve symlink entry semantics: deleting or renaming a symlink inside an authorized workspace affects the link itself, while reads, writes, searches, greps, globs, stats, and canonicalization through symlinks that resolve outside the workspace are rejected with an "outside authorized workspace" error.
 
 ### PTY shell integration
 
@@ -103,7 +111,7 @@ BYOK. Cloud providers via `@ai-sdk/*`: **OpenAI, Anthropic, Google, xAI, Cerebra
 - **Composer** (`lib/composer.tsx`): React context providing shared input state (text, attachments, voice) for both the docked `AiInputBar` and any other surface. Attachments include image, text-file, and `selection` kinds — selections come from `useChatStore.attachSelection(text, source)` (drained into chips, not pasted into the textarea) and are wrapped as `<selection source="terminal|editor">…</selection>` blocks at submit. Composer derives `isBusy` from `agentMeta.status` so it can mount safely before sessions hydrate.
 - **Voice input**: streamed transcription pipeline. Toggled from the composer.
 - **Live context bridge**: `App.tsx` calls `setLive({ getCwd, getTerminalContext, … })` so tools can read the *currently active* terminal's cwd + last 300 lines of buffer. Lazy by design — don't pre-snapshot.
-- **Tools** (`tools/tools.ts`): `read_file`, `list_directory`, `fs_search`, `fs_grep` auto-execute. `write_file`, `create_directory`, `rename`, `delete`, `run_command`, `shell_session_run`, `shell_bg_spawn` set `needsApproval: true` and the AI SDK pauses for an in-UI confirmation card. Auto-send after approval uses `lastAssistantMessageIsCompleteWithApprovalResponses`. `lib/security.ts` is a deny-list refusing obvious secret paths (`.env*`, `.ssh/`, credentials, keychain dirs) — apply on **both** read and write paths and don't bypass it.
+- **Tools** (`tools/tools.ts`): `read_file`, `list_directory`, `fs_search`, `fs_grep` auto-execute. `write_file`, `create_directory`, `rename`, `delete`, `run_command`, `shell_session_run`, `shell_bg_spawn` set `needsApproval: true` and the AI SDK pauses for an in-UI confirmation card. Auto-send after approval uses `lastAssistantMessageIsCompleteWithApprovalResponses`. `lib/security.ts` is the AI-only deny-list refusing obvious secret paths (`.env*`, `.ssh/`, credentials, keychain dirs) on both read and write paths. Keep it as defense-in-depth; do not use it as the native editor/explorer filesystem policy.
 - **Edit diffs**: AI-proposed edits open in a side-by-side diff tab (`ai-diff` tab kind); user accepts/rejects per hunk before the write tool actually runs.
 - **Skills / snippets**: reusable prompt fragments + tool-bundles surfaced in the composer.
 

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use tauri::Emitter;
 use tempfile::NamedTempFile;
 
-use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
@@ -44,9 +44,21 @@ pub struct FileStat {
 }
 
 #[tauri::command]
-pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<ReadResult, String> {
+pub fn fs_read_file(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<ReadResult, String> {
+    fs_read_file_impl(&path, workspace, &registry)
+}
+
+pub fn fs_read_file_impl(
+    path: &str,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
+) -> Result<ReadResult, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let p = resolve_path(&path, &workspace);
+    let p = super::authorize_existing_path(registry, &resolve_path(path, &workspace))?;
     let meta = std::fs::metadata(&p).map_err(|e| {
         log::debug!("fs_read_file stat({}) failed: {e}", p.display());
         e.to_string()
@@ -98,16 +110,38 @@ fn write_atomic(target: &Path, content: &[u8]) -> std::io::Result<()> {
     Ok(())
 }
 
+pub fn authorize_write_target(registry: &WorkspaceRegistry, target: &Path) -> Result<(), String> {
+    if target.exists() {
+        super::authorize_existing_path(registry, target)?;
+    } else {
+        super::authorize_create_target(registry, target)?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn fs_write_file(
     path: String,
     content: String,
     workspace: Option<WorkspaceEnv>,
     source: Option<String>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
+    fs_write_file_impl(&path, &content, workspace, source, &registry, &app)
+}
+
+pub fn fs_write_file_impl(
+    path: &str,
+    content: &str,
+    workspace: Option<WorkspaceEnv>,
+    source: Option<String>,
+    registry: &WorkspaceRegistry,
+    app: &tauri::AppHandle,
+) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let target = resolve_path(&path, &workspace);
+    let target = resolve_path(path, &workspace);
+    authorize_write_target(registry, &target)?;
     let original_permissions = fs::metadata(&target).ok().map(|m| m.permissions());
     write_atomic(&target, content.as_bytes()).map_err(|e| {
         log::warn!("fs_write_file({}) failed: {e}", target.display());
@@ -120,7 +154,7 @@ pub fn fs_write_file(
     let _ = app.emit(
         "fs:file-written",
         FileWrittenEvent {
-            path: path.clone(),
+            path: path.to_string(),
             source,
         },
     );
@@ -129,17 +163,25 @@ pub fn fs_write_file(
 }
 
 #[tauri::command]
-pub fn fs_canonicalize(path: String, workspace: Option<WorkspaceEnv>) -> Result<String, String> {
+pub fn fs_canonicalize(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<String, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
     let p = resolve_path(&path, &workspace);
-    let canon = std::fs::canonicalize(&p).map_err(|e| e.to_string())?;
+    let canon = super::authorize_existing_path(&registry, &p)?;
     Ok(super::to_canon(&canon))
 }
 
 #[tauri::command]
-pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat, String> {
+pub fn fs_stat(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<FileStat, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let p = resolve_path(&path, &workspace);
+    let p = super::authorize_existing_path(&registry, &resolve_path(&path, &workspace))?;
     let meta = std::fs::metadata(&p).map_err(|e| e.to_string())?;
     let kind = if meta.is_dir() {
         StatKind::Dir
@@ -165,12 +207,19 @@ pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat
 mod tests {
     use super::*;
 
+    fn registry_for(path: &Path) -> WorkspaceRegistry {
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(path).expect("authorize workspace");
+        registry
+    }
+
     #[test]
     fn read_file_classifies_utf8_as_text() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let f = dir.path().join("a.txt");
         std::fs::write(&f, b"hello world").unwrap();
-        match fs_read_file(f.to_string_lossy().into_owned(), None).unwrap() {
+        match fs_read_file_impl(&f.to_string_lossy(), None, &registry).unwrap() {
             ReadResult::Text { content, size } => {
                 assert_eq!(content, "hello world");
                 assert_eq!(size, 11);
@@ -182,10 +231,11 @@ mod tests {
     #[test]
     fn read_file_detects_binary_via_null_byte() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let f = dir.path().join("a.bin");
         std::fs::write(&f, b"PNG\0\x89image").unwrap();
         assert!(matches!(
-            fs_read_file(f.to_string_lossy().into_owned(), None).unwrap(),
+            fs_read_file_impl(&f.to_string_lossy(), None, &registry).unwrap(),
             ReadResult::Binary { .. }
         ));
     }
@@ -193,13 +243,58 @@ mod tests {
     #[test]
     fn read_file_detects_binary_via_invalid_utf8() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let f = dir.path().join("a.bin");
         // Invalid UTF-8 with no null byte: must still classify as binary.
         std::fs::write(&f, [0xff, 0xfe, 0xfd, 0xfc]).unwrap();
         assert!(matches!(
-            fs_read_file(f.to_string_lossy().into_owned(), None).unwrap(),
+            fs_read_file_impl(&f.to_string_lossy(), None, &registry).unwrap(),
             ReadResult::Binary { .. }
         ));
+    }
+
+    #[test]
+    fn read_file_rejects_unauthorized_path() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let f = outside.path().join("secret.txt");
+        std::fs::write(&f, b"secret").unwrap();
+
+        let err = match fs_read_file_impl(&f.to_string_lossy(), None, &registry) {
+            Ok(_) => panic!("expected unauthorized read to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
+
+    #[test]
+    fn write_file_rejects_unauthorized_path() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+
+        let err =
+            authorize_write_target(&registry, &outside.path().join("secret.txt")).unwrap_err();
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_file_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let target = outside.path().join("secret.txt");
+        std::fs::write(&target, b"secret").unwrap();
+        let link = allowed.path().join("link.txt");
+        symlink(&target, &link).unwrap();
+
+        let err = super::super::authorize_existing_path(&registry, &link).unwrap_err();
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+        assert_eq!(std::fs::read(&target).unwrap(), b"secret");
     }
 
     #[test]

--- a/src-tauri/src/modules/fs/grep.rs
+++ b/src-tauri/src/modules/fs/grep.rs
@@ -9,7 +9,7 @@ use ignore::{WalkBuilder, WalkState};
 use serde::Serialize;
 
 use super::to_canon;
-use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
 const FILE_SIZE_CAP: u64 = 5 * 1024 * 1024;
 const DEFAULT_MAX_RESULTS: usize = 200;
@@ -51,12 +51,33 @@ pub fn fs_grep(
     case_insensitive: Option<bool>,
     max_results: Option<usize>,
     workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<GrepResponse, String> {
+    fs_grep_impl(
+        &pattern,
+        &root,
+        glob,
+        case_insensitive,
+        max_results,
+        workspace,
+        &registry,
+    )
+}
+
+pub fn fs_grep_impl(
+    pattern: &str,
+    root: &str,
+    glob: Option<Vec<String>>,
+    case_insensitive: Option<bool>,
+    max_results: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
 ) -> Result<GrepResponse, String> {
     if pattern.is_empty() {
         return Err("empty pattern".into());
     }
     let workspace = WorkspaceEnv::from_option(workspace);
-    let root_path = resolve_path(&root, &workspace);
+    let root_path = super::authorize_existing_path(registry, &resolve_path(root, &workspace))?;
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
@@ -67,7 +88,7 @@ pub fn fs_grep(
     let matcher = RegexMatcherBuilder::new()
         .case_insensitive(case_insensitive.unwrap_or(false))
         .line_terminator(Some(b'\n'))
-        .build(&pattern)
+        .build(pattern)
         .map_err(|e| format!("bad regex: {e}"))?;
 
     let globs = build_globset(glob.as_deref().unwrap_or(&[]))?;
@@ -93,7 +114,7 @@ pub fn fs_grep(
         let scanned = scanned.clone();
         let truncated = truncated.clone();
         let root_path = root_path.clone();
-        let root_display = root.clone();
+        let root_display = root.to_string();
         let workspace = workspace.clone();
 
         Box::new(move |dent_res| {
@@ -185,18 +206,29 @@ pub fn fs_glob(
     root: String,
     max_results: Option<usize>,
     workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<GlobResponse, String> {
+    fs_glob_impl(&pattern, &root, max_results, workspace, &registry)
+}
+
+pub fn fs_glob_impl(
+    pattern: &str,
+    root: &str,
+    max_results: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
 ) -> Result<GlobResponse, String> {
     if pattern.is_empty() {
         return Err("empty pattern".into());
     }
     let workspace = WorkspaceEnv::from_option(workspace);
-    let root_path = resolve_path(&root, &workspace);
+    let root_path = super::authorize_existing_path(registry, &resolve_path(root, &workspace))?;
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
     let cap = max_results.unwrap_or(500).clamp(1, HARD_MAX_RESULTS);
 
-    let glob = Glob::new(&pattern).map_err(|e| format!("bad glob: {e}"))?;
+    let glob = Glob::new(pattern).map_err(|e| format!("bad glob: {e}"))?;
     let mut gb = GlobSetBuilder::new();
     gb.add(glob);
     let set = gb.build().map_err(|e| format!("globset build: {e}"))?;
@@ -230,12 +262,77 @@ pub fn fs_glob(
             continue;
         }
         hits.push(GlobHit {
-            path: display_path(path, &root_path, &root, &workspace),
+            path: display_path(path, &root_path, root, &workspace),
             rel,
         });
     }
 
     Ok(GlobResponse { hits, truncated })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_for(path: &std::path::Path) -> WorkspaceRegistry {
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(path).expect("authorize workspace");
+        registry
+    }
+
+    fn s(path: &std::path::Path) -> String {
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn grep_and_glob_reject_unauthorized_root() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        std::fs::write(outside.path().join("secret.txt"), b"secret").unwrap();
+
+        let err = match fs_grep_impl(
+            "secret",
+            &s(outside.path()),
+            None,
+            None,
+            None,
+            None,
+            &registry,
+        ) {
+            Ok(_) => panic!("expected unauthorized grep to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+
+        let err = match fs_glob_impl("*.txt", &s(outside.path()), None, None, &registry) {
+            Ok(_) => panic!("expected unauthorized glob to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn grep_rejects_symlinked_root_escape() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let link = allowed.path().join("outside-link");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        let err = match fs_grep_impl("x", &s(&link), None, None, None, None, &registry) {
+            Ok(_) => panic!("expected symlinked root to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+
+        let err = match fs_glob_impl("*.txt", &s(&link), None, None, &registry) {
+            Ok(_) => panic!("expected symlinked root to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
 }
 
 fn display_path(

--- a/src-tauri/src/modules/fs/mod.rs
+++ b/src-tauri/src/modules/fs/mod.rs
@@ -4,7 +4,11 @@ pub mod mutate;
 pub mod search;
 pub mod tree;
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
+
+use crate::modules::workspace::WorkspaceRegistry;
+
+const OUTSIDE_AUTHORIZED_WORKSPACE: &str = "outside authorized workspace";
 
 /// The single canonical-to-display conversion: forward slashes, Windows
 /// verbatim `\\?\` prefix stripped. Route every such conversion through here.
@@ -18,6 +22,114 @@ pub fn to_canon(p: impl AsRef<Path>) -> String {
     {
         // Backslashes are legal in Unix filenames; never rewrite them.
         s.into_owned()
+    }
+}
+
+fn outside_authorized_workspace(path: &Path) -> String {
+    format!("{OUTSIDE_AUTHORIZED_WORKSPACE}: {}", path.display())
+}
+
+fn ensure_authorized(registry: &WorkspaceRegistry, canonical: PathBuf) -> Result<PathBuf, String> {
+    if registry.is_authorized(&canonical) {
+        Ok(canonical)
+    } else {
+        Err(outside_authorized_workspace(&canonical))
+    }
+}
+
+/// Authorize an operation that follows the target, such as read/stat/search.
+pub fn authorize_existing_path(
+    registry: &WorkspaceRegistry,
+    path: &Path,
+) -> Result<PathBuf, String> {
+    let canonical = registry
+        .canonicalize_cached(path)
+        .map_err(|e| e.to_string())?;
+    ensure_authorized(registry, canonical)
+}
+
+/// Authorize an operation that acts on the directory entry itself. Symlink
+/// deletes/renames are allowed when the link lives in an authorized workspace,
+/// while ordinary files/directories are authorized by their canonical target.
+pub fn authorize_entry_path(registry: &WorkspaceRegistry, path: &Path) -> Result<(), String> {
+    let meta = std::fs::symlink_metadata(path).map_err(|e| e.to_string())?;
+    if meta.file_type().is_symlink() {
+        authorize_directory_entry_location(registry, path)?;
+        return Ok(());
+    }
+
+    authorize_existing_path(registry, path).map(|_| ())
+}
+
+fn authorize_directory_entry_location(
+    registry: &WorkspaceRegistry,
+    path: &Path,
+) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("path has no parent: {}", path.display()))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| format!("path has no file name: {}", path.display()))?;
+    let name_path = Path::new(name);
+    if name_path
+        .components()
+        .any(|c| !matches!(c, Component::Normal(_)))
+    {
+        return Err(format!("path traversal is not allowed: {}", path.display()));
+    }
+
+    let mut candidate = authorize_existing_path(registry, parent)?;
+    candidate.push(name);
+    if registry.is_authorized(&candidate) {
+        Ok(())
+    } else {
+        Err(outside_authorized_workspace(&candidate))
+    }
+}
+
+/// Authorize a missing destination by canonicalizing its nearest existing
+/// ancestor and rejecting unresolved `..` traversal after that ancestor.
+pub fn authorize_create_target(registry: &WorkspaceRegistry, path: &Path) -> Result<(), String> {
+    if path.exists() {
+        return authorize_existing_path(registry, path).map(|_| ());
+    }
+
+    let mut missing = Vec::new();
+    let mut ancestor = path;
+    while !ancestor.exists() {
+        let name = ancestor.file_name().ok_or_else(|| {
+            format!(
+                "cannot resolve nearest existing ancestor: {}",
+                path.display()
+            )
+        })?;
+        missing.push(name.to_os_string());
+        ancestor = ancestor.parent().ok_or_else(|| {
+            format!(
+                "cannot resolve nearest existing ancestor: {}",
+                path.display()
+            )
+        })?;
+    }
+
+    let canonical_ancestor = authorize_existing_path(registry, ancestor)?;
+    let mut candidate = canonical_ancestor;
+    for component in missing.iter().rev() {
+        let component_path = Path::new(component);
+        if component_path
+            .components()
+            .any(|c| !matches!(c, Component::Normal(_)))
+        {
+            return Err(format!("path traversal is not allowed: {}", path.display()));
+        }
+        candidate.push(component);
+    }
+
+    if registry.is_authorized(&candidate) {
+        Ok(())
+    } else {
+        Err(outside_authorized_workspace(&candidate))
     }
 }
 

--- a/src-tauri/src/modules/fs/mutate.rs
+++ b/src-tauri/src/modules/fs/mutate.rs
@@ -1,12 +1,31 @@
-use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
 /// Creates a new empty file. Fails if the file already exists.
 #[tauri::command]
-pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+pub fn fs_create_file(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<(), String> {
+    fs_create_file_impl(&path, workspace, &registry)
+}
+
+pub fn fs_create_file_impl(
+    path: &str,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
+) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let p = resolve_path(&path, &workspace);
+    let p = resolve_path(path, &workspace);
+    super::authorize_create_target(registry, &p)?;
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
+    }
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            log::debug!("fs_create_file({}) parent create failed: {e}", p.display());
+            e.to_string()
+        })?;
     }
     std::fs::write(&p, "").map_err(|e| {
         log::debug!("fs_create_file({}) failed: {e}", p.display());
@@ -18,9 +37,22 @@ pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(
 /// Parents are created as needed — matches the common "new folder" UX
 /// where typing "a/b/c" creates the full chain.
 #[tauri::command]
-pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+pub fn fs_create_dir(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<(), String> {
+    fs_create_dir_impl(&path, workspace, &registry)
+}
+
+pub fn fs_create_dir_impl(
+    path: &str,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
+) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let p = resolve_path(&path, &workspace);
+    let p = resolve_path(path, &workspace);
+    super::authorize_create_target(registry, &p)?;
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
     }
@@ -32,16 +64,32 @@ pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<()
 
 /// Renames (or moves) a path. Refuses to overwrite an existing target.
 #[tauri::command]
-pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+pub fn fs_rename(
+    from: String,
+    to: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<(), String> {
+    fs_rename_impl(&from, &to, workspace, &registry)
+}
+
+pub fn fs_rename_impl(
+    from: &str,
+    to: &str,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
+) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let from_p = resolve_path(&from, &workspace);
-    let to_p = resolve_path(&to, &workspace);
+    let from_p = resolve_path(from, &workspace);
+    let to_p = resolve_path(to, &workspace);
     if !from_p.exists() {
         return Err(format!("not found: {}", from_p.display()));
     }
     if to_p.exists() {
         return Err(format!("already exists: {}", to_p.display()));
     }
+    super::authorize_entry_path(registry, &from_p)?;
+    super::authorize_create_target(registry, &to_p)?;
     std::fs::rename(&from_p, &to_p).map_err(|e| {
         log::debug!(
             "fs_rename({} -> {}) failed: {e}",
@@ -55,13 +103,26 @@ pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> R
 /// Deletes a file or directory (recursively for dirs). Callers are
 /// responsible for confirming destructive operations with the user.
 #[tauri::command]
-pub fn fs_delete(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
+pub fn fs_delete(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<(), String> {
+    fs_delete_impl(&path, workspace, &registry)
+}
+
+pub fn fs_delete_impl(
+    path: &str,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
+) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let p = resolve_path(&path, &workspace);
+    let p = resolve_path(path, &workspace);
     let meta = std::fs::symlink_metadata(&p).map_err(|e| {
         log::debug!("fs_delete stat({}) failed: {e}", p.display());
         e.to_string()
     })?;
+    super::authorize_entry_path(registry, &p)?;
 
     let result = if meta.is_dir() {
         std::fs::remove_dir_all(&p)
@@ -83,17 +144,24 @@ mod tests {
         p.to_string_lossy().into_owned()
     }
 
+    fn registry_for(path: &std::path::Path) -> WorkspaceRegistry {
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(path).expect("authorize workspace");
+        registry
+    }
+
     #[test]
     fn create_file_makes_empty_and_refuses_to_clobber() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let f = dir.path().join("new.txt");
-        fs_create_file(s(f.clone()), None).expect("create");
+        fs_create_file_impl(&s(f.clone()), None, &registry).expect("create");
         assert!(f.exists());
         assert_eq!(std::fs::read(&f).unwrap(), b"");
 
         // A second create must error, not truncate existing content.
         std::fs::write(&f, b"data").unwrap();
-        let err = fs_create_file(s(f.clone()), None).unwrap_err();
+        let err = fs_create_file_impl(&s(f.clone()), None, &registry).unwrap_err();
         assert!(err.contains("already exists"), "got: {err}");
         assert_eq!(std::fs::read(&f).unwrap(), b"data");
     }
@@ -101,32 +169,36 @@ mod tests {
     #[test]
     fn create_dir_builds_nested_chain_and_refuses_existing() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let nested = dir.path().join("a/b/c");
-        fs_create_dir(s(nested.clone()), None).expect("create dir");
+        fs_create_dir_impl(&s(nested.clone()), None, &registry).expect("create dir");
         assert!(nested.is_dir());
-        let err = fs_create_dir(s(nested), None).unwrap_err();
+        let err = fs_create_dir_impl(&s(nested), None, &registry).unwrap_err();
         assert!(err.contains("already exists"), "got: {err}");
     }
 
     #[test]
     fn rename_moves_and_never_overwrites() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let from = dir.path().join("a.txt");
         let to = dir.path().join("b.txt");
         std::fs::write(&from, b"payload").unwrap();
 
-        fs_rename(s(from.clone()), s(to.clone()), None).expect("rename");
+        fs_rename_impl(&s(from.clone()), &s(to.clone()), None, &registry).expect("rename");
         assert!(!from.exists());
         assert_eq!(std::fs::read(&to).unwrap(), b"payload");
 
         // Missing source is reported, not silently ignored.
-        let err = fs_rename(s(from), s(dir.path().join("c.txt")), None).unwrap_err();
+        let err =
+            fs_rename_impl(&s(from), &s(dir.path().join("c.txt")), None, &registry).unwrap_err();
         assert!(err.contains("not found"), "got: {err}");
 
         // Refusing to overwrite an existing target is the data-loss guard.
         let occupied = dir.path().join("keep.txt");
         std::fs::write(&occupied, b"keep").unwrap();
-        let err = fs_rename(s(to.clone()), s(occupied.clone()), None).unwrap_err();
+        let err =
+            fs_rename_impl(&s(to.clone()), &s(occupied.clone()), None, &registry).unwrap_err();
         assert!(err.contains("already exists"), "got: {err}");
         assert_eq!(std::fs::read(&occupied).unwrap(), b"keep");
         assert!(to.exists());
@@ -135,19 +207,75 @@ mod tests {
     #[test]
     fn delete_removes_file_then_dir_recursively() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = registry_for(dir.path());
         let f = dir.path().join("x.txt");
         std::fs::write(&f, b"x").unwrap();
-        fs_delete(s(f.clone()), None).expect("delete file");
+        fs_delete_impl(&s(f.clone()), None, &registry).expect("delete file");
         assert!(!f.exists());
 
         let sub = dir.path().join("sub");
         std::fs::create_dir_all(sub.join("inner")).unwrap();
         std::fs::write(sub.join("inner/y.txt"), b"y").unwrap();
-        fs_delete(s(sub.clone()), None).expect("delete dir");
+        fs_delete_impl(&s(sub.clone()), None, &registry).expect("delete dir");
         assert!(!sub.exists());
 
-        let err = fs_delete(s(dir.path().join("missing")), None).unwrap_err();
+        let err = fs_delete_impl(&s(dir.path().join("missing")), None, &registry).unwrap_err();
         assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn create_and_rename_reject_unauthorized_destinations() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+
+        let err =
+            fs_create_file_impl(&s(outside.path().join("new.txt")), None, &registry).unwrap_err();
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+
+        let err =
+            fs_create_dir_impl(&s(outside.path().join("nested")), None, &registry).unwrap_err();
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+
+        let source = allowed.path().join("source.txt");
+        std::fs::write(&source, b"payload").unwrap();
+        let err = fs_rename_impl(
+            &s(source),
+            &s(outside.path().join("dest.txt")),
+            None,
+            &registry,
+        )
+        .unwrap_err();
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
+
+    #[test]
+    fn create_and_rename_allow_nested_authorized_paths() {
+        let allowed = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let nested_file = allowed.path().join("a/b/c.txt");
+        fs_create_file_impl(&s(nested_file.clone()), None, &registry).expect("create nested file");
+        assert!(nested_file.exists());
+
+        let from = allowed.path().join("from.txt");
+        let to = allowed.path().join("deep/to.txt");
+        std::fs::create_dir_all(to.parent().unwrap()).unwrap();
+        std::fs::write(&from, b"payload").unwrap();
+        fs_rename_impl(&s(from), &s(to.clone()), None, &registry).expect("rename nested");
+        assert_eq!(std::fs::read(&to).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn delete_rejects_unauthorized_path() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let victim = outside.path().join("victim.txt");
+        std::fs::write(&victim, b"keep").unwrap();
+
+        let err = fs_delete_impl(&s(victim.clone()), None, &registry).unwrap_err();
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+        assert_eq!(std::fs::read(&victim).unwrap(), b"keep");
     }
 
     // Deleting a symlink that points at a directory must remove only the link,
@@ -156,14 +284,16 @@ mod tests {
     #[test]
     fn delete_does_not_follow_symlink_into_target() {
         let dir = tempfile::tempdir().unwrap();
-        let real = dir.path().join("real");
+        let registry = registry_for(dir.path());
+        let outside = tempfile::tempdir().unwrap();
+        let real = outside.path().join("real");
         std::fs::create_dir(&real).unwrap();
         std::fs::write(real.join("keep.txt"), b"keep").unwrap();
 
         let link = dir.path().join("link");
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        fs_delete(s(link.clone()), None).expect("delete symlink");
+        fs_delete_impl(&s(link.clone()), None, &registry).expect("delete symlink");
         assert!(!link.exists(), "symlink itself should be gone");
         assert!(real.is_dir(), "target dir must survive");
         assert_eq!(std::fs::read(real.join("keep.txt")).unwrap(), b"keep");

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -2,7 +2,7 @@ use ignore::WalkBuilder;
 use serde::Serialize;
 
 use super::to_canon;
-use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
 #[derive(Serialize)]
 pub struct SearchHit {
@@ -49,6 +49,18 @@ pub fn fs_search(
     limit: Option<usize>,
     workspace: Option<WorkspaceEnv>,
     show_hidden: Option<bool>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<SearchResult, String> {
+    fs_search_impl(&root, &query, limit, workspace, show_hidden, &registry)
+}
+
+pub fn fs_search_impl(
+    root: &str,
+    query: &str,
+    limit: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
+    show_hidden: Option<bool>,
+    registry: &WorkspaceRegistry,
 ) -> Result<SearchResult, String> {
     let q = query.trim().to_lowercase();
     if q.is_empty() {
@@ -60,7 +72,7 @@ pub fn fs_search(
     let cap = limit.unwrap_or(200).min(1000);
     let show_hidden = show_hidden.unwrap_or(false);
     let workspace = WorkspaceEnv::from_option(workspace);
-    let root_path = resolve_path(&root, &workspace);
+    let root_path = super::authorize_existing_path(registry, &resolve_path(root, &workspace))?;
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
@@ -117,7 +129,7 @@ pub fn fs_search(
             .unwrap_or_default();
         let is_dir = dent.file_type().map(|t| t.is_dir()).unwrap_or(false);
         out.push(SearchHit {
-            path: display_path(path, &root_path, &root, &workspace),
+            path: display_path(path, &root_path, root, &workspace),
             rel,
             name,
             is_dir,
@@ -150,6 +162,18 @@ pub fn fs_list_files(
     max_depth: Option<usize>,
     workspace: Option<WorkspaceEnv>,
     show_hidden: Option<bool>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<ListFilesResult, String> {
+    fs_list_files_impl(&root, limit, max_depth, workspace, show_hidden, &registry)
+}
+
+pub fn fs_list_files_impl(
+    root: &str,
+    limit: Option<usize>,
+    max_depth: Option<usize>,
+    workspace: Option<WorkspaceEnv>,
+    show_hidden: Option<bool>,
+    registry: &WorkspaceRegistry,
 ) -> Result<ListFilesResult, String> {
     const DEFAULT_LIMIT: usize = 2_000;
     const HARD_LIMIT: usize = 10_000;
@@ -160,7 +184,7 @@ pub fn fs_list_files(
     let depth = max_depth.unwrap_or(DEFAULT_DEPTH).clamp(1, HARD_DEPTH);
     let show_hidden = show_hidden.unwrap_or(false);
     let workspace = WorkspaceEnv::from_option(workspace);
-    let root_path = resolve_path(&root, &workspace);
+    let root_path = super::authorize_existing_path(registry, &resolve_path(root, &workspace))?;
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
@@ -216,6 +240,51 @@ pub fn fs_list_files(
 
     files.sort_by_key(|a| a.to_lowercase());
     Ok(ListFilesResult { files, truncated })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_for(path: &std::path::Path) -> WorkspaceRegistry {
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(path).expect("authorize workspace");
+        registry
+    }
+
+    fn s(path: &std::path::Path) -> String {
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn search_rejects_unauthorized_root() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        std::fs::write(outside.path().join("secret.txt"), b"secret").unwrap();
+
+        let err = match fs_search_impl(&s(outside.path()), "secret", None, None, None, &registry) {
+            Ok(_) => panic!("expected unauthorized search to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_files_rejects_symlinked_root_escape() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let link = allowed.path().join("outside-link");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        let err = match fs_list_files_impl(&s(&link), None, None, None, None, &registry) {
+            Ok(_) => panic!("expected symlinked root to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
 }
 
 fn display_path(

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -2,7 +2,7 @@ use std::time::UNIX_EPOCH;
 
 use serde::Serialize;
 
-use crate::modules::workspace::{resolve_path, WorkspaceEnv};
+use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
 #[derive(Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -29,9 +29,19 @@ pub fn fs_read_dir(
     path: String,
     show_hidden: bool,
     workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<Vec<DirEntry>, String> {
+    fs_read_dir_impl(&path, show_hidden, workspace, &registry)
+}
+
+pub fn fs_read_dir_impl(
+    path: &str,
+    show_hidden: bool,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
 ) -> Result<Vec<DirEntry>, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let root = resolve_path(&path, &workspace);
+    let root = super::authorize_existing_path(registry, &resolve_path(path, &workspace))?;
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("fs_read_dir({}) failed: {e}", root.display());
         e.to_string()
@@ -104,9 +114,19 @@ pub fn list_subdirs(
     path: String,
     show_hidden: bool,
     workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<Vec<String>, String> {
+    list_subdirs_impl(&path, show_hidden, workspace, &registry)
+}
+
+pub fn list_subdirs_impl(
+    path: &str,
+    show_hidden: bool,
+    workspace: Option<WorkspaceEnv>,
+    registry: &WorkspaceRegistry,
 ) -> Result<Vec<String>, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
-    let root = resolve_path(&path, &workspace);
+    let root = super::authorize_existing_path(registry, &resolve_path(path, &workspace))?;
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("list_subdirs({}) read_dir failed: {e}", root.display());
         e.to_string()
@@ -127,4 +147,54 @@ pub fn list_subdirs(
 
     dirs.sort_by_key(|a| a.to_lowercase());
     Ok(dirs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_for(path: &std::path::Path) -> WorkspaceRegistry {
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(path).expect("authorize workspace");
+        registry
+    }
+
+    fn s(path: &std::path::Path) -> String {
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn read_dir_rejects_unauthorized_root() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+
+        let err = match fs_read_dir_impl(&s(outside.path()), true, None, &registry) {
+            Ok(_) => panic!("expected unauthorized read_dir to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+
+        let err = match list_subdirs_impl(&s(outside.path()), true, None, &registry) {
+            Ok(_) => panic!("expected unauthorized list_subdirs to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_dir_rejects_symlinked_root_escape() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let registry = registry_for(allowed.path());
+        let link = allowed.path().join("outside-link");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        let err = match fs_read_dir_impl(&s(&link), true, None, &registry) {
+            Ok(_) => panic!("expected symlinked root to fail"),
+            Err(err) => err,
+        };
+        assert!(err.contains("outside authorized workspace"), "got: {err}");
+    }
 }

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -111,9 +111,6 @@ pub fn authorize_user_spawn_cwd(
 
 pub fn bootstrap_registry(registry: &WorkspaceRegistry) {
     let _ = registry.authorize(resolve_launch_dir());
-    if let Some(home) = dirs::home_dir() {
-        let _ = registry.authorize(home);
-    }
 }
 
 #[tauri::command]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -299,14 +299,9 @@ export default function App() {
   );
   useEffect(() => {
     homeDir()
-      .then(async (p) => {
+      .then((p) => {
         const normalized = p.replace(/\\/g, "/");
         setHome(normalized);
-        try {
-          await native.workspaceAuthorize(normalized);
-        } catch {
-          // Bootstrap already authorizes home from Rust; ignore.
-        }
       })
       .catch(() => setHome(null));
   }, []);


### PR DESCRIPTION
Enforce workspace authorization at the native filesystem IPC boundary.

The Rust fs commands now resolve paths through `WorkspaceRegistry` before reading, writing, searching, renaming, or deleting. This prevents app-origin JavaScript from using direct `fs_*` invokes outside explicitly authorized workspace roots, while preserving normal editor and explorer access to files inside the workspace.

This also stops implicitly authorizing the home directory on startup. Home is only authorized when it is deliberately selected as the active workspace root. AI sensitive-path checks remain as defense-in-depth for agent tools rather than becoming the native editor/explorer policy.

Local verification completed with the Rust and frontend test suites plus a local release build and app launch.