### PR TITLE
feat(tabs): inline tab rename on double-click

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1408,6 +1408,7 @@ export default function App() {
             onNewGitGraph={openGitGraphFromContext}
             onClose={handleClose}
             onPin={pinTab}
+            onRename={(id, name) => updateTab(id, { customTitle: name || undefined })}
             onToggleSidebar={toggleSidebar}
             onSplit={splitActivePaneInActiveTab}
             canSplit={

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -43,6 +43,8 @@ type Props = {
   onClose: (id: number) => void;
   /** Promote a preview (transient) tab to persistent. */
   onPin: (id: number) => void;
+  /** Rename a tab. Empty string reverts to the auto-derived label. */
+  onRename: (id: number, name: string) => void;
   onToggleSidebar: () => void;
   onSplit: (dir: "row" | "col") => void;
   /** Active tab is a terminal and below the per-tab pane cap. */
@@ -67,6 +69,7 @@ export function Header({
   onNewGitGraph,
   onClose,
   onPin,
+  onRename,
   onToggleSidebar,
   onSplit,
   canSplit,
@@ -200,6 +203,7 @@ export function Header({
           onNewGitGraph={onNewGitGraph}
           onClose={onClose}
           onPin={onPin}
+          onRename={onRename}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -21,7 +21,7 @@ import {
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
 type Props = {
@@ -36,6 +36,8 @@ type Props = {
   onClose: (id: number) => void;
   /** Pin (promote) a preview tab to persistent on double-click. */
   onPin: (id: number) => void;
+  /** Rename a tab. Empty string reverts to the auto-derived label. */
+  onRename: (id: number, name: string) => void;
   compact?: boolean;
 };
 
@@ -50,9 +52,23 @@ export function TabBar({
   onNewGitGraph,
   onClose,
   onPin,
+  onRename,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editingId !== null) inputRef.current?.focus();
+  }, [editingId]);
+
+  const commitRename = () => {
+    if (editingId === null) return;
+    onRename(editingId, editValue.trim());
+    setEditingId(null);
+  };
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -95,7 +111,12 @@ export function TabBar({
                   key={t.id}
                   value={String(t.id)}
                   data-tab-id={t.id}
-                  onDoubleClick={() => isPreview && onPin(t.id)}
+                  onDoubleClick={(e) => {
+                    if (isPreview) { onPin(t.id); return; }
+                    e.preventDefault();
+                    setEditingId(t.id);
+                    setEditValue(labelFor(t));
+                  }}
                   onAuxClick={(e) => {
                     if (e.button === 1 && tabs.length > 1) {
                       e.preventDefault();
@@ -122,19 +143,37 @@ export function TabBar({
                     )}
                   >
                     <TabIcon tab={t} />
-                    {/* Preview tabs use italic to signal the transient state,
-                        matching the visual convention from VSCode. */}
-                    <span className={cn("truncate", isPreview && "italic")}>
-                      {labelFor(t)}
-                    </span>
-                    {t.kind === "editor" && t.dirty ? (
+                    {editingId === t.id ? (
+                      <input
+                        ref={inputRef}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") { e.preventDefault(); commitRename(); }
+                          if (e.key === "Escape") { e.stopPropagation(); setEditingId(null); }
+                          e.stopPropagation();
+                        }}
+                        onBlur={commitRename}
+                        onClick={(e) => e.stopPropagation()}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        className="min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none"
+                        style={{ width: `${Math.max(editValue.length, 3)}ch` }}
+                      />
+                    ) : (
+                      /* Preview tabs use italic to signal the transient state,
+                         matching the visual convention from VSCode. */
+                      <span className={cn("truncate", isPreview && "italic")}>
+                        {labelFor(t)}
+                      </span>
+                    )}
+                    {t.kind === "editor" && t.dirty && editingId !== t.id ? (
                       <span
                         aria-label="Unsaved changes"
                         className="size-1.5 shrink-0 rounded-full bg-foreground/70"
                       />
                     ) : null}
                   </span>
-                  {tabs.length > 1 && (
+                  {tabs.length > 1 && editingId !== t.id && (
                     <span
                       role="button"
                       aria-label="Close tab"
@@ -285,6 +324,7 @@ function TabIcon({ tab }: { tab: Tab }) {
 }
 
 function labelFor(t: Tab): string {
+  if (t.customTitle) return t.customTitle;
   if (t.kind === "editor") return t.title;
   if (t.kind === "preview") return t.title;
   if (t.kind === "markdown") return t.title;

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -20,6 +20,7 @@ export type TerminalTab = {
   id: number;
   kind: "terminal";
   title: string;
+  customTitle?: string;
   cwd?: string;
   paneTree: PaneNode;
   activeLeafId: number;
@@ -31,6 +32,7 @@ export type EditorTab = {
   id: number;
   kind: "editor";
   title: string;
+  customTitle?: string;
   path: string;
   dirty: boolean;
   /**
@@ -45,6 +47,7 @@ export type PreviewTab = {
   id: number;
   kind: "preview";
   title: string;
+  customTitle?: string;
   url: string;
 };
 
@@ -52,6 +55,7 @@ export type MarkdownTab = {
   id: number;
   kind: "markdown";
   title: string;
+  customTitle?: string;
   path: string;
 };
 
@@ -61,6 +65,7 @@ export type AiDiffTab = {
   id: number;
   kind: "ai-diff";
   title: string;
+  customTitle?: string;
   path: string;
   /** "" for newly created files. */
   originalContent: string;
@@ -75,6 +80,7 @@ export type GitDiffTab = {
   id: number;
   kind: "git-diff";
   title: string;
+  customTitle?: string;
   path: string;
   repoRoot: string;
   mode: "-" | "+";
@@ -85,6 +91,7 @@ export type GitHistoryTab = {
   id: number;
   kind: "git-history";
   title: string;
+  customTitle?: string;
   repoRoot: string;
 };
 
@@ -92,6 +99,7 @@ export type GitCommitFileDiffTab = {
   id: number;
   kind: "git-commit-file";
   title: string;
+  customTitle?: string;
   repoRoot: string;
   sha: string;
   shortSha: string;
@@ -112,6 +120,7 @@ export type Tab =
 
 export type TabPatch = Partial<{
   title: string;
+  customTitle: string;
   cwd: string;
   path: string;
   dirty: boolean;
@@ -580,9 +589,14 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setTabs((t) =>
       t.map((x) => {
         if (x.id !== id) return x;
+        // customTitle: explicit undefined in the patch clears it (revert to auto label).
+        const customTitlePatch = "customTitle" in patch
+          ? { customTitle: patch.customTitle || undefined }
+          : {};
         if (x.kind === "terminal") {
           return {
             ...x,
+            ...customTitlePatch,
             ...(patch.title !== undefined && { title: patch.title }),
             ...(patch.cwd !== undefined && { cwd: patch.cwd }),
           };
@@ -590,6 +604,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         if (x.kind === "preview") {
           return {
             ...x,
+            ...customTitlePatch,
             ...(patch.title !== undefined && { title: patch.title }),
             ...(patch.url !== undefined && {
               url: patch.url,
@@ -600,6 +615,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         if (x.kind === "markdown") {
           return {
             ...x,
+            ...customTitlePatch,
             ...(patch.title !== undefined && { title: patch.title }),
           };
         }
@@ -611,6 +627,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         return {
           ...x,
           ...autoPin,
+          ...customTitlePatch,
           ...(patch.title !== undefined && { title: patch.title }),
           ...(patch.dirty !== undefined && { dirty: patch.dirty }),
           ...(patch.path !== undefined && { path: patch.path }),


### PR DESCRIPTION
## What

Adds inline tab renaming: double-clicking any non-preview tab activates a small text input directly in the tab strip. Confirming the name (Enter or blur) sets a `customTitle` on that tab; clearing it reverts to the auto-derived label.

## Why

Users working with many open terminals or editors often want to distinguish tabs by context rather than by filename or shell cwd. There is no current way to label a tab manually.

## How

- `useTabs.ts` — adds an optional `customTitle` field to every tab variant and handles it in `updateTab` (explicit `undefined` clears it).
- `TabBar.tsx` — manages `editingId`/`editValue` state locally; renders an `<input>` in place of the label span when that tab is being edited. Event propagation is stopped so clicks on the input don't trigger tab switching or other handlers.
- `Header.tsx` / `App.tsx` — threads the new `onRename` prop down from `App` to `TabBar`.

`labelFor()` checks `customTitle` first, then falls through to the existing logic, so nothing changes for tabs that have never been renamed.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If UI) tested in `pnpm tauri dev`

Flows exercised manually:
- Double-click a terminal tab → input appears pre-filled with current label; Enter commits; new name persists across tab switches.
- Double-click an editor tab → same flow; dirty indicator hidden while editing.
- Escape cancels without changing the name.
- Clear the input and confirm → tab reverts to its auto-derived label.
- Double-click a preview tab → still pins it (existing behavior unchanged).
- Close button and tab switching unaffected while no rename is active.

## Screenshots / GIFs

<!-- Before: static label — After: inline input on double-click -->
> UI change — tested visually in `pnpm tauri dev`. Happy to attach a GIF if that would help review.

## Notes for reviewer

- The input width is driven by `${Math.max(editValue.length, 3)}ch` so it stays snug without a layout shift.
- `customTitle` is not persisted across sessions (no workspace state touched). Could be a natural follow-up if desired.