### PR TITLE
feat: sidebar position setting (dock left or right)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -391,6 +391,7 @@ export default function App() {
   const openaiCompatibleBaseURL = usePreferencesStore(
     (s) => s.openaiCompatibleBaseURL,
   );
+  const sidebarPosition = usePreferencesStore((s) => s.sidebarPosition);
   const hasLocalModel =
     (lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0) ||
     (mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0) ||
@@ -1319,77 +1320,104 @@ export default function App() {
               orientation="horizontal"
               className="min-h-0 flex-1"
             >
-              <ResizablePanel
-                id="sidebar"
-                panelRef={sidebarRef}
-                defaultSize={`${sidebarWidthRef.current}px`}
-                minSize={`${SIDEBAR_MIN_WIDTH}px`}
-                maxSize={`${SIDEBAR_MAX_WIDTH}px`}
-                collapsible
-                collapsedSize={0}
-                onResize={(size) => {
-                  if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
-                }}
-              >
-                <div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">
-                  <div className="min-h-0 flex-1">
-                    {sidebarView === "explorer" ? (
-                      <FileExplorer
-                        ref={explorerRef}
-                        rootPath={explorerRoot}
-                        onOpenFile={handleOpenFile}
-                        onPathRenamed={handlePathRenamed}
-                        onPathDeleted={handlePathDeleted}
-                        onRevealInTerminal={cdInNewTab}
-                        onAttachToAgent={handleAttachFileToAgent}
-                        onOpenMarkdownPreview={openMarkdownPreview}
-                      />
-                    ) : (
-                      <SourceControlPanel
-                        open
-                        sourceControl={sourceControl}
-                        onOpenDiff={openGitDiffTab}
-                        onOpenGitGraph={openGitGraphFromContext}
-                      />
-                    )}
-                  </div>
-                  <SidebarRail
-                    activeView={sidebarView}
-                    onSelectView={persistSidebarView}
-                    changedCount={sourceControl.changedCount}
-                  />
-                </div>
-              </ResizablePanel>
-              <ResizableHandle withHandle />
-              <ResizablePanel id="workspace" defaultSize="78%" minSize="30%">
-                <div className="flex h-full min-h-0 flex-col">
-                  <div className="relative min-h-0 flex-1">
-                    {workspaceSurface}
-                  </div>
-
-                  {keysLoaded ? (
-                    <motion.div
-                      data-ai-input-bar
-                      initial={false}
-                      animate={{
-                        height: panelOpen ? "auto" : 0,
-                        opacity: panelOpen ? 1 : 0,
-                      }}
-                      transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
-                      className="overflow-hidden"
-                      aria-hidden={!panelOpen}
-                    >
-                      {hasComposer ? (
-                        <AiInputBar />
-                      ) : (
-                        <AiInputBarConnect
-                          onAdd={() => void openSettingsWindow("models")}
-                        />
+              {(() => {
+                const sidebarPanel = (
+                  <ResizablePanel
+                    key="sidebar"
+                    id="sidebar"
+                    panelRef={sidebarRef}
+                    defaultSize={`${sidebarWidthRef.current}px`}
+                    minSize={`${SIDEBAR_MIN_WIDTH}px`}
+                    maxSize={`${SIDEBAR_MAX_WIDTH}px`}
+                    collapsible
+                    collapsedSize={0}
+                    onResize={(size) => {
+                      if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
+                    }}
+                  >
+                    <div
+                      className={cn(
+                        "flex h-full min-h-0 flex-col bg-card",
+                        sidebarPosition === "right"
+                          ? "border-l border-border/60"
+                          : "border-r border-border/60",
                       )}
-                    </motion.div>
-                  ) : null}
-                </div>
-              </ResizablePanel>
+                    >
+                      <div className="min-h-0 flex-1">
+                        {sidebarView === "explorer" ? (
+                          <FileExplorer
+                            ref={explorerRef}
+                            rootPath={explorerRoot}
+                            onOpenFile={handleOpenFile}
+                            onPathRenamed={handlePathRenamed}
+                            onPathDeleted={handlePathDeleted}
+                            onRevealInTerminal={cdInNewTab}
+                            onAttachToAgent={handleAttachFileToAgent}
+                            onOpenMarkdownPreview={openMarkdownPreview}
+                          />
+                        ) : (
+                          <SourceControlPanel
+                            open
+                            sourceControl={sourceControl}
+                            onOpenDiff={openGitDiffTab}
+                            onOpenGitGraph={openGitGraphFromContext}
+                          />
+                        )}
+                      </div>
+                      <SidebarRail
+                        activeView={sidebarView}
+                        onSelectView={persistSidebarView}
+                        changedCount={sourceControl.changedCount}
+                      />
+                    </div>
+                  </ResizablePanel>
+                );
+                const workspacePanel = (
+                  <ResizablePanel
+                    key="workspace"
+                    id="workspace"
+                    defaultSize="78%"
+                    minSize="30%"
+                  >
+                    <div className="flex h-full min-h-0 flex-col">
+                      <div className="relative min-h-0 flex-1">
+                        {workspaceSurface}
+                      </div>
+
+                      {keysLoaded ? (
+                        <motion.div
+                          data-ai-input-bar
+                          initial={false}
+                          animate={{
+                            height: panelOpen ? "auto" : 0,
+                            opacity: panelOpen ? 1 : 0,
+                          }}
+                          transition={{
+                            duration: 0.18,
+                            ease: [0.16, 1, 0.3, 1],
+                          }}
+                          className="overflow-hidden"
+                          aria-hidden={!panelOpen}
+                        >
+                          {hasComposer ? (
+                            <AiInputBar />
+                          ) : (
+                            <AiInputBarConnect
+                              onAdd={() => void openSettingsWindow("models")}
+                            />
+                          )}
+                        </motion.div>
+                      ) : null}
+                    </div>
+                  </ResizablePanel>
+                );
+                const handle = (
+                  <ResizableHandle key="handle" withHandle />
+                );
+                return sidebarPosition === "right"
+                  ? [workspacePanel, handle, sidebarPanel]
+                  : [sidebarPanel, handle, workspacePanel];
+              })()}
             </ResizablePanelGroup>
           </main>
 

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -18,6 +18,8 @@ export const DEFAULT_THEME_ID = "terax-default";
 
 export type BackgroundKind = "none" | "image";
 
+export type SidebarPosition = "left" | "right";
+
 export const EDITOR_THEMES = [
   "atomone",
   "aura",
@@ -81,6 +83,7 @@ export type Preferences = {
   terminalScrollback: number;
   lastWslDistro: string | null;
   zoomLevel: number;
+  sidebarPosition: SidebarPosition;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
 };
 
@@ -120,6 +123,7 @@ const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
+const KEY_SIDEBAR_POSITION = "sidebarPosition";
 const KEY_SHORTCUTS = "shortcuts";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
@@ -172,6 +176,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
   lastWslDistro: null,
   zoomLevel: 1.0,
+  sidebarPosition: "left",
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
 };
 
@@ -280,6 +285,9 @@ export async function loadPreferences(): Promise<Preferences> {
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
     zoomLevel: get<number>(KEY_ZOOM_LEVEL) ?? DEFAULT_PREFERENCES.zoomLevel,
+    sidebarPosition:
+      get<SidebarPosition>(KEY_SIDEBAR_POSITION) ??
+      DEFAULT_PREFERENCES.sidebarPosition,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -459,6 +467,10 @@ export async function setZoomLevel(value: number): Promise<void> {
   await writePref(KEY_ZOOM_LEVEL, value);
 }
 
+export async function setSidebarPosition(value: SidebarPosition): Promise<void> {
+  await writePref(KEY_SIDEBAR_POSITION, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {},
 ): Promise<void> {
@@ -510,6 +522,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
+    [KEY_SIDEBAR_POSITION]: "sidebarPosition",
     [KEY_SHORTCUTS]: "shortcuts",
   };
   // Same-process writes still fire onChange immediately; cross-window writes

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   AiContentGenerator02Icon,
   Alert02Icon,
@@ -133,6 +134,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   onOpenDiff,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
+  const sidebarPosition = usePreferencesStore((s) => s.sidebarPosition);
   const refreshAnimationRef = useRef<number | null>(null);
   const [refreshAnimating, setRefreshAnimating] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -605,7 +607,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                       </button>
                     </TooltipTrigger>
                     <TooltipContent
-                      side="left"
+                      side={sidebarPosition === "right" ? "right" : "left"}
                       className={cn(
                         SOURCE_CONTROL_TOOLTIP_CLASS,
                         "text-[10.5px]",

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -15,13 +15,14 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import type { ThemePref } from "@/modules/settings/store";
+import type { SidebarPosition, ThemePref } from "@/modules/settings/store";
 import {
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAutostart,
   setRestoreWindowState,
   setShowHidden,
+  setSidebarPosition,
   setTerminalFontFamily,
   setTerminalLetterSpacing,
   setTerminalFontSize,
@@ -74,6 +75,7 @@ export function GeneralSection() {
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
+  const sidebarPosition = usePreferencesStore((s) => s.sidebarPosition);
 
   useEffect(() => {
     let alive = true;
@@ -152,6 +154,16 @@ export function GeneralSection() {
             onValueChange={(v) => void setZoomLevel(v[0] ?? 1)}
           />
         </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label>Layout</Label>
+        <SettingRow
+          title="Sidebar position"
+          description="Dock the file explorer and source control panel to the left or right edge of the window."
+        >
+          <SidebarPositionToggle value={sidebarPosition} />
+        </SettingRow>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -324,5 +336,36 @@ function Label({ children }: { children: React.ReactNode }) {
     <span className="text-[11px] font-medium tracking-tight text-muted-foreground">
       {children}
     </span>
+  );
+}
+
+function SidebarPositionToggle({ value }: { value: SidebarPosition }) {
+  const options: { id: SidebarPosition; label: string }[] = [
+    { id: "left", label: "Left" },
+    { id: "right", label: "Right" },
+  ];
+  return (
+    <div className="inline-flex overflow-hidden rounded-md border border-border/60">
+      {options.map((o, i) => {
+        const active = value === o.id;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => void setSidebarPosition(o.id)}
+            className={cn(
+              "h-7 px-3 text-[11.5px] transition-colors",
+              i > 0 && "border-l border-border/60",
+              active
+                ? "bg-foreground/10 text-foreground"
+                : "bg-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds a typed `sidebarPosition: "left" | "right"` preference (default `left`) so users can dock the file explorer / source control panel to either edge of the window.

- New `sidebarPosition` field on the existing prefs store with cross-window sync via the established `terax://prefs-changed` event.
- Exposed in **Settings → General → Layout** as a Left/Right segmented toggle (an enum, not a boolean, so segmented control rather than a Switch).
- `App.tsx` conditionally renders the `ResizablePanelGroup` children in either `sidebar → handle → workspace` or `workspace → handle → sidebar` order, and flips the sidebar container's directional border (`border-r` ↔ `border-l`). Both panels keep their stable `id`s (`"sidebar"`, `"workspace"`) so existing persisted widths survive the swap.
- `SourceControlPanel`'s generate-commit-message tooltip now opens *away* from the sidebar (right when sidebar is right, left when sidebar is left) so it stays on-screen.

Out of scope: top/bottom docking, keybinding to flip position, per-workspace memory. Context-menu `side` props in the Explorer are left to Radix auto-flip; can be made explicit if right-dock testing surfaces clipping.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean (errors in `src/modules/updater/useUpdater.ts` on my local install are pre-existing on `main` and unrelated to this change)
- [x] `pnpm test` — 45/45 pass
- [x] Manual verification via `pnpm tauri dev` — toggle works, layout flips, persists across restart

## Sorry
This replaces #470 — that PR opened by accident with a bunch of unrelated commits from my fork. Closed cleanly.