### PR TITLE
fix(windows,terminal): System32 launch dir, PTY reload reap, paste + stale-render, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,23 @@ jobs:
       - name: cargo test
         working-directory: src-tauri
         run: cargo test --locked
+
+  rust-platforms:
+    name: rust-check (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: cargo check
+        working-directory: src-tauri
+        run: cargo check --all-targets --locked

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,7 +85,8 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    workspace::init_launch_cwd();
+    let cli_dir = parse_launch_dir();
+    workspace::init_launch_cwd(cli_dir.as_deref());
 
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
@@ -114,17 +115,18 @@ pub fn run() {
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
-            if let Some(launch_dir) = parse_launch_dir() {
-                let _ = registry.authorize(&launch_dir);
+            if let Some(ref launch_dir) = cli_dir {
+                let _ = registry.authorize(launch_dir);
             }
             registry
         })
-        .manage(LaunchDir(Mutex::new(parse_launch_dir())))
+        .manage(LaunchDir(Mutex::new(cli_dir)))
         .invoke_handler(tauri::generate_handler![
             pty::pty_open,
             pty::pty_write,
             pty::pty_resize,
             pty::pty_close,
+            pty::pty_close_all,
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -158,3 +158,27 @@ pub fn pty_close(state: tauri::State<PtyState>, id: u32) -> Result<(), String> {
     }
     Ok(())
 }
+
+// A fresh webview load orphans the previous frontend's sessions in this still
+// running process; reap them on boot before any new tab spawns.
+#[tauri::command]
+pub fn pty_close_all(state: tauri::State<PtyState>) -> Result<usize, String> {
+    let drained: Vec<(u32, Arc<Session>)> = {
+        let mut sessions = state.sessions.write().unwrap();
+        sessions.drain().collect()
+    };
+    let count = drained.len();
+    for (id, s) in drained {
+        if let Err(e) = s.killer.lock().unwrap().kill() {
+            log::debug!("pty_close_all: kill id={id} returned {e}");
+        }
+        thread::Builder::new()
+            .name(format!("terax-pty-drop-{id}"))
+            .spawn(move || session::drop_session(s))
+            .expect("spawn pty drop thread");
+    }
+    if count > 0 {
+        log::info!("pty_close_all: reaped {count} orphaned session(s)");
+    }
+    Ok(count)
+}

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -37,7 +37,10 @@ impl WorkspaceRegistry {
     pub fn canonicalize_cached<P: AsRef<Path>>(&self, path: P) -> std::io::Result<PathBuf> {
         let key = path.as_ref().to_path_buf();
         {
-            let cache = self.canonical_cache.lock().expect("canonical cache poisoned");
+            let cache = self
+                .canonical_cache
+                .lock()
+                .expect("canonical cache poisoned");
             if let Some(entry) = cache.get(&key) {
                 if entry.inserted_at.elapsed() < CANONICAL_TTL {
                     return Ok(entry.canonical.clone());
@@ -45,7 +48,10 @@ impl WorkspaceRegistry {
             }
         }
         let canonical = std::fs::canonicalize(&key)?;
-        let mut cache = self.canonical_cache.lock().expect("canonical cache poisoned");
+        let mut cache = self
+            .canonical_cache
+            .lock()
+            .expect("canonical cache poisoned");
         if cache.len() >= CANONICAL_CACHE_CAP {
             cache.retain(|_, entry| entry.inserted_at.elapsed() < CANONICAL_TTL);
             if cache.len() >= CANONICAL_CACHE_CAP {
@@ -61,7 +67,6 @@ impl WorkspaceRegistry {
         );
         Ok(canonical)
     }
-
 }
 
 // `None` means "use bootstrapped default". `Some` is canonicalized to defeat
@@ -75,8 +80,8 @@ pub fn authorize_spawn_cwd(
         return Ok(None);
     };
     let resolved = resolve_path(cwd, workspace);
-    let canonical = std::fs::canonicalize(&resolved)
-        .map_err(|e| format!("cwd not accessible: {e}"))?;
+    let canonical =
+        std::fs::canonicalize(&resolved).map_err(|e| format!("cwd not accessible: {e}"))?;
     if !canonical.is_dir() {
         return Err(format!("cwd is not a directory: {}", canonical.display()));
     }
@@ -100,8 +105,8 @@ pub fn authorize_user_spawn_cwd(
         return Ok(None);
     };
     let resolved = resolve_path(cwd, workspace);
-    let canonical = std::fs::canonicalize(&resolved)
-        .map_err(|e| format!("cwd not accessible: {e}"))?;
+    let canonical =
+        std::fs::canonicalize(&resolved).map_err(|e| format!("cwd not accessible: {e}"))?;
     if !canonical.is_dir() {
         return Err(format!("cwd is not a directory: {}", canonical.display()));
     }
@@ -141,12 +146,18 @@ pub async fn workspace_current_dir(
 // (file dialogs, plugin chdir) can't shift the value seen by IPC or spawn.
 static LAUNCH_CWD: OnceLock<Option<PathBuf>> = OnceLock::new();
 
-pub fn init_launch_cwd() {
-    LAUNCH_CWD.get_or_init(|| {
-        std::env::current_dir()
-            .ok()
-            .filter(|p| is_usable_launch_dir(p))
-    });
+pub fn init_launch_cwd(cli_dir: Option<&str>) {
+    LAUNCH_CWD.get_or_init(|| resolve_launch_cwd(cli_dir, std::env::current_dir().ok()));
+}
+
+fn resolve_launch_cwd(cli_dir: Option<&str>, env_cwd: Option<PathBuf>) -> Option<PathBuf> {
+    if let Some(dir) = cli_dir {
+        let p = PathBuf::from(dir);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    env_cwd.filter(|p| is_usable_launch_dir(p))
 }
 
 pub fn launch_cwd_snapshot() -> Option<PathBuf> {
@@ -157,7 +168,10 @@ fn resolve_launch_dir() -> PathBuf {
     if let Some(cwd) = launch_cwd_snapshot() {
         return cwd;
     }
-    if let Some(cwd) = std::env::current_dir().ok().filter(|p| is_usable_launch_dir(p)) {
+    if let Some(cwd) = std::env::current_dir()
+        .ok()
+        .filter(|p| is_usable_launch_dir(p))
+    {
         return cwd;
     }
     dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"))
@@ -360,7 +374,11 @@ pub(crate) fn wsl_exec_capture(
 ) -> Result<String, String> {
     validate_wsl_distro_name(distro)?;
     let mut cmd = std::process::Command::new("wsl.exe");
-    cmd.arg("-d").arg(distro).arg("--exec").arg(program).args(args);
+    cmd.arg("-d")
+        .arg(distro)
+        .arg("--exec")
+        .arg(program)
+        .args(args);
     crate::modules::proc::hide_console(&mut cmd);
     let out = cmd.output().map_err(|e| e.to_string())?;
     if !out.status.success() {
@@ -731,5 +749,27 @@ mod auth_tests {
         let err = authorize_spawn_cwd(&reg, Some(&s), &WorkspaceEnv::Local)
             .expect_err("symlink-escape must be rejected");
         assert!(err.contains("outside"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_launch_cwd_prefers_cli_dir_over_env() {
+        let cli = tempdir("cli");
+        let env = tempdir("env");
+        let s = cli.to_string_lossy().into_owned();
+        let resolved = resolve_launch_cwd(Some(&s), Some(env.clone()));
+        assert_eq!(resolved.as_deref(), Some(cli.as_path()));
+    }
+
+    #[test]
+    fn resolve_launch_cwd_falls_back_to_env_when_cli_missing() {
+        let env = tempdir("envonly");
+        assert_eq!(resolve_launch_cwd(None, Some(env.clone())), Some(env));
+    }
+
+    #[test]
+    fn resolve_launch_cwd_ignores_nonexistent_cli_dir() {
+        let env = tempdir("envfb");
+        let resolved = resolve_launch_cwd(Some("/no/such/terax/dir"), Some(env.clone()));
+        assert_eq!(resolved, Some(env));
     }
 }

--- a/src/lib/launchDir.ts
+++ b/src/lib/launchDir.ts
@@ -3,7 +3,9 @@ import { invoke } from "@tauri-apps/api/core";
 let cached: string | undefined;
 
 export async function initLaunchDir(): Promise<void> {
-  const dir = await invoke<string | null>("get_launch_dir").catch(() => null);
+  const dir =
+    (await invoke<string | null>("get_launch_dir").catch(() => null)) ??
+    (await invoke<string>("workspace_current_dir").catch(() => null));
   cached = dir ? dir.replace(/\\/g, "/") : undefined;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import "@fontsource/jetbrains-mono/cyrillic-700.css";
 import "@xterm/xterm/css/xterm.css";
 import "./styles/globals.css";
 
+import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
@@ -14,6 +15,9 @@ import { USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
 if (USE_CUSTOM_WINDOW_CONTROLS) {
   document.documentElement.dataset.chrome = "borderless";
 }
+
+// Reap PTY sessions orphaned by a prior webview load before any tab spawns.
+await invoke("pty_close_all").catch(() => {});
 
 // Seed before first paint so default tab mounts at target cwd (no flicker).
 await initLaunchDir();

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -83,7 +83,9 @@ function getRecycler(): HTMLDivElement {
 const MCR_BG_ACTIVE = 4.5;
 const MCR_BG_INACTIVE = 1;
 
-function bgActive(prefs: ReturnType<typeof usePreferencesStore.getState>): boolean {
+function bgActive(
+  prefs: ReturnType<typeof usePreferencesStore.getState>,
+): boolean {
   return prefs.backgroundKind === "image" && !!prefs.backgroundImageId;
 }
 
@@ -187,7 +189,7 @@ function createSlot(): Slot {
         void navigator.clipboard
           .readText()
           .then((text) => {
-            if (text) bridge.writeToPty(text);
+            if (text) slot.term.paste(text);
           })
           .catch(() => {});
       }
@@ -280,6 +282,8 @@ export function acquireSlot(params: AcquireParams): Slot {
 }
 
 function bindSlot(slot: Slot, p: AcquireParams): void {
+  const stale =
+    !slot.webglAddon || performance.now() - slot.lastUsedAt > SLOT_STALE_MS;
   slot.currentLeafId = p.leafId;
   slot.lastUsedAt = performance.now();
 
@@ -351,16 +355,22 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
     adapter?.resolveLeaf(p.leafId)?.kickPty(slot.term.cols, slot.term.rows);
   }
 
-  scheduleUnhide(slot);
+  scheduleUnhide(slot, stale);
 
   p.onSearchReady(slot.searchAddon);
 }
 
-function scheduleUnhide(slot: Slot): void {
+function scheduleUnhide(slot: Slot, stale: boolean): void {
   slot.unhideRaf = requestAnimationFrame(() => {
     slot.unhideRaf = requestAnimationFrame(() => {
       slot.unhideRaf = null;
       slot.host.style.visibility = "";
+      if (stale) {
+        if (!slot.webglAddon) attachWebgl(slot);
+        try {
+          slot.term.refresh(0, slot.term.rows - 1);
+        } catch {}
+      }
       const leafId = slot.currentLeafId;
       if (leafId !== null && adapter?.isLeafFocused(leafId)) {
         slot.term.focus();
@@ -490,6 +500,9 @@ function detachSlotFromLeaf(slot: Slot): void {
 }
 
 const WEBGL_RECOVERY_DELAY_MS = 250;
+// Below this a re-shown slot is fresh enough to trust; above it, repaint on
+// unhide to defeat silent GPU/context staleness.
+const SLOT_STALE_MS = 10_000;
 
 function attachWebgl(slot: Slot): void {
   if (slot.webglAddon || !slot.term.element) return;
@@ -516,6 +529,11 @@ function attachWebgl(slot: Slot): void {
         if (slot.webglAddon) return;
         if (!usePreferencesStore.getState().terminalWebglEnabled) return;
         attachWebgl(slot);
+        if (slot.webglAddon) {
+          try {
+            slot.term.refresh(0, slot.term.rows - 1);
+          } catch {}
+        }
       }, WEBGL_RECOVERY_DELAY_MS);
     });
     slot.term.loadAddon(webgl);
@@ -661,7 +679,8 @@ export function getSlotForLeaf(leafId: number): Slot | null {
 }
 
 const IS_MAC =
-  typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad/.test(navigator.userAgent);
 
 function isTerminalCopy(e: KeyboardEvent): boolean {
   return (


### PR DESCRIPTION
## What

Batch of Windows/terminal stability fixes, replacing the salvageable parts of #454.

- **System32 launch dir**: prefer the CLI arg over the process cwd in `init_launch_cwd` ("Open with Terax" leaves the process cwd at System32 on Windows). Parse the launch dir once and reuse it; `launchDir.ts` falls back to `workspace_current_dir` after a webview reload. Closes the System32 half of #450.
- **PTY reap on reload**: a fresh webview load orphaned the previous frontend's shells in the still-running process. `pty_close_all` reaps them deterministically on boot before any tab spawns (replaces the racy beforeunload idea).
- **Bracketed paste (#456)**: terminal paste wrote raw text to the PTY, so multi-line pastes submitted line-by-line in TUI agents. Routed through `term.paste()` (bracketed-paste wrapped + CRLF-normalized).
- **Stale-render repaint (#443)**: a renderer slot parked long enough could wake with a dead WebGL context (sometimes with no contextlost event) and stay blank until a manual resize. Repaint on unhide only when the slot was parked past a threshold or its WebGL addon died; refresh after WebGL recovery re-attach. Memory-neutral, no slot-lifecycle change.
- **CI**: compile-check Windows and macOS on PRs (previously only Linux), so `cfg(windows)`/`cfg(macos)` code is built before release.

## Not included (deliberate)

`dunce` (verbatim `\\?\` never reaches ConPTY on main; no need for the dependency), sessionStorage tab persistence, and reload-blocking. Real session restore is a separate, later feature.

## Verification

`cargo clippy --all-targets --locked -D warnings`, `cargo test --locked`, `tsc --noEmit`, `pnpm test` all green on macOS. #456 and #443 need manual confirmation on Windows/macOS.

Supersedes #454 (System32 catch by @JyotirmoyDas05).