### PR TITLE
fix(editor): reload file from disk when editor tab is activated

### DIFF
--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -301,11 +301,33 @@ export function buildConfiguredLanguageModel(
 const PLAN_MODE_PROMPT = `## PLAN MODE — ACTIVE
 Mutating tools (write_file, edit, multi_edit, create_directory) will queue their changes for the user to review as a single diff. Do NOT execute bash_run or bash_background while plan mode is active — restrict yourself to reads (read_file, grep, glob, list_directory) and the queued mutations. After queueing the full set of edits, stop and return a brief summary; do not continue acting until the user has accepted/rejected.`;
 
+/** Models known to emit XML tool calls instead of JSON (e.g. Qwen via Ollama).
+ *  We append an explicit instruction to use JSON format for tool calls. */
+const XML_TOOL_CALL_MODELS = new Set<string>([
+  "qwen3.5",
+  "qwen3.5:14b",
+  "qwen3.5:32b",
+  "qwen3.5-coder",
+  "qwen3.5-coder:14b",
+  "qwen3.5-coder:32b",
+  "qwen2.5",
+  "qwen2.5:14b",
+  "qwen2.5:32b",
+  "qwen2.5:72b",
+  "qwen2.5-coder",
+  "qwen2.5-coder:14b",
+  "qwen2.5-coder:32b",
+]);
+
+const JSON_TOOL_CALL_INSTRUCTION = `\n\n## Tool call format
+When calling tools, use the JSON tool call format. Do NOT use XML tags.`;
+
 function buildStableSystem(
   modelId: string,
   persona: { name: string; instructions: string } | null,
   customInstructions: string | undefined,
   projectMemory: string | null,
+  resolvedModelId?: string,
 ): string {
   const base = selectSystemPrompt(modelId);
   const personaBlock = persona?.instructions.trim()
@@ -318,7 +340,12 @@ function buildStableSystem(
     projectMemory && projectMemory.trim().length > 0
       ? `\n\n## PROJECT — TERAX.md\n${projectMemory.trim()}`
       : "";
-  return `${base}${memoryBlock}${personaBlock}${customBlock}`;
+  const toolFormatBlock =
+    resolvedModelId &&
+    XML_TOOL_CALL_MODELS.has(resolvedModelId.toLowerCase())
+      ? JSON_TOOL_CALL_INSTRUCTION
+      : "";
+  return `${base}${memoryBlock}${personaBlock}${customBlock}${toolFormatBlock}`;
 }
 
 // OpenAI / Gemini / DeepSeek apply prefix caching automatically; only
@@ -407,11 +434,23 @@ export async function runAgentStream(opts: RunAgentOptions) {
   const info = resolveModel(modelId, endpoints);
   const provider = info.provider;
 
+  const resolvedModelId =
+    modelId === "lmstudio-local"
+      ? opts.lmstudioModelId
+      : modelId === "mlx-local"
+        ? opts.mlxModelId
+        : modelId === "ollama-local"
+          ? opts.ollamaModelId
+          : modelId === "openai-compatible-custom"
+            ? opts.openaiCompatibleModelId
+            : getModel(modelId).id;
+
   const stableSystem = buildStableSystem(
     modelId,
     opts.agentPersona ?? null,
     opts.customInstructions,
     opts.projectMemory ?? null,
+    resolvedModelId,
   );
 
   const history = await convertToModelMessages(opts.uiMessages);

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -10,6 +10,7 @@ import {
 import {
   DEFAULT_MODEL_ID,
   endpointIdFromCompatModel,
+  getModel,
   getModelContextLimit,
   isCompatModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
@@ -21,6 +22,7 @@ import {
   resolveModel,
   selectSystemPrompt,
   type CustomEndpoint,
+  type ModelId,
   type ProviderId,
 } from "../config";
 import { buildTools, type ToolContext } from "../tools/tools";
@@ -443,7 +445,7 @@ export async function runAgentStream(opts: RunAgentOptions) {
           ? opts.ollamaModelId
           : modelId === "openai-compatible-custom"
             ? opts.openaiCompatibleModelId
-            : getModel(modelId).id;
+            : getModel(modelId as ModelId).id;
 
   const stableSystem = buildStableSystem(
     modelId,

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -53,6 +53,7 @@ export type EditorPaneHandle = {
 
 type Props = {
   path: string;
+  isActive?: boolean;
   onDirtyChange?: (dirty: boolean) => void;
   onSaved?: () => void;
   onClose?: () => void;
@@ -65,13 +66,21 @@ function formatBytes(n: number): string {
 }
 
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
-  function EditorPane({ path, onDirtyChange, onSaved, onClose }, ref) {
+  function EditorPane({ path, isActive, onDirtyChange, onSaved, onClose }, ref) {
     const { doc, onChange, save, reload } = useDocument({
       path,
       onDirtyChange,
     });
     const reloadRef = useRef(reload);
     reloadRef.current = reload;
+
+    const prevActiveRef = useRef(isActive);
+    useEffect(() => {
+      if (isActive && !prevActiveRef.current) {
+        reloadRef.current();
+      }
+      prevActiveRef.current = isActive;
+    }, [isActive]);
     const cmRef = useRef<ReactCodeMirrorRef>(null);
     const themeExt = useEditorThemeExt();
     const vimMode = usePreferencesStore((s) => s.vimMode);

--- a/src/modules/editor/EditorStack.tsx
+++ b/src/modules/editor/EditorStack.tsx
@@ -113,6 +113,7 @@ export function EditorStack({
               <EditorPane
                 ref={getRefCallback(t.id)}
                 path={t.path}
+                isActive={t.id === activeId}
                 onDirtyChange={getDirtyCallback(t.id)}
                 onClose={getCloseCallback(t.id)}
               />


### PR DESCRIPTION
fixes #459, fixes #846

## Summary (Editor Reload Fix — #459)

- Open editor tabs were not refreshed when switching to them after external modifications (by agents, git operations, or other editors)
- All editor instances are always mounted in the DOM (hidden via `invisible pointer-events-none` CSS), so no React lifecycle hook triggered a re-read when a tab became visible
- Added an `isActive` prop to `EditorPane` that triggers `reload()` when the tab transitions from inactive to active
- `reload()` is a no-op if the buffer has unsaved edits, preventing data loss

## Summary (Qwen XML Tool Call Fix — #846)

- Qwen3.5 via Ollama outputs XML-style tool calls instead of JSON, which the Vercel AI SDK v6 cannot parse
- Added `XML_TOOL_CALL_MODELS` set with known Qwen model IDs that emit XML tool calls
- Added `JSON_TOOL_CALL_INSTRUCTION` constant with explicit instruction to use JSON format
- Modified `buildStableSystem()` to append JSON instruction when resolved model matches the known XML-emitting set
- Updated `runAgentStream()` to compute `resolvedModelId` and pass it to `buildStableSystem()`

## Changes

- `src/modules/editor/EditorPane.tsx` — track active state, call reload on activation
- `src/modules/editor/EditorStack.tsx` — pass `isActive` prop to `EditorPane`
- `src/modules/ai/lib/agent.ts` — add JSON tool call instruction for Qwen models via Ollama

## Verification

- TypeScript compiles clean (`tsc --noEmit`)
- All tests pass (`npm test` — 45/45)
- `cargo check` / `cargo test` pass for Rust components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI tool-call formatting by selecting the correct JSON vs. XML tool-call behavior for supported model types and local/custom model aliases.

* **New Features**
  * Editor panes now reload their file contents when they become active (e.g., when switching between open files/tabs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->