### PR TITLE
feat(terminal): insert dropped file paths into the active terminal pane

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -60,6 +60,7 @@ import {
   respawnSession,
   TerminalStack,
   type TerminalPaneHandle,
+  useTerminalFileDrop,
 } from "@/modules/terminal";
 import { ThemeProvider } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
@@ -121,6 +122,7 @@ export default function App() {
   const [activeEditorHandle, setActiveEditorHandle] =
     useState<EditorPaneHandle | null>(null);
   const { zoomIn, zoomOut, zoomReset } = useZoom();
+  useTerminalFileDrop();
   const explorerRef = useRef<FileExplorerHandle>(null);
   const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
 

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -4,6 +4,7 @@ export {
   disposeSession,
   respawnSession,
 } from "./lib/useTerminalSession";
+export { useTerminalFileDrop } from "./lib/useTerminalFileDrop";
 export {
   hasLeaf,
   isLeaf,

--- a/src/modules/terminal/lib/quoteShellPath.ts
+++ b/src/modules/terminal/lib/quoteShellPath.ts
@@ -1,0 +1,13 @@
+import { IS_WINDOWS } from "@/lib/platform";
+
+/** Shell-quote an absolute path for pasting into a live terminal prompt. */
+export function quoteShellPath(p: string): string {
+  if (IS_WINDOWS) return `"${p.replace(/"/g, '""')}"`;
+  return `'${p.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Joined, shell-quoted paths with a trailing space so the cursor lands
+ * ready for the next argument. */
+export function formatDroppedPaths(paths: string[]): string {
+  return `${paths.map(quoteShellPath).join(" ")} `;
+}

--- a/src/modules/terminal/lib/useTerminalFileDrop.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.ts
@@ -1,0 +1,44 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { useEffect } from "react";
+import { formatDroppedPaths } from "./quoteShellPath";
+import { writeToLeafPty } from "./useTerminalSession";
+
+/** Wires native OS file drops into the terminal pane under the cursor.
+ * Drops outside any terminal leaf (editor, file explorer, AI input bar,
+ * tabbar, etc.) are intentionally ignored. */
+export function useTerminalFileDrop(): void {
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+
+    void getCurrentWebview()
+      .onDragDropEvent((e) => {
+        if (e.payload.type !== "drop") return;
+        const paths = e.payload.paths;
+        if (!paths.length) return;
+
+        // Tauri reports PhysicalPosition; elementFromPoint expects CSS px.
+        const dpr = window.devicePixelRatio || 1;
+        const x = e.payload.position.x / dpr;
+        const y = e.payload.position.y / dpr;
+        const el = document.elementFromPoint(x, y);
+        const leafEl = el?.closest<HTMLElement>("[data-pane-leaf]");
+        if (!leafEl) return;
+
+        const leafId = Number(leafEl.dataset.paneLeaf);
+        if (!Number.isFinite(leafId)) return;
+
+        writeToLeafPty(leafId, formatDroppedPaths(paths));
+      })
+      .then((fn) => {
+        if (disposed) fn();
+        else unlisten = fn;
+      })
+      .catch((err) => console.error("[terax] drag-drop listen failed:", err));
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -275,6 +275,13 @@ export function disposeSession(leafId: number): void {
   sessions.delete(leafId);
 }
 
+export function writeToLeafPty(leafId: number, data: string): boolean {
+  const s = sessions.get(leafId);
+  if (!s || s.disposed || s.shellExited || !s.pty) return false;
+  s.pty.write(data);
+  return true;
+}
+
 type Options = {
   leafId: number;
   container: React.RefObject<HTMLDivElement | null>;


### PR DESCRIPTION
## Summary
- Subscribe to Tauri's `onDragDropEvent` and route OS-level file drops to the terminal leaf under the cursor, writing shell-quoted absolute paths to its PTY (iTerm2/Terminal.app style).
- Drops outside a terminal pane (editor, file explorer, AI input bar, tabbar) are intentionally a no-op for now — the listener uses the existing `data-pane-leaf` attribute (`PaneTreeView.tsx`) to detect the drop target without adding new DOM markers.
- POSIX paths get single-quote-wrapped with `'` escaped as `'\''`; Windows paths get double-quote-wrapped with `"` doubled. Multiple files are space-separated with a trailing space so the cursor lands ready for the next argument.

## Files
- `src/modules/terminal/lib/useTerminalSession.ts` — add module-level `writeToLeafPty(leafId, data)` alongside the existing `disposeSession` / `respawnSession` helpers.
- `src/modules/terminal/lib/quoteShellPath.ts` (new) — `quoteShellPath` + `formatDroppedPaths`, reusing `IS_WINDOWS` from `@/lib/platform`.
- `src/modules/terminal/lib/useTerminalFileDrop.ts` (new) — hook that wires the webview drag-drop event to the right leaf's PTY.
- `src/modules/terminal/index.ts` — export the new hook.
- `src/app/App.tsx` — call `useTerminalFileDrop()` once.

No Tauri config changes needed — `dragDropEnabled` was already on by default; we were just dropping the event on the floor.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Plain path file dropped into terminal → quoted absolute path appears at the prompt with trailing space
- [x] Path with spaces (`~/Library/Application Support/...`) → wrapped in single quotes, shell doesn't word-split
- [x] Multiple files dropped together → space-separated quoted paths
- [x] Drop on editor pane → no reaction
- [x] Drop on file explorer pane → no reaction
- [x] Drop on tabbar (terminal tab area but outside the pane content) → no reaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)