### PR TITLE
feat(terminal): macOS line/word readline bindings (Cmd+Arrow, Cmd/Opt+Backspace)

### DIFF
--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -1,41 +1,137 @@
 import { describe, expect, it } from "vitest";
 
-import { terminalWordNavigationSequence } from "./keymap";
+import {
+  terminalDeleteSequence,
+  terminalLineNavigationSequence,
+  terminalWordNavigationSequence,
+  type TerminalKeyEvent,
+} from "./keymap";
+
+const evt = (partial: Partial<TerminalKeyEvent>): TerminalKeyEvent => ({
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  key: "",
+  code: "",
+  ...partial,
+});
 
 describe("terminalWordNavigationSequence", () => {
   it("maps Option+Left to readline word-left", () => {
     expect(
-      terminalWordNavigationSequence({
-        altKey: true,
-        ctrlKey: false,
-        metaKey: false,
-        key: "ArrowLeft",
-        code: "ArrowLeft",
-      }),
+      terminalWordNavigationSequence(
+        evt({ altKey: true, key: "ArrowLeft", code: "ArrowLeft" }),
+      ),
     ).toBe("\x1bb");
   });
 
   it("maps Option+Right to readline word-right", () => {
     expect(
-      terminalWordNavigationSequence({
-        altKey: true,
-        ctrlKey: false,
-        metaKey: false,
-        key: "ArrowRight",
-        code: "ArrowRight",
-      }),
+      terminalWordNavigationSequence(
+        evt({ altKey: true, key: "ArrowRight", code: "ArrowRight" }),
+      ),
     ).toBe("\x1bf");
   });
 
   it("does not remap plain arrows", () => {
     expect(
-      terminalWordNavigationSequence({
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        key: "ArrowLeft",
-        code: "ArrowLeft",
-      }),
+      terminalWordNavigationSequence(
+        evt({ key: "ArrowLeft", code: "ArrowLeft" }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("terminalLineNavigationSequence", () => {
+  it("maps Cmd+Left to readline line-start on macOS", () => {
+    expect(
+      terminalLineNavigationSequence(
+        evt({ metaKey: true, key: "ArrowLeft", code: "ArrowLeft" }),
+        { isMac: true },
+      ),
+    ).toBe("\x01");
+  });
+
+  it("maps Cmd+Right to readline line-end on macOS", () => {
+    expect(
+      terminalLineNavigationSequence(
+        evt({ metaKey: true, key: "ArrowRight", code: "ArrowRight" }),
+        { isMac: true },
+      ),
+    ).toBe("\x05");
+  });
+
+  it("does not remap Cmd+Arrow off macOS", () => {
+    expect(
+      terminalLineNavigationSequence(
+        evt({ metaKey: true, key: "ArrowLeft", code: "ArrowLeft" }),
+        { isMac: false },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not remap Cmd+Option+Arrow (selection-style combos pass through)", () => {
+    expect(
+      terminalLineNavigationSequence(
+        evt({ metaKey: true, altKey: true, key: "ArrowLeft", code: "ArrowLeft" }),
+        { isMac: true },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("terminalDeleteSequence", () => {
+  it("maps Cmd+Backspace to kill-to-line-start on macOS", () => {
+    expect(
+      terminalDeleteSequence(
+        evt({ metaKey: true, key: "Backspace", code: "Backspace" }),
+        { isMac: true },
+      ),
+    ).toBe("\x15");
+  });
+
+  it("maps Option+Backspace to kill-word-backward on macOS", () => {
+    expect(
+      terminalDeleteSequence(
+        evt({ altKey: true, key: "Backspace", code: "Backspace" }),
+        { isMac: true },
+      ),
+    ).toBe("\x17");
+  });
+
+  it("maps Ctrl+Backspace to kill-word-backward off macOS", () => {
+    expect(
+      terminalDeleteSequence(
+        evt({ ctrlKey: true, key: "Backspace", code: "Backspace" }),
+        { isMac: false },
+      ),
+    ).toBe("\x17");
+  });
+
+  it("does not remap Ctrl+Backspace on macOS (reserved for native readline binding)", () => {
+    expect(
+      terminalDeleteSequence(
+        evt({ ctrlKey: true, key: "Backspace", code: "Backspace" }),
+        { isMac: true },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not remap Cmd+Backspace off macOS", () => {
+    expect(
+      terminalDeleteSequence(
+        evt({ metaKey: true, key: "Backspace", code: "Backspace" }),
+        { isMac: false },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not remap plain Backspace", () => {
+    expect(
+      terminalDeleteSequence(
+        evt({ key: "Backspace", code: "Backspace" }),
+        { isMac: true },
+      ),
     ).toBeNull();
   });
 });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -3,9 +3,43 @@ export type TerminalKeyEvent = Pick<
   "altKey" | "ctrlKey" | "metaKey" | "key" | "code"
 >;
 
+export type PlatformOpts = { isMac: boolean };
+
 export function terminalWordNavigationSequence(event: TerminalKeyEvent): string | null {
   if (!event.altKey || event.ctrlKey || event.metaKey) return null;
   if (event.key === "ArrowLeft" || event.code === "ArrowLeft") return "\x1bb";
   if (event.key === "ArrowRight" || event.code === "ArrowRight") return "\x1bf";
+  return null;
+}
+
+/** Cmd+Left/Right → readline line-start (Ctrl+A) / line-end (Ctrl+E).
+ * macOS-only — Cmd doesn't exist as a navigation modifier elsewhere. */
+export function terminalLineNavigationSequence(
+  event: TerminalKeyEvent,
+  opts: PlatformOpts,
+): string | null {
+  if (!opts.isMac) return null;
+  if (!event.metaKey || event.altKey || event.ctrlKey) return null;
+  if (event.key === "ArrowLeft" || event.code === "ArrowLeft") return "\x01";
+  if (event.key === "ArrowRight" || event.code === "ArrowRight") return "\x05";
+  return null;
+}
+
+/** Modifier+Backspace deletion:
+ *   macOS  Cmd+Backspace    → Ctrl+U (kill-to-line-start)
+ *   macOS  Option+Backspace → Ctrl+W (kill-word-backward)
+ *   Other  Ctrl+Backspace   → Ctrl+W (kill-word-backward)
+ */
+export function terminalDeleteSequence(
+  event: TerminalKeyEvent,
+  opts: PlatformOpts,
+): string | null {
+  if (event.key !== "Backspace" && event.code !== "Backspace") return null;
+  if (opts.isMac) {
+    if (event.metaKey && !event.altKey && !event.ctrlKey) return "\x15";
+    if (event.altKey && !event.metaKey && !event.ctrlKey) return "\x17";
+    return null;
+  }
+  if (event.ctrlKey && !event.altKey && !event.metaKey) return "\x17";
   return null;
 }

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -8,7 +8,11 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
-import { terminalWordNavigationSequence } from "./keymap";
+import {
+  terminalDeleteSequence,
+  terminalLineNavigationSequence,
+  terminalWordNavigationSequence,
+} from "./keymap";
 
 export const POOL_MAX_SIZE = 5;
 const FIT_DEBOUNCE_MS = 8;
@@ -160,15 +164,24 @@ function createSlot(): Slot {
     if (leafId === null) return false;
     const bridge = adapter?.resolveLeaf(leafId);
     if (!bridge) return true;
+    const lineNavigation = terminalLineNavigationSequence(event, {
+      isMac: IS_MAC,
+    });
+    if (lineNavigation) {
+      event.preventDefault();
+      if (event.type === "keydown") bridge.writeToPty(lineNavigation);
+      return false;
+    }
     const wordNavigation = terminalWordNavigationSequence(event);
     if (wordNavigation) {
       event.preventDefault();
       if (event.type === "keydown") bridge.writeToPty(wordNavigation);
       return false;
     }
-    if (isCtrlBackspace(event)) {
+    const deleteSeq = terminalDeleteSequence(event, { isMac: IS_MAC });
+    if (deleteSeq) {
       event.preventDefault();
-      if (event.type === "keydown") bridge.writeToPty("\x17");
+      if (event.type === "keydown") bridge.writeToPty(deleteSeq);
       return false;
     }
     if (isShiftEnter(event)) {
@@ -702,13 +715,6 @@ function isTerminalPaste(e: KeyboardEvent): boolean {
     !e.metaKey &&
     (e.code === "KeyV" || e.key === "v" || e.key === "V")
   );
-}
-
-function isCtrlBackspace(e: KeyboardEvent): boolean {
-  const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
-  const isMac = /Mac|iPhone|iPad/.test(ua);
-  const mod = isMac ? e.metaKey : e.ctrlKey;
-  return mod && (e.key === "Backspace" || e.code === "Backspace");
 }
 
 function isShiftEnter(e: KeyboardEvent): boolean {


### PR DESCRIPTION
## Summary

Brings the terminal's macOS key handling in line with Terminal.app / iTerm2 defaults so command-line editing feels native.

| Key                  | Was      | Now                  | Readline                |
| -------------------- | -------- | -------------------- | ----------------------- |
| **Cmd + Left**       | (no-op)  | `\x01` (Ctrl+A)      | beginning-of-line       |
| **Cmd + Right**      | (no-op)  | `\x05` (Ctrl+E)      | end-of-line             |
| **Cmd + Backspace**  | `\x17`   | `\x15` (Ctrl+U)      | unix-line-discard       |
| **Option + Backspace** | (no-op) | `\x17` (Ctrl+W)      | unix-word-rubout        |

Linux / Windows behavior is unchanged — `Ctrl + Backspace` still sends `\x17` (kill word backward).

The one **behavior change**: `Cmd + Backspace` on macOS used to delete a single word (`\x17`) and now deletes to the line start (`\x15`). That matches Terminal.app and iTerm2 defaults — the word-delete on macOS belongs to `Option + Backspace`, which this PR also adds.

## Implementation

- Extends `src/modules/terminal/lib/keymap.ts` with two new pure functions: `terminalLineNavigationSequence(event, { isMac })` and `terminalDeleteSequence(event, { isMac })`. Both follow the existing `terminalWordNavigationSequence` style — `TerminalKeyEvent` input, `string | null` output, no side effects, easy to unit-test.
- `src/modules/terminal/lib/rendererPool.ts`'s `attachCustomKeyEventHandler` now consults all three keymap functions in sequence; removed the inline `isCtrlBackspace` (its userAgent sniffing was duplicated logic) — the local `IS_MAC` constant is reused.
- Added vitest coverage for the new functions, including off-platform / wrong-modifier negative cases, and refactored the existing test setup to share a small `evt()` helper.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test src/modules/terminal/lib/keymap.test.ts` — 13/13 pass
- [ ] macOS: in a bash/zsh prompt with some text typed, verify Cmd+Left/Right jump to start/end of line
- [ ] macOS: Cmd+Backspace clears the whole current line; Option+Backspace removes the previous word
- [ ] macOS: Option+Left/Right still does word navigation (unchanged)
- [ ] Linux/Windows: Ctrl+Backspace still deletes the previous word (unchanged)
- [ ] All platforms: Shift+Enter, Ctrl+Shift+C/V copy/paste unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)