### PR TITLE
feat(terminal): user-configurable shell with auto-detection fallback

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
-  esbuild: set this to true or false
-  msw: set this to true or false
+  esbuild: true
+  msw: true

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -41,6 +41,7 @@ pub async fn pty_open(
     rows: u16,
     cwd: Option<String>,
     workspace: Option<WorkspaceEnv>,
+    shell_override: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
@@ -50,7 +51,8 @@ pub async fn pty_open(
         e
     })?;
     let session = tauri::async_runtime::spawn_blocking(move || {
-        session::spawn(cols, rows, cwd, workspace, on_data, on_exit).map(|(s, _)| s)
+        session::spawn(cols, rows, cwd, workspace, shell_override, on_data, on_exit)
+            .map(|(s, _)| s)
     })
     .await
     .map_err(|e| {

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -94,6 +94,7 @@ pub fn spawn(
     rows: u16,
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    shell_override: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<(Arc<Session>, PtySize), String> {
@@ -109,7 +110,7 @@ pub fn spawn(
     };
     let pair = pty_system.openpty(size).map_err(|e| e.to_string())?;
 
-    let cmd = shell_init::build_command(cwd, workspace)?;
+    let cmd = shell_init::build_command(cwd, workspace, shell_override)?;
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -50,15 +50,16 @@ fn fish_init_script() -> &'static str {
 pub fn build_command(
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    shell_override: Option<String>,
 ) -> Result<CommandBuilder, String> {
     #[cfg(unix)]
     {
         let _ = workspace;
-        unix::build(cwd)
+        unix::build(cwd, shell_override)
     }
     #[cfg(windows)]
     {
-        windows::build(cwd, workspace)
+        windows::build(cwd, workspace, shell_override)
     }
 }
 
@@ -127,10 +128,28 @@ mod unix {
 
     impl Shell {
         pub fn detect() -> (Shell, String) {
-            let path = login_shell()
-                .or_else(|| std::env::var("SHELL").ok())
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| "/bin/zsh".into());
+            let shell_env = std::env::var("SHELL").ok().filter(|s| !s.is_empty());
+
+            // Detection order:
+            // 1. FISH_VERSION is exported by fish to all child processes, so its
+            //    presence means terax was launched from fish. Prefer the fish binary
+            //    from PATH in that case, falling back to $SHELL if it's already fish.
+            // 2. $SHELL — explicit user preference, and more up-to-date than getpwuid
+            //    on macOS where Homebrew fish installs often don't update /etc/passwd.
+            // 3. getpwuid login shell — system fallback.
+            // 4. /bin/zsh hardcoded last resort.
+            let path = if std::env::var("FISH_VERSION").is_ok() {
+                shell_env
+                    .clone()
+                    .filter(|s| s.contains("fish"))
+                    .or_else(which_fish)
+                    .or(shell_env)
+                    .or_else(login_shell)
+            } else {
+                shell_env.or_else(login_shell)
+            }
+            .unwrap_or_else(|| "/bin/zsh".into());
+
             let name = path.rsplit('/').next().unwrap_or("").to_string();
             let shell = match name.as_str() {
                 "zsh" => Shell::Zsh,
@@ -140,6 +159,13 @@ mod unix {
             };
             (shell, path)
         }
+    }
+
+    fn which_fish() -> Option<String> {
+        std::env::var("PATH").ok()?.split(':').find_map(|dir| {
+            let p = std::path::Path::new(dir).join("fish");
+            p.exists().then(|| p.to_string_lossy().into_owned())
+        })
     }
 
     fn login_shell() -> Option<String> {
@@ -158,8 +184,23 @@ mod unix {
         }
     }
 
-    pub fn build(cwd: Option<String>) -> Result<CommandBuilder, String> {
-        let (shell, shell_path) = Shell::detect();
+    pub fn build(cwd: Option<String>, shell_override: Option<String>) -> Result<CommandBuilder, String> {
+        let (shell, shell_path) = match shell_override {
+            Some(ref path) if !path.is_empty() && std::path::Path::new(path).exists() => {
+                let kind = match path.rsplit('/').next().unwrap_or("") {
+                    "zsh" => Shell::Zsh,
+                    "bash" => Shell::Bash,
+                    "fish" => Shell::Fish,
+                    _ => Shell::Other,
+                };
+                (kind, path.clone())
+            }
+            Some(ref path) if !path.is_empty() => {
+                log::warn!("shell override '{}' not found, falling back to auto-detect", path);
+                Shell::detect()
+            }
+            _ => Shell::detect(),
+        };
         let mut cmd = CommandBuilder::new(&shell_path);
         super::apply_common(&mut cmd, cwd);
 
@@ -310,7 +351,7 @@ mod windows {
         args: Vec<String>,
     }
 
-    pub fn build(cwd: Option<String>, workspace: WorkspaceEnv) -> Result<CommandBuilder, String> {
+    pub fn build(cwd: Option<String>, workspace: WorkspaceEnv, _shell_override: Option<String>) -> Result<CommandBuilder, String> {
         if let WorkspaceEnv::Wsl { distro } = workspace {
             return build_wsl(cwd, distro);
         }

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -79,6 +79,7 @@ export type Preferences = {
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  terminalShell: string;
   lastWslDistro: string | null;
   zoomLevel: number;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
@@ -118,6 +119,7 @@ const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_TERMINAL_SHELL = "terminalShell";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_SHORTCUTS = "shortcuts";
@@ -170,6 +172,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  terminalShell: "",
   lastWslDistro: null,
   zoomLevel: 1.0,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
@@ -276,6 +279,8 @@ export async function loadPreferences(): Promise<Preferences> {
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
     ),
+    terminalShell:
+      get<string>(KEY_TERMINAL_SHELL) ?? DEFAULT_PREFERENCES.terminalShell,
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
@@ -451,6 +456,10 @@ export async function setTerminalScrollback(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_SCROLLBACK, clampScrollback(value));
 }
 
+export async function setTerminalShell(value: string): Promise<void> {
+  await writePref(KEY_TERMINAL_SHELL, value.trim());
+}
+
 export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
@@ -508,6 +517,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_TERMINAL_SHELL]: "terminalShell",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_SHORTCUTS]: "shortcuts",

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -18,6 +18,7 @@ export async function openPty(
   rows: number,
   handlers: PtyHandlers,
   cwd?: string,
+  shell?: string,
 ): Promise<PtySession> {
   // Raw bytes — no base64/JSON round-trip; messages arrive as ArrayBuffer.
   const onData = new Channel<ArrayBuffer>();
@@ -43,6 +44,7 @@ export async function openPty(
     rows,
     cwd: cwd ?? null,
     workspace: currentWorkspaceEnv(),
+    shellOverride: shell || null,
     onData,
     onExit,
   });

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -145,6 +145,7 @@ async function openPtyForSession(
 ): Promise<PtySession> {
   const startCols = s.cols > 0 ? s.cols : 80;
   const startRows = s.rows > 0 ? s.rows : 24;
+  const shellOverride = usePreferencesStore.getState().terminalShell || undefined;
   return openPty(
     startCols,
     startRows,
@@ -160,6 +161,7 @@ async function openPtyForSession(
       },
     },
     cwd,
+    shellOverride,
   );
 }
 

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -26,6 +26,7 @@ import {
   setTerminalLetterSpacing,
   setTerminalFontSize,
   setTerminalScrollback,
+  setTerminalShell,
   setTerminalWebglEnabled,
   setVimMode,
   setZoomLevel,
@@ -73,6 +74,7 @@ export function GeneralSection() {
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
 
   useEffect(() => {
@@ -215,6 +217,18 @@ export function GeneralSection() {
           <Switch
             checked={terminalWebglEnabled}
             onCheckedChange={(v) => void setTerminalWebglEnabled(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Shell"
+          description="Full path to the shell binary (e.g. /opt/homebrew/bin/fish). Leave blank to auto-detect."
+        >
+          <input
+            type="text"
+            value={terminalShell}
+            placeholder="Auto-detect"
+            onChange={(e) => void setTerminalShell(e.target.value)}
+            className="h-8 w-48 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
           />
         </SettingRow>
         <SettingRow


### PR DESCRIPTION
## Summary

- Adds a **Shell** text field under Settings → General → Terminal
- The chosen shell path is passed through to the Rust PTY spawn (`pty_open` Tauri command)
- Shell kind (fish/bash/zsh) is inferred from the binary name for correct initialization
- Falls back to auto-detection when the field is blank or the path doesn't exist on disk

## Motivation

Users who run fish, nushell, or other non-default shells had no way to tell Terax which shell to use — it always defaulted to the system shell or `/bin/zsh`. This makes the terminal feel wrong for anyone whose daily driver isn't zsh.

## Test plan

- [ ] Open Settings → General → Terminal, set Shell to `/opt/homebrew/bin/fish` (or your shell)
- [ ] Open a new terminal tab — it should launch the configured shell
- [ ] Clear the field and reopen a tab — should fall back to auto-detected shell
- [ ] Enter a non-existent path — should fall back gracefully (warning logged, no crash)