### PR TITLE
fix: prevent MissingToolResultsError by denying pending approvals on follow-up

### DIFF
--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -305,6 +305,28 @@ export function AiComposerProvider({ children }: ProviderProps) {
 
     if (!sessionId) return;
     const chat = getOrCreateChat(sessionId);
+
+    // Deny any pending tool approvals before sending a follow-up.
+    // This prevents MissingToolResultsError from the AI SDK.
+    for (const m of chat.messages) {
+      if (m.role !== "assistant") continue;
+      (m as { parts: unknown[] }).parts = m.parts.map((p) => {
+        const part = p as { state?: string; approval?: { id: string } };
+        if (part.state === "approval-requested") {
+          return {
+            ...part,
+            state: "output-denied" as const,
+            approval: {
+              id: part.approval?.id ?? "unknown",
+              approved: false,
+              reason: "Superseded by follow-up prompt",
+            },
+          };
+        }
+        return part;
+      });
+    }
+
     void chat.sendMessage({ role: "user", parts } as Parameters<
       typeof chat.sendMessage
     >[0]);


### PR DESCRIPTION
What
Auto-deny pending tool call approvals when the user sends a follow-up prompt, preventing the MissingToolResultsError that breaks the chat.

Why
When the AI agent makes tool calls that require user approval (e.g., write_file, bash_run), the AI SDK pauses with "approval-requested" state on those tool parts. If the user sends a follow-up message instead of clicking Approve/Deny, the SDK's convertToLanguageModelPrompt validation finds tool calls without corresponding results and throws MissingToolResultsError. This leaves the chat in an unrecoverable error state — the approval buttons stop working and no further prompts can be processed.

How
In the composer's submit() function, before calling chat.sendMessage(), we iterate through the chat's assistant messages and mutate any tool parts in "approval-requested" state to "output-denied" state with approved: false. The AI SDK's convertToModelMessages already handles the "output-denied" state correctly, producing a proper tool-result with "execution-denied" output, so the subsequent validation in convertToLanguageModelPrompt passes without error.

Testing
 pnpm exec tsc --noEmit clean
 Manual smoke-test of the affected feature: start a chat → prompt the agent to run a command → send a follow-up prompt before approving → verify no error and chat continues normally
 (If you touched src-tauri) cargo check clean
 (If UI) tested in pnpm tauri dev
Screenshots / GIFs
N/A — behavioral fix, no UI changes.

Notes for reviewer
The fix mutates the chat's internal message state directly (via chat.messages getter which returns a reference to the internal array). This is necessary because the Chat class doesn't expose an API to batch-deny pending approvals. An alternative would be to call addToolApprovalResponse() for each pending approval, but that method sets state to "approval-responded" which is not handled by convertToModelMessages (only "output-denied", "output-available", and "output-error" are), so the error would still occur.

Before change:

<img width="1370" height="603" alt="598016063-4fcd8cb4-12a4-4e38-b8c5-c9c39361ac8f" src="https://github.com/user-attachments/assets/8a3470ec-7d78-4738-a66e-eeeecb511326" />

After Change:

<img width="1494" height="924" alt="598016276-1ff8d604-ac2f-42a9-9e84-abff8952754d" src="https://github.com/user-attachments/assets/343850af-95a3-4b1e-8910-a08bd3149acb" />

