### PR TITLE
docs(pr-template): replace cargo check with cargo clippy in src-tauri checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Examples: feat(terminal): add split panes / fix(explorer): close button alignmen
 
 - [ ] `pnpm exec tsc --noEmit` clean
 - [ ] Manual smoke-test of the affected feature
-- [ ] (If you touched `src-tauri/`) `cargo check` clean
+- [ ] (If you touched `src-tauri/`) `cargo clippy` clean
 - [ ] (If UI) tested in `pnpm tauri dev`
 
 ## Screenshots / GIFs


### PR DESCRIPTION
## What

In `.github/PULL_REQUEST_TEMPLATE.md`, change the src-tauri checklist item from `cargo check` to `cargo clippy`.

## Why

The PR template at line 21 currently directs contributors to run `cargo check` for src-tauri changes, but the documented quality bar is `cargo clippy`:

- `CONTRIBUTING.md` line 78: ``cargo clippy`` clean, ``cargo fmt`` applied
- `TERAX.md` line 13: ``cd src-tauri && cargo clippy && cargo test --locked``

`cargo check` only runs the type checker and will not surface clippy lint violations. A contributor who follows the template faithfully can submit clippy-dirty code and only discover the mismatch during review.

## How

One-character change in the checklist line.

## Testing

Docs-only — no code paths affected.

## Notes for reviewer

If the intent was to keep `cargo check` as a lightweight pre-flight and rely on CI for clippy, happy to revert; flagging because the template currently reads as the authoritative pre-submit checklist.