### PR TITLE
feat(ai): /claude-code command to orchestrate agents via Terax AI

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import { AgentNotificationsBridge } from "@/modules/agents";
+import { firePendingReviewForSession } from "@/modules/agents/lib/review";
+import { useManagedAgentsStore } from "@/modules/agents/store/managedAgentsStore";
 import { Toaster } from "@/components/ui/sonner";
 import {
   AgentRunBridge,
@@ -45,6 +47,7 @@ import {
   type GitHistorySearchHandle,
 } from "@/modules/git-history";
 import { getLaunchDir } from "@/lib/launchDir";
+import { quoteShellArg } from "@/lib/shellQuote";
 import { useZoom } from "@/lib/useZoom";
 import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
 import {
@@ -83,6 +86,8 @@ import {
   leafIds,
   respawnSession,
   TerminalStack,
+  whenSessionReady,
+  writeToSession,
   type TerminalPaneHandle,
 } from "@/modules/terminal";
 import { ThemeProvider } from "@/modules/theme";
@@ -160,6 +165,7 @@ export default function App() {
     activeId,
     setActiveId,
     newTab,
+    newAgentTab,
     newPrivateTab,
     openFileTab,
     pinTab,
@@ -379,6 +385,7 @@ export default function App() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [newEditorOpen, setNewEditorOpen] = useState(false);
   const miniOpen = useChatStore((s) => s.mini.open);
+  const activeSessionId = useChatStore((s) => s.activeSessionId);
   const openMini = useChatStore((s) => s.openMini);
   const focusInput = useChatStore((s) => s.focusInput);
   const openPanel = useChatStore((s) => s.openPanel);
@@ -388,6 +395,10 @@ export default function App() {
   const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
   const setLive = useChatStore((s) => s.setLive);
   const respondToApproval = useChatStore((s) => s.respondToApproval);
+
+  useEffect(() => {
+    if (activeSessionId) firePendingReviewForSession(activeSessionId);
+  }, [activeSessionId]);
   const lmstudioModelId = usePreferencesStore((s) => s.lmstudioModelId);
   const lmstudioBaseURL = usePreferencesStore((s) => s.lmstudioBaseURL);
   const mlxModelId = usePreferencesStore((s) => s.mlxModelId);
@@ -800,10 +811,7 @@ export default function App() {
       if (activeLeafId === null) return;
       const term = terminalRefs.current.get(activeLeafId);
       if (!term) return;
-      const quoted = path.includes(" ")
-        ? `'${path.replace(/'/g, `'\\''`)}'`
-        : path;
-      term.write(`cd ${quoted}\r`);
+      term.write(`cd ${quoteShellArg(path)}\r`);
       term.focus();
     },
     [activeLeafId],
@@ -817,10 +825,7 @@ export default function App() {
         if (!tab || tab.kind !== "terminal") return;
         const t = terminalRefs.current.get(tab.activeLeafId);
         if (!t) return;
-        const quoted = path.includes(" ")
-          ? `'${path.replace(/'/g, `'\\''`)}'`
-          : path;
-        t.write(`cd ${quoted}\r`);
+        t.write(`cd ${quoteShellArg(path)}\r`);
         t.focus();
       }, 80);
     },
@@ -1242,8 +1247,40 @@ export default function App() {
         openPreviewTab(url);
         return true;
       },
