### PR TITLE
feat(tabs): add tab renaming functionality

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -186,6 +186,7 @@ export default function App() {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
+    renameTab,
   } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -1394,6 +1395,7 @@ export default function App() {
             onNewGitGraph={openGitGraphFromContext}
             onClose={handleClose}
             onPin={pinTab}
+            onRename={renameTab}
             onToggleSidebar={toggleSidebar}
             onSplit={splitActivePaneInActiveTab}
             canSplit={

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -43,6 +43,8 @@ type Props = {
   onClose: (id: number) => void;
   /** Promote a preview (transient) tab to persistent. */
   onPin: (id: number) => void;
+  /** Rename a tab. */
+  onRename: (id: number, title: string) => void;
   onToggleSidebar: () => void;
   onSplit: (dir: "row" | "col") => void;
   /** Active tab is a terminal and below the per-tab pane cap. */
@@ -67,6 +69,7 @@ export function Header({
   onNewGitGraph,
   onClose,
   onPin,
+  onRename,
   onToggleSidebar,
   onSplit,
   canSplit,
@@ -200,6 +203,7 @@ export function Header({
           onNewGitGraph={onNewGitGraph}
           onClose={onClose}
           onPin={onPin}
+          onRename={onRename}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -21,7 +21,7 @@ import {
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
 type Props = {
@@ -36,6 +36,7 @@ type Props = {
   onClose: (id: number) => void;
   /** Pin (promote) a preview tab to persistent on double-click. */
   onPin: (id: number) => void;
+  onRename: (id: number, title: string) => void;
   compact?: boolean;
 };
 
@@ -51,8 +52,13 @@ export function TabBar({
   onClose,
   onPin,
   compact,
+  onRename,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [renamingId, setRenamingId] = useState<number | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const renamingIdRef = useRef<number | null>(null);
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -76,6 +82,41 @@ export function TabBar({
     active?.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [activeId, tabs.length]);
 
+  
+  useEffect(() => {
+    if (renamingId !== null) {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    }
+  }, [renamingId]);
+
+  function startRename(tab: Tab) {
+    setRenamingId(tab.id);
+    renamingIdRef.current = tab.id;
+    setRenameValue(tab.title);
+  }
+
+  function commitRename() {
+    if (renamingId !== null) {
+      onRename(renamingId, renameValue);
+    }
+    renamingIdRef.current = null;
+    setRenamingId(null);
+  }
+
+  function cancelRename() {
+    renamingIdRef.current = null;
+    setRenamingId(null);
+  }
+
+  function isRenameable(tab: Tab): boolean {
+    return (
+      tab.kind === "terminal" ||
+      tab.kind === "preview" ||
+      tab.kind === "git-history"
+    );
+  }
+
   return (
     <div
       ref={scrollRef}
@@ -90,12 +131,19 @@ export function TabBar({
           <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
             {tabs.map((t) => {
               const isPreview = t.kind === "editor" && (t as EditorTab).preview;
+              const isRenaming = renamingId === t.id;
               return (
                 <TabsTrigger
                   key={t.id}
                   value={String(t.id)}
                   data-tab-id={t.id}
-                  onDoubleClick={() => isPreview && onPin(t.id)}
+                  onDoubleClick={() => {
+                    if (renamingIdRef.current === t.id) return;
+                    if (isPreview) onPin(t.id);
+                    if (isRenameable(t)) {
+                      startRename(t);
+                    }
+                  }}
                   className={cn(
                     "group h-7 shrink-0 gap-1.5 rounded-md text-xs text-muted-foreground transition-colors data-[state=active]:bg-accent data-[state=active]:text-foreground hover:text-foreground/80 justify-between",
                     compact
@@ -112,11 +160,32 @@ export function TabBar({
                     )}
                   >
                     <TabIcon tab={t} />
-                    {/* Preview tabs use italic to signal the transient state,
-                        matching the visual convention from VSCode. */}
-                    <span className={cn("truncate", isPreview && "italic")}>
-                      {labelFor(t)}
-                    </span>
+                    {isRenaming ? (
+                      <input
+                        ref={renameInputRef}
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onBlur={commitRename}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            commitRename();
+                          }
+                          if (e.key === "Escape") {
+                            e.preventDefault();
+                            cancelRename();
+                          }
+                          e.stopPropagation();
+                        }}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        onClick={(e) => e.stopPropagation()}
+                        className="w-24 min-w-0 bg-transparent text-xs text-foreground outline-none border-b border-foreground/40 leading-none"
+                      />
+                    ) : (
+                      <span className={cn("truncate", isPreview && "italic")}>
+                        {labelFor(t)}
+                      </span>
+                    )}
                     {t.kind === "editor" && t.dirty ? (
                       <span
                         aria-label="Unsaved changes"
@@ -275,14 +344,15 @@ function TabIcon({ tab }: { tab: Tab }) {
 }
 
 function labelFor(t: Tab): string {
-  if (t.kind === "editor") return t.title;
-  if (t.kind === "preview") return t.title;
-  if (t.kind === "markdown") return t.title;
-  if (t.kind === "ai-diff") return t.title;
-  if (t.kind === "git-diff") return t.title;
-  if (t.kind === "git-history") return t.title;
-  if (t.kind === "git-commit-file") return t.title;
-  if (!t.cwd) return t.title;
-  const parts = t.cwd.split(/[\\/]/).filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : "/";
+  // For terminal tabs, check if user has customized the title
+  if (t.kind === "terminal") {
+    // If user has customized the title, always show it
+    if (t.customTitle) return t.title;
+    // Otherwise show directory name from cwd if available
+    if (!t.cwd) return t.title;
+    const parts = t.cwd.split(/[\\/]/).filter(Boolean);
+    return parts.length ? parts[parts.length - 1] : "/";
+  }
+  // For all other tab kinds, always use the title
+  return t.title;
 }

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -25,6 +25,8 @@ export type TerminalTab = {
   activeLeafId: number;
   /** AI agent cannot read buffer / context of this terminal. */
   private?: boolean;
+  /** Whether the title has been customized by the user. */
+  customTitle?: boolean;
 };
 
 export type EditorTab = {
@@ -794,6 +796,28 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     for (const lid of toDispose) disposeSession(lid);
   }, []);
 
+  
+  // Renames a tab
+  const renameTab = useCallback((id: number, title: string) => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    setTabs((curr) =>
+      curr.map((t) => {
+        if (t.id !== id) return t;
+        // Only allow renaming for terminal, preview, and git-history tabs
+        if (t.kind === "terminal" || t.kind === "preview" || t.kind === "git-history") {
+          return { 
+            ...t, 
+            title: trimmed,
+            ...(t.kind === "terminal" && { customTitle: true })
+          };
+        }
+        return t;
+      }),
+    );
+  }, []);
+
+
   return {
     tabs,
     activeId,
@@ -821,5 +845,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
+    renameTab,
   };
 }


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
Adds inline tab renaming for terminal, preview, and git-history tabs. Double-clicking a tab label replaces it with an inline input; `Enter` or blur commits, `Escape` cancels.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
Tabs currently display only process-derived or auto-generated names, making it hard to tell sessions apart when running multiple terminals simultaneously (e.g. a dev server, log tail, and git shell all look identical).
Closes #501 

## How
<!-- Brief notes on the approach, only if non-obvious. -->
- Added `renameTab(id, title)` to `useTabs` and a `customTitle` flag on `TerminalTab` so
  user-set names survive CWD updates without being overwritten by the directory-derived label.
- `TabBar` tracks `renamingId` + `renameValue` in local state; a `renamingIdRef` guards against
  stale closures in the double-click handler.
- The tab label conditionally renders an `<input>` vs the existing `<span>` — mouse and keyboard
  events are stopped from propagating so the input doesn't accidentally switch tabs or trigger
  Tauri drag.
- `onRename` prop threaded through `Header` → `TabBar` → `useTabs`.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If UI) tested in `pnpm tauri dev`

Flows exercised:
- Double-click terminal tab → input appears with current name pre-selected
- Type new name + `Enter` → label updates and persists
- Click away → commits rename
- `Escape` → reverts, original name unchanged
- CWD change after rename → custom title stays pinned, not overwritten
- Double-click on editor / markdown / ai-diff tabs → no rename triggered 

## Screenshots / GIFs
<img alt="renaming-tabs" src="https://github.com/user-attachments/assets/b710f30a-2f85-42d5-972e-78572c6f290f" />


## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
