### PR TITLE
feat(terminal): clear scrollback with Cmd+K

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -80,6 +80,7 @@ import {
 import { StatusBar } from "@/modules/statusbar";
 import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
 import {
+  clearFocusedTerminal,
   disposeSession,
   findLeafCwd,
   hasLeaf,
@@ -1027,6 +1028,9 @@ export default function App() {
       "pane.focusNext": () => focusNextPaneInTab(activeId, 1),
       "pane.focusPrev": () => focusNextPaneInTab(activeId, -1),
       "pane.source": toggleSourceControl,
+      "terminal.clear": () => {
+        clearFocusedTerminal();
+      },
       "search.focus": () => searchInlineRef.current?.focus(),
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
@@ -1075,6 +1079,13 @@ export default function App() {
         if (!inTerminal) return false;
         const sel = captureActiveSelection();
         return !sel || !sel.trim();
+      }
+      if (id === "terminal.clear") {
+        // Only intercept ⌘K while a terminal is focused; elsewhere let the key
+        // fall through (we never preventDefault when disabled).
+        const target =
+          (e.target as HTMLElement | null) ?? document.activeElement;
+        return !(target as HTMLElement | null)?.closest?.(".xterm");
       }
       return false;
     },

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -18,6 +18,7 @@ export type ShortcutId =
   | "pane.focusNext"
   | "pane.focusPrev"
   | "pane.source"
+  | "terminal.clear"
   | "search.focus"
   | "explorer.search"
   | "explorer.focus"
@@ -36,6 +37,7 @@ export type ShortcutGroup =
   | "General"
   | "Tabs"
   | "Panes"
+  | "Terminal"
   | "Search"
   | "AI"
   | "View"
@@ -129,6 +131,15 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Toggle source panel",
     group: "Panes",
     defaultBindings: [{ [MOD_PROP]: true, key: "g" }],
+  },
+  {
+    id: "terminal.clear",
+    label: "Clear terminal",
+    group: "Terminal",
+    // macOS Terminal's ⌘K (clear scrollback, keep the prompt). Default only on
+    // macOS — on other platforms Ctrl+K is readline's kill-line, so we leave it
+    // unbound and let users assign their own in settings.
+    defaultBindings: IS_MAC ? [{ meta: true, key: "k" }] : [],
   },
   {
     id: "tab.next",
@@ -233,6 +244,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   "General",
   "Tabs",
   "Panes",
+  "Terminal",
   "View",
   "Search",
   "AI",

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -1,6 +1,7 @@
 export { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 export { TerminalStack } from "./TerminalStack";
 export {
+  clearFocusedTerminal,
   disposeSession,
   leafIdForPty,
   respawnSession,

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -98,6 +98,22 @@ export function writeToSession(leafId: number, data: string): boolean {
   return true;
 }
 
+/**
+ * Clear the scrollback and screen of the currently focused terminal, keeping
+ * the active prompt line — macOS Terminal's ⌘K behaviour. Returns false when no
+ * focused terminal slot is bound (e.g. focus is in the editor or AI panel).
+ */
+export function clearFocusedTerminal(): boolean {
+  for (const [leafId, s] of sessions) {
+    if (!s.visibleNow || !s.focusedNow) continue;
+    const slot = getSlotForLeaf(leafId);
+    if (!slot) continue;
+    slot.term.clear();
+    return true;
+  }
+  return false;
+}
+
 export function leafIdForPty(ptyId: number): number | null {
   for (const [leafId, s] of sessions) {
     if (s.pty?.id === ptyId) return leafId;


### PR DESCRIPTION
## Summary

Adds a `terminal.clear` shortcut that replicates macOS Terminal's ⌘K — clears the focused terminal's scrollback and screen while keeping the active prompt line.

- Implemented as a registry shortcut so it appears in the Shortcuts dialog and is user-customizable.
- The window capture-phase handler intercepts the key before xterm sees it, so it works even when the terminal has focus.
- Default binding is **macOS-only (⌘K)** since `Ctrl+K` is readline's kill-line on Linux/Windows.

## Files

- `src/modules/shortcuts/shortcuts.ts` — register `terminal.clear` with default `Cmd+K` on macOS.
- `src/app/App.tsx` — wire the action to `clearFocusedTerminal()`.
- `src/modules/terminal/lib/useTerminalSession.ts` — new `clearFocusedTerminal()` that finds the visible+focused session and calls `term.clear()`.
- `src/modules/terminal/index.ts` — re-export.

## Test plan

- [x] Open a terminal, run several commands to fill scrollback.
- [x] Press `Cmd+K` — scrollback + screen cleared, active prompt line preserved.
- [x] Focus AI panel / editor and press `Cmd+K` — no-op (returns false).
- [x] Open Shortcuts dialog — `terminal.clear` listed and rebindable.
- [x] Linux/Windows — no default binding registered (verify `Ctrl+K` still does readline kill-line in shell).