+      spawnManagedAgent: (prompt: string, sessionId: string) => {
+        const oneLine = prompt.replace(/\s*\r?\n\s*/g, " ").trim();
+        if (!oneLine) return null;
+        const cwd = findCwd();
+        const short = oneLine.length > 32 ? `${oneLine.slice(0, 32)}…` : oneLine;
+        const { tabId, leafId } = newAgentTab(cwd ?? undefined, `claude · ${short}`);
+        useManagedAgentsStore
+          .getState()
+          .register({ leafId, tabId, sessionId, task: oneLine, cwd });
+        // Claude reads settings.json at startup, so the review-loop hooks must
+        // be in place before the command runs. Best-effort: never block spawn.
+        const hooksReady = invoke("agent_enable_claude_hooks").catch(() => {});
+        void Promise.all([whenSessionReady(leafId), hooksReady]).then(() => {
+          if (writeToSession(leafId, `claude ${quoteShellArg(oneLine)}\r`)) {
+            useManagedAgentsStore.getState().setPhase(leafId, "working");
+          }
+        });
+        return { tabId, leafId };
+      },
+      readLeafBuffer: (leafId: number) => {
+        const buf = terminalRefs.current.get(leafId)?.getBuffer(300);
+        return buf ? redactSensitive(buf) : null;
+      },
     });
