### PR TITLE
feat(agents): dismiss and clear-all controls for agent notifications

### DIFF
--- a/src/modules/agents/components/NotificationBell.tsx
+++ b/src/modules/agents/components/NotificationBell.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import {
+  Cancel01Icon,
   CheckmarkCircle02Icon,
   Loading03Icon,
   Notification01Icon,
@@ -77,41 +78,59 @@ const NOTIF_LABEL: Record<AgentNotification["kind"], string> = {
 function NotificationRow({
   n,
   onClick,
+  onRemove,
 }: {
   n: AgentNotification;
   onClick: () => void;
+  onRemove: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors hover:bg-accent"
+    <div
+      className="group relative flex w-full items-center gap-2.5 rounded-lg px-2 py-2 transition-colors hover:bg-accent"
     >
-      <span className="flex w-4 shrink-0 items-center justify-center">
-        {n.kind === "finished" ? (
-          <HugeiconsIcon
-            icon={CheckmarkCircle02Icon}
-            size={15}
-            strokeWidth={1.75}
-            className="text-muted-foreground"
-          />
-        ) : (
-          <span
-            className={cn(
-              "size-1.5 rounded-full",
-              n.kind === "error" ? "bg-destructive" : "bg-primary",
-            )}
-          />
-        )}
-      </span>
-      <span className="min-w-0 flex-1 truncate text-sm text-foreground">
-        {n.agent}{" "}
-        <span className="text-muted-foreground">{NOTIF_LABEL[n.kind]}</span>
-      </span>
-      <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
-        {relativeTime(n.at)}
-      </span>
-    </button>
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex flex-1 items-center gap-2.5 text-left"
+      >
+        <span className="flex w-4 shrink-0 items-center justify-center">
+          {n.kind === "finished" ? (
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              size={15}
+              strokeWidth={1.75}
+              className="text-muted-foreground"
+            />
+          ) : (
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                n.kind === "error" ? "bg-destructive" : "bg-primary",
+              )}
+            />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+          {n.agent}{" "}
+          <span className="text-muted-foreground">{NOTIF_LABEL[n.kind]}</span>
+        </span>
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground group-hover:invisible">
+          {relativeTime(n.at)}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        title="Dismiss"
+        aria-label="Dismiss notification"
+        className="absolute right-2 hidden size-5 items-center justify-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground group-hover:flex"
+      >
+        <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+      </button>
+    </div>
   );
 }
 
@@ -123,6 +142,8 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
   const localAgent = useAgentStore((s) => s.localAgent);
   const notifications = useAgentStore((s) => s.notifications);
   const markAllRead = useAgentStore((s) => s.markAllRead);
+  const removeNotification = useAgentStore((s) => s.removeNotification);
+  const clearNotifications = useAgentStore((s) => s.clearNotifications);
 
   const active = useMemo(() => Object.values(sessions), [sessions]);
   const activeCount = active.length + (localAgent ? 1 : 0);
@@ -205,15 +226,26 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
         sideOffset={8}
         className="w-80 overflow-hidden p-0 gap-0.5"
       >
-        <div className="flex h-10 items-center px-3 pt-0.5">
+        <div className="flex h-10 items-center gap-2 px-3 pt-0.5">
           <span className="flex gap-1 text-[13px] text-foreground">
             Notifications
           </span>
-          {activeCount > 0 ? (
-            <span className="ml-auto rounded-full bg-accent px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
-              {activeCount} active
-            </span>
-          ) : null}
+          <div className="ml-auto flex items-center gap-1.5">
+            {notifications.length > 0 ? (
+              <button
+                type="button"
+                onClick={clearNotifications}
+                className="rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                Clear all
+              </button>
+            ) : null}
+            {activeCount > 0 ? (
+              <span className="rounded-full bg-accent px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
+                {activeCount} active
+              </span>
+            ) : null}
+          </div>
         </div>
 
         {empty ? (
@@ -247,6 +279,7 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
                 key={n.id}
                 n={n}
                 onClick={() => activateNotification(n)}
+                onRemove={() => removeNotification(n.id)}
               />
             ))}
           </div>

--- a/src/modules/agents/store/agentStore.ts
+++ b/src/modules/agents/store/agentStore.ts
@@ -22,6 +22,7 @@ type AgentStoreState = {
     n: Omit<AgentNotification, "id" | "at" | "read">,
   ) => void;
   markAllRead: () => void;
+  removeNotification: (id: string) => void;
   clearNotifications: () => void;
 };
 
@@ -99,5 +100,12 @@ export const useAgentStore = create<AgentStoreState>((set) => ({
       return { notifications: s.notifications.map((n) => ({ ...n, read: true })) };
     }),
 
-  clearNotifications: () => set({ notifications: [] }),
+  removeNotification: (id) =>
+    set((s) => {
+      const next = s.notifications.filter((n) => n.id !== id);
+      return next.length === s.notifications.length ? s : { notifications: next };
+    }),
+
+  clearNotifications: () =>
+    set((s) => (s.notifications.length === 0 ? s : { notifications: [] })),
 }));


### PR DESCRIPTION
## Summary

Adds per-row dismiss and a header "Clear all" button to the agent notifications popover, so finished / attention / error notifications can be cleaned up without waiting for the 50-entry cap to evict them.

- Each notification row reveals a small `×` on hover (uses `Cancel01Icon`, matching the project's other dismiss buttons). The `×` overlays the timestamp position so the row width stays stable.
- The popover header gains a compact "Clear all" button to the left of the active-count pill, visible only when `notifications.length > 0`.
- Live status rows (working / waiting) stay non-removable — the session still exists, so dismissing them would lie about app state.

## Files

- `src/modules/agents/components/NotificationBell.tsx` — hover-`×` per notification row + header "Clear all" button.
- `src/modules/agents/store/agentStore.ts` — new `removeNotification(id)` action; `clearNotifications` short-circuits when the list is already empty.

## Test plan

- [x] Trigger several notifications (let agents finish / request attention).
- [x] Hover a notification row — `×` appears over the timestamp; click dismisses just that row.
- [x] With ≥1 notification, header shows "Clear all"; clicking it empties the notifications list.
- [x] With 0 notifications, "Clear all" is hidden (header stays clean).
- [x] Active (working / waiting) status rows have no `×` and are not affected by "Clear all".
- [x] Unread badge math still works — clearing notifications zeroes the `unreadDone` contribution to the badge.