### PR TITLE
feat(tabs): rename terminal tabs via right-click

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1169,6 +1169,11 @@ export default function App() {
     [updateTab],
   );
 
+  const handleRenameTab = useCallback(
+    (id: number, title: string) => updateTab(id, { customTitle: title.trim() }),
+    [updateTab],
+  );
+
   const searchTarget = useMemo<SearchTarget>(() => {
     if (isTerminalTab && activeLeafId !== null && activeSearchAddon)
       return {
@@ -1394,6 +1399,7 @@ export default function App() {
             onNewGitGraph={openGitGraphFromContext}
             onClose={handleClose}
             onPin={pinTab}
+            onRename={handleRenameTab}
             onToggleSidebar={toggleSidebar}
             onSplit={splitActivePaneInActiveTab}
             canSplit={

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -43,6 +43,8 @@ type Props = {
   onClose: (id: number) => void;
   /** Promote a preview (transient) tab to persistent. */
   onPin: (id: number) => void;
+  /** Set a terminal tab's custom label; empty string resets to default. */
+  onRename: (id: number, title: string) => void;
   onToggleSidebar: () => void;
   onSplit: (dir: "row" | "col") => void;
   /** Active tab is a terminal and below the per-tab pane cap. */
@@ -67,6 +69,7 @@ export function Header({
   onNewGitGraph,
   onClose,
   onPin,
+  onRename,
   onToggleSidebar,
   onSplit,
   canSplit,
@@ -200,6 +203,7 @@ export function Header({
           onNewGitGraph={onNewGitGraph}
           onClose={onClose}
           onPin={onPin}
+          onRename={onRename}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -1,5 +1,12 @@
 import { Button } from "@/components/ui/button";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -21,7 +28,8 @@ import {
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { labelFor } from "./lib/tabLabel";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
 type Props = {
@@ -36,6 +44,8 @@ type Props = {
   onClose: (id: number) => void;
   /** Pin (promote) a preview tab to persistent on double-click. */
   onPin: (id: number) => void;
+  /** Set a terminal tab's custom label; empty string resets to default. */
+  onRename: (id: number, title: string) => void;
   compact?: boolean;
 };
 
@@ -50,9 +60,11 @@ export function TabBar({
   onNewGitGraph,
   onClose,
   onPin,
+  onRename,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -90,7 +102,8 @@ export function TabBar({
           <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
             {tabs.map((t) => {
               const isPreview = t.kind === "editor" && (t as EditorTab).preview;
-              return (
+              const isEditing = editingId === t.id;
+              const trigger = (
                 <TabsTrigger
                   key={t.id}
                   value={String(t.id)}
@@ -112,11 +125,22 @@ export function TabBar({
                     )}
                   >
                     <TabIcon tab={t} />
-                    {/* Preview tabs use italic to signal the transient state,
-                        matching the visual convention from VSCode. */}
-                    <span className={cn("truncate", isPreview && "italic")}>
-                      {labelFor(t)}
-                    </span>
+                    {isEditing ? (
+                      <TabRenameInput
+                        initial={labelFor(t)}
+                        onCommit={(value) => {
+                          onRename(t.id, value);
+                          setEditingId(null);
+                        }}
+                        onCancel={() => setEditingId(null)}
+                      />
+                    ) : (
+                      /* Preview tabs use italic to signal the transient state,
+                         matching the visual convention from VSCode. */
+                      <span className={cn("truncate", isPreview && "italic")}>
+                        {labelFor(t)}
+                      </span>
+                    )}
                     {t.kind === "editor" && t.dirty ? (
                       <span
                         aria-label="Unsaved changes"
@@ -124,7 +148,7 @@ export function TabBar({
                       />
                     ) : null}
                   </span>
-                  {tabs.length > 1 && (
+                  {tabs.length > 1 && !isEditing && (
                     <span
                       role="button"
                       aria-label="Close tab"
@@ -142,6 +166,37 @@ export function TabBar({
                     </span>
                   )}
                 </TabsTrigger>
+              );
+
+              if (t.kind !== "terminal") return trigger;
+
+              return (
+                <ContextMenu key={t.id}>
+                  <ContextMenuTrigger asChild>{trigger}</ContextMenuTrigger>
+                  <ContextMenuContent className="min-w-36">
+                    <ContextMenuItem onSelect={() => setEditingId(t.id)}>
+                      <HugeiconsIcon
+                        icon={PencilEdit02Icon}
+                        size={14}
+                        strokeWidth={1.75}
+                      />
+                      <span className="flex-1">Rename</span>
+                    </ContextMenuItem>
+                    {tabs.length > 1 && (
+                      <>
+                        <ContextMenuSeparator />
+                        <ContextMenuItem onSelect={() => onClose(t.id)}>
+                          <HugeiconsIcon
+                            icon={Cancel01Icon}
+                            size={14}
+                            strokeWidth={1.75}
+                          />
+                          <span className="flex-1">Close</span>
+                        </ContextMenuItem>
+                      </>
+                    )}
+                  </ContextMenuContent>
+                </ContextMenu>
               );
             })}
           </TabsList>
@@ -274,15 +329,55 @@ function TabIcon({ tab }: { tab: Tab }) {
   );
 }
 
-function labelFor(t: Tab): string {
-  if (t.kind === "editor") return t.title;
-  if (t.kind === "preview") return t.title;
-  if (t.kind === "markdown") return t.title;
-  if (t.kind === "ai-diff") return t.title;
-  if (t.kind === "git-diff") return t.title;
-  if (t.kind === "git-history") return t.title;
-  if (t.kind === "git-commit-file") return t.title;
-  if (!t.cwd) return t.title;
-  const parts = t.cwd.split(/[\\/]/).filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : "/";
+function TabRenameInput({
+  initial,
+  onCommit,
+  onCancel,
+}: {
+  initial: string;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  // Guards against the blur handler firing a second time after Enter/Escape
+  // already resolved the edit (Escape must not commit the default name).
+  const done = useRef(false);
+
+  useEffect(() => {
+    ref.current?.select();
+  }, []);
+
+  const commit = (value: string) => {
+    if (done.current) return;
+    done.current = true;
+    // No change to the displayed label: don't freeze the cwd-derived default
+    // into a custom title.
+    if (value.trim() === initial.trim()) onCancel();
+    else onCommit(value);
+  };
+  const cancel = () => {
+    if (done.current) return;
+    done.current = true;
+    onCancel();
+  };
+
+  return (
+    <input
+      ref={ref}
+      defaultValue={initial}
+      aria-label="Rename tab"
+      className={cn(
+        "w-28 min-w-0 rounded-sm bg-background px-1 text-xs text-foreground",
+        "outline-none ring-1 ring-border focus:ring-ring",
+      )}
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === "Enter") commit(e.currentTarget.value);
+        else if (e.key === "Escape") cancel();
+      }}
+      onBlur={(e) => commit(e.currentTarget.value)}
+    />
+  );
 }

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -102,7 +102,33 @@ export function TabBar({
           <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
             {tabs.map((t) => {
               const isPreview = t.kind === "editor" && (t as EditorTab).preview;
-              const isEditing = editingId === t.id;
+
+              // While renaming, render a non-button cell so the <input> is not
+              // nested inside the trigger <button> (invalid HTML, and WebKit
+              // blocks focus/selection on inputs inside buttons).
+              if (editingId === t.id && t.kind === "terminal") {
+                return (
+                  <div
+                    key={t.id}
+                    data-tab-id={t.id}
+                    className={cn(
+                      "flex h-7 shrink-0 items-center gap-1.5 rounded-md bg-accent text-xs text-foreground",
+                      compact ? "px-1.5" : "px-2",
+                    )}
+                  >
+                    <TabIcon tab={t} />
+                    <TabRenameInput
+                      initial={labelFor(t)}
+                      onCommit={(value) => {
+                        onRename(t.id, value);
+                        setEditingId(null);
+                      }}
+                      onCancel={() => setEditingId(null)}
+                    />
+                  </div>
+                );
+              }
+
               const trigger = (
                 <TabsTrigger
                   key={t.id}
@@ -125,22 +151,11 @@ export function TabBar({
                     )}
                   >
                     <TabIcon tab={t} />
-                    {isEditing ? (
-                      <TabRenameInput
-                        initial={labelFor(t)}
-                        onCommit={(value) => {
-                          onRename(t.id, value);
-                          setEditingId(null);
-                        }}
-                        onCancel={() => setEditingId(null)}
-                      />
-                    ) : (
-                      /* Preview tabs use italic to signal the transient state,
-                         matching the visual convention from VSCode. */
-                      <span className={cn("truncate", isPreview && "italic")}>
-                        {labelFor(t)}
-                      </span>
-                    )}
+                    {/* Preview tabs use italic to signal the transient state,
+                        matching the visual convention from VSCode. */}
+                    <span className={cn("truncate", isPreview && "italic")}>
+                      {labelFor(t)}
+                    </span>
                     {t.kind === "editor" && t.dirty ? (
                       <span
                         aria-label="Unsaved changes"
@@ -148,7 +163,7 @@ export function TabBar({
                       />
                     ) : null}
                   </span>
-                  {tabs.length > 1 && !isEditing && (
+                  {tabs.length > 1 && (
                     <span
                       role="button"
                       aria-label="Close tab"
@@ -339,26 +354,32 @@ function TabRenameInput({
   onCancel: () => void;
 }) {
   const ref = useRef<HTMLInputElement>(null);
-  // Guards against the blur handler firing a second time after Enter/Escape
-  // already resolved the edit (Escape must not commit the default name).
+  // Guards against a trailing blur re-resolving an edit that Enter/Escape
+  // already finished (Escape must never commit).
   const done = useRef(false);
 
   useEffect(() => {
-    ref.current?.select();
+    // Focus on the next frame so it runs after the context menu restores focus
+    // to its trigger when closing; a synchronous focus would be stolen.
+    const raf = requestAnimationFrame(() => {
+      ref.current?.focus();
+      ref.current?.select();
+    });
+    return () => cancelAnimationFrame(raf);
   }, []);
 
-  const commit = (value: string) => {
+  const finish = (fn: () => void) => {
     if (done.current) return;
     done.current = true;
-    // No change to the displayed label: don't freeze the cwd-derived default
-    // into a custom title.
-    if (value.trim() === initial.trim()) onCancel();
-    else onCommit(value);
+    fn();
   };
-  const cancel = () => {
-    if (done.current) return;
-    done.current = true;
-    onCancel();
+
+  // explicit = the user pressed Enter, which pins even the unchanged label. A
+  // plain blur with no change must not freeze the cwd-derived default into a
+  // custom title.
+  const commit = (value: string, explicit: boolean) => {
+    if (!explicit && value.trim() === initial.trim()) finish(onCancel);
+    else finish(() => onCommit(value));
   };
 
   return (
@@ -370,14 +391,17 @@ function TabRenameInput({
         "w-28 min-w-0 rounded-sm bg-background px-1 text-xs text-foreground",
         "outline-none ring-1 ring-border focus:ring-ring",
       )}
-      onClick={(e) => e.stopPropagation()}
-      onPointerDown={(e) => e.stopPropagation()}
       onKeyDown={(e) => {
         e.stopPropagation();
-        if (e.key === "Enter") commit(e.currentTarget.value);
-        else if (e.key === "Escape") cancel();
+        if (e.key === "Enter") commit(e.currentTarget.value, true);
+        else if (e.key === "Escape") finish(onCancel);
       }}
-      onBlur={(e) => commit(e.currentTarget.value)}
+      onBlur={(e) => {
+        // Switching windows/apps blurs the input; keep the edit open instead
+        // of resolving it on the way out.
+        if (!document.hasFocus()) return;
+        commit(e.currentTarget.value, false);
+      }}
     />
   );
 }

--- a/src/modules/tabs/lib/tabLabel.test.ts
+++ b/src/modules/tabs/lib/tabLabel.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { labelFor } from "./tabLabel";
+import type { TerminalTab } from "./useTabs";
+
+function terminalTab(over: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 1,
+    kind: "terminal",
+    title: "shell",
+    paneTree: { kind: "leaf", id: 2 },
+    activeLeafId: 2,
+    ...over,
+  };
+}
+
+describe("labelFor (terminal tabs)", () => {
+  it("derives the label from the last cwd segment", () => {
+    expect(labelFor(terminalTab({ cwd: "/Users/me/projects/terax-ai" }))).toBe(
+      "terax-ai",
+    );
+  });
+
+  it("falls back to the title when there is no cwd", () => {
+    expect(labelFor(terminalTab({ title: "private" }))).toBe("private");
+  });
+
+  it("prefers a custom title over the cwd-derived name", () => {
+    expect(
+      labelFor(terminalTab({ cwd: "/Users/me/projects/terax-ai", customTitle: "Server" })),
+    ).toBe("Server");
+  });
+
+  it("keeps the custom title after the cwd changes (survives cd)", () => {
+    const renamed = terminalTab({ cwd: "/Users/me/a", customTitle: "Server" });
+    const afterCd = { ...renamed, cwd: "/Users/me/b/c" };
+    expect(labelFor(afterCd)).toBe("Server");
+  });
+
+  it("handles Windows-style cwd separators", () => {
+    expect(labelFor(terminalTab({ cwd: "C:\\Users\\me\\proj" }))).toBe("proj");
+  });
+});

--- a/src/modules/tabs/lib/tabLabel.ts
+++ b/src/modules/tabs/lib/tabLabel.ts
@@ -1,0 +1,21 @@
+import type { Tab } from "./useTabs";
+
+/**
+ * The label shown on a tab. Non-terminal tabs use their stored title; terminal
+ * tabs prefer a user-set custom name, then fall back to the last segment of the
+ * cwd. Keeping this pure makes the "custom name survives a cd" invariant
+ * testable without rendering the bar.
+ */
+export function labelFor(t: Tab): string {
+  if (t.kind === "editor") return t.title;
+  if (t.kind === "preview") return t.title;
+  if (t.kind === "markdown") return t.title;
+  if (t.kind === "ai-diff") return t.title;
+  if (t.kind === "git-diff") return t.title;
+  if (t.kind === "git-history") return t.title;
+  if (t.kind === "git-commit-file") return t.title;
+  if (t.customTitle) return t.customTitle;
+  if (!t.cwd) return t.title;
+  const parts = t.cwd.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : "/";
+}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -25,6 +25,8 @@ export type TerminalTab = {
   activeLeafId: number;
   /** AI agent cannot read buffer / context of this terminal. */
   private?: boolean;
+  /** User-set label that overrides the cwd-derived name. Survives cd. */
+  customTitle?: string;
 };
 
 export type EditorTab = {
@@ -116,6 +118,8 @@ export type TabPatch = Partial<{
   path: string;
   dirty: boolean;
   url: string;
+  /** Empty string resets a terminal tab to its cwd-derived name. */
+  customTitle: string;
 }>;
 
 function basename(path: string): string {
@@ -585,6 +589,9 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             ...x,
             ...(patch.title !== undefined && { title: patch.title }),
             ...(patch.cwd !== undefined && { cwd: patch.cwd }),
+            ...(patch.customTitle !== undefined && {
+              customTitle: patch.customTitle === "" ? undefined : patch.customTitle,
+            }),
           };
         }
         if (x.kind === "preview") {


### PR DESCRIPTION
## What
Right-clicking a terminal tab now opens a context menu with **Rename** (and **Close**). Rename opens an inline input on the tab; the chosen name persists.

## Why
Tabs are labelled by the last segment of their cwd, so two tabs in similarly named directories are hard to tell apart and there was no way to give a tab a meaningful name. Requested behaviour: right-click a tab to rename it.

## How
- New optional `customTitle` on `TerminalTab`. It takes precedence over the cwd-derived label, so a renamed tab keeps its name across a `cd`. An empty value resets to the default.
- `updateTab` handles the `customTitle` patch (empty string clears it).
- `labelFor` is extracted from `TabBar.tsx` into a pure module (`lib/tabLabel.ts`) so the precedence/"survives cd" logic is unit-testable.
- `TabBar` wraps terminal tabs in the existing `ContextMenu` primitive (Radix, already a dependency — no new deps) and renders an inline `<input>` while editing. Enter commits, Esc cancels, blur commits, no-change is a no-op (so it never freezes the cwd default into a custom title).

Scope kept to terminal tabs only.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo check` clean — n/a, no Rust touched
- [ ] (If UI) tested in `pnpm tauri dev`

`pnpm test` passes (83/83), including a new `tabLabel.test.ts` that locks the invariants: cwd-derived label, title fallback, custom title precedence, custom title surviving a cwd change, and Windows-style separators.

Draft: I have not yet run the GUI (`pnpm tauri dev`) to smoke-test the interaction and capture a GIF — doing that and attaching the recording before marking ready for review.

## Screenshots / GIFs
_To be added (rename interaction GIF) before marking ready for review._

## Notes for reviewer
- Per CONTRIBUTING this is a UI/feature change that normally wants prior discussion — opening as a draft for alignment. Happy to move it to an issue/Discord first if you'd prefer.
- `labelFor` was moved out of `TabBar.tsx` into `lib/tabLabel.ts`; the only behavioural change is the new `customTitle` precedence line.