-  }, [setLive, activeId, tabs, explorerRoot, launchCwd, home, openPreviewTab]);
+  }, [
+    setLive,
+    activeId,
+    tabs,
+    explorerRoot,
+    launchCwd,
+    home,
+    openPreviewTab,
+    newAgentTab,
+  ]);
 
   const workspaceSurface = (
     <div className="relative h-full min-h-0">

--- a/src/lib/shellQuote.test.ts
+++ b/src/lib/shellQuote.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { quoteShellArg } from "./shellQuote";
+
+describe("quoteShellArg (posix)", () => {
+  const q = (s: string) => quoteShellArg(s, false);
+
+  it("wraps a plain string in single quotes", () => {
+    expect(q("fix the bug")).toBe("'fix the bug'");
+  });
+
+  it("escapes embedded single quotes with the '\\'' dance", () => {
+    expect(q("it's broken")).toBe("'it'\\''s broken'");
+  });
+
+  it("neutralizes shell metacharacters", () => {
+    expect(q("a; rm -rf / $(whoami) `id` && b")).toBe(
+      "'a; rm -rf / $(whoami) `id` && b'",
+    );
+  });
+
+  it("quotes an empty string to a real empty argument", () => {
+    expect(q("")).toBe("''");
+  });
+
+  it("cannot break out of the quoted argument", () => {
+    expect(q("'; rm -rf /; '")).toBe("''\\''; rm -rf /; '\\'''");
+  });
+});
+
+describe("quoteShellArg (windows/pwsh)", () => {
+  const q = (s: string) => quoteShellArg(s, true);
+
+  it("wraps a plain string in single quotes", () => {
+    expect(q("fix the bug")).toBe("'fix the bug'");
+  });
+
+  it("doubles embedded single quotes", () => {
+    expect(q("it's broken")).toBe("'it''s broken'");
+  });
+
+  it("keeps backticks and $ literal inside single quotes", () => {
+    expect(q("$env:PATH `n")).toBe("'$env:PATH `n'");
+  });
+
+  it("quotes an empty string", () => {
+    expect(q("")).toBe("''");
+  });
+});

--- a/src/lib/shellQuote.ts
+++ b/src/lib/shellQuote.ts
@@ -1,0 +1,8 @@
+import { IS_WINDOWS } from "./platform";
+
+export function quoteShellArg(value: string, windows = IS_WINDOWS): string {
+  if (windows) {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/modules/agents/components/AgentNotificationsBridge.tsx
+++ b/src/modules/agents/components/AgentNotificationsBridge.tsx
@@ -2,10 +2,12 @@ import type { Tab } from "@/modules/tabs";
 import { hasLeaf, leafIdForPty } from "@/modules/terminal";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
+import { maybeTriggerManagedReview } from "../lib/review";
 import { routeAgentNotification } from "../lib/route";
 import type { AgentSession, AgentSignal } from "../lib/types";
 import { useWindowFocus } from "../lib/useWindowFocus";
 import { useAgentStore } from "../store/agentStore";
+import { useManagedAgentsStore } from "../store/managedAgentsStore";
 
 type Activate = (tabId: number, leafId: number) => void;
 type Ctx = {
@@ -79,10 +81,12 @@ function handleSignal(sig: AgentSignal, ctx: Ctx): void {
       store.setStatus(leafId, "waiting");
       const session = store.sessions[leafId];
       if (session) route(session, "finished", ctx);
+      maybeTriggerManagedReview(leafId);
       return;
     }
     case "exited":
       store.finish(leafId);
+      useManagedAgentsStore.getState().remove(leafId);
       return;
   }
 }

--- a/src/modules/agents/lib/review.ts
+++ b/src/modules/agents/lib/review.ts
@@ -1,0 +1,58 @@
+import { getOrCreateChat, useChatStore } from "@/modules/ai/store/chatStore";
+import {
+  useManagedAgentsStore,
+  type ManagedAgent,
+} from "../store/managedAgentsStore";
+
+function buildReviewDirective(m: ManagedAgent): string {
+  const remaining = m.maxRounds - m.rounds;
+  const lastRound =
+    remaining <= 1
+      ? " This is the last automatic review round, so make any follow-up count."
+      : "";
+  return `The Claude Code agent you are supervising has finished its turn on:
+
+> ${m.task}
+
+Call read_agent_output to see what it actually did and reported. Then decide: if the task is complete, confirm it is done (do not call send_to_agent); otherwise call send_to_agent with one precise follow-up.${lastRound}`;
+}
+
+function canReview(m: ManagedAgent): boolean {
+  if (m.phase === "done") return false;
+  if (m.rounds >= m.maxRounds) return false;
+  if (m.reviewedAtRound >= m.rounds) return false;
+  return true;
+}
+
+function fireReview(m: ManagedAgent): void {
+  const store = useManagedAgentsStore.getState();
+  store.markReviewed(m.leafId);
+  store.setPhase(m.leafId, "reviewing");
+  const chat = getOrCreateChat(m.sessionId);
+  void chat.sendMessage({
+    role: "user",
+    parts: [{ type: "text", text: buildReviewDirective(m) }],
+  } as Parameters<typeof chat.sendMessage>[0]);
+}
+
+export function maybeTriggerManagedReview(leafId: number): void {
+  const store = useManagedAgentsStore.getState();
+  const m = store.get(leafId);
+  if (!m || !canReview(m)) return;
+  if (useChatStore.getState().activeSessionId !== m.sessionId) {
+    store.setPendingReview(leafId, true);
+    return;
+  }
+  fireReview(m);
+}
+
+export function firePendingReviewForSession(sessionId: string): void {
+  const store = useManagedAgentsStore.getState();
+  const m = store.getBySessionId(sessionId);
+  if (!m?.pendingReview) return;
+  if (!canReview(m)) {
+    store.setPendingReview(m.leafId, false);
+    return;
+  }
+  fireReview(m);
+}

--- a/src/modules/agents/store/managedAgentsStore.ts
+++ b/src/modules/agents/store/managedAgentsStore.ts
@@ -1,0 +1,113 @@
+import { create } from "zustand";
+
+export const DEFAULT_MAX_ROUNDS = 3;
+
+export type ManagedPhase = "spawning" | "working" | "reviewing" | "done";
+
+export type ManagedAgent = {
+  leafId: number;
+  tabId: number;
+  sessionId: string;
+  task: string;
+  cwd: string | null;
+  rounds: number;
+  maxRounds: number;
+  phase: ManagedPhase;
+  reviewedAtRound: number;
+  pendingReview: boolean;
+};
+
+type ManagedAgentsState = {
+  agents: Record<number, ManagedAgent>;
+  register: (a: {
+    leafId: number;
+    tabId: number;
+    sessionId: string;
+    task: string;
+    cwd: string | null;
+    maxRounds?: number;
+  }) => void;
+  setPhase: (leafId: number, phase: ManagedPhase) => void;
+  markReviewed: (leafId: number) => void;
+  setPendingReview: (leafId: number, pending: boolean) => void;
+  bumpRound: (leafId: number) => void;
+  remove: (leafId: number) => void;
+  get: (leafId: number) => ManagedAgent | undefined;
+  getBySessionId: (sessionId: string) => ManagedAgent | undefined;
+};
+
+export const useManagedAgentsStore = create<ManagedAgentsState>((set, get) => ({
+  agents: {},
+
+  register: ({ leafId, tabId, sessionId, task, cwd, maxRounds }) =>
+    set((s) => ({
+      agents: {
+        ...s.agents,
+        [leafId]: {
+          leafId,
+          tabId,
+          sessionId,
+          task,
+          cwd,
+          rounds: 0,
+          maxRounds: maxRounds ?? DEFAULT_MAX_ROUNDS,
+          phase: "spawning",
+          reviewedAtRound: -1,
+          pendingReview: false,
+        },
+      },
+    })),
+
+  setPhase: (leafId, phase) =>
+    set((s) => {
+      const a = s.agents[leafId];
+      if (!a || a.phase === phase) return s;
+      return { agents: { ...s.agents, [leafId]: { ...a, phase } } };
+    }),
+
+  markReviewed: (leafId) =>
+    set((s) => {
+      const a = s.agents[leafId];
+      if (!a) return s;
+      return {
+        agents: {
+          ...s.agents,
+          [leafId]: { ...a, reviewedAtRound: a.rounds, pendingReview: false },
+        },
+      };
+    }),
+
+  setPendingReview: (leafId, pending) =>
+    set((s) => {
+      const a = s.agents[leafId];
+      if (!a || a.pendingReview === pending) return s;
+      return {
+        agents: { ...s.agents, [leafId]: { ...a, pendingReview: pending } },
+      };
+    }),
+
+  bumpRound: (leafId) =>
+    set((s) => {
+      const a = s.agents[leafId];
+      if (!a) return s;
+      return {
+        agents: {
+          ...s.agents,
+          [leafId]: { ...a, rounds: a.rounds + 1, phase: "working" },
+        },
+      };
+    }),
+
+  remove: (leafId) =>
+    set((s) => {
+      if (!s.agents[leafId]) return s;
+      const next = { ...s.agents };
+      delete next[leafId];
+      return { agents: next };
+    }),
+
+  get: (leafId) => get().agents[leafId],
+
+  getBySessionId: (sessionId) =>
+    Object.values(get().agents).find((a) => a.sessionId === sessionId),
+}));

--- a/src/modules/ai/lib/slashCommands.ts
+++ b/src/modules/ai/lib/slashCommands.ts
@@ -1,4 +1,8 @@
-import { CheckListIcon, SparklesIcon } from "@hugeicons/core-free-icons";
+import {
+  CheckListIcon,
+  ClaudeIcon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons";
 import { usePlanStore } from "../store/planStore";
 
 /**
@@ -12,6 +16,20 @@ export type SlashOutcome =
   | { kind: "handled"; toast?: string }
   | { kind: "send-prompt"; prompt: string; commandName?: string }
   | { kind: "none" };
+
+function claudeCodeDirective(request: string): string {
+  return `The user wants to drive a Claude Code agent through you. Their request:
+
+<request>
+${request}
+</request>
+
+You are the orchestrator, not the implementer. Do not write the code yourself.
+1. Call read_agent_output to see whether a Claude Code agent is already active in this session.
+2. If none is active: turn the request into one clear, complete, self-contained prompt (state the concrete goal, relevant constraints, and what "done" looks like) and call spawn_coding_agent with it.
+3. If one is active: read its latest output, then craft a precise follow-up and call send_to_agent.
+Sharpen vague requests into precise engineering instructions; keep each agent prompt focused on one coherent unit of work.`;
+}
 
 const INIT_PROMPT = `Scan this workspace and produce TERAX.md at the workspace root with:
 
@@ -42,6 +60,12 @@ export const SLASH_COMMANDS: Record<string, SlashCommandMeta> = {
     invocation: "/plan",
     label: "Plan mode",
     icon: CheckListIcon,
+  },
+  "claude-code": {
+    name: "claude-code",
+    invocation: "/claude-code",
+    label: "Delegate to Claude Code",
+    icon: ClaudeIcon,
   },
 };
 
@@ -79,6 +103,16 @@ export function tryRunSlashCommand(input: string): SlashOutcome {
         kind: "send-prompt",
         prompt: INIT_PROMPT,
         commandName: "init",
+      };
+    }
+    case "claude-code": {
+      if (!tail) {
+        return { kind: "handled", toast: "Usage: /claude-code <request>" };
+      }
+      return {
+        kind: "send-prompt",
+        prompt: claudeCodeDirective(tail),
+        commandName: "claude-code",
       };
     }
     default:

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -41,6 +41,11 @@ type Live = {
   getWorkspaceRoot: () => string | null;
   getActiveFile: () => string | null;
   openPreview: (url: string) => boolean;
+  spawnManagedAgent: (
+    prompt: string,
+    sessionId: string,
+  ) => { tabId: number; leafId: number } | null;
+  readLeafBuffer: (leafId: number) => string | null;
 };
 
 export type AgentRunStatus =
@@ -159,6 +164,8 @@ const NOOP_LIVE: Live = {
   getWorkspaceRoot: () => null,
   getActiveFile: () => null,
   openPreview: () => false,
+  spawnManagedAgent: () => null,
+  readLeafBuffer: () => null,
 };
 
 const CHATS_LRU_CAP = 8;
@@ -219,6 +226,10 @@ function makeChat(sessionId: string): Chat<UIMessage> {
     injectIntoActivePty: (text) =>
       useChatStore.getState().live.injectIntoActivePty(text),
     openPreview: (url) => useChatStore.getState().live.openPreview(url),
+    spawnAgent: (prompt) =>
+      useChatStore.getState().live.spawnManagedAgent(prompt, sessionId),
+    readAgentOutput: (leafId) =>
+      useChatStore.getState().live.readLeafBuffer(leafId),
     readCache,
     getSessionId: () => sessionId,
   };

--- a/src/modules/ai/tools/agent.ts
+++ b/src/modules/ai/tools/agent.ts
@@ -1,0 +1,125 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { useManagedAgentsStore } from "@/modules/agents/store/managedAgentsStore";
+import { writeToSession } from "@/modules/terminal";
+import type { ToolContext } from "./context";
+
+// Claude Code's TUI treats a trailing CR in the same write chunk as the text
+// as a literal newline, not a submit. Send the Enter as a separate chunk once
+// the input has rendered so it registers as a standalone keypress.
+const SUBMIT_DELAY_MS = 90;
+
+function hasControlChars(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c < 0x20 || c === 0x7f) return true;
+  }
+  return false;
+}
+
+function tailLines(text: string, n: number): string {
+  const parts = text.split("\n");
+  return parts.length <= n ? text : parts.slice(parts.length - n).join("\n");
+}
+
+export function buildManagedAgentTools(ctx: ToolContext) {
+  return {
+    spawn_coding_agent: tool({
+      description:
+        "Spawn a Claude Code agent in a new terminal tab and give it the prompt. Use this when the user (via /claude-code) wants work delegated and no agent is active yet in this session. Craft a complete, self-contained prompt first; the user approves it before the agent starts. Do not call this if an agent is already active — use send_to_agent instead.",
+      inputSchema: z.object({
+        prompt: z
+          .string()
+          .min(1)
+          .describe(
+            "The full, self-contained task prompt for the Claude Code agent.",
+          ),
+      }),
+      needsApproval: true,
+      execute: async ({ prompt }) => {
+        const sessionId = ctx.getSessionId();
+        if (!sessionId) return { error: "no active chat session" };
+        const store = useManagedAgentsStore.getState();
+        if (store.getBySessionId(sessionId)) {
+          return {
+            error:
+              "a Claude Code agent is already active in this session; use send_to_agent to give it more work",
+          };
+        }
+        const spawned = ctx.spawnAgent(prompt);
+        if (!spawned) return { error: "could not spawn the agent" };
+        return {
+          ok: true,
+          tab_id: spawned.tabId,
+          message: "Claude Code agent spawned. It will start working shortly.",
+        };
+      },
+    }),
+
+    send_to_agent: tool({
+      description:
+        "Send a follow-up instruction to the active Claude Code agent in this session. Use after reviewing its output to request fixes or the next unit of work. The instruction is typed into the agent's prompt and submitted once the user approves. Read its latest output first so the follow-up is informed.",
+      inputSchema: z.object({
+        instruction: z
+          .string()
+          .min(1)
+          .describe(
+            "One clear, self-contained instruction for the agent. No control characters.",
+          ),
+      }),
+      needsApproval: true,
+      execute: async ({ instruction }) => {
+        const sessionId = ctx.getSessionId();
+        const store = useManagedAgentsStore.getState();
+        const managed = sessionId ? store.getBySessionId(sessionId) : undefined;
+        if (!managed) {
+          return {
+            error:
+              "no Claude Code agent is active in this session; spawn one with spawn_coding_agent",
+          };
+        }
+        const oneLine = instruction.replace(/\s*\r?\n\s*/g, " ").trim();
+        if (!oneLine) return { error: "empty instruction" };
+        if (hasControlChars(oneLine)) {
+          return { error: "instruction contains control characters" };
+        }
+        if (!writeToSession(managed.leafId, oneLine)) {
+          store.remove(managed.leafId);
+          return { error: "agent terminal is no longer available (closed?)" };
+        }
+        setTimeout(() => writeToSession(managed.leafId, "\r"), SUBMIT_DELAY_MS);
+        store.bumpRound(managed.leafId);
+        return { ok: true, sent: oneLine, round: store.get(managed.leafId)?.rounds };
+      },
+    }),
+
+    read_agent_output: tool({
+      description:
+        "Inspect the Claude Code agent in this session: whether one is active, its status, and the tail of its terminal output. Call this first when handling a /claude-code request so you know whether to spawn a new agent or follow up with the existing one, and to see what it has done and reported.",
+      inputSchema: z.object({
+        lines: z
+          .number()
+          .int()
+          .min(1)
+          .max(400)
+          .optional()
+          .describe("Trailing lines of the agent terminal to return. Default 120."),
+      }),
+      execute: async ({ lines }) => {
+        const sessionId = ctx.getSessionId();
+        const managed = sessionId
+          ? useManagedAgentsStore.getState().getBySessionId(sessionId)
+          : undefined;
+        if (!managed) return { active: false };
+        const raw = ctx.readAgentOutput(managed.leafId);
+        return {
+          active: true,
+          phase: managed.phase,
+          rounds: managed.rounds,
+          max_rounds: managed.maxRounds,
+          output: raw ? tailLines(raw, lines ?? 120) : "",
+        };
+      },
+    }),
+  } as const;
+}

