### PR TITLE
feat(fs): live filesystem watcher for explorer tree and open editors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1314,6 +1314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,6 +2165,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2349,26 @@ dependencies = [
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -2547,6 +2596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2639,6 +2689,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2718,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5223,6 +5300,7 @@ dependencies = [
  "keyring",
  "libc",
  "log",
+ "notify",
  "portable-pty",
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ bytes = "1"
 futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"
+notify = "8.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
         .manage(pty::PtyState::default())
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())
+        .manage(fs::watch::FsWatchState::default())
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
@@ -137,6 +138,8 @@ pub fn run() {
             fs::mutate::fs_create_dir,
             fs::mutate::fs_rename,
             fs::mutate::fs_delete,
+            fs::watch::fs_watch_add,
+            fs::watch::fs_watch_remove,
             fs::search::fs_search,
             fs::search::fs_list_files,
             fs::grep::fs_grep,

--- a/src-tauri/src/modules/fs/mod.rs
+++ b/src-tauri/src/modules/fs/mod.rs
@@ -3,6 +3,7 @@ pub mod grep;
 pub mod mutate;
 pub mod search;
 pub mod tree;
+pub mod watch;
 
 use std::path::Path;
 

--- a/src-tauri/src/modules/fs/watch.rs
+++ b/src-tauri/src/modules/fs/watch.rs
@@ -1,0 +1,310 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::{AppHandle, Emitter, State};
+
+use crate::modules::fs::to_canon;
+use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
+
+// Quiet-gap before a batch flushes; MAX_WINDOW caps latency under a long stream.
+const DEBOUNCE: Duration = Duration::from_millis(150);
+const MAX_WINDOW: Duration = Duration::from_millis(1000);
+
+// Matched on the final path component. Never watched even when expanded: large
+// or generated trees where live updates cost more than they're worth.
+const SKIP_DIRS: &[&str] = &[
+    // VCS
+    ".git",
+    ".hg",
+    ".svn",
+    ".jj",
+    // JS / web
+    "node_modules",
+    "bower_components",
+    ".pnpm-store",
+    ".yarn",
+    "dist",
+    "build",
+    "out",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".astro",
+    ".vite",
+    ".turbo",
+    ".parcel-cache",
+    ".angular",
+    ".vercel",
+    ".netlify",
+    ".output",
+    ".cache",
+    // Rust
+    "target",
+    // Python
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".tox",
+    ".nox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".ipynb_checkpoints",
+    ".eggs",
+    // JVM / Gradle
+    ".gradle",
+    // .NET
+    "obj",
+    // Go / PHP
+    "vendor",
+    // Elixir
+    "_build",
+    "deps",
+    // Dart / Flutter
+    ".dart_tool",
+    // Haskell
+    "dist-newstyle",
+    ".stack-work",
+    // Swift / Zig
+    ".build",
+    "zig-cache",
+    "zig-out",
+    // CMake (CLion)
+    "cmake-build-debug",
+    "cmake-build-release",
+    // IDE / coverage / infra
+    ".idea",
+    "coverage",
+    ".nyc_output",
+    ".terraform",
+];
+
+fn is_skipped(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| SKIP_DIRS.contains(&n))
+}
+
+#[derive(Default)]
+pub struct FsWatchState {
+    inner: Mutex<Option<WatchInner>>,
+}
+
+struct WatchInner {
+    watcher: RecommendedWatcher,
+    // Explorer (expanded dirs) and editor (dirs of open files) can request the
+    // same dir; unwatch only when the last requester releases it.
+    refcounts: HashMap<PathBuf, usize>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct ChangedPayload {
+    paths: Vec<String>,
+}
+
+fn ensure_started(state: &FsWatchState, app: &AppHandle) -> Result<(), String> {
+    let mut guard = state.inner.lock().expect("fs watch state poisoned");
+    if guard.is_some() {
+        return Ok(());
+    }
+
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
+    let watcher = RecommendedWatcher::new(
+        move |res| {
+            let _ = tx.send(res);
+        },
+        Config::default(),
+    )
+    .map_err(|e| e.to_string())?;
+
+    let app = app.clone();
+    std::thread::Builder::new()
+        .name("terax-fs-watch".into())
+        .spawn(move || drain_loop(rx, app))
+        .map_err(|e| e.to_string())?;
+
+    *guard = Some(WatchInner {
+        watcher,
+        refcounts: HashMap::new(),
+    });
+    Ok(())
+}
+
+fn drain_loop(rx: mpsc::Receiver<notify::Result<Event>>, app: AppHandle) {
+    loop {
+        let first = match rx.recv() {
+            Ok(ev) => ev,
+            Err(_) => return,
+        };
+
+        let mut paths: HashSet<String> = HashSet::new();
+        collect(&mut paths, first);
+
+        let deadline = Instant::now() + MAX_WINDOW;
+        loop {
+            let timeout = DEBOUNCE.min(deadline.saturating_duration_since(Instant::now()));
+            match rx.recv_timeout(timeout) {
+                Ok(ev) => collect(&mut paths, ev),
+                Err(RecvTimeoutError::Timeout) => break,
+                Err(RecvTimeoutError::Disconnected) => return,
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+        }
+
+        if paths.is_empty() {
+            continue;
+        }
+        let _ = app.emit(
+            "fs:changed",
+            ChangedPayload {
+                paths: paths.into_iter().collect(),
+            },
+        );
+    }
+}
+
+fn collect(set: &mut HashSet<String>, ev: notify::Result<Event>) {
+    let Ok(ev) = ev else { return };
+    if matches!(ev.kind, EventKind::Access(_)) {
+        return;
+    }
+    for p in ev.paths {
+        set.insert(to_canon(&p));
+    }
+}
+
+fn add_paths(inner: &mut WatchInner, paths: Vec<PathBuf>) {
+    for canonical in paths {
+        let current = inner.refcounts.get(&canonical).copied().unwrap_or(0);
+        if current == 0 {
+            match inner.watcher.watch(&canonical, RecursiveMode::NonRecursive) {
+                Ok(()) => {
+                    inner.refcounts.insert(canonical, 1);
+                }
+                Err(e) => log::debug!("fs_watch add {} failed: {e}", canonical.display()),
+            }
+        } else {
+            inner.refcounts.insert(canonical, current + 1);
+        }
+    }
+}
+
+fn remove_paths(inner: &mut WatchInner, paths: Vec<PathBuf>) {
+    for key in paths {
+        let current = inner.refcounts.get(&key).copied().unwrap_or(0);
+        if current <= 1 {
+            inner.refcounts.remove(&key);
+            let _ = inner.watcher.unwatch(&key);
+        } else {
+            inner.refcounts.insert(key, current - 1);
+        }
+    }
+}
+
+// Canonical keys keep add/remove symmetric regardless of how the path was spelled.
+fn prepare_add(
+    registry: &WorkspaceRegistry,
+    workspace: &WorkspaceEnv,
+    paths: Vec<String>,
+) -> Vec<PathBuf> {
+    paths
+        .into_iter()
+        .filter_map(|raw| {
+            let resolved = resolve_path(&raw, workspace);
+            let canonical = std::fs::canonicalize(&resolved).ok()?;
+            if !canonical.is_dir() || is_skipped(&canonical) || !registry.is_authorized(&canonical) {
+                return None;
+            }
+            Some(canonical)
+        })
+        .collect()
+}
+
+#[tauri::command]
+pub fn fs_watch_add(
+    paths: Vec<String>,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+    state: State<'_, FsWatchState>,
+    registry: State<'_, WorkspaceRegistry>,
+) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let prepared = prepare_add(&registry, &workspace, paths);
+    if prepared.is_empty() {
+        return Ok(());
+    }
+    ensure_started(&state, &app)?;
+    let mut guard = state.inner.lock().expect("fs watch state poisoned");
+    if let Some(inner) = guard.as_mut() {
+        add_paths(inner, prepared);
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn fs_watch_remove(
+    paths: Vec<String>,
+    workspace: Option<WorkspaceEnv>,
+    state: State<'_, FsWatchState>,
+) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    // A removed/renamed dir no longer canonicalizes; fall back so the refcount
+    // entry is still released.
+    let prepared: Vec<PathBuf> = paths
+        .into_iter()
+        .map(|raw| {
+            let resolved = resolve_path(&raw, &workspace);
+            std::fs::canonicalize(&resolved).unwrap_or(resolved)
+        })
+        .collect();
+    let mut guard = state.inner.lock().expect("fs watch state poisoned");
+    if let Some(inner) = guard.as_mut() {
+        remove_paths(inner, prepared);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skip_filter_matches_basename() {
+        assert!(is_skipped(Path::new("/a/b/node_modules")));
+        assert!(is_skipped(Path::new("/x/target")));
+        assert!(is_skipped(Path::new("/p/obj")));
+        assert!(!is_skipped(Path::new("/a/src")));
+        assert!(!is_skipped(Path::new("/a/node_modules/pkg")));
+    }
+
+    #[test]
+    fn collect_ignores_access_and_dedups() {
+        let mut set = HashSet::new();
+        collect(
+            &mut set,
+            Ok(Event {
+                kind: EventKind::Access(notify::event::AccessKind::Read),
+                paths: vec![PathBuf::from("/a/x")],
+                attrs: Default::default(),
+            }),
+        );
+        assert!(set.is_empty());
+
+        let modify = || {
+            Ok(Event {
+                kind: EventKind::Modify(notify::event::ModifyKind::Any),
+                paths: vec![PathBuf::from("/a/x")],
+                attrs: Default::default(),
+            })
+        };
+        collect(&mut set, modify());
+        collect(&mut set, modify());
+        assert_eq!(set.len(), 1);
+    }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -48,6 +48,12 @@ import { getLaunchDir } from "@/lib/launchDir";
 import { useZoom } from "@/lib/useZoom";
 import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
 import {
+  listenFsChanged,
+  parentDir,
+  watchAdd,
+  watchRemove,
+} from "@/modules/explorer/lib/watch";
+import {
   Header,
   type SearchInlineHandle,
   type SearchTarget,
@@ -487,6 +493,39 @@ export default function App() {
     );
     return () => {
       void unlistenPromise.then((un) => un());
+    };
+  }, []);
+
+  const editorWatchRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const want = new Set<string>();
+    for (const t of tabs) if (t.kind === "editor") want.add(parentDir(t.path));
+    const prev = editorWatchRef.current;
+    const toAdd = [...want].filter((d) => !prev.has(d));
+    const toRemove = [...prev].filter((d) => !want.has(d));
+    watchAdd(toAdd);
+    watchRemove(toRemove);
+    editorWatchRef.current = want;
+  }, [tabs]);
+
+  useEffect(() => {
+    let alive = true;
+    let unlisten: (() => void) | undefined;
+    void listenFsChanged((paths) => {
+      const changed = new Set(paths.map((p) => p.replace(/\\/g, "/")));
+      for (const t of tabsRef.current) {
+        if (t.kind !== "editor") continue;
+        if (changed.has(t.path.replace(/\\/g, "/"))) {
+          editorRefs.current.get(t.id)?.reload();
+        }
+      }
+    }).then((un) => {
+      if (alive) unlisten = un;
+      else un();
+    });
+    return () => {
+      alive = false;
+      unlisten?.();
     };
   }, []);
 

--- a/src/modules/editor/lib/useDocument.ts
+++ b/src/modules/editor/lib/useDocument.ts
@@ -22,7 +22,6 @@ type Options = {
 export function useDocument({ path, onDirtyChange }: Options) {
   const [doc, setDoc] = useState<DocumentState>({ status: "loading" });
   const [dirty, setDirty] = useState(false);
-  const [reloadCounter, setReloadCounter] = useState(0);
 
   // Track the saved buffer so we can detect changes cheaply.
   const savedRef = useRef<string>("");
@@ -75,15 +74,32 @@ export function useDocument({ path, onDirtyChange }: Options) {
     return () => {
       cancelled = true;
     };
-  }, [path, reloadCounter]);
+  }, [path]);
 
-  /** Re-read the file from disk. No-op (silent) if the buffer is dirty —
-   *  callers shouldn't clobber unsaved user edits. Returns whether reload ran. */
+  // Skipped while dirty (never clobber unsaved edits) and when disk already
+  // matches the buffer (self-save / duplicate watcher event → no re-render).
   const reload = useCallback((): boolean => {
     if (dirtyRef.current) return false;
-    setReloadCounter((n) => n + 1);
+    void invoke<ReadResult>("fs_read_file", {
+      path,
+      workspace: currentWorkspaceEnv(),
+    })
+      .then((res) => {
+        if (res.kind === "text") {
+          if (res.content === savedRef.current) return;
+          savedRef.current = res.content;
+          bufferRef.current = res.content;
+          setDirty(false);
+          setDoc({ status: "ready", content: res.content, size: res.size });
+        } else if (res.kind === "binary") {
+          setDoc({ status: "binary", size: res.size });
+        } else if (res.kind === "toolarge") {
+          setDoc({ status: "toolarge", size: res.size, limit: res.limit });
+        }
+      })
+      .catch((e) => setDoc({ status: "error", message: String(e) }));
     return true;
-  }, []);
+  }, [path]);
 
   const onChange = useCallback((next: string) => {
     bufferRef.current = next;

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { listenFsChanged, watchAdd, watchRemove } from "./watch";
 
 export type DirEntry = {
   name: string;
@@ -34,6 +35,31 @@ export function dirname(path: string): string {
   return path.slice(0, i);
 }
 
+const EXPANSION_CACHE_LIMIT = 8;
+const expansionCache = new Map<string, string[]>();
+
+function rememberExpansion(root: string, expanded: Set<string>): void {
+  expansionCache.delete(root);
+  if (expanded.size > 0) expansionCache.set(root, [...expanded]);
+  while (expansionCache.size > EXPANSION_CACHE_LIMIT) {
+    const oldest = expansionCache.keys().next().value;
+    if (oldest === undefined) break;
+    expansionCache.delete(oldest);
+  }
+}
+
+function recallExpansion(root: string): string[] {
+  const v = expansionCache.get(root);
+  if (!v) return [];
+  expansionCache.delete(root);
+  expansionCache.set(root, v);
+  return v;
+}
+
+function isUnder(key: string, root: string): boolean {
+  return key === root || key.startsWith(`${root}/`);
+}
+
 type Options = {
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
@@ -49,9 +75,32 @@ export function useFileTree(rootPath: string | null, options?: Options) {
   );
   const [renaming, setRenaming] = useState<string | null>(null);
 
+  const expandedRef = useRef(expanded);
+  const nodesRef = useRef(nodes);
+  const watchedRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     showHiddenRef.current = showHidden;
   }, [showHidden]);
+
+  useEffect(() => {
+    expandedRef.current = expanded;
+  }, [expanded]);
+
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
+
+  const addWatch = useCallback((path: string) => {
+    if (watchedRef.current.has(path)) return;
+    watchedRef.current.add(path);
+    watchAdd([path]);
+  }, []);
+
+  const removeWatch = useCallback((path: string) => {
+    if (!watchedRef.current.delete(path)) return;
+    watchRemove([path]);
+  }, []);
 
   const fetchChildren = useCallback(async (path: string) => {
     setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
@@ -61,7 +110,44 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         showHidden: showHiddenRef.current,
         workspace: currentWorkspaceEnv(),
       });
-      setNodes((s) => ({ ...s, [path]: { status: "loaded", entries } }));
+
+      const liveDirs = new Set(
+        entries.filter((e) => e.kind === "dir").map((e) => joinPath(path, e.name)),
+      );
+      const removedRoots: string[] = [];
+      for (const key of Object.keys(nodesRef.current)) {
+        if (dirname(key) === path && !liveDirs.has(key)) removedRoots.push(key);
+      }
+      const dead = new Set<string>();
+      if (removedRoots.length > 0) {
+        const candidates = new Set<string>([
+          ...Object.keys(nodesRef.current),
+          ...expandedRef.current,
+          ...watchedRef.current,
+        ]);
+        for (const k of candidates) {
+          if (removedRoots.some((r) => isUnder(k, r))) dead.add(k);
+        }
+      }
+
+      setNodes((s) => {
+        const next: TreeState = {};
+        for (const [k, v] of Object.entries(s)) if (!dead.has(k)) next[k] = v;
+        next[path] = { status: "loaded", entries };
+        return next;
+      });
+
+      if (dead.size > 0) {
+        setExpanded((c) => {
+          let changed = false;
+          const n = new Set(c);
+          for (const d of dead) if (n.delete(d)) changed = true;
+          return changed ? n : c;
+        });
+        const toUnwatch: string[] = [];
+        for (const d of dead) if (watchedRef.current.delete(d)) toUnwatch.push(d);
+        watchRemove(toUnwatch);
+      }
     } catch (e) {
       setNodes((s) => ({
         ...s,
@@ -70,7 +156,8 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     }
   }, []);
 
-  // Root change → reset state.
+  // Root change → restore the cached expansion for this root, re-scope watches,
+  // and persist the outgoing root's expansion on the way out.
   useEffect(() => {
     if (!rootPath) {
       setNodes({});
@@ -81,10 +168,47 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     }
     setPendingCreate(null);
     setRenaming(null);
-    setExpanded(new Set());
+
+    const restored = recallExpansion(rootPath);
+    setExpanded(new Set(restored));
     setNodes({});
+
+    const toWatch = [rootPath, ...restored];
     void fetchChildren(rootPath);
+    for (const d of restored) void fetchChildren(d);
+    for (const p of toWatch) watchedRef.current.add(p);
+    watchAdd(toWatch);
+
+    return () => {
+      rememberExpansion(rootPath, expandedRef.current);
+      if (watchedRef.current.size > 0) {
+        watchRemove([...watchedRef.current]);
+        watchedRef.current.clear();
+      }
+    };
   }, [rootPath, fetchChildren]);
+
+  useEffect(() => {
+    let alive = true;
+    let unlisten: (() => void) | undefined;
+    void listenFsChanged((paths) => {
+      const current = nodesRef.current;
+      const dirs = new Set<string>();
+      for (const p of paths) {
+        const parent = dirname(p);
+        if (current[parent]?.status === "loaded") dirs.add(parent);
+        if (current[p]?.status === "loaded") dirs.add(p);
+      }
+      for (const d of dirs) void fetchChildren(d);
+    }).then((un) => {
+      if (alive) unlisten = un;
+      else un();
+    });
+    return () => {
+      alive = false;
+      unlisten?.();
+    };
+  }, [fetchChildren]);
 
   useEffect(() => {
     if (!rootPath) return;
@@ -100,36 +224,38 @@ export function useFileTree(rootPath: string | null, options?: Options) {
 
   const toggle = useCallback(
     (path: string) => {
-      setExpanded((curr) => {
-        const next = new Set(curr);
-        if (next.has(path)) next.delete(path);
-        else next.add(path);
-        return next;
-      });
-      setNodes((curr) => {
-        if (!curr[path] || curr[path].status === "error") {
-          void fetchChildren(path);
-        }
-        return curr;
-      });
+      if (expandedRef.current.has(path)) {
+        setExpanded((curr) => {
+          const next = new Set(curr);
+          next.delete(path);
+          return next;
+        });
+        removeWatch(path);
+      } else {
+        setExpanded((curr) => {
+          const next = new Set(curr);
+          next.add(path);
+          return next;
+        });
+        addWatch(path);
+        void fetchChildren(path);
+      }
     },
-    [fetchChildren],
+    [fetchChildren, addWatch, removeWatch],
   );
 
   const expand = useCallback(
     (path: string) => {
+      if (expandedRef.current.has(path)) return;
       setExpanded((curr) => {
-        if (curr.has(path)) return curr;
         const next = new Set(curr);
         next.add(path);
         return next;
       });
-      setNodes((curr) => {
-        if (!curr[path]) void fetchChildren(path);
-        return curr;
-      });
+      addWatch(path);
+      void fetchChildren(path);
     },
-    [fetchChildren],
+    [fetchChildren, addWatch],
   );
 
   const refresh = useCallback(
@@ -153,13 +279,14 @@ export function useFileTree(rootPath: string | null, options?: Options) {
           next.add(parentPath);
           return next;
         });
+        addWatch(parentPath);
       }
       setNodes((curr) => {
         if (!curr[parentPath]) void fetchChildren(parentPath);
         return curr;
       });
     },
-    [rootPath, fetchChildren],
+    [rootPath, fetchChildren, addWatch],
   );
 
   const cancelCreate = useCallback(() => setPendingCreate(null), []);

--- a/src/modules/explorer/lib/watch.ts
+++ b/src/modules/explorer/lib/watch.ts
@@ -1,0 +1,38 @@
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+
+const FS_CHANGED_EVENT = "fs:changed";
+
+type FsChangedPayload = { paths: string[] };
+
+export function watchAdd(paths: string[]): void {
+  if (paths.length === 0) return;
+  void invoke("fs_watch_add", {
+    paths,
+    workspace: currentWorkspaceEnv(),
+  }).catch(() => {});
+}
+
+export function watchRemove(paths: string[]): void {
+  if (paths.length === 0) return;
+  void invoke("fs_watch_remove", {
+    paths,
+    workspace: currentWorkspaceEnv(),
+  }).catch(() => {});
+}
+
+export function listenFsChanged(
+  handler: (paths: string[]) => void,
+): Promise<() => void> {
+  return getCurrentWebviewWindow().listen<FsChangedPayload>(
+    FS_CHANGED_EVENT,
+    (e) => handler(e.payload.paths),
+  );
+}
+
+export function parentDir(path: string): string {
+  const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (i <= 0) return path.slice(0, i + 1) || path;
+  return path.slice(0, i);
+}


### PR DESCRIPTION
Auto-refresh the file explorer and open editor tabs when the filesystem changes, from any source: AI fs tools, AI shell, the user's terminal, or external editors. No more manual refresh / close-reopen.

## Design
Scoped, non-recursive `notify` watcher over `WorkspaceRegistry` roots. Watches only what is visible: expanded explorer dirs + parent dirs of open editor files. Refcounted so explorer and editor sharing a dir unwatch only when both release. One background thread, debounced (150ms gap, 1s cap) and coalesced into a single `fs:changed` batch. Lazy init: zero cost until the explorer/editor first asks for a watch.

Memory is O(visible nodes), not O(repo size) — no Linux inotify blowup, no recursive walk. Heavy/generated dirs (node_modules, target, .git, dist, __pycache__, ...) are never watched.

## Frontend
- `useFileTree`: watch on expand, unwatch on collapse, refetch on re-expand; `fs:changed` refetches only loaded dirs.
- Per-root expansion cache (LRU 8) so switching tabs / cwd no longer collapses the tree.
- Prune: a refetch drops vanished subtrees from nodes/expanded/watches.
- `App.tsx`: watches dirs of open editor files; `fs:changed` reloads matching tabs.
- `useDocument.reload`: compares disk vs buffer — self-saves and duplicate events cause no re-render; dirty buffers are never clobbered.

Existing `fs:file-written` (typed source, theme ingest) is kept; the watcher complements it.

## Verify
- `cargo clippy --all-targets --locked -D warnings`, `cargo test --locked` (101 passed)
- `pnpm build`
- Manual: AI create file / `mkdir` in terminal / `git checkout` editing an open file all reflect live.