### PR TITLE
feat(terminal): clickable file paths in terminal output

### DIFF
--- a/docs/superpowers/plans/2026-05-22-terminal-links-and-local-whisper.md
+++ b/docs/superpowers/plans/2026-05-22-terminal-links-and-local-whisper.md
@@ -1,0 +1,2536 @@
+# Clickable terminal paths + local Whisper — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two independent features in one branch: (1) clickable file paths in the terminal that open in an in-app editor tab with line:col jump, gated by an existence check; (2) provider-selectable voice transcription with an in-browser Whisper default so voice input no longer requires an OpenAI key.
+
+**Architecture:**
+- Terminal links: a custom xterm `registerLinkProvider` runs alongside `WebLinksAddon`. It tokenizes path candidates, cheap-rejects obvious non-files, resolves against the leaf's OSC-7-tracked CWD, and probes existence via a new `fs_exists` Tauri command behind an LRU cache. Clicking calls a new `SlotAdapter.openFile(path, line?, col?)` populated by `App.tsx`, which calls `openFileTab(path, false, { line, col })`. `EditorPane` consumes a one-shot `pendingSelection` on the tab.
+- Local Whisper: `@huggingface/transformers` runs in a Web Worker; the existing `useWhisperRecording` hook is refactored behind a `Transcriber` interface with two implementations (OpenAI cloud / local in-app). Settings expose a `voiceProvider` toggle. Local is the default. The mic button stops requiring an OpenAI key.
+
+**Tech Stack:** TypeScript, React 19, Vite 7, Tauri 2 (Rust), xterm.js 6 + addons, CodeMirror 6, @uiw/react-codemirror, Zustand, vitest, `@huggingface/transformers` (new), AI SDK 6.
+
+**Specification:** `docs/superpowers/specs/2026-05-22-terminal-links-and-local-whisper-design.md`
+
+---
+
+## Codebase orientation (read before starting)
+
+- **Terminal renderer pool:** `src/modules/terminal/lib/rendererPool.ts`. `createSlot()` (line 114) is where xterm addons are loaded — that's where the new link provider goes. `SlotAdapter` (line 18) is the bridge between the pool and per-leaf React state; it's the right place to add `getCwd` + `openFile`.
+- **Pool wiring:** `src/modules/terminal/lib/useTerminalSession.ts:61` is the *single* call to `configureRendererPool({...})`. Each leaf's `Session` already tracks `lastCwd` (line 38) populated by the OSC 7 handler. We expose it through `SlotAdapter`.
+- **OSC 7 handler:** `src/modules/terminal/lib/osc-handlers.ts:19` already gives us secure (post-command) cwd updates per leaf.
+- **Tabs API:** `src/modules/tabs/lib/useTabs.ts:205` exports `openFileTab(path, pin)`. Already wired through `App.tsx:155, 539, 792`. We add an optional 3rd `selection` parameter.
+- **Editor pane:** `src/modules/editor/EditorPane.tsx` — `cmRef.current?.view` is the CodeMirror `EditorView` we dispatch onto. The `path` prop is the only identifier; selection has to be threaded as a separate prop.
+- **Whisper hook:** `src/modules/ai/hooks/useWhisperRecording.ts` — single file, ~115 lines. Replaced by a thinner orchestrator that delegates to a `Transcriber`.
+- **Mic UI:** `src/modules/ai/components/AiStatusBarControls.tsx:125-153`. Status text echo in `src/modules/ai/components/AiInputBar.tsx:210`.
+- **Composer plumbing:** `src/modules/ai/lib/composer.tsx:148` calls `useWhisperRecording`. The hook's return shape is the public API consumed by `AiStatusBarControls` and `AiInputBar` — extending it is the lowest-impact path.
+- **Preferences:** `src/modules/settings/store.ts` holds the schema, persistence, and setters (Tauri `LazyStore`). `src/modules/settings/preferences.ts` is the Zustand store layered on top. New prefs need entries in both files plus a key in the `onPreferencesChange` mapper at the bottom of `store.ts`.
+- **Rust commands:** `src-tauri/src/modules/fs/file.rs` already has `fs_read_file`, `fs_write_file`, `fs_canonicalize`, `fs_stat`. Same pattern (`#[tauri::command]`, `WorkspaceEnv` arg, `resolve_path` from `crate::modules::workspace`). Commands are registered in `src-tauri/src/lib.rs:121-148` inside `invoke_handler!`.
+- **Tests:** Vitest. Existing tests at `src/modules/preview/PreviewPane.test.ts`, `src/modules/terminal/lib/osc-handlers.test.ts`, `src/modules/ai/lib/security.test.ts`. Run with `pnpm test`.
+
+---
+
+# Feature A — Clickable terminal paths
+
+## Task A1: Add `fs_exists` Rust command
+
+**Files:**
+- Modify: `src-tauri/src/modules/fs/file.rs:1-200`
+- Modify: `src-tauri/src/lib.rs:121-148`
+
+- [ ] **Step 1: Add the command implementation**
+
+Add this at the end of `src-tauri/src/modules/fs/file.rs`, before the `#[cfg(all(test, unix))] mod tests {` block:
+
+```rust
+#[tauri::command]
+pub fn fs_exists(path: String, workspace: Option<WorkspaceEnv>) -> Result<bool, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
+    // `try_exists` distinguishes "definitely missing" from "couldn't check"
+    // (permission errors, broken filesystem). For terminal click-to-open
+    // we collapse both into "not clickable" — false is the safe default.
+    Ok(p.try_exists().unwrap_or(false))
+}
+```
+
+- [ ] **Step 2: Register the command**
+
+In `src-tauri/src/lib.rs`, find the `invoke_handler![` block (line 121) and add `fs::file::fs_exists,` immediately after the existing `fs::file::fs_canonicalize,` line:
+
+```rust
+            fs::file::fs_read_file,
+            fs::file::fs_write_file,
+            fs::file::fs_stat,
+            fs::file::fs_canonicalize,
+            fs::file::fs_exists,
+            fs::mutate::fs_create_file,
+```
+
+- [ ] **Step 3: Verify Rust build**
+
+Run: `cd src-tauri && cargo check`
+Expected: succeeds with no errors. The new command compiles and is referenced by the handler macro.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/modules/fs/file.rs src-tauri/src/lib.rs
+git commit -m "feat(fs): add fs_exists tauri command"
+```
+
+---
+
+## Task A2: Path-candidate matcher
+
+**Files:**
+- Create: `src/modules/terminal/lib/pathMatcher.ts`
+- Create: `src/modules/terminal/lib/pathMatcher.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/modules/terminal/lib/pathMatcher.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { extractPathCandidates } from "./pathMatcher";
+
+describe("extractPathCandidates", () => {
+  it("matches a relative compiler path with line and col", () => {
+    const out = extractPathCandidates("src/foo.ts:42:5: error TS2322: …");
+    expect(out).toEqual([
+      { text: "src/foo.ts:42:5", start: 0, end: 15, path: "src/foo.ts", line: 42, col: 5 },
+    ]);
+  });
+
+  it("matches a relative path with only a line number", () => {
+    const out = extractPathCandidates("see ./bar.rs:7 for details");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ path: "./bar.rs", line: 7, col: undefined });
+  });
+
+  it("matches an absolute path", () => {
+    const out = extractPathCandidates("opened /etc/hosts");
+    expect(out).toEqual([
+      { text: "/etc/hosts", start: 7, end: 17, path: "/etc/hosts", line: undefined, col: undefined },
+    ]);
+  });
+
+  it("matches a Windows-style drive path", () => {
+    const out = extractPathCandidates("see C:\\Users\\me\\notes.md");
+    expect(out).toHaveLength(1);
+    expect(out[0].path).toBe("C:\\Users\\me\\notes.md");
+  });
+
+  it("matches a bare filename with extension", () => {
+    const out = extractPathCandidates("touched README.md and package.json");
+    expect(out.map((c) => c.path)).toEqual(["README.md", "package.json"]);
+  });
+
+  it("rejects URLs (left to WebLinksAddon)", () => {
+    expect(extractPathCandidates("see https://example.com/foo.ts")).toEqual([]);
+  });
+
+  it("rejects semver, hex hashes, and bare numbers", () => {
+    expect(extractPathCandidates("version 1.2.3 sha abc1234def5 num 12.345")).toEqual([]);
+  });
+
+  it("rejects timestamps", () => {
+    expect(extractPathCandidates("[2026-05-22T12:34:56] hi")).toEqual([]);
+  });
+
+  it("skips lines longer than 1024 chars", () => {
+    const big = "a".repeat(1100) + " /etc/hosts";
+    expect(extractPathCandidates(big)).toEqual([]);
+  });
+
+  it("caps results at 32 per line", () => {
+    const tokens = Array.from({ length: 50 }, (_, i) => `f${i}.ts`).join(" ");
+    expect(extractPathCandidates(tokens).length).toBeLessThanOrEqual(32);
+  });
+
+  it("preserves correct ranges for multiple matches", () => {
+    const line = "a.ts and b.ts";
+    const out = extractPathCandidates(line);
+    expect(out).toEqual([
+      { text: "a.ts", start: 0, end: 4, path: "a.ts", line: undefined, col: undefined },
+      { text: "b.ts", start: 9, end: 13, path: "b.ts", line: undefined, col: undefined },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/modules/terminal/lib/pathMatcher.test.ts`
+Expected: FAIL — `Cannot find module './pathMatcher'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/modules/terminal/lib/pathMatcher.ts`:
+
+```ts
+/**
+ * Match file-path candidates in a single terminal line. The output is
+ * deliberately permissive — false positives are filtered later by an
+ * existence check against the filesystem. We only do *cheap* rejection
+ * here for tokens that obviously cannot be files (URLs, semver, hashes,
+ * timestamps), to avoid wasting fs probes.
+ *
+ * Each result includes the byte range *in the input line* so xterm can
+ * convert it to a buffer-cell range for underline + click hit-testing.
+ */
+export interface PathCandidate {
+  /** The exact substring as it appears in the line. */
+  text: string;
+  /** Inclusive start index into the line. */
+  start: number;
+  /** Exclusive end index into the line. */
+  end: number;
+  /** The file-path part (without trailing `:line[:col]`). */
+  path: string;
+  line?: number;
+  col?: number;
+}
+
+const MAX_LINE_LENGTH = 1024;
+const MAX_TOKEN_LENGTH = 512;
+const MAX_CANDIDATES_PER_LINE = 32;
+
+// Matches:
+//   /abs/path  (POSIX absolute)
+//   ~/path     (tilde — caller can choose whether to expand)
+//   ./rel  ../rel  multi/segment/path
+//   bare.ext   (single token containing a dot)
+//   C:\Win\path  C:/Win/path
+// Each may be suffixed with :LINE[:COL].
+//
+// Allowed path chars: letters, digits, _ - . / \ ~ (no spaces, no quotes,
+// no parentheses — those are line-noise around real paths).
+const PATH_REGEX =
+  /(?:[A-Za-z]:[\\/])?(?:\.{1,2}[\\/])?[A-Za-z0-9_~][A-Za-z0-9_./\\-]*(?::(\d+)(?::(\d+))?)?/g;
+
+const URL_REGEX = /:\/\//;
+// Pure number (123 or 12.345) — no slash, no letter.
+const PURE_NUMBER_REGEX = /^\d+(?:\.\d+)*$/;
+// Semver-ish: 1.2.3, 1.2.3-rc.1, 1.2 — three+ dot groups of digits.
+const SEMVER_REGEX = /^\d+\.\d+(?:\.\d+)(?:[.\-][A-Za-z0-9]+)*$/;
+// Hex hash: 7+ hex chars, no dot, no slash.
+const HEX_HASH_REGEX = /^[0-9a-f]{7,}$/i;
+// ISO timestamp fragment (heuristic — Real ones contain `T` and colons).
+const TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+function looksLikeNonPath(token: string): boolean {
+  if (token.length > MAX_TOKEN_LENGTH) return true;
+  if (URL_REGEX.test(token)) return true;
+  if (PURE_NUMBER_REGEX.test(token)) return true;
+  if (SEMVER_REGEX.test(token)) return true;
+  if (HEX_HASH_REGEX.test(token)) return true;
+  if (TIMESTAMP_REGEX.test(token)) return true;
+  // Pure single-word tokens with no slash, no dot — not a path.
+  if (!token.includes("/") && !token.includes("\\") && !token.includes(".")) {
+    return true;
+  }
+  // A bare-filename candidate must have a real extension (1-6 letter/digit chars
+  // after the final dot). "foo." or "foo.123" are not files; "foo.ts" / "foo.md" are.
+  if (!token.includes("/") && !token.includes("\\")) {
+    const dot = token.lastIndexOf(".");
+    if (dot < 0) return true;
+    const ext = token.slice(dot + 1);
+    if (!/^[A-Za-z][A-Za-z0-9]{0,5}$/.test(ext)) return true;
+  }
+  return false;
+}
+
+export function extractPathCandidates(line: string): PathCandidate[] {
+  if (line.length > MAX_LINE_LENGTH) return [];
+
+  const out: PathCandidate[] = [];
+  // Reset the regex's lastIndex — the `g` flag preserves state across calls.
+  PATH_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PATH_REGEX.exec(line)) !== null) {
+    if (out.length >= MAX_CANDIDATES_PER_LINE) break;
+    const text = match[0];
+    const start = match.index;
+    const end = start + text.length;
+    const lineNum = match[1] ? Number(match[1]) : undefined;
+    const colNum = match[2] ? Number(match[2]) : undefined;
+    // Strip the suffix to get the bare path.
+    let path = text;
+    if (lineNum !== undefined) {
+      const colonIdx = text.indexOf(":", text.startsWith("C:") ? 2 : 0);
+      if (colonIdx > 0) path = text.slice(0, colonIdx);
+    }
+    if (looksLikeNonPath(path)) continue;
+    out.push({ text, start, end, path, line: lineNum, col: colNum });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test src/modules/terminal/lib/pathMatcher.test.ts`
+Expected: all 10 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/terminal/lib/pathMatcher.ts src/modules/terminal/lib/pathMatcher.test.ts
+git commit -m "feat(terminal): path-candidate matcher for clickable links"
+```
+
+---
+
+## Task A3: Existence cache (LRU with TTL)
+
+**Files:**
+- Create: `src/modules/terminal/lib/existenceCache.ts`
+- Create: `src/modules/terminal/lib/existenceCache.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/modules/terminal/lib/existenceCache.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExistenceCache } from "./existenceCache";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("existenceCache", () => {
+  it("calls the probe once per path and caches the result", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe);
+
+    await expect(cache.exists("/a")).resolves.toBe(true);
+    await expect(cache.exists("/a")).resolves.toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes a positive entry after positive TTL elapses", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe);
+
+    await cache.exists("/a");
+    vi.advanceTimersByTime(31_000);
+    await cache.exists("/a");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-probes a negative entry after the shorter negative TTL", async () => {
+    const probe = vi.fn().mockResolvedValue(false);
+    const cache = createExistenceCache(probe);
+
+    await cache.exists("/missing");
+    vi.advanceTimersByTime(6_000);
+    await cache.exists("/missing");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates an entry explicitly", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe);
+
+    await cache.exists("/a");
+    cache.invalidate("/a");
+    await cache.exists("/a");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least-recently-used entry past capacity", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe, { capacity: 2 });
+
+    await cache.exists("/a");
+    await cache.exists("/b");
+    await cache.exists("/c"); // evicts /a
+    await cache.exists("/a"); // re-probe after eviction
+    expect(probe).toHaveBeenCalledTimes(4);
+  });
+
+  it("coalesces concurrent probes of the same path", async () => {
+    let resolve!: (v: boolean) => void;
+    const probe = vi.fn(
+      () => new Promise<boolean>((r) => { resolve = r; }),
+    );
+    const cache = createExistenceCache(probe);
+
+    const p1 = cache.exists("/slow");
+    const p2 = cache.exists("/slow");
+    expect(probe).toHaveBeenCalledTimes(1);
+    resolve(true);
+    await expect(p1).resolves.toBe(true);
+    await expect(p2).resolves.toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/modules/terminal/lib/existenceCache.test.ts`
+Expected: FAIL — `Cannot find module './existenceCache'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/modules/terminal/lib/existenceCache.ts`:
+
+```ts
+/**
+ * LRU cache wrapping an async existence probe. Designed for the terminal
+ * link-provider hot path: we may probe the same path many times per second
+ * as the user scrolls and hovers, and want stale-while-valid semantics.
+ *
+ * Positive entries live longer than negatives because a file appearing
+ * is more common than one vanishing in a terminal session, and the
+ * worst-case for a stale positive (one missed underline) is far less
+ * disruptive than the worst-case for a stale negative (perpetually
+ * un-clickable file the user just created).
+ */
+export interface ExistenceCacheOptions {
+  capacity?: number;
+  positiveTtlMs?: number;
+  negativeTtlMs?: number;
+  /** Defaults to `Date.now`. Vitest can swap with `vi.useFakeTimers`. */
+  now?: () => number;
+}
+
+export interface ExistenceCache {
+  exists(path: string): Promise<boolean>;
+  invalidate(path: string): void;
+  clear(): void;
+}
+
+type Entry = { value: boolean; expiresAt: number };
+
+const DEFAULTS = {
+  capacity: 4096,
+  positiveTtlMs: 30_000,
+  negativeTtlMs: 5_000,
+};
+
+export function createExistenceCache(
+  probe: (path: string) => Promise<boolean>,
+  opts: ExistenceCacheOptions = {},
+): ExistenceCache {
+  const capacity = opts.capacity ?? DEFAULTS.capacity;
+  const posTtl = opts.positiveTtlMs ?? DEFAULTS.positiveTtlMs;
+  const negTtl = opts.negativeTtlMs ?? DEFAULTS.negativeTtlMs;
+  const now = opts.now ?? Date.now;
+
+  // Map preserves insertion order, so we can re-insert on hit to bump LRU
+  // recency without a separate list. Eviction = drop the first key.
+  const entries = new Map<string, Entry>();
+  const inflight = new Map<string, Promise<boolean>>();
+
+  function bump(key: string, entry: Entry) {
+    entries.delete(key);
+    entries.set(key, entry);
+    while (entries.size > capacity) {
+      const oldest = entries.keys().next().value;
+      if (oldest === undefined) break;
+      entries.delete(oldest);
+    }
+  }
+
+  return {
+    async exists(path) {
+      const cached = entries.get(path);
+      if (cached && cached.expiresAt > now()) {
+        bump(path, cached);
+        return cached.value;
+      }
+
+      const pending = inflight.get(path);
+      if (pending) return pending;
+
+      const probePromise = (async () => {
+        try {
+          const result = await probe(path);
+          bump(path, {
+            value: result,
+            expiresAt: now() + (result ? posTtl : negTtl),
+          });
+          return result;
+        } finally {
+          inflight.delete(path);
+        }
+      })();
+      inflight.set(path, probePromise);
+      return probePromise;
+    },
+
+    invalidate(path) {
+      entries.delete(path);
+    },
+
+    clear() {
+      entries.clear();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test src/modules/terminal/lib/existenceCache.test.ts`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/terminal/lib/existenceCache.ts src/modules/terminal/lib/existenceCache.test.ts
+git commit -m "feat(terminal): LRU+TTL existence cache for link provider"
+```
+
+---
+
+## Task A4: Extend `SlotAdapter` with `getCwd` and `openFile`
+
+**Files:**
+- Modify: `src/modules/terminal/lib/rendererPool.ts:18-22`
+- Modify: `src/modules/terminal/lib/useTerminalSession.ts:61-96`
+
+This task only widens the adapter interface and wires the per-leaf cwd through. The link provider is created in a later task and will consume these.
+
+- [ ] **Step 1: Extend the `SlotAdapter` type**
+
+In `src/modules/terminal/lib/rendererPool.ts`, replace lines 18-22:
+
+```ts
+export type SlotAdapter = {
+  resolveLeaf(leafId: number): LeafBridge | null;
+  evictLeaf(leafId: number): void;
+  isLeafFocused(leafId: number): boolean;
+  /** Current CWD for the leaf, or null if no OSC 7 was ever received. */
+  getCwd(leafId: number): string | null;
+  /**
+   * Open `path` in the editor pane. `path` may be relative; the adapter
+   * resolves it against `getCwd(leafId)` if so. Returns a promise that
+   * resolves to true on success, false if the file no longer exists.
+   */
+  openFile(leafId: number, path: string, line?: number, col?: number): Promise<boolean>;
+};
+```
+
+- [ ] **Step 2: Implement `getCwd` and stub `openFile` in `useTerminalSession.ts`**
+
+In `src/modules/terminal/lib/useTerminalSession.ts`, replace the `configureRendererPool({...})` call (starting line 61) with:
+
+```ts
+configureRendererPool({
+  resolveLeaf(leafId) {
+    const s = sessions.get(leafId);
+    if (!s) return null;
+    return {
+      writeToPty: (data) => {
+        s.pty?.write(data);
+      },
+      resizePty: (cols, rows) => {
+        s.cols = cols;
+        s.rows = rows;
+        s.pty?.resize(cols, rows);
+      },
+      kickPty: (cols, rows) => {
+        const pty = s.pty;
+        if (!pty || cols <= 0 || rows <= 0) return;
+        pty
+          .resize(cols, rows + 1)
+          .then(() => pty.resize(cols, rows))
+          .catch((e) => console.warn("[terax] kickPty failed:", e));
+      },
+    };
+  },
+  evictLeaf(leafId) {
+    const s = sessions.get(leafId);
+    if (!s) return;
+    unbindLeafFromSlot(leafId, s);
+  },
+  isLeafFocused(leafId) {
+    const s = sessions.get(leafId);
+    return !!s && s.visibleNow && s.focusedNow;
+  },
+  getCwd(leafId) {
+    const s = sessions.get(leafId);
+    return s?.lastCwd ?? null;
+  },
+  openFile: async (_leafId, _path, _line, _col) => {
+    // Wired from App.tsx in a later task. Default no-op so the link
+    // provider can still run before App is mounted.
+    return false;
+  },
+});
+```
+
+- [ ] **Step 3: Add a runtime hook so `App.tsx` can replace `openFile`**
+
+Still in `src/modules/terminal/lib/useTerminalSession.ts`, immediately after the `configureRendererPool({...})` call, add:
+
+```ts
+let openFileHandler: SlotAdapter["openFile"] = async () => false;
+
+export function setTerminalOpenFileHandler(handler: SlotAdapter["openFile"]): void {
+  openFileHandler = handler;
+}
+```
+
+Then change the `openFile` field inside the `configureRendererPool` call from the stub to:
+
+```ts
+  openFile: (leafId, path, line, col) => openFileHandler(leafId, path, line, col),
+```
+
+You'll also need to add the `SlotAdapter` import to the existing import block at the top of the file:
+
+```ts
+import {
+  acquireSlot,
+  applyBackgroundActive,
+  applyFontFamily,
+  applyFontSize,
+  applyLetterSpacing,
+  applyTheme as applyPoolTheme,
+  applyScrollback,
+  applyWebglPreference,
+  configureRendererPool,
+  focusSlot,
+  getSlotForLeaf,
+  releaseSlot,
+  setSlotFocused,
+  type SlotAdapter,
+} from "./rendererPool";
+```
+
+- [ ] **Step 4: Verify the project still builds**
+
+Run: `pnpm build`
+Expected: build succeeds. (We have not yet *consumed* `getCwd`/`openFile`, just widened the interface.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/terminal/lib/rendererPool.ts src/modules/terminal/lib/useTerminalSession.ts
+git commit -m "feat(terminal): widen SlotAdapter with getCwd + openFile"
+```
+
+---
+
+## Task A5: The link provider — combines matcher, cache, cwd, fs probe
+
+**Files:**
+- Create: `src/modules/terminal/lib/fileLinkProvider.ts`
+
+- [ ] **Step 1: Implement the provider**
+
+Create `src/modules/terminal/lib/fileLinkProvider.ts`:
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+import type { ILinkProvider, IBufferLine, IViewportRange, Terminal } from "@xterm/xterm";
+import { createExistenceCache } from "./existenceCache";
+import { extractPathCandidates } from "./pathMatcher";
+
+/**
+ * Path-resolution callbacks the provider needs from its host. Split out so
+ * `createSlot` (which doesn't know about React) can wire them via the
+ * slot adapter without import cycles.
+ */
+export interface FileLinkProviderDeps {
+  /** Current CWD for this terminal slot — used to resolve relative paths. */
+  getCwd(): string | null;
+  /** Click handler — fires when the user clicks a verified path link. */
+  onClick(absPath: string, line?: number, col?: number): void;
+  /** Called when the click target turns out to be missing on disk. */
+  onMissing?(absPath: string): void;
+}
+
+const cache = createExistenceCache((absPath) =>
+  invoke<boolean>("fs_exists", { path: absPath }).catch(() => false),
+);
+
+/**
+ * Exported for tests / cache invalidation from click-failure paths.
+ */
+export const fileExistenceCache = cache;
+
+function isAbsolute(p: string): boolean {
+  if (p.startsWith("/")) return true;
+  if (p.startsWith("~/")) return true;
+  if (/^[A-Za-z]:[\\/]/.test(p)) return true;
+  return false;
+}
+
+function joinCwd(cwd: string, rel: string): string {
+  // Strip leading "./". Don't try to collapse ".." here — the OS will
+  // do it on the Rust side when we canonicalize for the fs probe.
+  const r = rel.startsWith("./") ? rel.slice(2) : rel;
+  const sep = cwd.endsWith("/") ? "" : "/";
+  return cwd + sep + r;
+}
+
+function resolve(path: string, cwd: string | null): string | null {
+  if (isAbsolute(path)) return path;
+  if (!cwd) return null; // No cwd → can't resolve relative paths safely.
+  return joinCwd(cwd, path);
+}
+
+export function createFileLinkProvider(
+  term: Terminal,
+  deps: FileLinkProviderDeps,
+): ILinkProvider {
+  return {
+    provideLinks(bufferLineNumber: number, callback: (links: ReturnType<typeof toLink>[] | undefined) => void) {
+      const buf = term.buffer.active;
+      const line = buf.getLine(bufferLineNumber - 1);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+
+      // xterm gives bufferLineNumber as 1-based; getLine is 0-based. We also
+      // need to coalesce wrapped lines so a path split across two cells
+      // gets matched as one string.
+      const text = readLogicalLine(buf, bufferLineNumber - 1);
+      const candidates = extractPathCandidates(text);
+      if (candidates.length === 0) {
+        callback(undefined);
+        return;
+      }
+
+      const cwd = deps.getCwd();
+      void (async () => {
+        const verified: ReturnType<typeof toLink>[] = [];
+        for (const c of candidates) {
+          const abs = resolve(c.path, cwd);
+          if (!abs) continue;
+          // eslint-disable-next-line no-await-in-loop
+          const ok = await cache.exists(abs);
+          if (!ok) continue;
+          verified.push(
+            toLink(c.start + 1, bufferLineNumber, c.text, () => {
+              void (async () => {
+                const stillOk = await cache.exists(abs);
+                if (!stillOk) {
+                  cache.invalidate(abs);
+                  deps.onMissing?.(abs);
+                  return;
+                }
+                deps.onClick(abs, c.line, c.col);
+              })();
+            }),
+          );
+        }
+        callback(verified.length ? verified : undefined);
+      })();
+    },
+  };
+}
+
+function toLink(
+  startColumn: number,
+  bufferLineNumber: number,
+  text: string,
+  activate: () => void,
+) {
+  const range: IViewportRange = {
+    start: { x: startColumn, y: bufferLineNumber },
+    end: { x: startColumn + text.length - 1, y: bufferLineNumber },
+  };
+  return {
+    range,
+    text,
+    activate,
+  };
+}
+
+/**
+ * Reads `index`'s logical line, joining wrapped continuations. xterm
+ * stores wrapped lines as `isWrapped = true` on the continuation.
+ */
+function readLogicalLine(buf: Terminal["buffer"]["active"], index: number): string {
+  // Walk backward to the start of the logical line.
+  let start = index;
+  while (start > 0 && buf.getLine(start)?.isWrapped) start--;
+  let out = "";
+  for (let i = start; i < buf.length; i++) {
+    const ln: IBufferLine | undefined = buf.getLine(i);
+    if (!ln) break;
+    if (i > start && !ln.isWrapped) break;
+    out += ln.translateToString(true);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 2: Verify it typechecks against the xterm types**
+
+Run: `pnpm build`
+Expected: build succeeds. If `ILinkProvider` / `IViewportRange` import errors fire, the xterm version may export them under a different name — open `node_modules/@xterm/xterm/typings/xterm.d.ts` and adjust the imports.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/modules/terminal/lib/fileLinkProvider.ts
+git commit -m "feat(terminal): xterm link provider for file paths"
+```
+
+---
+
+## Task A6: Register the link provider in the renderer pool
+
+**Files:**
+- Modify: `src/modules/terminal/lib/rendererPool.ts:114-160`
+
+- [ ] **Step 1: Wire the provider into `createSlot`**
+
+In `src/modules/terminal/lib/rendererPool.ts`, add the new import near the existing addon imports (line 5-10):
+
+```ts
+import { createFileLinkProvider, fileExistenceCache } from "./fileLinkProvider";
+```
+
+Then inside `createSlot()` (around line 122), replace the `WebLinksAddon` load with the existing one *plus* the new provider, **and store the new provider's disposer on the slot** so we can clean up:
+
+Find:
+
+```ts
+  term.loadAddon(
+    new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
+  );
+```
+
+Replace with:
+
+```ts
+  term.loadAddon(
+    new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
+  );
+
+  const fileLinkDisposer = term.registerLinkProvider(
+    createFileLinkProvider(term, {
+      getCwd: () => {
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return null;
+        return adapter?.getCwd(leafId) ?? null;
+      },
+      onClick: (absPath, line, col) => {
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return;
+        void adapter?.openFile(leafId, absPath, line, col).then((ok) => {
+          if (!ok) fileExistenceCache.invalidate(absPath);
+        });
+      },
+      onMissing: (absPath) => fileExistenceCache.invalidate(absPath),
+    }),
+  );
+```
+
+The variable `fileLinkDisposer` is intentionally unused for now — xterm will dispose it when the terminal is disposed. (If you want lifecycle to be precise, push it into `slot.oscDisposers`; that array is already cleaned up at slot release and on terminal teardown.)
+
+To make this clean, push the disposer into `slot.oscDisposers` *after* `slot` is constructed. Find the line that creates the slot object literal (around line 132) — after that, add:
+
+```ts
+  slot.oscDisposers.push(() => fileLinkDisposer.dispose());
+```
+
+(Note: the `createSlot` function returns `slot`; you'll need to register the provider *after* `slot` is defined so the `getCwd`/`onClick` closures can read `slot.currentLeafId`. If the order in your edited file would require referencing `slot` before declaration, restructure: declare `let slot: Slot;` early, build `slot` literal, then register the provider, then `slots.push(slot)`.)
+
+A working ordering for `createSlot`:
+
+```ts
+function createSlot(): Slot {
+  const term = new Terminal(termOptions());
+  const fitAddon = new FitAddon();
+  const searchAddon = new SearchAddon();
+  const serializeAddon = new SerializeAddon();
+  term.loadAddon(fitAddon);
+  term.loadAddon(searchAddon);
+  term.loadAddon(serializeAddon);
+  term.loadAddon(
+    new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
+  );
+
+  const host = document.createElement("div");
+  host.style.cssText = "width:100%;height:100%;";
+  host.setAttribute("data-terax-slot", String(slots.length));
+  getRecycler().appendChild(host);
+  term.open(host);
+
+  const slot: Slot = {
+    id: slots.length,
+    term,
+    fitAddon,
+    searchAddon,
+    serializeAddon,
+    host,
+    webglAddon: null,
+    webglCanvases: [],
+    currentLeafId: null,
+    oscDisposers: [],
+    observer: null,
+    fitTimer: null,
+    ptyTimer: null,
+    unhideRaf: null,
+    lastCols: term.cols,
+    lastRows: term.rows,
+    lastW: 0,
+    lastH: 0,
+    lastUsedAt: 0,
+  };
+
+  const fileLinkDisposer = term.registerLinkProvider(
+    createFileLinkProvider(term, {
+      getCwd: () => {
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return null;
+        return adapter?.getCwd(leafId) ?? null;
+      },
+      onClick: (absPath, line, col) => {
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return;
+        void adapter?.openFile(leafId, absPath, line, col).then((ok) => {
+          if (!ok) fileExistenceCache.invalidate(absPath);
+        });
+      },
+      onMissing: (absPath) => fileExistenceCache.invalidate(absPath),
+    }),
+  );
+  slot.oscDisposers.push(() => fileLinkDisposer.dispose());
+
+  attachWebgl(slot);
+  // ... existing key/data handlers unchanged ...
+```
+
+(Keep the existing `attachWebgl`, `term.attachCustomKeyEventHandler`, `term.onData`, `slots.push(slot)` blocks exactly as they were.)
+
+- [ ] **Step 2: Verify the project builds**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/modules/terminal/lib/rendererPool.ts
+git commit -m "feat(terminal): register file-link provider on each xterm slot"
+```
+
+---
+
+## Task A7: Extend `openFileTab` with a `selection` parameter
+
+**Files:**
+- Modify: `src/modules/tabs/lib/useTabs.ts:30-42, 205-276`
+
+- [ ] **Step 1: Extend `EditorTab` with a one-shot `pendingSelection` field**
+
+In `src/modules/tabs/lib/useTabs.ts`, change the `EditorTab` type (around line 30):
+
+```ts
+export type EditorTab = {
+  id: number;
+  kind: "editor";
+  title: string;
+  path: string;
+  dirty: boolean;
+  /**
+   * True while the tab is in the transient "preview" state — opened by a
+   * single-click in the explorer and not yet pinned by the user. A preview tab
+   * is replaced by the next single-click rather than accumulating.
+   */
+  preview: boolean;
+  /**
+   * One-shot scroll/cursor target consumed by EditorPane on the next render.
+   * Set when opened from a terminal-link click; cleared as soon as the editor
+   * applies it. Coordinates are 1-based (matching compiler output).
+   */
+  pendingSelection?: { line: number; col?: number };
+};
+```
+
+- [ ] **Step 2: Add an optional `selection` parameter to `openFileTab`**
+
+Replace the `openFileTab = useCallback(...)` definition starting at line 205 with:
+
+```ts
+  const openFileTab = useCallback(
+    (
+      path: string,
+      pin = true,
+      selection?: { line: number; col?: number },
+    ) => {
+      let targetId: number | null = null;
+      setTabs((curr) => {
+        if (pin) {
+          const existing = curr.find(
+            (t) => t.kind === "editor" && t.path === path,
+          );
+          if (existing) {
+            targetId = existing.id;
+            return curr.map((t) =>
+              t.id === existing.id
+                ? {
+                    ...t,
+                    preview: false,
+                    ...(selection
+                      ? { pendingSelection: selection }
+                      : {}),
+                  }
+                : t,
+            );
+          }
+          const id = nextIdRef.current++;
+          targetId = id;
+          return [
+            ...curr,
+            {
+              id,
+              kind: "editor",
+              title: basename(path),
+              path,
+              dirty: false,
+              preview: false,
+              ...(selection ? { pendingSelection: selection } : {}),
+            } satisfies EditorTab,
+          ];
+        }
+        const persistent = curr.find(
+          (t) => t.kind === "editor" && t.path === path && !(t as EditorTab).preview,
+        );
+        if (persistent) {
+          targetId = persistent.id;
+          return selection
+            ? curr.map((t) =>
+                t.id === persistent.id
+                  ? { ...t, pendingSelection: selection }
+                  : t,
+              )
+            : curr;
+        }
+        const existingPreview = curr.find(
+          (t) => t.kind === "editor" && t.path === path && (t as EditorTab).preview,
+        );
+        if (existingPreview) {
+          targetId = existingPreview.id;
+          return selection
+            ? curr.map((t) =>
+                t.id === existingPreview.id
+                  ? { ...t, pendingSelection: selection }
+                  : t,
+              )
+            : curr;
+        }
+        const previewIdx = curr.findIndex(
+          (t) => t.kind === "editor" && (t as EditorTab).preview,
+        );
+        const id = nextIdRef.current++;
+        targetId = id;
+        const tab: EditorTab = {
+          id,
+          kind: "editor",
+          title: basename(path),
+          path,
+          dirty: false,
+          preview: true,
+          ...(selection ? { pendingSelection: selection } : {}),
+        };
+        if (previewIdx === -1) return [...curr, tab];
+        const next = [...curr];
+        next[previewIdx] = tab;
+        return next;
+      });
+      if (targetId !== null) setActiveId(targetId);
+      return targetId as number | null;
+    },
+    [],
+  );
+```
+
+- [ ] **Step 3: Add a `clearPendingSelection` helper**
+
+Below the `pinTab` callback (around line 282), add:
+
+```ts
+  const clearPendingSelection = useCallback((id: number) => {
+    setTabs((curr) =>
+      curr.map((t) =>
+        t.id === id && t.kind === "editor"
+          ? { ...t, pendingSelection: undefined }
+          : t,
+      ),
+    );
+  }, []);
+```
+
+Then add `clearPendingSelection,` to the returned object at the bottom of `useTabs` (the same place `openFileTab,` and `pinTab,` are listed near line 782).
+
+- [ ] **Step 4: Verify the project builds**
+
+Run: `pnpm build`
+Expected: build succeeds. (Existing callers of `openFileTab(path)` and `openFileTab(path, false)` keep working — the new arg is optional.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/tabs/lib/useTabs.ts
+git commit -m "feat(tabs): one-shot pendingSelection on openFileTab"
+```
+
+---
+
+## Task A8: Consume `pendingSelection` in `EditorPane`
+
+**Files:**
+- Modify: `src/modules/editor/EditorPane.tsx:50-55, 215-265`
+- Modify: `src/modules/editor/EditorStack.tsx` (props plumbing — caller of `EditorPane`)
+
+- [ ] **Step 1: Add `pendingSelection` + `onSelectionApplied` props to `EditorPane`**
+
+In `src/modules/editor/EditorPane.tsx`, change the `Props` type (around line 50):
+
+```ts
+type Props = {
+  path: string;
+  onDirtyChange?: (dirty: boolean) => void;
+  onSaved?: () => void;
+  onClose?: () => void;
+  /**
+   * One-shot scroll/cursor target. The pane dispatches a CodeMirror transaction
+   * to move the selection there and scroll it into view, then calls
+   * `onSelectionApplied` to clear it from the tab store.
+   */
+  pendingSelection?: { line: number; col?: number };
+  onSelectionApplied?: () => void;
+};
+```
+
+Change the function signature to destructure the new props:
+
+```tsx
+export const EditorPane = forwardRef<EditorPaneHandle, Props>(
+  function EditorPane(
+    { path, onDirtyChange, onSaved, onClose, pendingSelection, onSelectionApplied },
+    ref,
+  ) {
+```
+
+- [ ] **Step 2: Add a CodeMirror effect that applies the selection**
+
+In `src/modules/editor/EditorPane.tsx`, immediately after the language-resolve effect (after the `useEffect` block that ends around line 215, *before* `useImperativeHandle`), add:
+
+```tsx
+    useEffect(() => {
+      if (!pendingSelection) return;
+      if (doc.status !== "ready" && doc.status !== "saving") return;
+      const view = cmRef.current?.view;
+      if (!view) return;
+
+      const { line, col } = pendingSelection;
+      const totalLines = view.state.doc.lines;
+      const targetLine = Math.max(1, Math.min(line, totalLines));
+      const lineInfo = view.state.doc.line(targetLine);
+      const offset =
+        col !== undefined
+          ? Math.max(lineInfo.from, Math.min(lineInfo.to, lineInfo.from + col - 1))
+          : lineInfo.from;
+
+      // Defer one microtask so CodeMirror has flushed any prior doc-load
+      // transactions. Without this, scrollIntoView can no-op on the first paint.
+      Promise.resolve().then(() => {
+        const v = cmRef.current?.view;
+        if (!v) return;
+        v.dispatch({
+          selection: { anchor: offset, head: offset },
+          scrollIntoView: true,
+        });
+        v.focus();
+        onSelectionApplied?.();
+      });
+    }, [pendingSelection, doc.status, onSelectionApplied]);
+```
+
+Note: `doc.status` from `useDocument` exposes the loading/ready states. We gate on `ready`/`saving` so we don't try to dispatch before the document content has loaded.
+
+- [ ] **Step 3: Plumb props through `EditorStack.tsx`**
+
+Open `src/modules/editor/EditorStack.tsx` and locate where it renders `<EditorPane ... />` and where it consumes the tabs list. Add a prop on the stack that exposes `clearPendingSelection` (from `useTabs`), and pass each tab's `pendingSelection` plus a per-tab `onSelectionApplied` callback into `EditorPane`.
+
+If `EditorStack` doesn't already receive the tab object, change its props to accept the full `EditorTab` (or at least `pendingSelection` and `onSelectionApplied`). The wiring lives wherever `EditorStack` is rendered — typically `src/app/App.tsx` around the editor-pane mount.
+
+A minimal change inside `EditorStack.tsx`:
+
+```tsx
+<EditorPane
+  ref={editorPaneRef}
+  path={tab.path}
+  pendingSelection={tab.pendingSelection}
+  onSelectionApplied={() => onSelectionApplied?.(tab.id)}
+  // ... existing props (onDirtyChange, onSaved, onClose) unchanged ...
+/>
+```
+
+And add `onSelectionApplied?: (tabId: number) => void;` to `EditorStack`'s Props.
+
+- [ ] **Step 4: Wire `clearPendingSelection` from `App.tsx`**
+
+In `src/app/App.tsx`, find the `useTabs()` destructure (around line 155 where `openFileTab` is destructured) and add `clearPendingSelection` to it. Then pass it down to the `<EditorStack onSelectionApplied={clearPendingSelection} />` mount.
+
+- [ ] **Step 5: Verify the project builds**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/modules/editor/EditorPane.tsx src/modules/editor/EditorStack.tsx src/app/App.tsx
+git commit -m "feat(editor): apply pendingSelection on tab open"
+```
+
+---
+
+## Task A9: Wire `openFile` from `App.tsx` to `openFileTab`
+
+**Files:**
+- Modify: `src/app/App.tsx` (around the `useTabs` destructure and a fresh effect)
+- Modify: `src/modules/terminal/lib/useTerminalSession.ts` (verify the `setTerminalOpenFileHandler` export is reachable)
+
+- [ ] **Step 1: Register the handler from `App.tsx`**
+
+In `src/app/App.tsx`, near the top imports add:
+
+```tsx
+import { setTerminalOpenFileHandler } from "@/modules/terminal/lib/useTerminalSession";
+```
+
+Then, *inside the App component*, after `openFileTab` is in scope (after the `useTabs(...)` destructure on line 155), add this effect:
+
+```tsx
+  useEffect(() => {
+    setTerminalOpenFileHandler(async (_leafId, path, line, col) => {
+      const id = openFileTab(
+        path,
+        false, // preview slot — VSCode-style
+        line !== undefined ? { line, col } : undefined,
+      );
+      return id !== null;
+    });
+    return () => {
+      setTerminalOpenFileHandler(async () => false);
+    };
+  }, [openFileTab]);
+```
+
+- [ ] **Step 2: Verify the project builds**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Smoke test**
+
+Run: `pnpm tauri dev`
+
+In the terminal that opens, run:
+
+```bash
+echo "see src/app/App.tsx:155 for context"
+ls README.md
+```
+
+Verify:
+1. `src/app/App.tsx:155` appears underlined (after a brief existence-probe delay).
+2. Clicking it opens `App.tsx` as a *preview* tab and scrolls to line 155.
+3. `README.md` is underlined and clicking opens it.
+4. A non-existent path printed to the terminal (e.g. `echo "see fake/missing.ts:10"`) is **not** underlined.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/App.tsx
+git commit -m "feat(terminal): wire link clicks to editor tabs with line jump"
+```
+
+---
+
+# Feature B — Local Whisper transcription
+
+## Task B1: Add `@huggingface/transformers` dependency
+
+**Files:**
+- Modify: `package.json`, `pnpm-lock.yaml`
+
+- [ ] **Step 1: Install the package**
+
+Run: `pnpm add @huggingface/transformers`
+Expected: dependency added; lockfile updated.
+
+- [ ] **Step 2: Sanity-check the install**
+
+Run: `pnpm build`
+Expected: build succeeds. (We haven't imported it yet, so this only verifies the dependency resolves cleanly.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "chore(deps): add @huggingface/transformers for local whisper"
+```
+
+---
+
+## Task B2: Extend preferences schema for voice provider
+
+**Files:**
+- Modify: `src/modules/settings/store.ts:49-85, 124, 140-160, 192-287, 420-470, 478-540`
+
+This is mechanical: each new preference needs (a) a `Preferences` type field, (b) a `DEFAULT_PREFERENCES` value, (c) a `KEY_*` constant, (d) a `loadPreferences` entry, (e) a setter, (f) an `onPreferencesChange` mapping. Follow the pattern used by every other preference in the file.
+
+- [ ] **Step 1: Add the type fields**
+
+In `src/modules/settings/store.ts`, find the `Preferences` type (around line 49) and add at the bottom of it (before the closing `};` on line 85):
+
+```ts
+  voiceProvider: "openai" | "local";
+  localWhisperModel: string;
+  localWhisperLanguage: string;
+```
+
+Also add a `WHISPER_MODELS` constant near the existing `EDITOR_THEMES` constant (around line 21):
+
+```ts
+export const WHISPER_MODELS = [
+  { id: "onnx-community/whisper-tiny.en", label: "tiny.en", sizeMB: 75, multilingual: false },
+  { id: "onnx-community/whisper-base.en", label: "base.en", sizeMB: 140, multilingual: false },
+  { id: "onnx-community/whisper-base", label: "base", sizeMB: 140, multilingual: true },
+  { id: "onnx-community/whisper-small.en", label: "small.en", sizeMB: 460, multilingual: false },
+  { id: "onnx-community/whisper-small", label: "small", sizeMB: 460, multilingual: true },
+] as const;
+
+export type WhisperModelId = (typeof WHISPER_MODELS)[number]["id"];
+```
+
+- [ ] **Step 2: Add the storage key constants**
+
+Add near the other `const KEY_*` declarations (around line 122):
+
+```ts
+const KEY_VOICE_PROVIDER = "voiceProvider";
+const KEY_LOCAL_WHISPER_MODEL = "localWhisperModel";
+const KEY_LOCAL_WHISPER_LANGUAGE = "localWhisperLanguage";
+```
+
+- [ ] **Step 3: Add the defaults**
+
+In `DEFAULT_PREFERENCES` (around line 140), add:
+
+```ts
+  voiceProvider: "local",
+  localWhisperModel: "onnx-community/whisper-base",
+  localWhisperLanguage: "auto",
+```
+
+- [ ] **Step 4: Add the loaders**
+
+In `loadPreferences` (around line 192), add inside the returned object (you'll see it has `theme`, `themeId`, etc. — add at the bottom alongside `shortcuts`):
+
+```ts
+    voiceProvider:
+      get<"openai" | "local">(KEY_VOICE_PROVIDER) ??
+      DEFAULT_PREFERENCES.voiceProvider,
+    localWhisperModel:
+      get<string>(KEY_LOCAL_WHISPER_MODEL) ??
+      DEFAULT_PREFERENCES.localWhisperModel,
+    localWhisperLanguage:
+      get<string>(KEY_LOCAL_WHISPER_LANGUAGE) ??
+      DEFAULT_PREFERENCES.localWhisperLanguage,
+```
+
+- [ ] **Step 5: Add the setters**
+
+Below the existing setters (after `setZoomLevel`, around line 460), add:
+
+```ts
+export async function setVoiceProvider(value: "openai" | "local"): Promise<void> {
+  await writePref(KEY_VOICE_PROVIDER, value);
+}
+
+export async function setLocalWhisperModel(value: string): Promise<void> {
+  await writePref(KEY_LOCAL_WHISPER_MODEL, value);
+}
+
+export async function setLocalWhisperLanguage(value: string): Promise<void> {
+  await writePref(KEY_LOCAL_WHISPER_LANGUAGE, value);
+}
+```
+
+- [ ] **Step 6: Wire the change-listener map**
+
+In `onPreferencesChange` (around line 478), inside the `map` object literal, add entries:
+
+```ts
+    [KEY_VOICE_PROVIDER]: "voiceProvider",
+    [KEY_LOCAL_WHISPER_MODEL]: "localWhisperModel",
+    [KEY_LOCAL_WHISPER_LANGUAGE]: "localWhisperLanguage",
+```
+
+- [ ] **Step 7: Verify the build**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/modules/settings/store.ts
+git commit -m "feat(prefs): voice provider + local whisper model settings"
+```
+
+---
+
+## Task B3: Audio decode / downmix / resample helpers
+
+**Files:**
+- Create: `src/modules/ai/lib/audio.ts`
+- Create: `src/modules/ai/lib/audio.test.ts`
+
+The model expects mono Float32 PCM at 16 kHz. MediaRecorder gives us WebM/Opus (or similar) at the device's native sample rate — usually 48 kHz. We decode with the WebAudio `OfflineAudioContext`, downmix channels by averaging, and resample by passing a 16 kHz target rate.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/modules/ai/lib/audio.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { blobToMonoPcm16k, downmixToMono, TARGET_SAMPLE_RATE } from "./audio";
+
+describe("downmixToMono", () => {
+  it("returns the single channel unchanged for mono input", () => {
+    const ch = new Float32Array([0.1, 0.2, 0.3]);
+    expect(downmixToMono([ch])).toEqual(ch);
+  });
+
+  it("averages channels for stereo input", () => {
+    const l = new Float32Array([0.0, 0.5, 1.0]);
+    const r = new Float32Array([1.0, 0.5, 0.0]);
+    expect(Array.from(downmixToMono([l, r]))).toEqual([0.5, 0.5, 0.5]);
+  });
+
+  it("averages all three channels for surround input", () => {
+    const a = new Float32Array([0, 3]);
+    const b = new Float32Array([0, 3]);
+    const c = new Float32Array([0, 3]);
+    expect(Array.from(downmixToMono([a, b, c]))).toEqual([0, 3]);
+  });
+});
+
+describe("blobToMonoPcm16k", () => {
+  it("uses OfflineAudioContext at the target sample rate", async () => {
+    // Mock an AudioBuffer + OfflineAudioContext just enough to verify
+    // we ask for 16 kHz mono and return its rendered channel data.
+    const numFrames = 48_000;
+    const stereoBuffer = {
+      numberOfChannels: 1,
+      length: numFrames,
+      sampleRate: 48_000,
+      duration: 1,
+      getChannelData: () => new Float32Array(numFrames).fill(0.42),
+    };
+    const renderedFrames = 16_000;
+    const renderedBuffer = {
+      numberOfChannels: 1,
+      length: renderedFrames,
+      sampleRate: 16_000,
+      duration: 1,
+      getChannelData: () => new Float32Array(renderedFrames).fill(0.42),
+    };
+    const ctorCalls: Array<{ ch: number; len: number; rate: number }> = [];
+    class FakeOfflineCtx {
+      destination = {};
+      constructor(ch: number, len: number, rate: number) {
+        ctorCalls.push({ ch, len, rate });
+      }
+      createBufferSource() {
+        return {
+          buffer: null as null | unknown,
+          connect: () => {},
+          start: () => {},
+        };
+      }
+      decodeAudioData() {
+        return Promise.resolve(stereoBuffer);
+      }
+      startRendering() {
+        return Promise.resolve(renderedBuffer);
+      }
+    }
+    vi.stubGlobal("OfflineAudioContext", FakeOfflineCtx);
+
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "audio/webm" });
+    const out = await blobToMonoPcm16k(blob);
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(out.length).toBe(renderedFrames);
+    expect(TARGET_SAMPLE_RATE).toBe(16_000);
+    // Last constructor call is the render context (16k); decode context
+    // is the first call. Both must use mono.
+    expect(ctorCalls[ctorCalls.length - 1].rate).toBe(16_000);
+    expect(ctorCalls[ctorCalls.length - 1].ch).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/modules/ai/lib/audio.test.ts`
+Expected: FAIL — `Cannot find module './audio'`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `src/modules/ai/lib/audio.ts`:
+
+```ts
+/** Whisper's expected sample rate. The model is trained on 16 kHz mono. */
+export const TARGET_SAMPLE_RATE = 16_000;
+
+/**
+ * Average all channels into a single mono Float32Array. For mono input
+ * the channel is returned unchanged. Surround layouts are flattened to
+ * a centered mix, which is acceptable for speech transcription.
+ */
+export function downmixToMono(channels: Float32Array[]): Float32Array {
+  if (channels.length === 0) return new Float32Array(0);
+  if (channels.length === 1) return channels[0];
+  const len = channels[0].length;
+  const out = new Float32Array(len);
+  const n = channels.length;
+  for (let i = 0; i < len; i++) {
+    let s = 0;
+    for (let c = 0; c < n; c++) s += channels[c][i];
+    out[i] = s / n;
+  }
+  return out;
+}
+
+/**
+ * Decode a MediaRecorder blob (WebM/Opus, OGG, MP4, etc.) to a mono
+ * Float32 PCM array at TARGET_SAMPLE_RATE. Two OfflineAudioContexts:
+ * one for decode (native rate), one for high-quality resample (target rate).
+ */
+export async function blobToMonoPcm16k(blob: Blob): Promise<Float32Array> {
+  const ab = await blob.arrayBuffer();
+
+  // A short-lived OfflineAudioContext for decoding. The frame count and
+  // sample rate are irrelevant for decodeAudioData — they're just required
+  // by the constructor. We use the target rate so the WebAudio
+  // implementation has a clean default if it auto-resamples.
+  const decodeCtx = new OfflineAudioContext(1, 1, TARGET_SAMPLE_RATE);
+  const decoded = await decodeCtx.decodeAudioData(ab);
+
+  // Collect the decoded channels into an array of Float32Arrays.
+  const decodedChannels: Float32Array[] = [];
+  for (let c = 0; c < decoded.numberOfChannels; c++) {
+    decodedChannels.push(decoded.getChannelData(c));
+  }
+  const mono = downmixToMono(decodedChannels);
+
+  // If already at the right rate, skip the render pass.
+  if (decoded.sampleRate === TARGET_SAMPLE_RATE) return mono;
+
+  const frames = Math.ceil(decoded.duration * TARGET_SAMPLE_RATE);
+  const renderCtx = new OfflineAudioContext(1, frames, TARGET_SAMPLE_RATE);
+  const src = renderCtx.createBufferSource();
+  // Reconstruct a single-channel buffer at the decoded rate so the
+  // OfflineAudioContext's resampler does the rate conversion.
+  const buf = new AudioBuffer({
+    length: mono.length,
+    numberOfChannels: 1,
+    sampleRate: decoded.sampleRate,
+  });
+  buf.copyToChannel(mono, 0);
+  src.buffer = buf;
+  src.connect(renderCtx.destination);
+  src.start(0);
+  const rendered = await renderCtx.startRendering();
+  return rendered.getChannelData(0);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test src/modules/ai/lib/audio.test.ts`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/ai/lib/audio.ts src/modules/ai/lib/audio.test.ts
+git commit -m "feat(ai): audio decode + downmix + 16k resample helpers"
+```
+
+---
+
+## Task B4: Whisper Web Worker
+
+**Files:**
+- Create: `src/modules/ai/workers/whisperWorker.ts`
+
+The worker owns the transformers.js pipeline singleton and a tiny message protocol. It runs in a separate thread so transcription doesn't freeze the UI.
+
+- [ ] **Step 1: Implement the worker**
+
+Create `src/modules/ai/workers/whisperWorker.ts`:
+
+```ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Web Worker hosting a singleton @huggingface/transformers Whisper pipeline.
+ * Main-thread protocol:
+ *   In:  { kind: "load", model }
+ *        { kind: "transcribe", pcm: Float32Array, language? }
+ *        { kind: "unload" }
+ *   Out: { kind: "progress", file, loaded, total }
+ *        { kind: "ready", model, backend: "gpu" | "cpu" }
+ *        { kind: "result", text }
+ *        { kind: "error", message }
+ *
+ * The pipeline is created lazily on `load` and reused across transcriptions.
+ * Switching models triggers a fresh load. Posting a transcribe before the
+ * pipeline is ready will await the in-flight load (load is idempotent).
+ */
+
+import { pipeline, env, type AutomaticSpeechRecognitionPipeline } from "@huggingface/transformers";
+
+// Allow the library to fetch ONNX builds from the HF Hub.
+env.allowRemoteModels = true;
+env.allowLocalModels = false;
+
+type InMessage =
+  | { kind: "load"; model: string }
+  | { kind: "transcribe"; pcm: Float32Array; language?: string }
+  | { kind: "unload" };
+
+type OutMessage =
+  | { kind: "progress"; file: string; loaded: number; total: number }
+  | { kind: "ready"; model: string; backend: "gpu" | "cpu" }
+  | { kind: "result"; text: string }
+  | { kind: "error"; message: string };
+
+let currentModel: string | null = null;
+let asr: AutomaticSpeechRecognitionPipeline | null = null;
+let loadingPromise: Promise<void> | null = null;
+let loadedBackend: "gpu" | "cpu" = "cpu";
+
+function post(msg: OutMessage, transfer?: Transferable[]) {
+  if (transfer) (self as any).postMessage(msg, transfer);
+  else (self as any).postMessage(msg);
+}
+
+async function ensureLoaded(model: string): Promise<void> {
+  if (asr && currentModel === model) return;
+  if (loadingPromise && currentModel === model) return loadingPromise;
+
+  asr = null;
+  currentModel = model;
+
+  loadingPromise = (async () => {
+    // transformers.js will try WebGPU first when the device is "webgpu";
+    // it falls back to WASM on platforms (e.g. WebKitGTK on Linux) without
+    // WebGPU support. We attempt webgpu first then explicitly fall back.
+    try {
+      asr = (await pipeline("automatic-speech-recognition", model, {
+        device: "webgpu",
+        progress_callback: (p: any) => {
+          if (p?.status === "progress") {
+            post({
+              kind: "progress",
+              file: p.file ?? "",
+              loaded: p.loaded ?? 0,
+              total: p.total ?? 0,
+            });
+          }
+        },
+      })) as AutomaticSpeechRecognitionPipeline;
+      loadedBackend = "gpu";
+    } catch (e) {
+      console.warn("[whisper] WebGPU init failed, falling back to WASM:", e);
+      asr = (await pipeline("automatic-speech-recognition", model, {
+        progress_callback: (p: any) => {
+          if (p?.status === "progress") {
+            post({
+              kind: "progress",
+              file: p.file ?? "",
+              loaded: p.loaded ?? 0,
+              total: p.total ?? 0,
+            });
+          }
+        },
+      })) as AutomaticSpeechRecognitionPipeline;
+      loadedBackend = "cpu";
+    }
+    post({ kind: "ready", model, backend: loadedBackend });
+  })();
+
+  try {
+    await loadingPromise;
+  } finally {
+    loadingPromise = null;
+  }
+}
+
+self.onmessage = async (ev: MessageEvent<InMessage>) => {
+  const msg = ev.data;
+  try {
+    if (msg.kind === "load") {
+      await ensureLoaded(msg.model);
+      return;
+    }
+    if (msg.kind === "unload") {
+      asr = null;
+      currentModel = null;
+      return;
+    }
+    if (msg.kind === "transcribe") {
+      if (!asr || !currentModel) {
+        post({ kind: "error", message: "Model not loaded" });
+        return;
+      }
+      const result: any = await asr(msg.pcm, {
+        language: msg.language && msg.language !== "auto" ? msg.language : undefined,
+        // 30 s windows are the standard Whisper preprocessing chunk.
+        chunk_length_s: 30,
+        stride_length_s: 5,
+      });
+      const text = typeof result?.text === "string" ? result.text : "";
+      post({ kind: "result", text });
+      return;
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    post({ kind: "error", message });
+  }
+};
+```
+
+- [ ] **Step 2: Verify the project builds with the worker**
+
+Run: `pnpm build`
+Expected: build succeeds. Vite's worker support requires the worker file to be referenced via `new Worker(new URL(...), { type: "module" })` from a regular module; we'll do that in the next task. The worker's TypeScript should compile in isolation as a module.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/modules/ai/workers/whisperWorker.ts
+git commit -m "feat(ai): Whisper worker — transformers.js with WebGPU/WASM fallback"
+```
+
+---
+
+## Task B5: Transcriber interface + factory
+
+**Files:**
+- Create: `src/modules/ai/lib/transcribers/index.ts`
+- Create: `src/modules/ai/lib/transcribers/openai.ts`
+- Create: `src/modules/ai/lib/transcribers/local.ts`
+
+- [ ] **Step 1: Define the interface**
+
+Create `src/modules/ai/lib/transcribers/index.ts`:
+
+```ts
+import { createLocalTranscriber, type LocalTranscriber } from "./local";
+import { createOpenAITranscriber } from "./openai";
+
+export type TranscriberState =
+  | { kind: "idle" }
+  | { kind: "loading"; file?: string; loaded: number; total: number }
+  | { kind: "loaded"; backend: "gpu" | "cpu" }
+  | { kind: "error"; message: string };
+
+export interface Transcriber {
+  /** Whether the user can press the mic button right now. */
+  ready(): boolean;
+  /** Optional explanation when ready() is false. */
+  unavailableReason(): string | null;
+  /** Begin pre-loading any expensive setup (model download/warmup). No-op for OpenAI. */
+  preload(): void;
+  /** Run transcription. May await preload internally. */
+  transcribe(blob: Blob): Promise<string>;
+  /** Subscribe to state changes (idle/loading/loaded/error). */
+  subscribe(listener: (state: TranscriberState) => void): () => void;
+  /** Snapshot of current state. */
+  getState(): TranscriberState;
+  /** Free any owned resources (model worker, etc.). */
+  unload(): void;
+  /** True for the local provider — surfaces UI affordances like Unload button. */
+  readonly isLocal: boolean;
+}
+
+export type TranscriberSelection =
+  | { kind: "openai"; apiKey: string | null }
+  | { kind: "local"; model: string; language: string };
+
+/**
+ * Returns a transcriber for the requested selection, or null when the
+ * selection is currently unusable (e.g. OpenAI without a key). UI may
+ * still call the returned Transcriber's `ready()` to render an inline
+ * "configure" affordance.
+ */
+export function createTranscriber(sel: TranscriberSelection): Transcriber {
+  if (sel.kind === "openai") {
+    return createOpenAITranscriber({ apiKey: sel.apiKey });
+  }
+  return createLocalTranscriber({ model: sel.model, language: sel.language });
+}
+
+export type { LocalTranscriber };
+```
+
+- [ ] **Step 2: Implement the OpenAI transcriber**
+
+Create `src/modules/ai/lib/transcribers/openai.ts`:
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+import { experimental_transcribe as transcribe } from "ai";
+import type { Transcriber, TranscriberState } from "./index";
+
+export function createOpenAITranscriber(opts: {
+  apiKey: string | null;
+}): Transcriber {
+  const listeners = new Set<(s: TranscriberState) => void>();
+  let state: TranscriberState = opts.apiKey
+    ? { kind: "loaded", backend: "cpu" } // "loaded" means no setup needed
+    : { kind: "error", message: "OpenAI API key not configured" };
+
+  function setState(next: TranscriberState) {
+    state = next;
+    for (const l of listeners) l(state);
+  }
+
+  return {
+    isLocal: false,
+    ready: () => state.kind === "loaded",
+    unavailableReason: () =>
+      state.kind === "error" ? state.message : null,
+    preload: () => {},
+    async transcribe(blob) {
+      if (!opts.apiKey) throw new Error("OpenAI API key not configured");
+      setState({ kind: "loading", loaded: 0, total: 0 });
+      try {
+        const openai = createOpenAI({ apiKey: opts.apiKey });
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        const { text } = await transcribe({
+          model: openai.transcription("whisper-1"),
+          audio: buf,
+        });
+        setState({ kind: "loaded", backend: "cpu" });
+        return text;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ kind: "error", message });
+        throw e;
+      }
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    getState: () => state,
+    unload: () => {},
+  };
+}
+```
+
+- [ ] **Step 3: Implement the local transcriber**
+
+Create `src/modules/ai/lib/transcribers/local.ts`:
+
+```ts
+import { blobToMonoPcm16k } from "../audio";
+import type { Transcriber, TranscriberState } from "./index";
+
+export interface LocalTranscriber extends Transcriber {
+  /** Force-reload the worker (used after model change). */
+  reload(): void;
+}
+
+type WorkerIn =
+  | { kind: "load"; model: string }
+  | { kind: "transcribe"; pcm: Float32Array; language?: string }
+  | { kind: "unload" };
+
+type WorkerOut =
+  | { kind: "progress"; file: string; loaded: number; total: number }
+  | { kind: "ready"; model: string; backend: "gpu" | "cpu" }
+  | { kind: "result"; text: string }
+  | { kind: "error"; message: string };
+
+export function createLocalTranscriber(opts: {
+  model: string;
+  language: string;
+}): LocalTranscriber {
+  const listeners = new Set<(s: TranscriberState) => void>();
+  let state: TranscriberState = { kind: "idle" };
+  let worker: Worker | null = null;
+  let readyResolve: (() => void) | null = null;
+  let readyPromise: Promise<void> | null = null;
+  let pendingTranscribe:
+    | { resolve: (text: string) => void; reject: (e: Error) => void }
+    | null = null;
+
+  function setState(next: TranscriberState) {
+    state = next;
+    for (const l of listeners) l(state);
+  }
+
+  function ensureWorker() {
+    if (worker) return;
+    worker = new Worker(
+      new URL("../../workers/whisperWorker.ts", import.meta.url),
+      { type: "module" },
+    );
+    readyPromise = new Promise<void>((resolve) => {
+      readyResolve = resolve;
+    });
+
+    worker.onmessage = (ev: MessageEvent<WorkerOut>) => {
+      const m = ev.data;
+      if (m.kind === "progress") {
+        setState({
+          kind: "loading",
+          file: m.file,
+          loaded: m.loaded,
+          total: m.total,
+        });
+        return;
+      }
+      if (m.kind === "ready") {
+        setState({ kind: "loaded", backend: m.backend });
+        readyResolve?.();
+        return;
+      }
+      if (m.kind === "result") {
+        const p = pendingTranscribe;
+        pendingTranscribe = null;
+        p?.resolve(m.text);
+        return;
+      }
+      if (m.kind === "error") {
+        setState({ kind: "error", message: m.message });
+        const p = pendingTranscribe;
+        pendingTranscribe = null;
+        p?.reject(new Error(m.message));
+      }
+    };
+    worker.onerror = (e) => {
+      setState({ kind: "error", message: String(e.message ?? e) });
+      const p = pendingTranscribe;
+      pendingTranscribe = null;
+      p?.reject(new Error(e.message || "worker error"));
+    };
+
+    const msg: WorkerIn = { kind: "load", model: opts.model };
+    worker.postMessage(msg);
+    setState({ kind: "loading", loaded: 0, total: 0 });
+  }
+
+  return {
+    isLocal: true,
+    ready: () => true, // Local is always available; load happens lazily.
+    unavailableReason: () => null,
+    preload: () => ensureWorker(),
+    async transcribe(blob) {
+      ensureWorker();
+      await readyPromise;
+      const pcm = await blobToMonoPcm16k(blob);
+      if (pcm.length < 16_000 * 0.2) {
+        // Too short — saves a worker roundtrip on accidental taps.
+        setState({ kind: "loaded", backend: "cpu" });
+        return "";
+      }
+
+      return new Promise<string>((resolve, reject) => {
+        pendingTranscribe = { resolve, reject };
+        const msg: WorkerIn = {
+          kind: "transcribe",
+          pcm,
+          language: opts.language,
+        };
+        worker!.postMessage(msg, [pcm.buffer]);
+      });
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    getState: () => state,
+    unload: () => {
+      worker?.terminate();
+      worker = null;
+      readyResolve = null;
+      readyPromise = null;
+      setState({ kind: "idle" });
+    },
+    reload: () => {
+      worker?.terminate();
+      worker = null;
+      readyResolve = null;
+      readyPromise = null;
+      setState({ kind: "idle" });
+      ensureWorker();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Verify the build**
+
+Run: `pnpm build`
+Expected: build succeeds. Vite will detect the `new Worker(new URL(...), { type: "module" })` pattern and emit the worker as a separate bundle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/modules/ai/lib/transcribers
+git commit -m "feat(ai): transcriber abstraction with OpenAI + local impls"
+```
+
+---
+
+## Task B6: Refactor `useWhisperRecording` to use the abstraction
+
+**Files:**
+- Modify: `src/modules/ai/hooks/useWhisperRecording.ts` (full rewrite)
+
+- [ ] **Step 1: Rewrite the hook**
+
+Replace `src/modules/ai/hooks/useWhisperRecording.ts` with:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useChatStore } from "../store/chatStore";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  createTranscriber,
+  type Transcriber,
+  type TranscriberState,
+} from "../lib/transcribers";
+
+const MIME_CANDIDATES = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/ogg;codecs=opus",
+  "audio/mp4",
+];
+
+function pickMime(): string | undefined {
+  if (typeof MediaRecorder === "undefined") return undefined;
+  for (const m of MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(m)) return m;
+  }
+  return undefined;
+}
+
+type RecordingState = "idle" | "recording" | "transcribing";
+
+export function useWhisperRecording({
+  onResult,
+}: {
+  onResult: (text: string) => void;
+}) {
+  const apiKey = useChatStore((s) => s.apiKeys.openai);
+  const voiceProvider = usePreferencesStore((s) => s.voiceProvider);
+  const localModel = usePreferencesStore((s) => s.localWhisperModel);
+  const localLanguage = usePreferencesStore((s) => s.localWhisperLanguage);
+
+  const [state, setState] = useState<RecordingState>("idle");
+  const [transcriberState, setTranscriberState] = useState<TranscriberState>({
+    kind: "idle",
+  });
+
+  const recRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const transcriberRef = useRef<Transcriber | null>(null);
+
+  // Recreate the transcriber whenever the selection changes.
+  useEffect(() => {
+    transcriberRef.current?.unload();
+    const t = createTranscriber(
+      voiceProvider === "local"
+        ? { kind: "local", model: localModel, language: localLanguage }
+        : { kind: "openai", apiKey: apiKey ?? null },
+    );
+    transcriberRef.current = t;
+    const unsub = t.subscribe(setTranscriberState);
+    return () => {
+      unsub();
+      t.unload();
+      if (transcriberRef.current === t) transcriberRef.current = null;
+    };
+  }, [voiceProvider, localModel, localLanguage, apiKey]);
+
+  const supported =
+    typeof navigator !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof MediaRecorder !== "undefined";
+
+  const teardownStream = () => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  };
+
+  const stop = useCallback(() => {
+    const rec = recRef.current;
+    if (rec && rec.state !== "inactive") rec.stop();
+  }, []);
+
+  const start = useCallback(async () => {
+    const t = transcriberRef.current;
+    if (!supported || !t || state !== "idle") return;
+    if (!t.ready()) return;
+
+    // Kick off model preload in parallel with capturing audio.
+    t.preload();
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mimeType = pickMime();
+      const rec = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      chunksRef.current = [];
+      rec.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      rec.onstop = async () => {
+        const blob = new Blob(chunksRef.current, {
+          type: rec.mimeType || "audio/webm",
+        });
+        chunksRef.current = [];
+        teardownStream();
+        if (blob.size === 0) {
+          setState("idle");
+          return;
+        }
+        setState("transcribing");
+        try {
+          const active = transcriberRef.current;
+          if (!active) return;
+          const text = await active.transcribe(blob);
+          if (text.trim()) onResult(text.trim());
+        } catch (e) {
+          console.error("whisper.transcribe", e);
+        } finally {
+          setState("idle");
+        }
+      };
+      recRef.current = rec;
+      rec.start();
+      setState("recording");
+    } catch (e) {
+      console.error("whisper.getUserMedia", e);
+      teardownStream();
+      setState("idle");
+    }
+  }, [onResult, state, supported]);
+
+  useEffect(() => {
+    return () => {
+      recRef.current?.stop();
+      teardownStream();
+    };
+  }, []);
+
+  const provider = voiceProvider;
+  const reasonUnavailable =
+    transcriberRef.current?.unavailableReason() ?? null;
+
+  return {
+    state,
+    recording: state === "recording",
+    transcribing: state === "transcribing",
+    start,
+    stop,
+    supported,
+    /** Backwards-compat alias used by current UI code paths. */
+    hasKey: provider === "openai" ? !!apiKey : true,
+    canRecord:
+      supported &&
+      (transcriberRef.current?.ready() ?? false),
+    reasonUnavailable,
+    /** The transcriber's own state (loading model / loaded / error). */
+    transcriberState,
+    provider,
+    isLocalLoading:
+      provider === "local" && transcriberState.kind === "loading",
+  };
+}
+```
+
+- [ ] **Step 2: Verify the build**
+
+Run: `pnpm build`
+Expected: build succeeds. Existing callers (`composer.tsx`, `AiStatusBarControls.tsx`, `AiInputBar.tsx`) still see `state`, `recording`, `transcribing`, `start`, `stop`, `supported`, `hasKey` — all unchanged. New fields are additive.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/modules/ai/hooks/useWhisperRecording.ts
+git commit -m "feat(ai): provider-agnostic voice recording hook"
+```
+
+---
+
+## Task B7: Update mic-button UI for new states
+
+**Files:**
+- Modify: `src/modules/ai/components/AiStatusBarControls.tsx:125-153`
+
+- [ ] **Step 1: Extend the button's title/disabled logic**
+
+In `src/modules/ai/components/AiStatusBarControls.tsx`, replace the mic-button block (lines 125-153) with:
+
+```tsx
+      {c.voice.supported && (
+        <IconBtn
+          title={
+            c.voice.isLocalLoading
+              ? `Downloading model… ${formatProgress(c.voice.transcriberState)}`
+              : !c.voice.canRecord
+                ? c.voice.reasonUnavailable ?? "Voice input unavailable"
+                : c.voice.recording
+                  ? "Stop & transcribe"
+                  : c.voice.transcribing
+                    ? "Transcribing…"
+                    : "Voice input"
+          }
+          onClick={() =>
+            c.voice.recording ? c.voice.stop() : void c.voice.start()
+          }
+          disabled={
+            c.isBusy ||
+            c.voice.transcribing ||
+            (!c.voice.canRecord && !c.voice.isLocalLoading)
+          }
+          className={cn(
+            c.voice.recording &&
+              "bg-destructive/10 text-destructive hover:bg-destructive/15",
+          )}
+        >
+          {c.voice.recording ? (
+            <span className="size-2 animate-pulse rounded-full bg-destructive" />
+          ) : c.voice.transcribing || c.voice.isLocalLoading ? (
+            <Spinner className="size-3" />
+          ) : (
+            <HugeiconsIcon icon={Mic01Icon} size={13} strokeWidth={1.75} />
+          )}
+        </IconBtn>
+      )}
+```
+
+- [ ] **Step 2: Add the progress formatter helper**
+
+At the top of the same file (after imports), add:
+
+```ts
+function formatProgress(state: { loaded?: number; total?: number; kind: string }): string {
+  if (state.kind !== "loading") return "";
+  const total = state.total ?? 0;
+  if (total <= 0) return "preparing…";
+  const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(0)} MB`;
+  return `${mb(state.loaded ?? 0)} / ${mb(total)}`;
+}
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/modules/ai/components/AiStatusBarControls.tsx
+git commit -m "feat(ai): mic button states for local model load + reason text"
+```
+
+---
+
+## Task B8: Surface model-download progress in `AiInputBar`
+
+**Files:**
+- Modify: `src/modules/ai/components/AiInputBar.tsx:210-340`
+
+- [ ] **Step 1: Extend the `voiceLabel` derivation**
+
+In `src/modules/ai/components/AiInputBar.tsx`, find the `voiceLabel` definition (around line 210) and replace it with:
+
+```ts
+  const voiceLabel = c.voice.isLocalLoading
+    ? (() => {
+        const s = c.voice.transcriberState;
+        if (s.kind !== "loading") return "Loading model…";
+        const total = s.total ?? 0;
+        if (total <= 0) return "Loading model…";
+        const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(0)} MB`;
+        return `Downloading model · ${mb(s.loaded ?? 0)} / ${mb(total)}`;
+      })()
+    : c.voice.recording
+      ? "Recording…"
+      : c.voice.transcribing
+        ? "Transcribing…"
+        : null;
+```
+
+The downstream JSX that renders `{voiceLabel && (...)}` does not change.
+
+- [ ] **Step 2: Verify the build**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/modules/ai/components/AiInputBar.tsx
+git commit -m "feat(ai): show model-download progress in input bar"
+```
+
+---
+
+## Task B9: Settings UI — Voice input section
+
+**Files:**
+- Find the AI section file in `src/settings/sections/` (e.g. `ModelsSection.tsx` or a sibling) and either add a new section file or extend the existing AI section.
+- Create: `src/settings/sections/VoiceInputSection.tsx`
+
+- [ ] **Step 1: Locate where sections register**
+
+Run: `grep -rn "ModelsSection\|sections/" src/settings | head -30`
+Identify the parent component that mounts sections (settings.html entry typically lives at `src/settings/`). Add `VoiceInputSection` to the same registration list.
+
+- [ ] **Step 2: Create the section**
+
+Create `src/settings/sections/VoiceInputSection.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  WHISPER_MODELS,
+  setVoiceProvider,
+  setLocalWhisperModel,
+  setLocalWhisperLanguage,
+  type WhisperModelId,
+} from "@/modules/settings/store";
+import { useChatStore } from "@/modules/ai/store/chatStore";
+
+export function VoiceInputSection() {
+  const voiceProvider = usePreferencesStore((s) => s.voiceProvider);
+  const localModel = usePreferencesStore((s) => s.localWhisperModel);
+  const localLanguage = usePreferencesStore((s) => s.localWhisperLanguage);
+  const openaiKey = useChatStore((s) => s.apiKeys.openai);
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h2 className="text-sm font-semibold">Voice input</h2>
+        <p className="text-xs text-muted-foreground">
+          Transcribe speech to text in the composer. Choose a local model for
+          offline use or OpenAI's hosted Whisper for the lowest setup cost.
+        </p>
+      </header>
+
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="radio"
+            name="voiceProvider"
+            checked={voiceProvider === "local"}
+            onChange={() => void setVoiceProvider("local")}
+          />
+          <span>Local (in-app)</span>
+        </label>
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="radio"
+            name="voiceProvider"
+            checked={voiceProvider === "openai"}
+            onChange={() => void setVoiceProvider("openai")}
+          />
+          <span>OpenAI cloud</span>
+          {!openaiKey && voiceProvider === "openai" ? (
+            <span className="text-amber-500">needs an OpenAI key</span>
+          ) : null}
+        </label>
+      </div>
+
+      {voiceProvider === "local" ? (
+        <div className="space-y-3 pl-4">
+          <label className="block text-xs">
+            Model
+            <select
+              className="ml-2 rounded border border-border bg-card px-2 py-1 text-xs"
+              value={localModel}
+              onChange={(e) => void setLocalWhisperModel(e.target.value as WhisperModelId)}
+            >
+              {WHISPER_MODELS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label} · {m.sizeMB} MB{m.multilingual ? "" : " · English only"}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-xs">
+            Language
+            <input
+              className="ml-2 w-32 rounded border border-border bg-card px-2 py-1 text-xs"
+              value={localLanguage}
+              onChange={(e) => void setLocalWhisperLanguage(e.target.value)}
+              placeholder="auto"
+              title='ISO 639-1 code (e.g. "en", "de"). Use "auto" for detection. Ignored by .en models.'
+            />
+          </label>
+
+          <p className="text-[11px] text-muted-foreground">
+            The model downloads on first use and is cached by your browser.
+          </p>
+        </div>
+      ) : (
+        <p className="pl-4 text-xs text-muted-foreground">
+          Uses the OpenAI API key configured in the AI section.
+        </p>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Register the section**
+
+Open the file you identified in Step 1 (the section registry) and add `VoiceInputSection` next to the existing sections. If the registry is a tab list, add a new tab entry pointing to `"voice"` and the section component.
+
+- [ ] **Step 4: Verify the build**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/settings/sections/VoiceInputSection.tsx <registry file>
+git commit -m "feat(settings): voice input section with provider + model selector"
+```
+
+---
+
+## Task B10: Final smoke test (Feature B)
+
+**Files:** none — manual verification.
+
+- [ ] **Step 1: Run the app**
+
+Run: `pnpm tauri dev`
+
+- [ ] **Step 2: Default-provider voice input (no OpenAI key)**
+
+1. Make sure no OpenAI API key is configured (clear it in settings if necessary).
+2. Click the mic icon in the AI composer.
+3. Confirm the icon shows a spinner and the input bar shows `Downloading model · X MB / Y MB` while the model downloads on first use.
+4. Speak a short phrase.
+5. Stop recording; confirm the transcribed text appears in the composer.
+
+- [ ] **Step 3: Switch to OpenAI cloud**
+
+1. In Settings → Voice input, switch provider to "OpenAI cloud".
+2. Without a key configured, confirm the mic button is disabled with a tooltip explaining why.
+3. Add an OpenAI API key, click the mic, record, and confirm transcription via the cloud API.
+
+- [ ] **Step 4: Model switch / unload**
+
+1. Switch back to Local, change the model from `base` to `tiny.en`.
+2. Confirm the next recording triggers a fresh download.
+3. (Optional smoke for the unload path, if you wired an Unload button in settings.)
+
+- [ ] **Step 5: Commit if any smoke-test tweaks were needed**
+
+```bash
+git add -A
+git commit -m "fix(ai): smoke-test adjustments to voice input"
+```
+
+(If no changes were needed, skip the commit.)
+
+---
+
+# Final tasks
+
+## Task Z1: README copy update
+
+**Files:**
+- Modify: `README.md` (voice-input section)
+
+- [ ] **Step 1: Update the README**
+
+Find the section about voice input in `README.md`. Replace any wording that says voice input requires an OpenAI key with copy that mentions the default is local (in-browser) transcription with no key required, and that OpenAI cloud Whisper remains an option in Settings → Voice input. Mention the first-run model download.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: voice input now local by default"
+```
+
+## Task Z2: Final full smoke
+
+**Files:** none — manual.
+
+- [ ] **Step 1: Run the full app one more time**
+
+Run: `pnpm tauri dev`
+
+- [ ] **Step 2: Verify both features together**
+
+1. In the terminal: `echo "see src/app/App.tsx:200"` — click it, confirm tab opens at line 200.
+2. In the terminal: `echo "see nonexistent/path.ts"` — confirm no underline.
+3. In the composer: click the mic, speak, confirm transcription.
+4. Verify nothing else regressed: open existing files via the explorer, run a few terminal commands, switch tabs.
+
+- [ ] **Step 3: Run the test suite**
+
+Run: `pnpm test`
+Expected: all tests pass (existing + new ones from A2, A3, B3).
+
+- [ ] **Step 4: Run the typecheck + build**
+
+Run: `pnpm build`
+Expected: build succeeds.
+
+---
+
+## Self-Review Notes (filled in by plan author after writing)
+
+**Spec coverage:** Every section of the spec maps to at least one task:
+- Spec §1 Terminal links → Tasks A1–A9.
+- Spec §2 Whisper architecture (worker + audio pipeline + transcriber + default model + lifecycle) → Tasks B1, B3, B4, B5, B6.
+- Spec §2 Settings UI → Task B9.
+- Spec §2 Mic button states → Tasks B7, B8.
+- Spec §2 Preferences additions → Task B2.
+- Spec §3 Error/edge cases — covered inline (matcher rejects, existence cache invalidation on click failure, decode failure handling in B3, model load failure surfacing via transcriberState in B6/B7).
+- Spec §4 Out of scope — nothing in the plan adds those.
+- Documentation follow-ups → Task Z1.
+
+**Placeholder scan:** All steps include either runnable commands or full code. No TBDs, no "implement appropriate error handling" without showing what.
+
+**Type consistency:** `Transcriber`, `TranscriberState`, and `LocalTranscriber` are consistent across Tasks B5, B6, B7, B8. The `SlotAdapter` extension in A4 matches its consumer in A6. `EditorTab.pendingSelection` in A7 matches the consumer in A8.
+
+**Open risks:**
+- `EditorStack.tsx` is referenced in A8 but its current shape isn't quoted — the engineer should grep for `<EditorPane` to find the exact prop-passing site. The intent is clear (thread `pendingSelection` and `onSelectionApplied` through).
+- The xterm `ILinkProvider` API and `IViewportRange` import names depend on the installed xterm version; if names differ, the engineer should `grep "ILinkProvider" node_modules/@xterm/xterm/typings/`.
+- transformers.js model IDs (`onnx-community/whisper-*`) exist as of writing but the engineer should verify by trying the first download. If 404s, switch to `Xenova/whisper-*` (the older but still-mirrored namespace).

--- a/docs/superpowers/specs/2026-05-22-terminal-links-and-local-whisper-design.md
+++ b/docs/superpowers/specs/2026-05-22-terminal-links-and-local-whisper-design.md
@@ -1,0 +1,293 @@
+# Terminal clickable paths + local Whisper
+
+**Date:** 2026-05-22
+**Status:** Draft for implementation
+
+Two independent features bundled into one spec because they're modest in size and share no code, only a release window:
+
+1. Make file paths in terminal output clickable, opening the file in an in-app editor tab.
+2. Add a local, in-browser Whisper transcription option so voice input no longer requires an OpenAI key.
+
+The existing OpenAI cloud transcription path remains as a user-selectable provider.
+
+---
+
+## 1. Terminal clickable paths
+
+### Goal
+
+When `tsc`, `eslint`, `rustc`, `grep -n`, `ripgrep`, `pytest`, etc. print a file path — including `path:line:col` and bare filenames — clicking the path opens the file in a Terax editor tab (preview slot), with the cursor scrolled to `line:col` when present.
+
+Critically: a path is underlined **only if it resolves to an existing file**, which kills the false-positive problem inherent to broad regex matchers.
+
+### Architecture
+
+Two link providers run side by side on each xterm instance:
+
+- The existing `WebLinksAddon` keeps owning real URLs (`http(s)://…`, `file://…`).
+- A new custom link provider, registered via `term.registerLinkProvider`, owns file paths.
+
+The two domains don't overlap — `WebLinksAddon` regex requires a URL scheme; the file-path matcher rejects anything with `://`.
+
+### Implementation outline
+
+**New module: `src/modules/terminal/lib/fileLinkProvider.ts`.**
+
+```
+provideLinks(bufferLineNumber, callback):
+  1. Read the line text from term.buffer.active.
+  2. Tokenize candidates with a permissive regex covering:
+       - absolute paths   ( /…, ~/…, C:\…)
+       - relative paths   ( ./…, ../…, slash-containing, etc.)
+       - bare filenames   ( foo.ts, README.md  — extension required)
+     Each may be suffixed with :line  or  :line:col .
+  3. Cheap-reject obvious non-files before any fs probe:
+       - pure numbers (12.345), semver, hex hashes, timestamps
+       - URLs (any token containing "://")
+       - tokens longer than 512 chars
+  4. Skip the line entirely if it's longer than 1024 chars; cap
+     candidates at 32 per line.
+  5. Resolve relative paths against the leaf's tracked cwd.
+  6. Existence probe per resolved absolute path via a new Rust command
+     `fs_exists`, gated by an LRU (see below).
+  7. callback([{ range, text }, ...]) with only the verified paths.
+```
+
+**Existence cache.** A module-level LRU keyed by absolute path. Positive results live 30 s, negative 5 s, bounded at 4096 entries. Entries are invalidated on click failure (ENOENT) so a moved/deleted file stops underlining on next hover.
+
+**Cwd source.** Each terminal leaf already emits `onCwd(cwd)` from the OSC 7 handler at `src/modules/terminal/lib/osc-handlers.ts:21`. The renderer pool needs the current cwd per slot to resolve relative paths; we extend the existing `SlotAdapter` interface (rather than passing it through every call site) with a `getCwd(leafId)` accessor. If a leaf never emits OSC 7 (uninstrumented shell), we resolve only absolute paths — no fallback guessing.
+
+**Click handler.** `handler(event, text)` calls a new `SlotAdapter.openFile(absPath, line?, col?)`. The adapter is populated in `App.tsx`, where the existing `openFileTab` callback is in scope. Modifier keys are ignored in this iteration (deferred — see "Out of scope").
+
+**Tab + editor changes.**
+
+- `openFileTab(path, pin)` in `src/modules/tabs/lib/useTabs.ts:205` gains an optional 3rd argument: `selection?: { line: number; col?: number }`. Stored on the `EditorTab` as a `pendingSelection` field.
+- `EditorPane` (CodeMirror) consumes `pendingSelection` in an effect: on mount or when it changes, it dispatches a CodeMirror transaction that sets the selection at the requested line/col, scrolls into view (centered), and then clears `pendingSelection` via a tab-store mutation. Clearing is essential — otherwise re-activating the tab much later would re-jump.
+
+### Out of scope
+
+- Cmd/Ctrl+click → "open in OS default app". One-line future extension (the link handler already receives the `event`).
+- Highlighting paths inside `file://` URLs beyond what `WebLinksAddon` already does.
+- Detecting paths in stack traces with unusual delimiters (`at Foo (path:line:col)` is matched by the regex; `at Foo @ path line 42` is not).
+
+### Files touched
+
+- **New:** `src/modules/terminal/lib/fileLinkProvider.ts`
+- **Modified:** `src/modules/terminal/lib/rendererPool.ts` (load second provider; extend `SlotAdapter` with `getCwd` and `openFile`)
+- **Modified:** `src/modules/terminal/TerminalStack.tsx` and `TerminalPane.tsx` (thread cwd through to renderer pool)
+- **Modified:** `src/modules/tabs/lib/useTabs.ts` (`selection?` parameter on `openFileTab`; new `pendingSelection` field on `EditorTab`)
+- **Modified:** `src/modules/editor/EditorPane.tsx` (consume `pendingSelection`)
+- **Modified:** `src/app/App.tsx` (wire `getCwd`/`openFile` into `SlotAdapter`)
+- **New (Rust):** `fs_exists` command in `src-tauri/src/modules/fs/file.rs`, registered in `src-tauri/src/lib.rs` alongside `fs_read_file` / `fs_canonicalize`. Signature follows the existing pattern: `fn fs_exists(path: String, workspace: Option<WorkspaceEnv>) -> Result<bool, String>`. Called from the link provider via `invoke<boolean>("fs_exists", { path })`. We follow the codebase's established custom-command pattern rather than introducing `@tauri-apps/plugin-fs` for a single call.
+- **Tests:** unit tests for the matcher regex (positive/negative cases) and the existence-cache LRU. Integration test for `openFileTab` with `selection` is reasonable; click-event simulation through xterm is not worth it.
+
+---
+
+## 2. Local Whisper transcription
+
+### Goal
+
+Replace the hardcoded OpenAI Whisper dependency in `src/modules/ai/hooks/useWhisperRecording.ts` with a provider-selectable transcription layer. Default to a local in-browser model so voice input works out of the box for users without an OpenAI key.
+
+### Architecture
+
+**Library.** `@huggingface/transformers` (ESM, maintained successor to `@xenova/transformers`). Ships ONNX Runtime with WebGPU + WASM execution providers, auto-selects per platform.
+
+WebGPU availability across Tauri platforms:
+
+- **macOS** (WKWebView, Sonoma+): WebGPU available.
+- **Windows** (WebView2 / Chromium): WebGPU available.
+- **Linux** (WebKitGTK): no WebGPU — auto-falls-back to WASM (CPU, slower but works).
+
+We do not surface this choice; we just show "Loaded (CPU)" vs "Loaded (GPU)" in settings status for the curious.
+
+**Worker boundary.** Inference is heavy and must not block the UI. New file: `src/modules/ai/workers/whisperWorker.ts`, instantiated via Vite's recommended pattern: `new Worker(new URL("./whisperWorker.ts", import.meta.url), { type: "module" })`. A singleton pipeline lives inside the worker; once loaded it stays warm until the user changes model, unloads explicitly, or switches provider.
+
+**Worker protocol.**
+
+```ts
+type In  = { kind: "load",       model: string }
+        | { kind: "transcribe",  pcm: Float32Array, language?: string }
+        | { kind: "unload" };
+
+type Out = { kind: "progress",   file: string, loaded: number, total: number }
+        | { kind: "ready",       model: string, backend: "gpu" | "cpu" }
+        | { kind: "result",      text: string }
+        | { kind: "error",       message: string };
+```
+
+`load` is idempotent. The HF library's progress callback is forwarded as `progress` events so the UI can show "Downloading… 43 MB / 140 MB". The PCM `Float32Array` is sent as a transferable to avoid copy overhead.
+
+**Audio pipeline (main thread).**
+
+```
+mic getUserMedia                                  (unchanged)
+  → MediaRecorder                                 (unchanged)
+  → on stop: Blob
+  → arrayBuffer → OfflineAudioContext.decodeAudioData
+  → mono downmix (channel average)
+  → resample to 16 kHz via OfflineAudioContext (16 000 Hz target rate)
+  → Float32Array PCM
+  → worker.postMessage({ kind: "transcribe", pcm }, [pcm.buffer])
+  → worker.onmessage("result") → onResult(text)
+```
+
+The decode + resample step is ~50 ms for a 10 s clip and stays on the main thread. If profiling shows this hurts on low-end machines we can move it into the worker later — out of scope for v1.
+
+**Transcriber abstraction.**
+
+`useWhisperRecording.ts` is refactored so the transcription call is provider-agnostic:
+
+```ts
+interface Transcriber {
+  transcribe(blob: Blob): Promise<string>;
+  // optional: progress + state for the local one
+  state?: "idle" | "loading" | "loaded" | "error";
+  progress?: { file: string; loaded: number; total: number };
+}
+```
+
+Two implementations:
+
+- `openaiTranscriber({ apiKey })` — the current code at `useWhisperRecording.ts:21-28`, lifted into its own module.
+- `localWhisperTranscriber({ model })` — owns the worker singleton, exposes `transcribe`, `state`, `progress`, `unload`. Decode/resample lives here, before posting to the worker.
+
+The hook reads `voiceProvider` from `usePreferencesStore` and selects the implementation via a small factory. The hook's public API (start/stop/state) is unchanged for callers.
+
+**Default model.** `onnx-community/whisper-base` (~140 MB quantized, multilingual). Rationale:
+
+- `tiny` is noticeably worse on accents and disfluencies — not a good first-run impression.
+- `small` is ~460 MB, rude as a default download.
+- `base` is the sweet spot.
+
+Selector in settings exposes: `tiny.en`, `base.en`, `base`, `small.en`, `small`. `.en` variants are English-only and meaningfully faster; we offer them but don't default to them (users speaking other languages would silently get gibberish).
+
+**Lifecycle.**
+
+- Worker is created lazily on first mic-click after Local is selected (not at app start — keeps cold start fast and respects users who never use voice).
+- Recording and model-load run in parallel on first use. If the user finishes speaking before the model is ready, the UI shows "Transcribing (waiting for model)…" and resolves when both arrive. Implementation: `start()` fires `worker.load()` if not loaded; the `MediaRecorder.onstop` handler awaits a `whenReady` promise before posting PCM.
+- "Unload" in settings sends `{ kind: "unload" }` and frees ~300 MB RAM. Provider switch and model switch both unload first.
+
+### Settings UI
+
+New panel section in `src/modules/settings`, header "Voice input":
+
+```
+Voice input
+  Provider              ( ) OpenAI cloud
+                        (•) Local (in-app)
+
+  ── shown when "Local" ──
+  Model                 [ whisper-base  ▾ ]   (tiny.en 75 MB · base.en 140 MB
+                                                · base 140 MB · small.en 460 MB · small 460 MB)
+  Language              [ Auto-detect   ▾ ]   (only for non-".en" models)
+  Status                Loaded (GPU) · 138 MB cached    [Unload]   [Clear cache]
+
+  ── shown when "OpenAI cloud" ──
+  Uses OpenAI API key from AI settings.
+  Model                 whisper-1                       (fixed)
+```
+
+**Preferences store additions** (`usePreferencesStore`, persisted via Tauri store plugin):
+
+```ts
+voiceProvider:        "openai" | "local"   // default: "local"
+localWhisperModel:    WhisperModelId       // default: "onnx-community/whisper-base"
+localWhisperLanguage: string | "auto"      // default: "auto"
+```
+
+### Mic button states
+
+The existing button at `src/modules/ai/components/AiStatusBarControls.tsx:125-153` already has idle / recording / transcribing. Two new states:
+
+- **loading-model** — first click after Local was selected, while model downloads + warms. Tooltip: "Downloading model… 43 MB / 140 MB". Clicking cancels the load and reverts to idle.
+- **disabled-no-config** — Local picked but load errored, *or* OpenAI picked without a key. Tooltip explains and links to settings.
+
+The current `!hasKey`-disabled gate is replaced by a provider-aware `canRecord` selector.
+
+### Files touched
+
+- **New:** `src/modules/ai/workers/whisperWorker.ts`
+- **New:** `src/modules/ai/lib/transcribers/openai.ts`
+- **New:** `src/modules/ai/lib/transcribers/local.ts`
+- **New:** `src/modules/ai/lib/transcribers/index.ts` (factory + `Transcriber` interface)
+- **New:** `src/modules/ai/lib/audio.ts` (Blob → 16 kHz mono PCM helpers)
+- **Modified:** `src/modules/ai/hooks/useWhisperRecording.ts` (provider-agnostic)
+- **Modified:** `src/modules/ai/components/AiStatusBarControls.tsx` (new states)
+- **Modified:** `src/modules/ai/lib/AiInputBar.tsx` (download-progress status text)
+- **Modified:** `src/modules/settings/preferences.ts` (new fields, defaults)
+- **Modified:** the settings panel that holds AI settings (new "Voice input" section)
+- **New dep:** `@huggingface/transformers`
+- **Tests:** unit tests for the audio decode/resample helpers (deterministic given a known WAV input); a worker-protocol smoke test that mocks the pipeline; provider-switching test on the hook.
+
+### Documentation follow-ups (not code)
+
+- `README.md` and `docs/ai-workflow.png` mention voice input requires an OpenAI key — copy needs updating.
+- Mention model first-run download in the README's voice-input section.
+
+---
+
+## 3. Error handling & edge cases
+
+### Terminal
+
+- **Existence-check races.** A file shown in the buffer can be deleted between cache fill and click. The click handler awaits `openFile(...)`; if it reports ENOENT, a transient toast in the terminal area says "File no longer exists" and the cache entry is invalidated so the next hover won't underline it. No retry.
+- **Cwd loss.** Leaves that never emit OSC 7 (shell not instrumented) keep `lastCwd = null`. Only absolute paths get underlined. No falling back to the host app's cwd — that would silently open the wrong file in a multi-project session.
+- **Perf ceiling.** Lines longer than 1024 chars are skipped wholesale; per-line candidate cap is 32; tokens longer than 512 chars are skipped. LRU cache is bounded at 4096 entries (positive 30 s, negative 5 s).
+- **False-positive damping.** Before any fs probe, cheap regex rejects: pure numbers, semver, hex hashes (no slash + no extension + length ≥ 7), URLs (anything with `://`), timestamps.
+- **Editor scroll-to-line consumption.** `pendingSelection` is cleared as soon as `EditorPane` applies it. Re-activating the tab months later must not re-jump.
+
+### Whisper
+
+- **Model load failure** (HF CDN unreachable, browser cache corrupted, OOM). Worker emits `{ kind: "error" }`. Hook surfaces an inline error in the composer status slot (same slot that today reads "Transcribing…") with a "Retry" button. No automatic cloud fallback — provider choice is explicit.
+- **Decode failure.** Some Linux WebKitGTK builds reject certain MediaRecorder MIME types. Caught in the decode step; we drop the recording and show "Couldn't decode audio — try a different codec in settings." `MIME_CANDIDATES` is extended slightly to include WAV fallback where supported; everything else is unchanged.
+- **Storage pressure.** Models live in the WebView's Cache Storage. "Clear cache" calls `caches.delete('transformers-cache')`. We don't manage quota — the browser does.
+- **Empty / silent recording.** `blob.size === 0` shortcut from current code is kept. Additionally we early-return if the post-decode PCM is shorter than 200 ms — saves a worker round-trip on accidental taps.
+- **Concurrency.** The explicit parallel path is recording-while-model-downloads (section 2 lifecycle). What's forbidden: starting a second recording while transcription is in flight — the mic button is `disabled` in the `transcribing` state, same as today.
+
+---
+
+## 4. Out of scope
+
+Listed explicitly so the implementation plan doesn't quietly absorb these:
+
+- **Streaming / real-time transcription.** The Whisper architecture supports it; this design is record-then-transcribe only.
+- **Speaker diarization, timestamps, language auto-switching mid-clip.**
+- **OpenAI-compatible base-URL config** for a third "self-hosted server" provider. Cheap to add but explicitly *not* what the user picked.
+- **Per-leaf Cmd/Ctrl+click → "open in OS default app"** for terminal links.
+- **Detecting paths inside `file://` URLs** beyond what `WebLinksAddon` already does.
+- **Worker-side audio decode** (only matters if main-thread resample becomes a measurable problem).
+- **Quota-aware model cache management.**
+
+---
+
+## 5. Testing strategy
+
+**Unit / vitest:**
+
+- File-link matcher regex: positive cases (`src/foo.ts`, `./bar.rs:42`, `/abs/x.py:10:5`, `README.md`) and negative cases (semver, hex hash, URL, plain number).
+- Existence-cache LRU: insertion, eviction, positive/negative TTLs, invalidation on click failure.
+- `openFileTab(path, pin, selection)` returns a tab with the right `pendingSelection`; same path called twice keeps the same tab id.
+- Audio: known WAV blob → mono 16 kHz Float32 PCM with expected length / sample rate.
+- Transcriber factory: returns local when provider is "local"; returns openai when "openai" with key; returns null + reason when "openai" without key.
+
+**Manual / smoke:**
+
+- Click a tsc-style `src/foo.ts:42:5` path in a real terminal session → file opens to that line.
+- Click a deleted file's path → toast shown; underline gone on next render.
+- First-run voice input with no OpenAI key, Local provider → model downloads with progress UI; transcription completes.
+- Switch provider to OpenAI cloud → next voice input uses the cloud path.
+- Unload model → status updates; next recording reloads.
+
+---
+
+## 6. Open questions
+
+None blocking. Resolved during brainstorming:
+
+- Matcher scope: broadest (bare filenames included), gated by existence check.
+- Click target: in-app preview tab.
+- Whisper backend: in-browser WASM/WebGPU via `@huggingface/transformers`.
+- Cloud fallback: keep both, user-selectable, no silent fallback.
+- Default provider: Local.
+- Default model: `onnx-community/whisper-base`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,7 @@ pub fn run() {
             fs::file::fs_write_file,
             fs::file::fs_stat,
             fs::file::fs_canonicalize,
+            fs::file::fs_exists,
             fs::mutate::fs_create_file,
             fs::mutate::fs_create_dir,
             fs::mutate::fs_rename,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -161,6 +161,16 @@ pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat
     })
 }
 
+#[tauri::command]
+pub fn fs_exists(path: String, workspace: Option<WorkspaceEnv>) -> Result<bool, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
+    // `try_exists` distinguishes "definitely missing" from "couldn't check"
+    // (permission errors, broken filesystem). For terminal click-to-open
+    // we collapse both into "not clickable" — false is the safe default.
+    Ok(p.try_exists().unwrap_or(false))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -90,6 +90,7 @@ import {
   writeToSession,
   type TerminalPaneHandle,
 } from "@/modules/terminal";
+import { setTerminalOpenFileHandler } from "@/modules/terminal/lib/useTerminalSession";
 import { ThemeProvider } from "@/modules/theme";
 import { listCustomThemes, saveCustomTheme } from "@/modules/theme/customThemes";
 import {
@@ -168,6 +169,7 @@ export default function App() {
     newAgentTab,
     newPrivateTab,
     openFileTab,
+    clearPendingSelection,
     pinTab,
     newPreviewTab,
     newMarkdownTab,
@@ -598,6 +600,20 @@ export default function App() {
     return () => {
       alive = false;
       unsub?.();
+    };
+  }, [openFileTab]);
+
+  useEffect(() => {
+    setTerminalOpenFileHandler(async (_leafId, path, line, col) => {
+      const id = openFileTab(
+        path,
+        false, // preview slot — VSCode-style
+        line !== undefined ? { line, col } : undefined,
+      );
+      return id !== null;
+    });
+    return () => {
+      setTerminalOpenFileHandler(async () => false);
     };
   }, [openFileTab]);
 
@@ -1314,6 +1330,7 @@ export default function App() {
           registerHandle={registerEditorHandle}
           onDirtyChange={handleEditorDirty}
           onCloseTab={disposeTab}
+          onSelectionApplied={clearPendingSelection}
         />
       </div>
       <div

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -52,6 +52,13 @@ type Props = {
   onDirtyChange?: (dirty: boolean) => void;
   onSaved?: () => void;
   onClose?: () => void;
+  /**
+   * One-shot scroll/cursor target. The pane dispatches a CodeMirror transaction
+   * to move the selection there and scroll it into view, then calls
+   * `onSelectionApplied` to clear it from the tab store.
+   */
+  pendingSelection?: { line: number; col?: number };
+  onSelectionApplied?: () => void;
 };
 
 function formatBytes(n: number): string {
@@ -61,7 +68,7 @@ function formatBytes(n: number): string {
 }
 
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
-  function EditorPane({ path, onDirtyChange, onSaved, onClose }, ref) {
+  function EditorPane({ path, onDirtyChange, onSaved, onClose, pendingSelection, onSelectionApplied }, ref) {
     const { doc, onChange, save, reload } = useDocument({ path, onDirtyChange });
     const reloadRef = useRef(reload);
     reloadRef.current = reload;
@@ -214,6 +221,51 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
         cancelled = true;
       };
     }, [path, doc.status]);
+
+    useEffect(() => {
+      if (!pendingSelection) return;
+      if (doc.status !== "ready") return;
+
+      const { line, col } = pendingSelection;
+      let cancelled = false;
+
+      // Wait for CodeMirror to finish mounting AND for its initial content
+      // transaction to settle. The view is created in an internal effect and
+      // its doc isn't populated until that effect runs; a Promise.resolve()
+      // microtask is too early in practice and reads an empty doc, which
+      // clamps targetLine to 1 and silently no-ops. Two rAFs reliably defer
+      // past mount + first paint.
+      const apply = () => {
+        if (cancelled) return;
+        const v = cmRef.current?.view;
+        if (!v || v.state.doc.lines === 0) return; // shouldn't happen but defensive
+        const totalLines = v.state.doc.lines;
+        const targetLine = Math.max(1, Math.min(line, totalLines));
+        const lineInfo = v.state.doc.line(targetLine);
+        const offset =
+          col !== undefined
+            ? Math.max(lineInfo.from, Math.min(lineInfo.to, lineInfo.from + col - 1))
+            : lineInfo.from;
+        v.dispatch({
+          selection: { anchor: offset, head: offset },
+          scrollIntoView: true,
+        });
+        v.focus();
+        onSelectionApplied?.();
+      };
+
+      let raf1 = 0;
+      let raf2 = 0;
+      raf1 = requestAnimationFrame(() => {
+        if (cancelled) return;
+        raf2 = requestAnimationFrame(apply);
+      });
+      return () => {
+        cancelled = true;
+        cancelAnimationFrame(raf1);
+        cancelAnimationFrame(raf2);
+      };
+    }, [pendingSelection, doc.status, onSelectionApplied]);
 
     useImperativeHandle(
       ref,

--- a/src/modules/editor/EditorStack.tsx
+++ b/src/modules/editor/EditorStack.tsx
@@ -9,6 +9,7 @@ type Props = {
   onDirtyChange: (id: number, dirty: boolean) => void;
   registerHandle: (id: number, handle: EditorPaneHandle | null) => void;
   onCloseTab: (id: number) => void;
+  onSelectionApplied?: (id: number) => void;
 };
 
 export function EditorStack({
@@ -17,6 +18,7 @@ export function EditorStack({
   onDirtyChange,
   registerHandle,
   onCloseTab,
+  onSelectionApplied,
 }: Props) {
   const editors = tabs.filter((t): t is EditorTab => t.kind === "editor");
 
@@ -27,6 +29,7 @@ export function EditorStack({
   const registerRef = useRef(registerHandle);
   const dirtyRef = useRef(onDirtyChange);
   const closeRef = useRef(onCloseTab);
+  const selectionAppliedRef = useRef(onSelectionApplied);
   useEffect(() => {
     registerRef.current = registerHandle;
   }, [registerHandle]);
@@ -36,12 +39,16 @@ export function EditorStack({
   useEffect(() => {
     closeRef.current = onCloseTab;
   }, [onCloseTab]);
+  useEffect(() => {
+    selectionAppliedRef.current = onSelectionApplied;
+  }, [onSelectionApplied]);
 
   const refCallbacks = useRef(
     new Map<number, (h: EditorPaneHandle | null) => void>(),
   );
   const dirtyCallbacks = useRef(new Map<number, (dirty: boolean) => void>());
   const closeCallbacks = useRef(new Map<number, () => void>());
+  const selectionAppliedCallbacks = useRef(new Map<number, () => void>());
 
   const getRefCallback = (id: number) => {
     let cb = refCallbacks.current.get(id);
@@ -67,6 +74,14 @@ export function EditorStack({
     }
     return cb;
   };
+  const getSelectionAppliedCallback = (id: number) => {
+    let cb = selectionAppliedCallbacks.current.get(id);
+    if (!cb) {
+      cb = () => selectionAppliedRef.current?.(id);
+      selectionAppliedCallbacks.current.set(id, cb);
+    }
+    return cb;
+  };
 
   // Drop callback entries for closed tabs to avoid unbounded growth.
   useEffect(() => {
@@ -79,6 +94,9 @@ export function EditorStack({
     }
     for (const id of closeCallbacks.current.keys()) {
       if (!live.has(id)) closeCallbacks.current.delete(id);
+    }
+    for (const id of selectionAppliedCallbacks.current.keys()) {
+      if (!live.has(id)) selectionAppliedCallbacks.current.delete(id);
     }
   }, [editors]);
 
@@ -102,6 +120,8 @@ export function EditorStack({
                 path={t.path}
                 onDirtyChange={getDirtyCallback(t.id)}
                 onClose={getCloseCallback(t.id)}
+                pendingSelection={t.pendingSelection}
+                onSelectionApplied={getSelectionAppliedCallback(t.id)}
               />
             </div>
           </div>

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -39,6 +39,12 @@ export type EditorTab = {
    * is replaced by the next single-click rather than accumulating.
    */
   preview: boolean;
+  /**
+   * One-shot scroll/cursor target consumed by EditorPane on the next render.
+   * Set when opened from a terminal-link click; cleared as soon as the editor
+   * applies it. Coordinates are 1-based (matching compiler output).
+   */
+  pendingSelection?: { line: number; col?: number };
 };
 
 export type PreviewTab = {
@@ -223,78 +229,118 @@ export function useTabs(initial?: Partial<TerminalTab>) {
    *   reused: if a persistent tab for the path already exists it is activated;
    *   otherwise the current preview slot is replaced with the new path.
    */
-  const openFileTab = useCallback((path: string, pin = true) => {
-    let targetId: number | null = null;
-    setTabs((curr) => {
-      if (pin) {
-        // Persistent open: find any existing editor tab, pin it if needed.
-        const existing = curr.find(
-          (t) => t.kind === "editor" && t.path === path,
-        );
-        if (existing) {
-          targetId = existing.id;
-          if ((existing as EditorTab).preview) {
-            return curr.map((t) =>
-              t.id === existing.id ? { ...t, preview: false } : t,
-            );
+  const openFileTab = useCallback(
+    (
+      path: string,
+      pin = true,
+      selection?: { line: number; col?: number },
+    ) => {
+      let targetId: number | null = null;
+      setTabs((curr) => {
+        if (pin) {
+          // Persistent open: find any existing editor tab, pin it if needed.
+          const existing = curr.find(
+            (t) => t.kind === "editor" && t.path === path,
+          );
+          if (existing) {
+            targetId = existing.id;
+            if ((existing as EditorTab).preview) {
+              return curr.map((t) =>
+                t.id === existing.id
+                  ? {
+                      ...t,
+                      preview: false,
+                      ...(selection !== undefined && {
+                        pendingSelection: selection,
+                      }),
+                    }
+                  : t,
+              );
+            }
+            if (selection !== undefined) {
+              return curr.map((t) =>
+                t.id === existing.id ? { ...t, pendingSelection: selection } : t,
+              );
+            }
+            return curr;
           }
-          return curr;
-        }
-        const id = nextIdRef.current++;
-        targetId = id;
-        return [
-          ...curr,
-          {
+          const id = nextIdRef.current++;
+          targetId = id;
+          return [
+            ...curr,
+            {
+              id,
+              kind: "editor",
+              title: basename(path),
+              path,
+              dirty: false,
+              preview: false,
+              ...(selection !== undefined && { pendingSelection: selection }),
+            } satisfies EditorTab,
+          ];
+        } else {
+          // Preview open: persistent tab for this path takes priority.
+          const persistent = curr.find(
+            (t) =>
+              t.kind === "editor" &&
+              t.path === path &&
+              !(t as EditorTab).preview,
+          );
+          if (persistent) {
+            targetId = persistent.id;
+            if (selection !== undefined) {
+              return curr.map((t) =>
+                t.id === persistent.id
+                  ? { ...t, pendingSelection: selection }
+                  : t,
+              );
+            }
+            return curr;
+          }
+          // Reuse the slot if it already shows the same path.
+          const existingPreview = curr.find(
+            (t) =>
+              t.kind === "editor" &&
+              t.path === path &&
+              (t as EditorTab).preview,
+          );
+          if (existingPreview) {
+            targetId = existingPreview.id;
+            if (selection !== undefined) {
+              return curr.map((t) =>
+                t.id === existingPreview.id
+                  ? { ...t, pendingSelection: selection }
+                  : t,
+              );
+            }
+            return curr;
+          }
+          // Replace the current preview slot, or append a new one.
+          const previewIdx = curr.findIndex(
+            (t) => t.kind === "editor" && (t as EditorTab).preview,
+          );
+          const id = nextIdRef.current++;
+          targetId = id;
+          const tab: EditorTab = {
             id,
             kind: "editor",
             title: basename(path),
             path,
             dirty: false,
-            preview: false,
-          } satisfies EditorTab,
-        ];
-      } else {
-        // Preview open: persistent tab for this path takes priority.
-        const persistent = curr.find(
-          (t) =>
-            t.kind === "editor" && t.path === path && !(t as EditorTab).preview,
-        );
-        if (persistent) {
-          targetId = persistent.id;
-          return curr;
+            preview: true,
+            ...(selection !== undefined && { pendingSelection: selection }),
+          };
+          if (previewIdx === -1) return [...curr, tab];
+          const next = [...curr];
+          next[previewIdx] = tab;
+          return next;
         }
-        // Reuse the slot if it already shows the same path.
-        const existingPreview = curr.find(
-          (t) =>
-            t.kind === "editor" && t.path === path && (t as EditorTab).preview,
-        );
-        if (existingPreview) {
-          targetId = existingPreview.id;
-          return curr;
-        }
-        // Replace the current preview slot, or append a new one.
-        const previewIdx = curr.findIndex(
-          (t) => t.kind === "editor" && (t as EditorTab).preview,
-        );
-        const id = nextIdRef.current++;
-        targetId = id;
-        const tab: EditorTab = {
-          id,
-          kind: "editor",
-          title: basename(path),
-          path,
-          dirty: false,
-          preview: true,
-        };
-        if (previewIdx === -1) return [...curr, tab];
-        const next = [...curr];
-        next[previewIdx] = tab;
-        return next;
-      }
-    });
-    if (targetId !== null) setActiveId(targetId);
-    return targetId as number | null;
-  }, []);
+      });
+      if (targetId !== null) setActiveId(targetId);
+      return targetId as number | null;
+    },
+    [],
+  );
 
   /**
    * Promotes a preview tab to a persistent one. Called on double-click of the
@@ -304,6 +350,16 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setTabs((curr) =>
       curr.map((t) =>
         t.id === id && t.kind === "editor" ? { ...t, preview: false } : t,
+      ),
+    );
+  }, []);
+
+  const clearPendingSelection = useCallback((id: number) => {
+    setTabs((curr) =>
+      curr.map((t) =>
+        t.id === id && t.kind === "editor"
+          ? { ...t, pendingSelection: undefined }
+          : t,
       ),
     );
   }, []);
@@ -803,6 +859,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     newPrivateTab,
     openFileTab,
     pinTab,
+    clearPendingSelection,
     newPreviewTab,
     newMarkdownTab,
     openAiDiffTab,

--- a/src/modules/terminal/lib/existenceCache.test.ts
+++ b/src/modules/terminal/lib/existenceCache.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createExistenceCache } from "./existenceCache";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("existenceCache", () => {
+  it("calls the probe once per path and caches the result", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe);
+
+    await expect(cache.exists("/a")).resolves.toBe(true);
+    await expect(cache.exists("/a")).resolves.toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes a positive entry after positive TTL elapses", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe);
+
+    await cache.exists("/a");
+    vi.advanceTimersByTime(31_000);
+    await cache.exists("/a");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-probes a negative entry after the shorter negative TTL", async () => {
+    const probe = vi.fn().mockResolvedValue(false);
+    const cache = createExistenceCache(probe);
+
+    await cache.exists("/missing");
+    vi.advanceTimersByTime(6_000);
+    await cache.exists("/missing");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates an entry explicitly", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe);
+
+    await cache.exists("/a");
+    cache.invalidate("/a");
+    await cache.exists("/a");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least-recently-used entry past capacity", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const cache = createExistenceCache(probe, { capacity: 2 });
+
+    await cache.exists("/a");
+    await cache.exists("/b");
+    await cache.exists("/c"); // evicts /a
+    await cache.exists("/a"); // re-probe after eviction
+    expect(probe).toHaveBeenCalledTimes(4);
+  });
+
+  it("coalesces concurrent probes of the same path", async () => {
+    let resolve!: (v: boolean) => void;
+    const probe = vi.fn(
+      () => new Promise<boolean>((r) => { resolve = r; }),
+    );
+    const cache = createExistenceCache(probe);
+
+    const p1 = cache.exists("/slow");
+    const p2 = cache.exists("/slow");
+    expect(probe).toHaveBeenCalledTimes(1);
+    resolve(true);
+    await expect(p1).resolves.toBe(true);
+    await expect(p2).resolves.toBe(true);
+  });
+});

--- a/src/modules/terminal/lib/existenceCache.ts
+++ b/src/modules/terminal/lib/existenceCache.ts
@@ -1,0 +1,93 @@
+/**
+ * LRU cache wrapping an async existence probe. Designed for the terminal
+ * link-provider hot path: we may probe the same path many times per second
+ * as the user scrolls and hovers, and want stale-while-valid semantics.
+ *
+ * Positive entries live longer than negatives because a file appearing
+ * is more common than one vanishing in a terminal session, and the
+ * worst-case for a stale positive (one missed underline) is far less
+ * disruptive than the worst-case for a stale negative (perpetually
+ * un-clickable file the user just created).
+ */
+export interface ExistenceCacheOptions {
+  capacity?: number;
+  positiveTtlMs?: number;
+  negativeTtlMs?: number;
+  /** Defaults to `Date.now`. Vitest can swap with `vi.useFakeTimers`. */
+  now?: () => number;
+}
+
+export interface ExistenceCache {
+  exists(path: string): Promise<boolean>;
+  invalidate(path: string): void;
+  clear(): void;
+}
+
+type Entry = { value: boolean; expiresAt: number };
+
+const DEFAULTS = {
+  capacity: 4096,
+  positiveTtlMs: 30_000,
+  negativeTtlMs: 5_000,
+};
+
+export function createExistenceCache(
+  probe: (path: string) => Promise<boolean>,
+  opts: ExistenceCacheOptions = {},
+): ExistenceCache {
+  const capacity = opts.capacity ?? DEFAULTS.capacity;
+  const posTtl = opts.positiveTtlMs ?? DEFAULTS.positiveTtlMs;
+  const negTtl = opts.negativeTtlMs ?? DEFAULTS.negativeTtlMs;
+  const now = opts.now ?? Date.now;
+
+  // Map preserves insertion order, so we can re-insert on hit to bump LRU
+  // recency without a separate list. Eviction = drop the first key.
+  const entries = new Map<string, Entry>();
+  const inflight = new Map<string, Promise<boolean>>();
+
+  function bump(key: string, entry: Entry) {
+    entries.delete(key);
+    entries.set(key, entry);
+    while (entries.size > capacity) {
+      const oldest = entries.keys().next().value;
+      if (oldest === undefined) break;
+      entries.delete(oldest);
+    }
+  }
+
+  return {
+    async exists(path) {
+      const cached = entries.get(path);
+      if (cached && cached.expiresAt > now()) {
+        bump(path, cached);
+        return cached.value;
+      }
+
+      const pending = inflight.get(path);
+      if (pending) return pending;
+
+      const probePromise = (async () => {
+        try {
+          const result = await probe(path);
+          bump(path, {
+            value: result,
+            expiresAt: now() + (result ? posTtl : negTtl),
+          });
+          return result;
+        } finally {
+          inflight.delete(path);
+        }
+      })();
+      inflight.set(path, probePromise);
+      return probePromise;
+    },
+
+    invalidate(path) {
+      entries.delete(path);
+    },
+
+    clear() {
+      entries.clear();
+    },
+  };
+}

--- a/src/modules/terminal/lib/fileLinkProvider.ts
+++ b/src/modules/terminal/lib/fileLinkProvider.ts
@@ -1,0 +1,154 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { Terminal } from "@xterm/xterm";
+import { createExistenceCache } from "./existenceCache";
+import { extractPathCandidates } from "./pathMatcher";
+
+/**
+ * Path-resolution callbacks the provider needs from its host. Split out so
+ * `createSlot` (which doesn't know about React) can wire them via the
+ * slot adapter without import cycles.
+ */
+export interface FileLinkProviderDeps {
+  /** Current CWD for this terminal slot — used to resolve relative paths. */
+  getCwd(): string | null;
+  /** Click handler — fires when the user clicks a verified path link. */
+  onClick(absPath: string, line?: number, col?: number): void;
+  /** Called when the click target turns out to be missing on disk. */
+  onMissing?(absPath: string): void;
+}
+
+const cache = createExistenceCache((absPath) =>
+  invoke<boolean>("fs_exists", { path: absPath }).catch(() => false),
+);
+
+/**
+ * Exported for tests / cache invalidation from click-failure paths.
+ */
+export const fileExistenceCache = cache;
+
+function isAbsolute(p: string): boolean {
+  if (p.startsWith("/")) return true;
+  if (/^[A-Za-z]:[\\/]/.test(p)) return true;
+  // ~ is a shell affordance, not a filesystem one — `fs_exists("~/foo")` would
+  // probe a literal "~" directory. Tilde paths are skipped (existence check
+  // will return false and they simply won't be underlined).
+  return false;
+}
+
+function joinCwd(cwd: string, rel: string): string {
+  const r = rel.startsWith("./") ? rel.slice(2) : rel;
+  const sep = cwd.endsWith("/") ? "" : "/";
+  return cwd + sep + r;
+}
+
+function resolve(path: string, cwd: string | null): string | null {
+  if (isAbsolute(path)) return path;
+  if (!cwd) return null;
+  return joinCwd(cwd, path);
+}
+
+// ILinkProvider, ILink, IBuffer, IBufferLine, IBufferRange are not exported
+// from @xterm/xterm, so we use Terminal's structural types directly.
+type IBuffer = Terminal["buffer"]["active"];
+
+/** A link object shaped to satisfy xterm's ILink interface. */
+type TermLink = ReturnType<typeof toLink>;
+
+/** A link provider shaped to satisfy xterm's ILinkProvider interface. */
+export interface FileLinkProvider {
+  provideLinks(bufferLineNumber: number, callback: (links: TermLink[] | undefined) => void): void;
+}
+
+export function createFileLinkProvider(
+  term: Terminal,
+  deps: FileLinkProviderDeps,
+): FileLinkProvider {
+  return {
+    provideLinks(bufferLineNumber: number, callback: (links: TermLink[] | undefined) => void) {
+      const buf = term.buffer.active;
+      const index = bufferLineNumber - 1;
+      const line = buf.getLine(index);
+      if (!line) {
+        callback(undefined);
+        return;
+      }
+
+      // We tokenize and place link ranges on the *logical* line (joined
+      // wrapped continuations). The reported range's y must therefore be the
+      // logical-start row, otherwise the underline lands on the wrong cell.
+      // The simplest correct behavior: only emit links when xterm asks about
+      // the logical-start row itself; continuation rows return no links.
+      // Paths that wrap mid-line are clickable only on their starting row —
+      // acceptable for v1 and avoids per-row coordinate translation.
+      if (line.isWrapped) {
+        callback(undefined);
+        return;
+      }
+
+      const text = readLogicalLine(buf, index);
+      const candidates = extractPathCandidates(text);
+      if (candidates.length === 0) {
+        callback(undefined);
+        return;
+      }
+
+      const cwd = deps.getCwd();
+      void (async () => {
+        const verified: ReturnType<typeof toLink>[] = [];
+        for (const c of candidates) {
+          const abs = resolve(c.path, cwd);
+          if (!abs) continue;
+          // eslint-disable-next-line no-await-in-loop
+          const ok = await cache.exists(abs);
+          if (!ok) continue;
+          verified.push(
+            toLink(c.start + 1, bufferLineNumber, c.text, () => {
+              void (async () => {
+                const stillOk = await cache.exists(abs);
+                if (!stillOk) {
+                  cache.invalidate(abs);
+                  deps.onMissing?.(abs);
+                  return;
+                }
+                deps.onClick(abs, c.line, c.col);
+              })();
+            }),
+          );
+        }
+        callback(verified.length ? verified : undefined);
+      })();
+    },
+  };
+}
+
+function toLink(
+  startColumn: number,
+  bufferLineNumber: number,
+  text: string,
+  activate: () => void,
+) {
+  const range = {
+    start: { x: startColumn, y: bufferLineNumber },
+    end: { x: startColumn + text.length - 1, y: bufferLineNumber },
+  };
+  return {
+    range,
+    text,
+    activate(_event: MouseEvent, _text: string) {
+      activate();
+    },
+  };
+}
+
+function readLogicalLine(buf: IBuffer, index: number): string {
+  let start = index;
+  while (start > 0 && buf.getLine(start)?.isWrapped) start--;
+  let out = "";
+  for (let i = start; i < buf.length; i++) {
+    const ln = buf.getLine(i);
+    if (!ln) break;
+    if (i > start && !ln.isWrapped) break;
+    out += ln.translateToString(true);
+  }
+  return out;
+}

--- a/src/modules/terminal/lib/pathMatcher.test.ts
+++ b/src/modules/terminal/lib/pathMatcher.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { extractPathCandidates } from "./pathMatcher";
+
+describe("extractPathCandidates", () => {
+  it("matches a relative compiler path with line and col", () => {
+    const out = extractPathCandidates("src/foo.ts:42:5: error TS2322: …");
+    expect(out).toEqual([
+      { text: "src/foo.ts:42:5", start: 0, end: 15, path: "src/foo.ts", line: 42, col: 5 },
+    ]);
+  });
+
+  it("matches a relative path with only a line number", () => {
+    const out = extractPathCandidates("see ./bar.rs:7 for details");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ path: "./bar.rs", line: 7, col: undefined });
+  });
+
+  it("matches an absolute path", () => {
+    const out = extractPathCandidates("opened /etc/hosts");
+    expect(out).toEqual([
+      { text: "/etc/hosts", start: 7, end: 17, path: "/etc/hosts", line: undefined, col: undefined },
+    ]);
+  });
+
+  it("matches a Windows-style drive path", () => {
+    const out = extractPathCandidates("see C:\\Users\\me\\notes.md");
+    expect(out).toHaveLength(1);
+    expect(out[0].path).toBe("C:\\Users\\me\\notes.md");
+  });
+
+  it("matches a bare filename with extension", () => {
+    const out = extractPathCandidates("touched README.md and package.json");
+    expect(out.map((c) => c.path)).toEqual(["README.md", "package.json"]);
+  });
+
+  it("rejects URLs (left to WebLinksAddon)", () => {
+    expect(extractPathCandidates("see https://example.com/foo.ts")).toEqual([]);
+  });
+
+  it("rejects semver, hex hashes, and bare numbers", () => {
+    expect(extractPathCandidates("version 1.2.3 sha abc1234def5 num 12.345")).toEqual([]);
+  });
+
+  it("rejects timestamps", () => {
+    expect(extractPathCandidates("[2026-05-22T12:34:56] hi")).toEqual([]);
+  });
+
+  it("skips lines longer than 1024 chars", () => {
+    const big = "a".repeat(1100) + " /etc/hosts";
+    expect(extractPathCandidates(big)).toEqual([]);
+  });
+
+  it("caps results at 32 per line", () => {
+    const tokens = Array.from({ length: 50 }, (_, i) => `f${i}.ts`).join(" ");
+    expect(extractPathCandidates(tokens).length).toBeLessThanOrEqual(32);
+  });
+
+  it("preserves correct ranges for multiple matches", () => {
+    const line = "a.ts and b.ts";
+    const out = extractPathCandidates(line);
+    expect(out).toEqual([
+      { text: "a.ts", start: 0, end: 4, path: "a.ts", line: undefined, col: undefined },
+      { text: "b.ts", start: 9, end: 13, path: "b.ts", line: undefined, col: undefined },
+    ]);
+  });
+});

--- a/src/modules/terminal/lib/pathMatcher.ts
+++ b/src/modules/terminal/lib/pathMatcher.ts
@@ -1,0 +1,107 @@
+/**
+ * Match file-path candidates in a single terminal line. The output is
+ * deliberately permissive — false positives are filtered later by an
+ * existence check against the filesystem. We only do *cheap* rejection
+ * here for tokens that obviously cannot be files (URLs, semver, hashes,
+ * timestamps), to avoid wasting fs probes.
+ *
+ * Each result includes the byte range *in the input line* so xterm can
+ * convert it to a buffer-cell range for underline + click hit-testing.
+ */
+export interface PathCandidate {
+  /** The exact substring as it appears in the line. */
+  text: string;
+  /** Inclusive start index into the line. */
+  start: number;
+  /** Exclusive end index into the line. */
+  end: number;
+  /** The file-path part (without trailing `:line[:col]`). */
+  path: string;
+  line?: number;
+  col?: number;
+}
+
+const MAX_LINE_LENGTH = 1024;
+const MAX_TOKEN_LENGTH = 512;
+const MAX_CANDIDATES_PER_LINE = 32;
+
+// Matches path-like tokens with optional :LINE[:COL] suffix.
+// Groups:
+//   (1) LINE number if present
+//   (2) COL number if present
+//
+// Path forms handled:
+//   C:\Win\path or C:/Win/path  (Windows drive)
+//   /abs/path                   (POSIX absolute)
+//   ./rel or ../rel             (relative with explicit prefix)
+//   bare.ext                    (single token with dot)
+//   multi/segment               (contains slash)
+//
+// We allow leading `/` explicitly in the alternation so POSIX absolute paths
+// are captured with their leading slash.
+const PATH_REGEX =
+  /(?:[A-Za-z]:[\\/][A-Za-z0-9_./\\-]*|\/[A-Za-z0-9_~][A-Za-z0-9_./\\-]*|\.{1,2}[\\/][A-Za-z0-9_~][A-Za-z0-9_./\\-]*|[A-Za-z0-9_~][A-Za-z0-9_./\\-]+)(?::(\d+)(?::(\d+))?)?/g;
+
+// Pure number (123 or 12.345) — no slash, no letter.
+const PURE_NUMBER_REGEX = /^\d+(?:\.\d+)*$/;
+// Semver-ish: 1.2.3, 1.2.3-rc.1 — three or more dot-separated digit groups.
+const SEMVER_REGEX = /^\d+\.\d+(?:\.\d+)+(?:[.\-][A-Za-z0-9]+)*$/;
+// Hex hash: 7+ hex chars, no dot, no slash.
+const HEX_HASH_REGEX = /^[0-9a-f]{7,}$/i;
+
+function looksLikeNonPath(token: string): boolean {
+  if (token.length > MAX_TOKEN_LENGTH) return true;
+  if (PURE_NUMBER_REGEX.test(token)) return true;
+  if (SEMVER_REGEX.test(token)) return true;
+  if (HEX_HASH_REGEX.test(token)) return true;
+  // Pure single-word tokens with no slash, no dot — not a path.
+  if (!token.includes("/") && !token.includes("\\") && !token.includes(".")) {
+    return true;
+  }
+  // A bare-filename candidate must have a real extension (1-6 letter/digit chars
+  // after the final dot). "foo." or "foo.123" are not files; "foo.ts" / "foo.md" are.
+  if (!token.includes("/") && !token.includes("\\")) {
+    const dot = token.lastIndexOf(".");
+    if (dot < 0) return true;
+    const ext = token.slice(dot + 1);
+    if (!/^[A-Za-z][A-Za-z0-9]{0,5}$/.test(ext)) return true;
+  }
+  return false;
+}
+
+export function extractPathCandidates(line: string): PathCandidate[] {
+  if (line.length > MAX_LINE_LENGTH) return [];
+
+  const out: PathCandidate[] = [];
+  // Reset the regex's lastIndex — the `g` flag preserves state across calls.
+  PATH_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PATH_REGEX.exec(line)) !== null) {
+    if (out.length >= MAX_CANDIDATES_PER_LINE) break;
+    const text = match[0];
+    const start = match.index;
+    const end = start + text.length;
+    const lineNum = match[1] !== undefined ? Number(match[1]) : undefined;
+    const colNum = match[2] !== undefined ? Number(match[2]) : undefined;
+
+    // Reject tokens that are part of a URL. In `https://example.com/foo.ts`,
+    // the regex matches `/example.com/foo.ts` (POSIX-absolute form) starting
+    // at the second `/` of `://`. Check for `://` in the two characters before
+    // the token's start (which would be `:/` sitting before our leading `/`).
+    if (start >= 2 && line.slice(start - 2, start) === ":/") continue;
+    // Also catch if the matched token itself starts with `://` (edge case).
+    if (text.startsWith("://")) continue;
+
+    // Strip the :LINE[:COL] suffix to get the bare path.
+    let path = text;
+    if (lineNum !== undefined) {
+      // For Windows paths starting with "C:", skip the drive colon.
+      const searchFrom = /^[A-Za-z]:/.test(text) ? 2 : 0;
+      const colonIdx = text.indexOf(":", searchFrom);
+      if (colonIdx !== -1) path = text.slice(0, colonIdx);
+    }
+    if (looksLikeNonPath(path)) continue;
+    out.push({ text, start, end, path, line: lineNum, col: colNum });
+  }
+  return out;
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -8,6 +8,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { createFileLinkProvider, fileExistenceCache } from "./fileLinkProvider";
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
@@ -23,6 +24,14 @@ export type SlotAdapter = {
   resolveLeaf(leafId: number): LeafBridge | null;
   evictLeaf(leafId: number): void;
   isLeafFocused(leafId: number): boolean;
+  /** Current CWD for the leaf, or null if no OSC 7 was ever received. */
+  getCwd(leafId: number): string | null;
+  /**
+   * Open `path` in the editor pane. `path` may be relative; the adapter
+   * resolves it against `getCwd(leafId)` if so. Returns a promise that
+   * resolves to true on success, false if the file no longer exists.
+   */
+  openFile(leafId: number, path: string, line?: number, col?: number): Promise<boolean>;
 };
 
 export type LeafBridge = {
@@ -156,6 +165,31 @@ function createSlot(): Slot {
     lastH: 0,
     lastUsedAt: 0,
   };
+
+  // The provider closes over `slot.currentLeafId`, which mutates as the slot
+  // rebinds — so a single registration is reused across every leaf this slot
+  // ever hosts. We deliberately drop the disposer: pool slots and their
+  // Terminals live for the entire app lifetime, so the provider never needs
+  // to be unregistered. Pushing onto `slot.oscDisposers` would be wrong —
+  // that array is replaced (not appended-to) on each `bindSlot`, which would
+  // dispose the provider after one leaf and never re-register it.
+  term.registerLinkProvider(
+    createFileLinkProvider(term, {
+      getCwd: () => {
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return null;
+        return adapter?.getCwd(leafId) ?? null;
+      },
+      onClick: (absPath, line, col) => {
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return;
+        void adapter?.openFile(leafId, absPath, line, col).then((ok) => {
+          if (!ok) fileExistenceCache.invalidate(absPath);
+        });
+      },
+      onMissing: (absPath) => fileExistenceCache.invalidate(absPath),
+    }),
+  );
 
   attachWebgl(slot);
 

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -23,6 +23,7 @@ import {
   getSlotForLeaf,
   releaseSlot,
   setSlotFocused,
+  type SlotAdapter,
 } from "./rendererPool";
 
 type Callbacks = {
@@ -140,7 +141,18 @@ configureRendererPool({
     const s = sessions.get(leafId);
     return !!s && s.visibleNow && s.focusedNow;
   },
+  getCwd(leafId) {
+    const s = sessions.get(leafId);
+    return s?.lastCwd ?? null;
+  },
+  openFile: (leafId, path, line, col) => openFileHandler(leafId, path, line, col),
 });
+
+let openFileHandler: SlotAdapter["openFile"] = async () => false;
+
+export function setTerminalOpenFileHandler(handler: SlotAdapter["openFile"]): void {
+  openFileHandler = handler;
+}
 
 function ensureSession(leafId: number, initialCwd?: string): Session {
   const existing = sessions.get(leafId);


### PR DESCRIPTION
## Summary

Detect path-shaped tokens in terminal output (`src/foo.ts:42:5`, `/abs/paths`, bare filenames with extensions), verify file existence, and underline only the verified ones. Clicking opens the file in a preview editor tab at the line/col.

## Design

- Runs alongside the existing `WebLinksAddon` (which keeps owning URLs). The new provider only fires for filesystem paths.
- False positives are killed by an fs-existence check rather than by a stricter regex — broader matching, fewer "doesn't underline this obvious path" complaints.
- New \`fs_exists\` Tauri command behind an LRU+TTL cache (30s positive, 5s negative).
- xterm \`registerLinkProvider\` does the underline; click hands off to \`SlotAdapter.openFile\`, which calls \`openFileTab\` with an optional \`selection\`.
- \`EditorPane\` consumes a one-shot \`pendingSelection\` via two rAFs so CodeMirror's initial doc transaction has settled before \`scrollIntoView\` dispatches (microtask was too early in practice).

## Out of scope

- Cmd/Ctrl-click → open in OS default app (easy 1-line extension later).
- Tilde-prefix \`~/\` paths (explicitly skipped — \`fs_exists\` would probe a literal \`~\` directory).

## Test Plan

- [ ] In the terminal, run \`echo \"see src/app/App.tsx:200\"\` and click the underlined path. Expect the file to open in a preview editor tab scrolled to line 200.
- [ ] Run \`echo \"see fake/missing.ts\"\` and confirm it is **not** underlined.
- [ ] Run a tsc/eslint error with a \`path:line:col\` reference. Click. Expect to jump to the error location.
- [ ] Confirm bare URLs (\`https://example.com\`) still open in the OS default browser (handled by the existing WebLinksAddon).
- [ ] Confirm 21 new vitest cases pass: \`pnpm test src/modules/terminal/lib/pathMatcher.test.ts\` (11) and \`pnpm test src/modules/terminal/lib/existenceCache.test.ts\` (6).