--- a/src/modules/ai/tools/context.ts
+++ b/src/modules/ai/tools/context.ts
@@ -13,6 +13,10 @@ export type ToolContext = {
   injectIntoActivePty: (text: string) => boolean;
   /** Open a new preview tab (in-app iframe) at the given URL. */
   openPreview: (url: string) => boolean;
+  /** Spawn a Claude Code agent in a new terminal tab, bound to this session. */
+  spawnAgent: (prompt: string) => { tabId: number; leafId: number } | null;
+  /** Read the terminal scrollback tail of a managed agent's leaf. */
+  readAgentOutput: (leafId: number) => string | null;
   readCache: Map<string, { size: number; hash: number }>;
   /** Active chat session id — used by tools that persist per-session state (todos). */
   getSessionId: () => string | null;

--- a/src/modules/ai/tools/tools.ts
+++ b/src/modules/ai/tools/tools.ts
@@ -1,3 +1,4 @@
+import { buildManagedAgentTools } from "./agent";
 import { buildEditTools } from "./edit";
 import { buildFsTools } from "./fs";
 import { buildSearchTools } from "./search";
@@ -36,6 +37,7 @@ export function buildTools(ctx: import("./context").ToolContext) {
     ...buildSubagentTools(ctx),
     ...buildTerminalTools(ctx),
     ...buildTodoTools(ctx),
+    ...buildManagedAgentTools(ctx),
   } as const;
 }
 

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -173,6 +173,27 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return tabId;
   }, []);
 
