### PR TITLE
feat(terminal): zsh Option+Right stops at word-end, matching Warp/iTerm2

### DIFF
--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -55,6 +55,16 @@ if [[ -z "$__TERAX_HOOKS_LOADED" ]]; then
     add-zsh-hook preexec _terax_preexec
   fi
 
+  # Warp/iTerm2-style word-end navigation: zsh's default `forward-word` (M-f /
+  # Option+Right) overshoots to the START of the next word; `emacs-forward-word`
+  # stops at the END of the current word, which is what nearly every other shell
+  # and GUI editor does. Only rebind when the binding is still the stock zsh
+  # default — respects any explicit remap in the user's .zshrc.
+  if (( $+widgets[emacs-forward-word] )) \
+     && [[ "$(bindkey '\ef')" == '"^[f" forward-word' ]]; then
+    bindkey '\ef' emacs-forward-word
+  fi
+
   _terax_precmd
 fi
 :


### PR DESCRIPTION
## Summary

Users coming from Warp / iTerm2 / Terminal.app expect `Option + →` to land at the **end of the current word** (cursor between the last letter and the trailing space). Today, on macOS's default shell (zsh), pressing it from `he│llo world` lands at `hello │world` instead of `hello│ world` — one position too far. This PR fixes that for zsh while leaving every other shell alone, because they're already correct.

## Shell-by-shell analysis

| Shell        | Default `M-f` behavior                                | Action       |
| ------------ | ----------------------------------------------------- | ------------ |
| **bash**     | `forward-word` → end of current/next word             | ✓ unchanged  |
| **zsh**      | `forward-word` → **start of next word** (overshoots)  | ✗ rebound    |
| **fish**     | `forward-word` → "stops after the end of current word" (per `bind` docs) | ✓ unchanged  |
| **PowerShell / PSReadLine** | `ForwardWord` → end of current/next word | ✓ unchanged  |

`M-b` (Option+Left) is "to start of current/previous word" in all four shells by default, which is already the expected behavior — no changes there.

## Implementation

One block added inside `src-tauri/src/modules/pty/scripts/zshrc.zsh`, guarded so it only fires once per shell and only when the binding is still the stock default — respects any explicit `bindkey '\ef' ...` in the user's own `.zshrc`:

```zsh
if (( $+widgets[emacs-forward-word] )) \
   && [[ "$(bindkey '\ef')" == '"^[f" forward-word' ]]; then
  bindkey '\ef' emacs-forward-word
fi
```

`emacs-forward-word` is a zsh-builtin widget that moves to the end of the next word (per `man zshzle`). The widget-existence check protects against extremely old zsh builds.

Scope is intentionally narrow:
- Only zsh, since the other three shells are already correct.
- Only `M-f` (forward) — backward direction is unchanged and already correct.
- Doesn't touch any other shell init files (`zshenv` / `zprofile` / `zlogin` / `bashrc` / `init.fish` / `profile.ps1`).
- Doesn't alter what the terminal emulator sends for Option+Right — still `\x1bf`, just like before.

## Test plan
- [ ] macOS, zsh: type `hello world`, place cursor inside `hello`, press Option+→ — cursor should land on `hello│ world` (right of `o`, left of space), not on `hello │world`.
- [ ] macOS, zsh: a user with `bindkey '\ef' vi-forward-word-end` (or anything else) in their `.zshrc` should keep their override — Terax does not clobber it.
- [ ] macOS, bash: `Option + →` behavior unchanged.
- [ ] macOS, fish: `Option + →` behavior unchanged.
- [ ] Windows, PowerShell: `Alt + F` behavior unchanged.
- [ ] `Option + ←` still lands at the start of the current/previous word in every shell (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)