### PR TITLE
feat(tabs): close tab on middle mouse button click

### DIFF
--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -96,6 +96,16 @@ export function TabBar({
                   value={String(t.id)}
                   data-tab-id={t.id}
                   onDoubleClick={() => isPreview && onPin(t.id)}
+                  onAuxClick={(e) => {
+                    if (e.button === 1 && tabs.length > 1) {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onClose(t.id);
+                    }
+                  }}
+                  onMouseDown={(e) => {
+                    if (e.button === 1) e.preventDefault();
+                  }}
                   className={cn(
                     "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
                     compact


### PR DESCRIPTION
## What changed

`src/modules/tabs/TabBar.tsx`: wire `onAuxClick` on each `TabsTrigger`. When `button === 1` (middle button) and `tabs.length > 1`, the tab closes. Paired with `onMouseDown` `preventDefault` on button 1 to suppress the browser middle-click autoscroll cursor.

10 lines added. No other files touched.

## Why

Middle-click-to-close is the long-standing browser tab convention and is explicitly listed as missing in #400 ("Mouse middle click on a terminal tab does not work"). Pre-discussed in #483.

## Behavior

- Middle-click any tab when 2+ open → closes the tab.
- Last remaining tab resists (mirrors the existing X button guard).
- Right-click (`button === 2`) is ignored.
- No autoscroll cursor flicker.

## How tested

Tested manually on macOS (Apple Silicon) via `pnpm tauri dev`:

- Spawned multiple terminal tabs; middle-click on each closes the targeted tab.
- With one tab remaining, middle-click is a no-op (matches X button behavior).
- Right-click on a tab does not close it.
- No autoscroll cursor appears on middle-click.

Cross-platform: `onAuxClick` + `e.button === 1` is standard DOM, no platform-specific code paths.

## Quality gates

- `pnpm exec tsc --noEmit` clean
- `pnpm test` — 45/45 passing
- `cargo clippy --all-targets` clean
- `cargo test --locked` — 96/96 passing
- `cargo fmt --check`: reports pre-existing diffs in unrelated Rust files (e.g. `modules/net.rs`, `modules/pty/agent_detect.rs`, WSL bridge) that exist on `main`. Per CONTRIBUTING.md ("only change what's needed"), I did not touch those.

## Tests

UI rendering territory; no new logic to lock. Per CONTRIBUTING.md: *"UI rendering, themes, syntax-highlight tables, and anything the type-checker already guarantees do not need tests."* The handler is pure event wiring covered by TypeScript.

## Related

- Discussion: #483
- Original report: #400