### PR TITLE
fix(ai): only show Ask Terax popup when clicking inside terminal or editor

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -721,6 +721,9 @@ export default function App() {
     };
     const onUp = (e: MouseEvent) => {
       if (isInsideAi(e.target)) return;
+      const el = e.target as HTMLElement | null;
+      const inContentArea = el?.closest?.(".xterm, .cm-editor");
+      if (!inContentArea) return;
       // Defer one tick so xterm/CodeMirror finalize the selection.
       setTimeout(() => {
         const text = captureActiveSelection();


### PR DESCRIPTION
fixes #463

## Summary

- "Ask Terax" popup was appearing when clicking anywhere (sidebar, tree-view, window bar, status bar) while any text was selected
- The `mouseup` handler checked for text selection globally without verifying where the click occurred
- Now only shows the popup when clicking inside a terminal (`.xterm`) or editor (`.cm-editor`) content area
- Follows the same `closest(".xterm")` pattern already used in the `shortcutsDisabled` guard

## Changes

- `src/app/App.tsx` — add content-area check in the mouseup handler

## How I tested

- Verified the fix follows existing patterns: `el.closest(".xterm")` is already used at line 1026 for the `ai.askSelection` shortcut guard
- `.cm-editor` is CodeMirror's standard top-level class on editor instances
- TypeScript compiles clean
- Behavior for non-reasoning models is unaffected

## Steps to reproduce the bug

1. Select text in a terminal or editor
2. Click on the sidebar, tree-view, or window bar
3. Before fix: "Ask Terax" popup appears at the click location
4. After fix: no popup — only appears when clicking inside terminal or editor area