### PR TITLE
feat(terminal): hover thumbnails for [Image #N] and pasted clipboard paths

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1967,6 +1967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4970,6 +4976,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -85,6 +85,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +774,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1167,6 +1208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1239,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1800,6 +1853,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,7 +2062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2130,6 +2194,20 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2602,6 +2680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2704,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2795,6 +2883,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -3372,6 +3461,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3533,6 +3635,18 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4923,7 +5037,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5289,6 +5403,7 @@ dependencies = [
 name = "terax"
 version = "0.7.3"
 dependencies = [
+ "arboard",
  "bytes",
  "dirs 5.0.1",
  "futures-util",
@@ -5301,6 +5416,7 @@ dependencies = [
  "libc",
  "log",
  "notify",
+ "png 0.17.16",
  "portable-pty",
  "reqwest 0.12.28",
  "serde",
@@ -5360,6 +5476,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5666,7 +5796,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -6152,6 +6282,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6874,6 +7010,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7064,6 +7217,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,8 @@ futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"
 notify = "8.2.0"
+arboard = { version = "3.4", features = ["image-data"] }
+png = "0.17"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, clipboard, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_window_state::StateFlags;
@@ -185,6 +185,8 @@ pub fn run() {
             net::lm_ping,
             net::ai_http_request,
             net::ai_http_stream,
+            clipboard::clipboard_read_image,
+            clipboard::clipboard_cleanup_temp_images,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/clipboard.rs
+++ b/src-tauri/src/modules/clipboard.rs
@@ -1,0 +1,159 @@
+//! Clipboard image paste for the terminal.
+//!
+//! When a CLI tool running inside the terminal needs a file (Claude Code,
+//! Codex, etc.) the user expects to paste a screenshot and get a path. The
+//! host terminal must intercept the empty paste, write the image to a temp
+//! PNG, and return the path so the frontend can shell-escape it.
+//!
+//! Strategy: text wins. If the clipboard has any non-empty text, we return
+//! `None` and let the caller fall back to a normal text paste. Image-only
+//! clipboards encode to PNG (max 10 MB) and land in the OS temp directory
+//! as `terax-clipboard-<unix-ms>-<pid>.png`.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_PNG_BYTES: usize = 10 * 1024 * 1024;
+const CLEANUP_AGE_SECS: u64 = 24 * 60 * 60;
+const FILE_PREFIX: &str = "terax-clipboard-";
+const FILE_SUFFIX: &str = ".png";
+
+#[tauri::command]
+pub async fn clipboard_read_image() -> Result<Option<String>, String> {
+    tokio::task::spawn_blocking(read_image_blocking)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn clipboard_cleanup_temp_images() -> Result<u32, String> {
+    tokio::task::spawn_blocking(cleanup_blocking)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+fn read_image_blocking() -> Result<Option<String>, String> {
+    let mut cb = arboard::Clipboard::new().map_err(|e| e.to_string())?;
+
+    // Text wins. arboard returns Err when the clipboard has no string entry —
+    // treat both empty and missing as "no text".
+    if let Ok(text) = cb.get_text() {
+        if !text.is_empty() {
+            return Ok(None);
+        }
+    }
+
+    let img = match cb.get_image() {
+        Ok(img) => img,
+        Err(_) => return Ok(None),
+    };
+
+    let width = u32::try_from(img.width).map_err(|_| "clipboard image width overflow".to_string())?;
+    let height =
+        u32::try_from(img.height).map_err(|_| "clipboard image height overflow".to_string())?;
+    if width == 0 || height == 0 {
+        return Ok(None);
+    }
+
+    let png = encode_rgba_to_png(&img.bytes, width, height)?;
+    if png.len() > MAX_PNG_BYTES {
+        return Err(format!(
+            "clipboard image too large: {} bytes (max {})",
+            png.len(),
+            MAX_PNG_BYTES
+        ));
+    }
+
+    let path = temp_png_path();
+    std::fs::write(&path, &png).map_err(|e| e.to_string())?;
+    Ok(Some(path.to_string_lossy().into_owned()))
+}
+
+fn cleanup_blocking() -> u32 {
+    let dir = std::env::temp_dir();
+    let now = SystemTime::now();
+    let mut removed: u32 = 0;
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let name_os = entry.file_name();
+        let Some(name) = name_os.to_str() else { continue };
+        if !name.starts_with(FILE_PREFIX) || !name.ends_with(FILE_SUFFIX) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(modified) = meta.modified() else { continue };
+        let Ok(age) = now.duration_since(modified) else { continue };
+        if age.as_secs() <= CLEANUP_AGE_SECS {
+            continue;
+        }
+        if std::fs::remove_file(entry.path()).is_ok() {
+            removed = removed.saturating_add(1);
+        }
+    }
+    removed
+}
+
+fn encode_rgba_to_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, String> {
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or_else(|| "clipboard image dimensions overflow".to_string())?;
+    if rgba.len() < expected {
+        return Err(format!(
+            "clipboard image data short: have {}, need {}",
+            rgba.len(),
+            expected
+        ));
+    }
+
+    let mut out: Vec<u8> = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut out, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().map_err(|e| e.to_string())?;
+        writer
+            .write_image_data(&rgba[..expected])
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(out)
+}
+
+fn temp_png_path() -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let name = format!("{FILE_PREFIX}{now}-{pid}{FILE_SUFFIX}");
+    std::env::temp_dir().join(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_rgba_round_trip() {
+        let rgba = vec![255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255];
+        let png = encode_rgba_to_png(&rgba, 2, 2).expect("encode");
+        assert!(png.starts_with(&[0x89, 0x50, 0x4E, 0x47]), "PNG signature");
+    }
+
+    #[test]
+    fn encode_rejects_short_buffer() {
+        let rgba = vec![0u8; 4];
+        let err = encode_rgba_to_png(&rgba, 2, 2).expect_err("must reject");
+        assert!(err.contains("data short"), "{err}");
+    }
+
+    #[test]
+    fn temp_path_uses_prefix() {
+        let p = temp_png_path();
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        assert!(name.starts_with(FILE_PREFIX), "{name}");
+        assert!(name.ends_with(FILE_SUFFIX), "{name}");
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod clipboard;
 pub mod fs;
 pub mod git;
 pub mod net;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,11 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'",
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$TEMP/terax-clipboard-*.png"]
+      }
     }
   },
   "bundle": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -80,6 +80,7 @@ import {
 import { StatusBar } from "@/modules/statusbar";
 import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
 import {
+  cleanupTempClipboardImages,
   disposeSession,
   findLeafCwd,
   hasLeaf,
@@ -324,6 +325,9 @@ export default function App() {
         }
       })
       .catch(() => setHome(null));
+    // Image-paste temp files accumulate in $TMPDIR; clear anything older than
+    // 24h on startup. Fire-and-forget — failure is non-fatal.
+    void cleanupTempClipboardImages();
   }, []);
 
   const switchWorkspace = useCallback(

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -77,6 +77,7 @@ export type Preferences = {
   vimMode: boolean;
   showHidden: boolean;
   terminalWebglEnabled: boolean;
+  terminalCopyOnSelect: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -118,6 +119,7 @@ const KEY_VIM_MODE = "vimMode";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
+const KEY_TERMINAL_COPY_ON_SELECT = "terminalCopyOnSelect";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -172,6 +174,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   vimMode: false,
   showHidden: false,
   terminalWebglEnabled: true,
+  terminalCopyOnSelect: false,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -279,6 +282,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
+    terminalCopyOnSelect:
+      get<boolean>(KEY_TERMINAL_COPY_ON_SELECT) ??
+      DEFAULT_PREFERENCES.terminalCopyOnSelect,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -443,6 +449,10 @@ export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
 }
 
+export async function setTerminalCopyOnSelect(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_COPY_ON_SELECT, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
@@ -532,6 +542,7 @@ export async function onPreferencesChange(
     [KEY_VIM_MODE]: "vimMode",
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
+    [KEY_TERMINAL_COPY_ON_SELECT]: "terminalCopyOnSelect",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -16,3 +16,4 @@ export {
   type PaneNode,
   type SplitDir,
 } from "./lib/panes";
+export { cleanupTempClipboardImages } from "./lib/imagePaste";

--- a/src/modules/terminal/lib/copyOnSelect.test.ts
+++ b/src/modules/terminal/lib/copyOnSelect.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { createCopyOnSelectHandler } from "./copyOnSelect";
+
+type ScheduledTask = { fn: () => void; ms: number };
+
+function makeScheduler() {
+  const tasks: ScheduledTask[] = [];
+  const schedule = (fn: () => void, ms: number) => {
+    const task: ScheduledTask = { fn, ms };
+    tasks.push(task);
+    return task;
+  };
+  const cancel = (handle: unknown) => {
+    const idx = tasks.indexOf(handle as ScheduledTask);
+    if (idx >= 0) tasks.splice(idx, 1);
+  };
+  const flushAll = () => {
+    while (tasks.length > 0) {
+      const t = tasks.shift()!;
+      t.fn();
+    }
+  };
+  return { schedule, cancel, flushAll, tasks };
+}
+
+describe("createCopyOnSelectHandler", () => {
+  it("copies the latest selection after the debounce", () => {
+    const copies: string[] = [];
+    const sched = makeScheduler();
+    const handler = createCopyOnSelectHandler({
+      isEnabled: () => true,
+      copy: (t) => copies.push(t),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+    });
+
+    handler.notify("hel");
+    handler.notify("hell");
+    handler.notify("hello");
+    expect(copies).toEqual([]);
+    sched.flushAll();
+    expect(copies).toEqual(["hello"]);
+  });
+
+  it("skips empty selections and preserves the previous copy", () => {
+    const copies: string[] = [];
+    const sched = makeScheduler();
+    const handler = createCopyOnSelectHandler({
+      isEnabled: () => true,
+      copy: (t) => copies.push(t),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+    });
+
+    handler.notify("first");
+    sched.flushAll();
+    handler.notify("");
+    sched.flushAll();
+    expect(copies).toEqual(["first"]);
+  });
+
+  it("dedupes consecutive identical selections", () => {
+    const copies: string[] = [];
+    const sched = makeScheduler();
+    const handler = createCopyOnSelectHandler({
+      isEnabled: () => true,
+      copy: (t) => copies.push(t),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+    });
+
+    handler.notify("same");
+    sched.flushAll();
+    handler.notify("same");
+    sched.flushAll();
+    expect(copies).toEqual(["same"]);
+  });
+
+  it("no-ops when the preference is off", () => {
+    const copies: string[] = [];
+    const sched = makeScheduler();
+    let enabled = false;
+    const handler = createCopyOnSelectHandler({
+      isEnabled: () => enabled,
+      copy: (t) => copies.push(t),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+    });
+
+    handler.notify("hello");
+    sched.flushAll();
+    expect(copies).toEqual([]);
+
+    enabled = true;
+    handler.notify("hello");
+    sched.flushAll();
+    expect(copies).toEqual(["hello"]);
+  });
+
+  it("re-checks isEnabled at flush time (toggle during debounce)", () => {
+    const copies: string[] = [];
+    const sched = makeScheduler();
+    let enabled = true;
+    const handler = createCopyOnSelectHandler({
+      isEnabled: () => enabled,
+      copy: (t) => copies.push(t),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+    });
+
+    handler.notify("hello");
+    enabled = false;
+    sched.flushAll();
+    expect(copies).toEqual([]);
+  });
+
+  it("dispose cancels a pending write", () => {
+    const copies: string[] = [];
+    const sched = makeScheduler();
+    const handler = createCopyOnSelectHandler({
+      isEnabled: () => true,
+      copy: (t) => copies.push(t),
+      schedule: sched.schedule,
+      cancel: sched.cancel,
+    });
+
+    handler.notify("pending");
+    handler.dispose();
+    sched.flushAll();
+    expect(copies).toEqual([]);
+  });
+});

--- a/src/modules/terminal/lib/copyOnSelect.ts
+++ b/src/modules/terminal/lib/copyOnSelect.ts
@@ -1,0 +1,86 @@
+/**
+ * Debounced copy-on-select handler factory.
+ *
+ * xterm's `onSelectionChange` fires on every cell flipped during a drag, so
+ * we coalesce calls with a short debounce and only copy when the selection
+ * has actually changed since the last successful write. Empty selections
+ * (deselection) are a no-op so the user's clipboard contents are preserved.
+ */
+export type CopyOnSelectHandler = {
+  /** Invoke on each `onSelectionChange` event. */
+  notify: (selection: string) => void;
+  /** Cancel the pending timer (call from slot teardown). */
+  dispose: () => void;
+};
+
+export type CopyOnSelectOptions = {
+  isEnabled: () => boolean;
+  copy: (text: string) => void;
+  debounceMs?: number;
+  /** Injectable for tests; defaults to globalThis.setTimeout/clearTimeout. */
+  schedule?: (fn: () => void, ms: number) => unknown;
+  cancel?: (handle: unknown) => void;
+};
+
+export function createCopyOnSelectHandler(
+  options: CopyOnSelectOptions,
+): CopyOnSelectHandler {
+  const {
+    isEnabled,
+    copy,
+    debounceMs = 50,
+    schedule = (fn, ms) => setTimeout(fn, ms),
+    cancel = (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+  } = options;
+
+  let timer: unknown = null;
+  let pending: string | null = null;
+  let lastCopied: string | null = null;
+
+  function flush(): void {
+    timer = null;
+    const text = pending;
+    pending = null;
+    if (text === null || text.length === 0) return;
+    if (text === lastCopied) return;
+    if (!isEnabled()) return;
+    lastCopied = text;
+    copy(text);
+  }
+
+  return {
+    notify(selection: string) {
+      if (!isEnabled()) {
+        // Don't accumulate state when the feature is off — the next enable
+        // should start clean.
+        if (timer !== null) {
+          cancel(timer);
+          timer = null;
+        }
+        pending = null;
+        return;
+      }
+      if (selection.length === 0) {
+        // Empty selection (deselect): cancel pending writes but keep
+        // `lastCopied` so re-selecting the same text doesn't re-copy.
+        if (timer !== null) {
+          cancel(timer);
+          timer = null;
+        }
+        pending = null;
+        return;
+      }
+      pending = selection;
+      if (timer === null) {
+        timer = schedule(flush, debounceMs);
+      }
+    },
+    dispose() {
+      if (timer !== null) {
+        cancel(timer);
+        timer = null;
+      }
+      pending = null;
+    },
+  };
+}

--- a/src/modules/terminal/lib/imagePaste.test.ts
+++ b/src/modules/terminal/lib/imagePaste.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import {
+  cleanupTempClipboardImages,
+  readClipboardImagePath,
+} from "./imagePaste";
+
+describe("imagePaste", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the path when Rust resolves with one", async () => {
+    invokeMock.mockResolvedValueOnce("/tmp/terax-clipboard-1.png");
+    await expect(readClipboardImagePath()).resolves.toBe(
+      "/tmp/terax-clipboard-1.png",
+    );
+    expect(invokeMock).toHaveBeenCalledWith("clipboard_read_image");
+  });
+
+  it("returns null when Rust resolves null (text or no image)", async () => {
+    invokeMock.mockResolvedValueOnce(null);
+    await expect(readClipboardImagePath()).resolves.toBeNull();
+  });
+
+  it("returns null and swallows errors so paste falls back to text", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("backend unavailable"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await expect(readClipboardImagePath()).resolves.toBeNull();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("cleanup invokes the rust command and swallows errors", async () => {
+    invokeMock.mockResolvedValueOnce(7);
+    await expect(cleanupTempClipboardImages()).resolves.toBeUndefined();
+    expect(invokeMock).toHaveBeenCalledWith("clipboard_cleanup_temp_images");
+
+    invokeMock.mockRejectedValueOnce(new Error("boom"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await expect(cleanupTempClipboardImages()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/modules/terminal/lib/imagePaste.ts
+++ b/src/modules/terminal/lib/imagePaste.ts
@@ -1,0 +1,25 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Reads an image from the OS clipboard via Rust and returns the path to a
+ * temp PNG. Returns `null` when the clipboard has any non-empty text (so the
+ * caller falls back to a normal text paste) or when no image is present.
+ */
+export async function readClipboardImagePath(): Promise<string | null> {
+  try {
+    const path = await invoke<string | null>("clipboard_read_image");
+    return path ?? null;
+  } catch (e) {
+    console.warn("[terax] clipboard image read failed:", e);
+    return null;
+  }
+}
+
+/** Fire-and-forget cleanup of `terax-clipboard-*.png` older than 24h. */
+export async function cleanupTempClipboardImages(): Promise<void> {
+  try {
+    await invoke("clipboard_cleanup_temp_images");
+  } catch (e) {
+    console.warn("[terax] clipboard temp cleanup failed:", e);
+  }
+}

--- a/src/modules/terminal/lib/imageThumbnails.test.ts
+++ b/src/modules/terminal/lib/imageThumbnails.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// `convertFileSrc` and the DOM Image/canvas path are exercised at runtime in
+// the renderer; the pure registry/resolution logic is what unit tests cover.
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (p: string) => `asset://localhost/${encodeURIComponent(p)}`,
+}));
+
+// jsdom can't decode asset:// URLs, so generateThumb's caught error spams
+// stderr. Silence the warn — the registry/resolution paths are what we test.
+beforeAll(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+import {
+  clearLeafImages,
+  registerPastedImage,
+  resetImagePromptCounter,
+  resolveImageEntry,
+} from "./imageThumbnails";
+
+afterEach(() => {
+  // Tests share module-level state; reset between runs.
+  clearLeafImages(1);
+  clearLeafImages(2);
+});
+
+const tempPath = (n: number) => `/tmp/terax-clipboard-1735000000${n}-1234.png`;
+
+describe("registerPastedImage + resolveImageEntry — path 1:1", () => {
+  it("matches a visible temp path token to the registered entry", () => {
+    const p = tempPath(1);
+    registerPastedImage(1, p);
+
+    const e = resolveImageEntry(1, `cat ${p}`);
+    expect(e?.path).toBe(p);
+    expect(e?.promptSeq).toBe(1);
+  });
+
+  it("matches when the line shows only the filename", () => {
+    registerPastedImage(1, tempPath(2));
+    const e = resolveImageEntry(1, `[Image] terax-clipboard-17350000002-1234.png`);
+    expect(e?.file).toBe("terax-clipboard-17350000002-1234.png");
+  });
+
+  it("prefers the most recent entry when two share a filename", () => {
+    // Same basename pasted twice — return the latest registration.
+    const p = tempPath(3);
+    registerPastedImage(1, p);
+    registerPastedImage(1, p);
+    const e = resolveImageEntry(1, p);
+    expect(e?.promptSeq).toBe(2);
+  });
+});
+
+describe("[Image #N] correlation via per-prompt counter", () => {
+  it("assigns promptSeq sequentially and resolves [Image #N]", () => {
+    registerPastedImage(1, tempPath(1));
+    registerPastedImage(1, tempPath(2));
+    registerPastedImage(1, tempPath(3));
+
+    expect(resolveImageEntry(1, "[Image #1]")?.path).toBe(tempPath(1));
+    expect(resolveImageEntry(1, "[Image #2]")?.path).toBe(tempPath(2));
+    expect(resolveImageEntry(1, "[Image #3]")?.path).toBe(tempPath(3));
+  });
+
+  it("resets the per-prompt counter on submit so #1 maps to the next paste", () => {
+    registerPastedImage(1, tempPath(1));
+    registerPastedImage(1, tempPath(2));
+    expect(resolveImageEntry(1, "[Image #1]")?.path).toBe(tempPath(1));
+
+    resetImagePromptCounter(1);
+    registerPastedImage(1, tempPath(3));
+    // After submit + new paste, [Image #1] now points to the new image.
+    expect(resolveImageEntry(1, "[Image #1]")?.path).toBe(tempPath(3));
+    // Earlier paste is still in the registry for path-token lookups.
+    expect(resolveImageEntry(1, tempPath(1))?.path).toBe(tempPath(1));
+  });
+
+  it("returns undefined for [Image #N] with no matching entry", () => {
+    registerPastedImage(1, tempPath(1));
+    expect(resolveImageEntry(1, "[Image #7]")).toBeUndefined();
+  });
+});
+
+describe("isolation between leaves and lifecycle", () => {
+  it("does not leak entries across leaves", () => {
+    registerPastedImage(1, tempPath(1));
+    registerPastedImage(2, tempPath(2));
+
+    expect(resolveImageEntry(1, "[Image #1]")?.path).toBe(tempPath(1));
+    expect(resolveImageEntry(2, "[Image #1]")?.path).toBe(tempPath(2));
+    // Leaf 1 never saw leaf 2's path.
+    expect(resolveImageEntry(1, tempPath(2))).toBeUndefined();
+  });
+
+  it("clearLeafImages drops the leaf's registry", () => {
+    registerPastedImage(1, tempPath(1));
+    clearLeafImages(1);
+    expect(resolveImageEntry(1, "[Image #1]")).toBeUndefined();
+    expect(resolveImageEntry(1, tempPath(1))).toBeUndefined();
+  });
+
+  it("returns undefined for a leaf with no registry", () => {
+    expect(resolveImageEntry(99, "[Image #1]")).toBeUndefined();
+  });
+});
+
+describe("no false matches on unrelated text", () => {
+  it("ignores tokens that don't match either pattern", () => {
+    registerPastedImage(1, tempPath(1));
+    expect(resolveImageEntry(1, "ls -la")).toBeUndefined();
+    expect(resolveImageEntry(1, "[Image]")).toBeUndefined();
+    expect(resolveImageEntry(1, "image.png")).toBeUndefined();
+  });
+});

--- a/src/modules/terminal/lib/imageThumbnails.ts
+++ b/src/modules/terminal/lib/imageThumbnails.ts
@@ -1,0 +1,261 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+import type { IDisposable, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+
+/**
+ * Hover thumbnails for clipboard images pasted into the terminal (builds on the
+ * image-paste feature from PR #506).
+ *
+ * #506 pastes the temp PNG path into the shell; a CLI agent like Claude Code
+ * reads it and renders an `[Image #N]` token. That token is owned by the agent,
+ * not Terax, so correlating it back to the pasted file is inherently best-effort.
+ * We use a hybrid scheme:
+ *
+ *  - **Path token** (`terax-clipboard-<ms>-<pid>.png`, visible in plain shells):
+ *    matched 1:1 against the registry — always correct.
+ *  - **`[Image #N]`** (Claude's rendering): mapped to the N-th image pasted in
+ *    the *current* prompt. The per-prompt counter resets when the user submits
+ *    (a bare Enter to the PTY), mirroring Claude's per-prompt numbering. Stale
+ *    `[Image #N]` tokens left in scrollback from earlier prompts may resolve to
+ *    the latest prompt's image — the documented limitation of not owning #N.
+ */
+
+const THUMB_MAX_DIM = 160;
+const MAX_ENTRIES_PER_LEAF = 50;
+
+// `terax-clipboard-<unix-ms>-<pid>.png` (see clipboard.rs FILE naming).
+const PATH_TOKEN = String.raw`terax-clipboard-\d+-\d+\.png`;
+const IMAGE_TOKEN = String.raw`\[Image #\d+\]`;
+// Combined matcher for the link provider (global, multi-match per line).
+const TOKEN_RE = new RegExp(`${IMAGE_TOKEN}|${PATH_TOKEN}`, "g");
+
+type ImageEntry = {
+  /** 1-based index within the prompt at paste time (maps to `[Image #N]`). */
+  promptSeq: number;
+  /** Absolute temp PNG path that was pasted. */
+  path: string;
+  /** Basename, for matching a visible path token. */
+  file: string;
+  /** Compressed JPEG data URL; filled asynchronously after paste. */
+  thumbUrl?: string;
+};
+
+type LeafImages = {
+  entries: ImageEntry[];
+  /** Images pasted since the last submit; reset by resetImagePromptCounter. */
+  promptCount: number;
+};
+
+const byLeaf = new Map<number, LeafImages>();
+
+function leafState(leafId: number): LeafImages {
+  let s = byLeaf.get(leafId);
+  if (!s) {
+    s = { entries: [], promptCount: 0 };
+    byLeaf.set(leafId, s);
+  }
+  return s;
+}
+
+function basename(p: string): string {
+  const i = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+/**
+ * Record an image just pasted into `leafId`'s terminal and kick off thumbnail
+ * generation. Called from the paste handler after the path is written to the PTY.
+ */
+export function registerPastedImage(leafId: number, path: string): void {
+  const s = leafState(leafId);
+  s.promptCount += 1;
+  const entry: ImageEntry = {
+    promptSeq: s.promptCount,
+    path,
+    file: basename(path),
+  };
+  s.entries.push(entry);
+  if (s.entries.length > MAX_ENTRIES_PER_LEAF) s.entries.shift();
+  void generateThumb(entry);
+}
+
+/** Reset the per-prompt counter — call when the user submits (bare Enter). */
+export function resetImagePromptCounter(leafId: number): void {
+  const s = byLeaf.get(leafId);
+  if (s) s.promptCount = 0;
+}
+
+/** Drop a leaf's registry on respawn/dispose. */
+export function clearLeafImages(leafId: number): void {
+  byLeaf.delete(leafId);
+}
+
+/**
+ * Resolve a matched terminal token to its registry entry. Path tokens match
+ * 1:1 by filename; `[Image #N]` maps to the N-th image of the current prompt.
+ * Exported for unit tests; `resolveThumb` is the runtime entry point.
+ */
+export function resolveImageEntry(
+  leafId: number,
+  text: string,
+): ImageEntry | undefined {
+  const s = byLeaf.get(leafId);
+  if (!s) return undefined;
+
+  const pathMatch = text.match(new RegExp(PATH_TOKEN));
+  if (pathMatch) {
+    const file = pathMatch[0];
+    for (let i = s.entries.length - 1; i >= 0; i--) {
+      if (s.entries[i].file === file) return s.entries[i];
+    }
+    return undefined;
+  }
+
+  const imgMatch = text.match(/\[Image #(\d+)\]/);
+  if (imgMatch) {
+    const n = Number(imgMatch[1]);
+    for (let i = s.entries.length - 1; i >= 0; i--) {
+      if (s.entries[i].promptSeq === n) return s.entries[i];
+    }
+  }
+  return undefined;
+}
+
+function resolveThumb(leafId: number, text: string): string | undefined {
+  return resolveImageEntry(leafId, text)?.thumbUrl;
+}
+
+async function generateThumb(entry: ImageEntry): Promise<void> {
+  try {
+    const src = convertFileSrc(entry.path);
+    entry.thumbUrl = await makeThumbnail(src);
+  } catch (e) {
+    console.warn("[terax] image thumbnail failed:", e);
+  }
+}
+
+/** Downscale an image URL to a small, compressed preview for hover. */
+function makeThumbnail(src: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const { width, height } = img;
+      if (!width || !height) {
+        reject(new Error("empty image"));
+        return;
+      }
+      const scale = Math.min(1, THUMB_MAX_DIM / Math.max(width, height));
+      const w = Math.max(1, Math.round(width * scale));
+      const h = Math.max(1, Math.round(height * scale));
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("no 2d context"));
+        return;
+      }
+      ctx.drawImage(img, 0, 0, w, h);
+      resolve(canvas.toDataURL("image/jpeg", 0.7));
+    };
+    img.onerror = () => reject(new Error("thumbnail decode failed"));
+    img.src = src;
+  });
+}
+
+// ---- Hover overlay -------------------------------------------------------
+
+const TOOLTIP_OFFSET = 14;
+
+function createTooltip(): HTMLImageElement {
+  const el = document.createElement("img");
+  el.setAttribute("data-terax-image-thumb", "");
+  el.style.cssText = [
+    "position:fixed",
+    "z-index:9999",
+    "max-width:240px",
+    "max-height:240px",
+    "border-radius:6px",
+    "box-shadow:0 4px 16px rgba(0,0,0,.4)",
+    "border:1px solid rgba(255,255,255,.12)",
+    "pointer-events:none",
+    "display:none",
+  ].join(";");
+  document.body.appendChild(el);
+  return el;
+}
+
+function showTooltip(el: HTMLImageElement, thumb: string, ev: MouseEvent): void {
+  el.src = thumb;
+  el.style.display = "block";
+  // Position bottom-right of the cursor, clamped to the viewport.
+  const x = Math.min(ev.clientX + TOOLTIP_OFFSET, window.innerWidth - 260);
+  const y = Math.min(ev.clientY + TOOLTIP_OFFSET, window.innerHeight - 260);
+  el.style.left = `${Math.max(8, x)}px`;
+  el.style.top = `${Math.max(8, y)}px`;
+}
+
+function hideTooltip(el: HTMLImageElement): void {
+  el.style.display = "none";
+  el.removeAttribute("src");
+}
+
+/**
+ * Register an xterm link provider that turns `[Image #N]` / pasted-path tokens
+ * into hover targets showing the compressed thumbnail. Registered once per slot
+ * (the term outlives leaf rebinds); `getLeafId` resolves the slot's current leaf
+ * at hover time. Returns a disposer that also removes the overlay element.
+ */
+export function registerImageThumbnailLinks(
+  term: Terminal,
+  getLeafId: () => number | null,
+): () => void {
+  const tooltip = createTooltip();
+
+  const provider: ILinkProvider = {
+    provideLinks(y, callback) {
+      const leafId = getLeafId();
+      if (leafId === null) {
+        callback(undefined);
+        return;
+      }
+      const line = term.buffer.active.getLine(y - 1);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+      const text = line.translateToString(true);
+      const links: ILink[] = [];
+      TOKEN_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = TOKEN_RE.exec(text)) !== null) {
+        const matchText = m[0];
+        const startX = m.index + 1; // xterm columns are 1-based
+        const endX = m.index + matchText.length; // inclusive last cell
+        links.push({
+          text: matchText,
+          range: { start: { x: startX, y }, end: { x: endX, y } },
+          activate: () => {},
+          hover: (event) => {
+            const thumb = resolveThumb(leafId, matchText);
+            if (thumb) showTooltip(tooltip, thumb, event as MouseEvent);
+          },
+          leave: () => hideTooltip(tooltip),
+        });
+      }
+      callback(links.length > 0 ? links : undefined);
+    },
+  };
+
+  let disposable: IDisposable | null = null;
+  try {
+    disposable = term.registerLinkProvider(provider);
+  } catch (e) {
+    console.warn("[terax] image link provider unavailable:", e);
+  }
+  return () => {
+    try {
+      disposable?.dispose();
+    } catch {}
+    tooltip.remove();
+  };
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -11,6 +11,11 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import { createCopyOnSelectHandler } from "./copyOnSelect";
 import { readClipboardImagePath } from "./imagePaste";
+import {
+  registerImageThumbnailLinks,
+  registerPastedImage,
+  resetImagePromptCounter,
+} from "./imageThumbnails";
 import { terminalWordNavigationSequence } from "./keymap";
 
 export const POOL_MAX_SIZE = 5;
@@ -198,6 +203,10 @@ function createSlot(): Slot {
   term.onData((data) => {
     const leafId = slot.currentLeafId;
     if (leafId === null) return;
+    // A bare CR is the Enter keystroke from this term (pastes never produce
+    // exactly "\r"); treat it as a submit and reset Claude's per-prompt
+    // [Image #N] correlation. See imageThumbnails.ts for the heuristic.
+    if (data === "\r") resetImagePromptCounter(leafId);
     adapter?.resolveLeaf(leafId)?.writeToPty(data);
   });
 
@@ -206,6 +215,10 @@ function createSlot(): Slot {
     copy: (text) => void navigator.clipboard.writeText(text).catch(() => {}),
   });
   term.onSelectionChange(() => copyOnSelect.notify(term.getSelection()));
+
+  // Register once per slot lifetime — slots are pool-permanent and the
+  // provider reads the current leafId at hover time.
+  registerImageThumbnailLinks(slot.term, () => slot.currentLeafId);
 
   slots.push(slot);
   return slot;
@@ -711,6 +724,9 @@ async function handleTerminalPaste(slot: Slot): Promise<void> {
   const imagePath = await readClipboardImagePath();
   if (imagePath) {
     slot.term.paste(quoteShellArg(imagePath));
+    if (slot.currentLeafId !== null) {
+      registerPastedImage(slot.currentLeafId, imagePath);
+    }
     return;
   }
   try {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -9,6 +9,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { createCopyOnSelectHandler } from "./copyOnSelect";
 import { readClipboardImagePath } from "./imagePaste";
 import { terminalWordNavigationSequence } from "./keymap";
 
@@ -199,6 +200,12 @@ function createSlot(): Slot {
     if (leafId === null) return;
     adapter?.resolveLeaf(leafId)?.writeToPty(data);
   });
+
+  const copyOnSelect = createCopyOnSelectHandler({
+    isEnabled: () => usePreferencesStore.getState().terminalCopyOnSelect,
+    copy: (text) => void navigator.clipboard.writeText(text).catch(() => {}),
+  });
+  term.onSelectionChange(() => copyOnSelect.notify(term.getSelection()));
 
   slots.push(slot);
   return slot;

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,4 +1,5 @@
 import { detectMonoFontFamily } from "@/lib/fonts";
+import { quoteShellArg } from "@/lib/shellQuote";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -8,6 +9,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { readClipboardImagePath } from "./imagePaste";
 import { terminalWordNavigationSequence } from "./keymap";
 
 export const POOL_MAX_SIZE = 5;
@@ -185,14 +187,7 @@ function createSlot(): Slot {
       return false;
     }
     if (isTerminalPaste(event)) {
-      if (event.type === "keydown") {
-        void navigator.clipboard
-          .readText()
-          .then((text) => {
-            if (text) slot.term.paste(text);
-          })
-          .catch(() => {});
-      }
+      if (event.type === "keydown") void handleTerminalPaste(slot);
       event.preventDefault();
       return false;
     }
@@ -694,14 +689,29 @@ function isTerminalCopy(e: KeyboardEvent): boolean {
 }
 
 function isTerminalPaste(e: KeyboardEvent): boolean {
-  return (
-    !IS_MAC &&
-    e.ctrlKey &&
-    e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyV" || e.key === "v" || e.key === "V")
-  );
+  const isV = e.code === "KeyV" || e.key === "v" || e.key === "V";
+  if (!isV) return false;
+  if (IS_MAC) {
+    return e.metaKey && !e.altKey && !e.ctrlKey;
+  }
+  // Windows/Linux: cover both Ctrl+V and Ctrl+Shift+V so image paste lands
+  // on the binding users actually press. Plain Ctrl+V loses its quoted-insert
+  // (^V) behavior here, which is the documented tradeoff for AI-terminal use.
+  return e.ctrlKey && !e.altKey && !e.metaKey;
+}
+
+async function handleTerminalPaste(slot: Slot): Promise<void> {
+  const imagePath = await readClipboardImagePath();
+  if (imagePath) {
+    slot.term.paste(quoteShellArg(imagePath));
+    return;
+  }
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text) slot.term.paste(text);
+  } catch {
+    /* ignore — empty clipboard or permission denial */
+  }
 }
 
 function isCtrlBackspace(e: KeyboardEvent): boolean {

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -3,6 +3,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { DormantRing } from "./dormantRing";
+import { clearLeafImages } from "./imageThumbnails";
 import {
   createShellIntegrationState,
   registerCwdHandler,
@@ -319,6 +320,9 @@ export async function respawnSession(
   s.shellExited = false;
   s.pendingExit = null;
   s.altScreenAtRelease = false;
+  // New shell — drop any clipboard-image registry from the dead one so the
+  // next [Image #N] from the new shell starts fresh.
+  clearLeafImages(leafId);
 
   const slot = getSlotForLeaf(leafId);
   if (slot) {
@@ -353,6 +357,7 @@ export function disposeSession(leafId: number): void {
   s.snapshot = null;
   s.pty?.close();
   s.pty = null;
+  clearLeafImages(leafId);
   sessions.delete(leafId);
   readyLeaves.delete(leafId);
   const waiters = readyWaiters.get(leafId);

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -26,6 +26,7 @@ import {
   setTerminalFontFamily,
   setTerminalLetterSpacing,
   setTerminalFontSize,
+  setTerminalCopyOnSelect,
   setTerminalScrollback,
   setTerminalWebglEnabled,
   setVimMode,
@@ -67,6 +68,9 @@ export function GeneralSection() {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
+  );
+  const terminalCopyOnSelect = usePreferencesStore(
+    (s) => s.terminalCopyOnSelect,
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
@@ -217,6 +221,15 @@ export function GeneralSection() {
           <Switch
             checked={terminalWebglEnabled}
             onCheckedChange={(v) => void setTerminalWebglEnabled(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Copy on select"
+          description="Automatically copy selected text to the clipboard, no shortcut needed. Matches kitty / iTerm2 behavior."
+        >
+          <Switch
+            checked={terminalCopyOnSelect}
+            onCheckedChange={(v) => void setTerminalCopyOnSelect(v)}
           />
         </SettingRow>
         <SettingRow


### PR DESCRIPTION
## Summary
Stacks on #506 — please merge #506 first; once it lands this PR's diff shrinks to just the thumbnail commit. Adds a hover preview for clipboard images pasted via the #506 flow.

#506 pastes the temp PNG path so a CLI agent like Claude Code can render an \`[Image #N]\` token in the terminal, but there's no way to peek at what you actually pasted. This PR makes hovering an \`[Image #N]\` or a visible \`terax-clipboard-…\.png\` token pop a small compressed thumbnail.

## Approach
- **Per-leaf registry** in \`imageThumbnails.ts\`. Each successful image paste from \`handleTerminalPaste\` records \`{ promptSeq, path, file, thumbUrl }\`; thumbnail generated async via \`convertFileSrc\` + downscale to 160 px JPEG (q = 0.7).
- **Hybrid correlation** for the hover target, because \`[Image #N]\` is owned by the CLI, not Terax:
  - **Path tokens** (\`terax-clipboard-<ms>-<pid>.png\`, visible in plain shells): matched 1:1 by basename — always correct.
  - **\`[Image #N]\`** (Claude's rendering): mapped to the N-th image of the current prompt. The per-prompt counter resets on a bare \`Enter\` (\`data === "\r"\` in \`term.onData\`; pastes never produce exactly \`"\r"\`), mirroring Claude's per-prompt numbering.
  - **Documented limitation**: stale \`[Image #N]\` tokens left in scrollback from earlier prompts may resolve to the latest prompt's image. Path-token matches are unaffected.
- **xterm \`registerLinkProvider\`** matches \`/\[Image #\d+\]|terax-clipboard-\d+-\d+\.png/\` per line and renders a fixed-position \`<img>\` overlay on \`hover\` / \`leave\`. Registered once per slot (slots are pool-permanent); reads \`slot.currentLeafId\` at hover time to track pool reassignments.
- Registry cleared in \`respawnSession\` + \`disposeSession\`; per-leaf cap of 50 entries.

## Tauri asset protocol
\`convertFileSrc\` only works if both pieces are in place — without the feature flag the \`tauri.conf.json\` setting is dead:
- \`Cargo.toml\`: \`tauri = { features = ["protocol-asset"] }\`
- \`tauri.conf.json\`: \`assetProtocol.enable: true\` + \`scope: ["\$TEMP/terax-clipboard-*.png"]\` (least privilege)

## Test plan
- [x] \`pnpm test\` — 74/74 (10 new unit tests cover path 1:1, \`[Image #N]\` mapping, per-prompt reset, leaf isolation, false-match guards)
- [x] \`pnpm exec tsc --noEmit\` clean
- [ ] Runtime smoke (requires a fresh \`pnpm tauri dev\` to pick up the \`protocol-asset\` feature): screenshot → Cmd+V in Claude Code pane → hover \`[Image #1]\` → see thumbnail; submit, paste again → hover new \`[Image #1]\` → see new thumbnail; in a plain shell, paste then hover the visible temp path → see thumbnail.

Refs #506