### PR TITLE
feat(preview): PlantUML diagram preview

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, fs, git, net, plantuml, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_window_state::StateFlags;
@@ -185,6 +185,8 @@ pub fn run() {
             net::lm_ping,
             net::ai_http_request,
             net::ai_http_stream,
+            plantuml::plantuml_fetch_svg,
+            plantuml::plantuml_render_local,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod fs;
 pub mod git;
 pub mod net;
+pub mod plantuml;
 pub mod proc;
 pub mod pty;
 pub mod secrets;

--- a/src-tauri/src/modules/plantuml.rs
+++ b/src-tauri/src/modules/plantuml.rs
@@ -1,0 +1,130 @@
+use serde::Serialize;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[derive(Debug, Serialize)]
+pub struct PlantUmlResult {
+    pub svg: Option<String>,
+    pub error: Option<String>,
+}
+
+const DEFAULT_SERVER: &str = "https://www.plantuml.com/plantuml/svg/";
+const FETCH_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_OUTPUT_BYTES: usize = 256 * 1024;
+
+#[tauri::command]
+pub async fn plantuml_fetch_svg(
+    encoded: String,
+    server_url: Option<String>,
+) -> Result<String, String> {
+    let base = server_url
+        .as_deref()
+        .unwrap_or(DEFAULT_SERVER)
+        .trim_end_matches('/');
+    let url = format!("{base}/{encoded}");
+
+    let parsed = reqwest::Url::parse(&url).map_err(|e| format!("invalid url: {e}"))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        s => return Err(format!("scheme not allowed: {s}")),
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "missing host".to_string())?;
+    if host.is_empty() {
+        return Err("empty host".into());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client
+        .get(parsed)
+        .send()
+        .await
+        .map_err(|e| format!("fetch failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("server returned {}", resp.status()));
+    }
+
+    let bytes = resp.bytes().await.map_err(|e| e.to_string())?;
+    if bytes.len() > MAX_OUTPUT_BYTES {
+        return Err(format!(
+            "response too large: {} bytes (limit {})",
+            bytes.len(),
+            MAX_OUTPUT_BYTES
+        ));
+    }
+
+    String::from_utf8(bytes.to_vec()).map_err(|e| format!("invalid utf8 in response: {e}"))
+}
+
+#[tauri::command]
+pub async fn plantuml_render_local(
+    diagram_text: String,
+    jar_path: String,
+    java_path: Option<String>,
+) -> Result<PlantUmlResult, String> {
+    let jar = Path::new(&jar_path);
+    if !jar.exists() {
+        return Err(format!("jar not found: {jar_path}"));
+    }
+    if jar.extension().and_then(|e| e.to_str()) != Some("jar") {
+        return Err("jar_path must end with .jar".into());
+    }
+
+    let java = java_path.unwrap_or_else(|| "java".into());
+
+    tokio::task::spawn_blocking(move || {
+        let mut child = Command::new(&java)
+            .arg("-jar")
+            .arg(&jar_path)
+            .arg("-tsvg")
+            .arg("-pipe")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("failed to spawn java: {e}"))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(diagram_text.as_bytes())
+                .map_err(|e| format!("stdin write failed: {e}"))?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| format!("process error: {e}"))?;
+
+        let stdout_len = output.stdout.len();
+        let stderr_len = output.stderr.len();
+
+        if stdout_len > MAX_OUTPUT_BYTES || stderr_len > MAX_OUTPUT_BYTES {
+            return Err(format!(
+                "output too large: stdout={stdout_len}, stderr={stderr_len}"
+            ));
+        }
+
+        let svg = if output.stdout.is_empty() {
+            None
+        } else {
+            Some(String::from_utf8_lossy(&output.stdout).into_owned())
+        };
+
+        let error = if output.stderr.is_empty() {
+            None
+        } else {
+            Some(String::from_utf8_lossy(&output.stderr).into_owned())
+        };
+
+        Ok(PlantUmlResult { svg, error })
+    })
+    .await
+    .map_err(|e| format!("task join error: {e}"))?
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,6 +62,7 @@ import {
   type SearchTarget,
 } from "@/modules/header";
 import { MarkdownStack } from "@/modules/markdown";
+import { PlantUmlStack } from "@/modules/plantuml";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -171,6 +172,7 @@ export default function App() {
     pinTab,
     newPreviewTab,
     newMarkdownTab,
+    newPlantUmlTab,
     openAiDiffTab,
     closeAiDiffTab,
     openGitDiffTab,
@@ -462,6 +464,7 @@ export default function App() {
   const isEditorTab = activeTab?.kind === "editor";
   const isPreviewTab = activeTab?.kind === "preview";
   const isMarkdownTab = activeTab?.kind === "markdown";
+  const isPlantUmlTab = activeTab?.kind === "plantuml";
   const isAiDiffTab = activeTab?.kind === "ai-diff";
   const isGitDiffTab =
     activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
@@ -994,6 +997,13 @@ export default function App() {
     [newMarkdownTab],
   );
 
+  const openPlantUmlPreview = useCallback(
+    (path: string) => {
+      newPlantUmlTab(path);
+    },
+    [newPlantUmlTab],
+  );
+
   const splitActivePaneInActiveTab = useCallback(
     (dir: "row" | "col") => {
       const t = tabsRef.current.find((x) => x.id === activeId);
@@ -1342,6 +1352,15 @@ export default function App() {
       <div
         className={cn(
           "absolute inset-0 px-3 pt-2 pb-2",
+          !isPlantUmlTab && "invisible pointer-events-none",
+        )}
+        aria-hidden={!isPlantUmlTab}
+      >
+        <PlantUmlStack tabs={tabs} activeId={activeId} />
+      </div>
+      <div
+        className={cn(
+          "absolute inset-0 px-3 pt-2 pb-2",
           !isAiDiffTab && "invisible pointer-events-none",
         )}
         aria-hidden={!isAiDiffTab}
@@ -1436,6 +1455,7 @@ export default function App() {
                         onRevealInTerminal={cdInNewTab}
                         onAttachToAgent={handleAttachFileToAgent}
                         onOpenMarkdownPreview={openMarkdownPreview}
+                        onOpenPlantUmlPreview={openPlantUmlPreview}
                       />
                     ) : (
                       <SourceControlPanel

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -46,6 +46,7 @@ type Props = {
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
+  onOpenPlantUmlPreview?: (path: string) => void;
 };
 
 type Row =
@@ -153,6 +154,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       onRevealInTerminal,
       onAttachToAgent,
       onOpenMarkdownPreview,
+      onOpenPlantUmlPreview,
     },
     ref,
   ) {
@@ -343,6 +345,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
               onRevealInTerminal={onRevealInTerminal}
               onAttachToAgent={onAttachToAgent}
               onOpenMarkdownPreview={onOpenMarkdownPreview}
+              onOpenPlantUmlPreview={onOpenPlantUmlPreview}
             />
           );
         }

--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -18,6 +18,7 @@ import {
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import type { useFileTree } from "./lib/useFileTree";
+import { isPlantUmlPath } from "@/modules/plantuml";
 
 type Tree = ReturnType<typeof useFileTree>;
 
@@ -36,6 +37,7 @@ export type EntryRowProps = {
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
+  onOpenPlantUmlPreview?: (path: string) => void;
 };
 
 function isMarkdownPath(path: string): boolean {
@@ -58,6 +60,7 @@ function EntryRowImpl(props: EntryRowProps) {
     onRevealInTerminal,
     onAttachToAgent,
     onOpenMarkdownPreview,
+    onOpenPlantUmlPreview,
   } = props;
 
   const [isConfirming, setIsConfirming] = useState(false);
@@ -144,6 +147,14 @@ function EntryRowImpl(props: EntryRowProps) {
           <ContextMenuItem
             className={COMPACT_ITEM}
             onSelect={() => onOpenMarkdownPreview(path)}
+          >
+            Open Preview
+          </ContextMenuItem>
+        )}
+        {!isDir && isPlantUmlPath(path) && onOpenPlantUmlPreview && (
+          <ContextMenuItem
+            className={COMPACT_ITEM}
+            onSelect={() => onOpenPlantUmlPreview(path)}
           >
             Open Preview
           </ContextMenuItem>

--- a/src/modules/plantuml/PlantUmlPreviewPane.tsx
+++ b/src/modules/plantuml/PlantUmlPreviewPane.tsx
@@ -1,0 +1,150 @@
+import { cn } from "@/lib/utils";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { encodePlantUml } from "./lib/encode";
+
+type ReadResult =
+  | { kind: "text"; content: string; size: number }
+  | { kind: "binary"; size: number }
+  | { kind: "toolarge"; size: number; limit: number };
+
+type PlantUmlResult = {
+  svg: string | null;
+  error: string | null;
+};
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "rendering" }
+  | { kind: "ready"; svg: string }
+  | { kind: "error"; message: string };
+
+type Props = {
+  path: string;
+  visible: boolean;
+};
+
+export function PlantUmlPreviewPane({ path, visible }: Props) {
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+  const lastContentHash = useRef("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const render = useCallback(async (text: string) => {
+    const hash = simpleHash(text);
+    if (hash === lastContentHash.current) return;
+    lastContentHash.current = hash;
+
+    setStatus({ kind: "rendering" });
+
+    const { plantumlBackend, plantumlServerUrl, plantumlJarPath, plantumlJavaPath } =
+      usePreferencesStore.getState();
+
+    try {
+      let svg: string;
+      if (plantumlBackend === "local" && plantumlJarPath) {
+        const result = await invoke<PlantUmlResult>("plantuml_render_local", {
+          diagramText: text,
+          jarPath: plantumlJarPath,
+          javaPath: plantumlJavaPath || "java",
+        });
+        if (result.svg) {
+          svg = result.svg;
+        } else {
+          setStatus({ kind: "error", message: result.error ?? "No output from PlantUML" });
+          return;
+        }
+      } else {
+        const encoded = await encodePlantUml(text);
+        const serverUrl = plantumlServerUrl || undefined;
+        svg = await invoke<string>("plantuml_fetch_svg", { encoded, serverUrl });
+      }
+      setStatus({ kind: "ready", svg });
+    } catch (e) {
+      setStatus({ kind: "error", message: String(e) });
+    }
+  }, []);
+
+  const loadAndRender = useCallback(async () => {
+    setStatus({ kind: "loading" });
+    try {
+      const res = await invoke<ReadResult>("fs_read_file", {
+        path,
+        workspace: currentWorkspaceEnv(),
+      });
+      if (res.kind === "text") {
+        await render(res.content);
+      } else if (res.kind === "binary") {
+        setStatus({ kind: "error", message: "Binary file cannot be rendered as PlantUML." });
+      } else {
+        setStatus({ kind: "error", message: `File too large: ${res.size} bytes.` });
+      }
+    } catch (e) {
+      setStatus({ kind: "error", message: String(e) });
+    }
+  }, [path, render]);
+
+  useEffect(() => {
+    void loadAndRender();
+  }, [loadAndRender]);
+
+  useEffect(() => {
+    const handler = (event: CustomEvent<{ paths: string[] }>) => {
+      if (!event.detail.paths.some((p) => p === path)) return;
+      clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => void loadAndRender(), 500);
+    };
+    window.addEventListener("fs:changed" as string, handler as EventListener);
+    return () => {
+      clearTimeout(debounceRef.current);
+      window.removeEventListener("fs:changed" as string, handler as EventListener);
+    };
+  }, [path, loadAndRender]);
+
+  const dataUrl =
+    status.kind === "ready"
+      ? `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(status.svg)))}`
+      : null;
+
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md border border-border/60 bg-background",
+        !visible && "pointer-events-none",
+      )}
+    >
+      <div className="flex h-8 shrink-0 items-center border-b border-border/60 px-3">
+        <span className="text-xs text-muted-foreground">PlantUML Preview</span>
+      </div>
+      <div className="flex flex-1 items-center justify-center overflow-auto p-4">
+        {status.kind === "loading" && (
+          <p className="text-[12px] text-muted-foreground">Loading...</p>
+        )}
+        {status.kind === "rendering" && (
+          <p className="text-[12px] text-muted-foreground">Rendering diagram...</p>
+        )}
+        {status.kind === "error" && (
+          <p className="max-w-md whitespace-pre-wrap text-[12px] text-destructive">
+            {status.message}
+          </p>
+        )}
+        {status.kind === "ready" && dataUrl && (
+          <img
+            src={dataUrl}
+            alt="PlantUML diagram"
+            className="max-h-full max-w-full object-contain"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function simpleHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return hash.toString(36);
+}

--- a/src/modules/plantuml/PlantUmlStack.tsx
+++ b/src/modules/plantuml/PlantUmlStack.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+import type { PlantUmlTab, Tab } from "@/modules/tabs";
+import { PlantUmlPreviewPane } from "./PlantUmlPreviewPane";
+
+type Props = {
+  tabs: Tab[];
+  activeId: number;
+};
+
+export function PlantUmlStack({ tabs, activeId }: Props) {
+  const plantumls = tabs.filter((t): t is PlantUmlTab => t.kind === "plantuml");
+  if (plantumls.length === 0) return null;
+  return (
+    <div className="relative h-full w-full">
+      {plantumls.map((t) => {
+        const visible = t.id === activeId;
+        return (
+          <div
+            key={t.id}
+            className={cn(
+              "absolute inset-0",
+              !visible && "invisible pointer-events-none",
+            )}
+            aria-hidden={!visible}
+          >
+            <PlantUmlPreviewPane path={t.path} visible={visible} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/modules/plantuml/index.ts
+++ b/src/modules/plantuml/index.ts
@@ -1,0 +1,2 @@
+export { PlantUmlStack } from "./PlantUmlStack";
+export { isPlantUmlPath } from "./lib/isPlantUmlPath";

--- a/src/modules/plantuml/lib/encode.ts
+++ b/src/modules/plantuml/lib/encode.ts
@@ -1,0 +1,51 @@
+const PLANTUML_ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_";
+
+function encode6bit(b: number): string {
+  return PLANTUML_ALPHABET[b & 0x3f];
+}
+
+function encode3bytes(b1: number, b2: number, b3: number): string {
+  return (
+    encode6bit(b1 >> 2) +
+    encode6bit(((b1 & 0x3) << 4) | (b2 >> 4)) +
+    encode6bit(((b2 & 0xf) << 2) | (b3 >> 6)) +
+    encode6bit(b3 & 0x3f)
+  );
+}
+
+function plantumlEncode(data: Uint8Array): string {
+  let result = "";
+  const len = data.length;
+  for (let i = 0; i < len; i += 3) {
+    const b1 = data[i];
+    const b2 = i + 1 < len ? data[i + 1] : 0;
+    const b3 = i + 2 < len ? data[i + 2] : 0;
+    result += encode3bytes(b1, b2, b3);
+  }
+  return result;
+}
+
+export async function encodePlantUml(text: string): Promise<string> {
+  const utf8 = new TextEncoder().encode(text);
+  const cs = new CompressionStream("deflate-raw");
+  const writer = cs.writable.getWriter();
+  writer.write(utf8);
+  writer.close();
+  const reader = cs.readable.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLen = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    totalLen += value.length;
+  }
+  const deflated = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    deflated.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return plantumlEncode(deflated);
+}

--- a/src/modules/plantuml/lib/isPlantUmlPath.ts
+++ b/src/modules/plantuml/lib/isPlantUmlPath.ts
@@ -1,0 +1,3 @@
+export function isPlantUmlPath(path: string): boolean {
+  return /\.(puml|plantuml|pu|wsd)$/i.test(path);
+}

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -85,6 +85,10 @@ export type Preferences = {
   zoomLevel: number;
   agentNotifications: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
+  plantumlBackend: "public" | "local";
+  plantumlServerUrl: string;
+  plantumlJarPath: string;
+  plantumlJavaPath: string;
 };
 
 const STORE_PATH = "terax-settings.json";
@@ -126,6 +130,10 @@ const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
 const KEY_SHORTCUTS = "shortcuts";
+const KEY_PLANTUML_BACKEND = "plantumlBackend";
+const KEY_PLANTUML_SERVER_URL = "plantumlServerUrl";
+const KEY_PLANTUML_JAR_PATH = "plantumlJarPath";
+const KEY_PLANTUML_JAVA_PATH = "plantumlJavaPath";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
 export const TERMINAL_FONT_SIZE_MIN = 8;
@@ -180,6 +188,10 @@ export const DEFAULT_PREFERENCES: Preferences = {
   zoomLevel: 1.0,
   agentNotifications: true,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
+  plantumlBackend: "public",
+  plantumlServerUrl: "https://www.plantuml.com/plantuml/svg/",
+  plantumlJarPath: "",
+  plantumlJavaPath: "java",
 };
 
 const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
@@ -302,6 +314,18 @@ export async function loadPreferences(): Promise<Preferences> {
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
+    plantumlBackend:
+      get<"public" | "local">(KEY_PLANTUML_BACKEND) ??
+      DEFAULT_PREFERENCES.plantumlBackend,
+    plantumlServerUrl:
+      get<string>(KEY_PLANTUML_SERVER_URL) ??
+      DEFAULT_PREFERENCES.plantumlServerUrl,
+    plantumlJarPath:
+      get<string>(KEY_PLANTUML_JAR_PATH) ??
+      DEFAULT_PREFERENCES.plantumlJarPath,
+    plantumlJavaPath:
+      get<string>(KEY_PLANTUML_JAVA_PATH) ??
+      DEFAULT_PREFERENCES.plantumlJavaPath,
   };
 }
 
@@ -496,6 +520,24 @@ export async function resetShortcuts(): Promise<void> {
   await writePref(KEY_SHORTCUTS, DEFAULT_PREFERENCES.shortcuts);
 }
 
+export async function setPlantumlBackend(
+  value: "public" | "local",
+): Promise<void> {
+  await writePref(KEY_PLANTUML_BACKEND, value);
+}
+
+export async function setPlantumlServerUrl(value: string): Promise<void> {
+  await writePref(KEY_PLANTUML_SERVER_URL, value.trim());
+}
+
+export async function setPlantumlJarPath(value: string): Promise<void> {
+  await writePref(KEY_PLANTUML_JAR_PATH, value.trim());
+}
+
+export async function setPlantumlJavaPath(value: string): Promise<void> {
+  await writePref(KEY_PLANTUML_JAVA_PATH, value.trim() || "java");
+}
+
 export type PrefKey = keyof Preferences;
 
 /** Subscribe to changes from any window (settings → main). */
@@ -540,6 +582,10 @@ export async function onPreferencesChange(
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
     [KEY_SHORTCUTS]: "shortcuts",
+    [KEY_PLANTUML_BACKEND]: "plantumlBackend",
+    [KEY_PLANTUML_SERVER_URL]: "plantumlServerUrl",
+    [KEY_PLANTUML_JAR_PATH]: "plantumlJarPath",
+    [KEY_PLANTUML_JAVA_PATH]: "plantumlJavaPath",
   };
   // Same-process writes still fire onChange immediately; cross-window writes
   // arrive via the Tauri event emitted by writePref().

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -278,6 +278,7 @@ function labelFor(t: Tab): string {
   if (t.kind === "editor") return t.title;
   if (t.kind === "preview") return t.title;
   if (t.kind === "markdown") return t.title;
+  if (t.kind === "plantuml") return t.title;
   if (t.kind === "ai-diff") return t.title;
   if (t.kind === "git-diff") return t.title;
   if (t.kind === "git-history") return t.title;

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -7,6 +7,7 @@ export {
   type EditorTab,
   type PreviewTab,
   type MarkdownTab,
+  type PlantUmlTab,
   type AiDiffTab,
   type GitDiffTab,
   type GitHistoryTab,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -55,6 +55,13 @@ export type MarkdownTab = {
   path: string;
 };
 
+export type PlantUmlTab = {
+  id: number;
+  kind: "plantuml";
+  title: string;
+  path: string;
+};
+
 export type AiDiffStatus = "pending" | "approved" | "rejected";
 
 export type AiDiffTab = {
@@ -105,6 +112,7 @@ export type Tab =
   | EditorTab
   | PreviewTab
   | MarkdownTab
+  | PlantUmlTab
   | AiDiffTab
   | GitDiffTab
   | GitHistoryTab
@@ -407,6 +415,24 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       const id = nextIdRef.current++;
       targetId = id;
       return [...curr, { id, kind: "markdown", title: basename(path), path }];
+    });
+    if (targetId !== null) setActiveId(targetId);
+    return targetId;
+  }, []);
+
+  const newPlantUmlTab = useCallback((path: string) => {
+    let targetId: number | null = null;
+    setTabs((curr) => {
+      const existing = curr.find(
+        (t) => t.kind === "plantuml" && t.path === path,
+      );
+      if (existing) {
+        targetId = existing.id;
+        return curr;
+      }
+      const id = nextIdRef.current++;
+      targetId = id;
+      return [...curr, { id, kind: "plantuml", title: basename(path), path }];
     });
     if (targetId !== null) setActiveId(targetId);
     return targetId;
@@ -805,6 +831,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     pinTab,
     newPreviewTab,
     newMarkdownTab,
+    newPlantUmlTab,
     openAiDiffTab,
     openGitDiffTab,
     openCommitHistoryTab,

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -21,6 +21,10 @@ import {
   TERMINAL_SCROLLBACK_PRESETS,
   setAgentNotifications,
   setAutostart,
+  setPlantumlBackend,
+  setPlantumlJarPath,
+  setPlantumlJavaPath,
+  setPlantumlServerUrl,
   setRestoreWindowState,
   setShowHidden,
   setTerminalFontFamily,
@@ -307,6 +311,8 @@ export function GeneralSection() {
         </SettingRow>
       </div>
 
+      <PlantUmlSection />
+
       <div className="flex flex-col gap-2">
         <Label>Startup</Label>
         <div className="flex flex-col gap-2">
@@ -330,6 +336,82 @@ export function GeneralSection() {
           </SettingRow>
         </div>
       </div>
+    </div>
+  );
+}
+
+function PlantUmlSection() {
+  const plantumlBackend = usePreferencesStore((s) => s.plantumlBackend);
+  const plantumlServerUrl = usePreferencesStore((s) => s.plantumlServerUrl);
+  const plantumlJarPath = usePreferencesStore((s) => s.plantumlJarPath);
+  const plantumlJavaPath = usePreferencesStore((s) => s.plantumlJavaPath);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>PlantUML</Label>
+      <SettingRow
+        title="Rendering backend"
+        description="Public server requires internet. Local jar keeps diagrams private."
+      >
+        <Select
+          value={plantumlBackend}
+          onValueChange={(v) => void setPlantumlBackend(v as "public" | "local")}
+        >
+          <SelectTrigger size="sm" className="h-8 w-36 text-[12px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="public" className="text-[12px]">
+              Public server
+            </SelectItem>
+            <SelectItem value="local" className="text-[12px]">
+              Local jar
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </SettingRow>
+      {plantumlBackend === "public" && (
+        <SettingRow
+          title="Server URL"
+          description="PlantUML server endpoint. Default: plantuml.com."
+        >
+          <input
+            type="text"
+            value={plantumlServerUrl}
+            placeholder="https://www.plantuml.com/plantuml/svg/"
+            onChange={(e) => void setPlantumlServerUrl(e.target.value)}
+            className="h-8 w-60 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+          />
+        </SettingRow>
+      )}
+      {plantumlBackend === "local" && (
+        <>
+          <SettingRow
+            title="Jar path"
+            description="Absolute path to plantuml.jar on your machine."
+          >
+            <input
+              type="text"
+              value={plantumlJarPath}
+              placeholder="/path/to/plantuml.jar"
+              onChange={(e) => void setPlantumlJarPath(e.target.value)}
+              className="h-8 w-60 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+            />
+          </SettingRow>
+          <SettingRow
+            title="Java path"
+            description='Path to java binary. Leave as "java" if it is on your PATH.'
+          >
+            <input
+              type="text"
+              value={plantumlJavaPath}
+              placeholder="java"
+              onChange={(e) => void setPlantumlJavaPath(e.target.value)}
+              className="h-8 w-60 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+            />
+          </SettingRow>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What
* feat(preview): PlantUML diagram preview with public server and local jar backends

Adds a new "plantuml" tab kind that renders .puml/.plantuml/.pu/.wsd files as SVG diagrams. Users can choose between the public plantuml.com server (default, zero-install) or a local PlantUML jar (configured in settings, keeps diagrams private). Preview is accessible via right-click "Open Preview" in the file explorer.

* feat(settings): PlantUML backend configuration UI

Adds a PlantUML section to General settings with backend toggle (public server vs local jar), server URL field, jar path, and java path inputs. Fields shown conditionally based on selected backend.

## Why
As a developer, I have .puml files (High level design - SWE.2 and Low level Design - SWE.3) to refer to before I start implementation.

## How
Extend the application logic. I saw that the Markdown file has a preview mode. so I asked Claude-opus to extend it with plantuml (refer to the attached .md file)
[planutml-preview.md](https://github.com/user-attachments/files/28215855/planutml-preview.md)

### Follow-up:
I will enhance this feature with side-by-side live edit preview as well.

## Testing
I compiled the rust application, tested it. Screenshots are added in the PR of my fork.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

### Context menu
<img width="212" height="319" alt="Screenshot 2026-05-25 at 2 40 50 PM" src="https://github.com/user-attachments/assets/3effbb7d-23ac-40e9-b97e-e74a2bd4963e" />

### Preview window
<img width="1794" height="1144" alt="Screenshot 2026-05-25 at 2 43 45 PM" src="https://github.com/user-attachments/assets/8fd78581-1e70-4683-9fd7-9492f279cf42" />

### Settings panel for public server
<img width="686" height="165" alt="Screenshot 2026-05-25 at 2 52 39 PM" src="https://github.com/user-attachments/assets/4bbf06bb-b8ee-4744-8d70-6e9b5c7354bb" />

### Settings panel for local plantuml file
<img width="669" height="237" alt="Screenshot 2026-05-25 at 2 52 45 PM" src="https://github.com/user-attachments/assets/046c33e6-7ada-47c7-a32c-60e31903535e" />


## Notes for reviewer
I am not a "rust+tauri+react" developer. This logic implemented base don plan in the .md file I have attached below.
[planutml-preview.md](https://github.com/user-attachments/files/28214273/planutml-preview.md)