+  const newAgentTab = useCallback(
+    (cwd: string | undefined, title: string) => {
+      const tabId = nextIdRef.current++;
+      const leafId = nextIdRef.current++;
+      setTabs((t) => [
+        ...t,
+        {
+          id: tabId,
+          kind: "terminal",
+          title,
+          cwd,
+          paneTree: { kind: "leaf", id: leafId, cwd },
+          activeLeafId: leafId,
+        },
+      ]);
+      setActiveId(tabId);
+      return { tabId, leafId };
+    },
+    [],
+  );
+
   const newPrivateTab = useCallback((cwd?: string) => {
     const tabId = nextIdRef.current++;
     const leafId = nextIdRef.current++;
@@ -778,6 +799,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     activeId,
     setActiveId,
     newTab,
+    newAgentTab,
     newPrivateTab,
     openFileTab,
     pinTab,

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -4,6 +4,8 @@ export {
   disposeSession,
   leafIdForPty,
   respawnSession,
+  whenSessionReady,
+  writeToSession,
 } from "./lib/useTerminalSession";
 export {
   findLeafCwd,

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -58,6 +58,46 @@ type Session = {
 
 const sessions = new Map<number, Session>();
 
+const readyLeaves = new Set<number>();
+const readyWaiters = new Map<
+  number,
+  { resolve: () => void; timer: ReturnType<typeof setTimeout> }[]
+>();
+
+function markSessionReady(leafId: number): void {
+  if (readyLeaves.has(leafId)) return;
+  readyLeaves.add(leafId);
+  const waiters = readyWaiters.get(leafId);
+  if (!waiters) return;
+  readyWaiters.delete(leafId);
+  for (const w of waiters) {
+    clearTimeout(w.timer);
+    w.resolve();
+  }
+}
+
+export function whenSessionReady(leafId: number, timeoutMs = 4000): Promise<void> {
+  if (readyLeaves.has(leafId)) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      const arr = readyWaiters.get(leafId);
+      const i = arr?.findIndex((w) => w.timer === timer) ?? -1;
+      if (arr && i >= 0) arr.splice(i, 1);
+      resolve();
+    }, timeoutMs);
+    const arr = readyWaiters.get(leafId) ?? [];
+    arr.push({ resolve, timer });
+    readyWaiters.set(leafId, arr);
+  });
+}
+
+export function writeToSession(leafId: number, data: string): boolean {
+  const s = sessions.get(leafId);
+  if (!s || !s.pty) return false;
+  void s.pty.write(data);
+  return true;
+}
+
 export function leafIdForPty(ptyId: number): number | null {
   for (const [leafId, s] of sessions) {
     if (s.pty?.id === ptyId) return leafId;
@@ -194,6 +234,7 @@ function bindLeafToSlot(leafId: number, s: Session): void {
       const cwd = registerCwdHandler(
         term,
         (next) => {
+          markSessionReady(leafId);
           if (s.lastCwd === next) return;
           s.lastCwd = next;
           s.callbacks.onCwd?.(next);
@@ -313,6 +354,15 @@ export function disposeSession(leafId: number): void {
   s.pty?.close();
   s.pty = null;
   sessions.delete(leafId);
+  readyLeaves.delete(leafId);
+  const waiters = readyWaiters.get(leafId);
+  if (waiters) {
+    readyWaiters.delete(leafId);
+    for (const w of waiters) {
+      clearTimeout(w.timer);
+      w.resolve();
+    }
+  }
 }
 
 type Options = {


### PR DESCRIPTION
Adds a `/claude-code` slash command to drive Claude Code agents through the Terax AI agent.