### PR TITLE
fix(ai): preserve reasoning content for reasoning models to prevent DeepSeek API error

### DIFF
--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -375,9 +375,10 @@ export async function runAgentStream(opts: RunAgentOptions) {
   );
 
   const history = await convertToModelMessages(opts.uiMessages);
+  const isReasoningModel = getModel(modelId).tags?.includes("reasoning");
   const prunedHistory = pruneMessages({
     messages: history,
-    reasoning: "all",
+    reasoning: isReasoningModel ? "none" : "all",
     emptyMessages: "remove",
   });
   const compact = compactModelMessagesDetailed(


### PR DESCRIPTION
fixes #458

## Summary

- DeepSeek reasoning models require that reasoning/thinking content from previous assistant messages be passed back in full on subsequent requests
- The previous `reasoning: "all"` option in `pruneMessages` stripped this content, causing the API to return: "the reasoning content in the thinking mode must be passed back to the api"
- Now checks if the model has the `"reasoning"` tag and only strips reasoning content for non-reasoning models

## Changes

- `src/modules/ai/lib/agent.ts` — conditionally preserve reasoning content based on model tags

## How I tested

- TypeScript compiles clean (`tsc --noEmit`)
- Manual reasoning: the `getModel(modelId).tags?.includes("reasoning")` check follows the existing pattern of `getModel(modelId).provider` used on line 368
- For reasoning models (DeepSeek Reasoner, DeepSeek V4 Pro, etc.) → `reasoning: "none"` preserves thinking content
- For non-reasoning models → `reasoning: "all"` strips reasoning as before (no behavioral change)