### PR TITLE
feat(ai): local Whisper transcription, voice provider toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Terax is a lightweight open-source terminal (ADE) built on Tauri 2 + Rust and Re
 - **BYOK providers:** OpenAI, Anthropic, Google (Gemini), Groq, xAI (Grok), Cerebras, OpenRouter, DeepSeek, Mistral, plus any OpenAI-compatible endpoint
 - **Local / offline:** LM Studio, MLX, Ollama
 - **Agentic workflow:** plans, sub-agents, project memory via `TERAX.md`, file read / write / edit / multi-edit / grep / glob, bash with approval gating, background processes
-- **Composer:** snippets via `#handle`, files via `@path`, slash commands, voice input, attach-to-agent from explorer or selection
+- **Composer:** snippets via `#handle`, files via `@path`, slash commands, attach-to-agent from explorer or selection
+- **Voice input:** transcribe with a local Whisper model in-app (no API key, no internet) or with OpenAI cloud Whisper. Local is the default; the model downloads on first use. Configure in **Settings -> Voice**.
 - **Custom agents** with their own system prompt and tool subset
 - **Plan mode** for multi-step work, generates and confirms before doing
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",
+    "@huggingface/transformers": "^4.2.0",
     "@iconify-json/catppuccin": "^1.2.17",
     "@lezer/highlight": "^1.2.3",
     "@radix-ui/react-use-controllable-state": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@hugeicons/react':
         specifier: ^1.1.6
         version: 1.1.6(react@19.2.5)
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@iconify-json/catppuccin':
         specifier: ^1.2.17
         version: 1.2.17
@@ -592,6 +595,9 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -921,6 +927,16 @@ packages:
     peerDependencies:
       react: '>=16.0.0'
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@iconify-json/catppuccin@1.2.17':
     resolution: {integrity: sha512-l1pFOADEUlw+j7V+yfFzBowdE4deeMuI4amqfKaN+7uTI9B0Ho24C86DitQk5zb62NkEM9poOyfuG7WS2bw6jg==}
 
@@ -929,6 +945,143 @@ packages:
 
   '@iconify/utils@3.1.0':
     resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -1076,6 +1229,36 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1813,79 +1996,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1965,28 +2135,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.3':
     resolution: {integrity: sha512-MmIA32rNEOrjh6wnevlR3OjjlCuwgZ4JMJo7Vrhk4Fk56Vxi7EeF7cekSKwvlrnfcn/ERC1LdcG3sFneU8WdoA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.3':
     resolution: {integrity: sha512-BiCy1YV0IKO+xbD7gyZnENU4jdwDygeGQjncJoeIE5Kp4UqWHFsKUSJ3pp7vYURrqVzwJX2xD5gQeGnoXp4xPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.3':
     resolution: {integrity: sha512-venvyAu0AMKdr0c1Oz23IJJdZ72zSwKyHrLvqQV1cn49vPAJk3AuVtDkJ1ayk1sYI4M4j8Jv6ZGflpaP0QVSXQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.3':
     resolution: {integrity: sha512-e3kColrZZCdtbwIOc07cNQ2zNf1sTPXTYLjjPlsgsaf+ttzAg/hOlDyEgHoOlBGxM88nPxeVaOGe9ThqVzPncg==}
@@ -2056,35 +2222,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -2432,6 +2593,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2495,6 +2660,10 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -2892,9 +3061,17 @@ packages:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
@@ -2913,6 +3090,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -2982,6 +3162,9 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -2998,6 +3181,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -3098,6 +3285,9 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -3179,6 +3369,14 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3190,8 +3388,14 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3416,6 +3620,9 @@ packages:
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -3484,28 +3691,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3533,6 +3736,9 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -3557,6 +3763,10 @@ packages:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3813,6 +4023,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   object-treeify@1.1.33:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
@@ -3831,6 +4045,19 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -3916,6 +4143,9 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
 
@@ -3944,6 +4174,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -4077,6 +4311,10 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -4108,13 +4346,25 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
     hasBin: true
 
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -4129,6 +4379,10 @@ packages:
   shadcn@4.3.1:
     resolution: {integrity: sha512-X3XodbqNKQLCoR4sZZLMKrx2XjfhSsoDLN5+7TLsEx/uDG2P3iyfOLfBlU+z7BVOpkFkbWCEA0LlbGqWg1oeyQ==}
     hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4183,6 +4437,9 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4350,6 +4607,10 @@ packages:
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -5142,6 +5403,11 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -5320,6 +5586,18 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@iconify-json/catppuccin@1.2.17':
     dependencies:
       '@iconify/types': 2.0.0
@@ -5331,6 +5609,102 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
       mlly: 1.8.2
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -5510,6 +5884,28 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6896,6 +7292,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.17: {}
+
   agent-base@7.1.4: {}
 
   ai@6.0.168(zod@4.3.6):
@@ -6956,6 +7354,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  boolean@3.2.0: {}
 
   brace-expansion@5.0.5:
     dependencies:
@@ -7347,7 +7747,19 @@ snapshots:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@3.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   delaunator@5.1.0:
     dependencies:
@@ -7360,6 +7772,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  detect-node@2.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -7419,6 +7833,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es6-error@4.1.1: {}
+
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -7477,6 +7893,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -7619,6 +8037,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  flatbuffers@25.9.23: {}
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -7688,13 +8108,33 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.1
+      serialize-error: 7.0.1
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
 
+  guid-typescript@1.0.9: {}
+
   hachure-fill@0.5.2: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -7917,6 +8357,8 @@ snapshots:
 
   json-schema@0.4.0: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonfile@6.2.1:
@@ -8006,6 +8448,8 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
@@ -8023,6 +8467,10 @@ snapshots:
   marked@16.4.2: {}
 
   marked@17.0.6: {}
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -8500,6 +8948,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  object-keys@1.1.1: {}
+
   object-treeify@1.1.33: {}
 
   on-finished@2.4.1:
@@ -8517,6 +8967,25 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.1
 
   open@11.0.0:
     dependencies:
@@ -8604,6 +9073,8 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  platform@1.3.6: {}
+
   points-on-curve@0.2.0: {}
 
   points-on-path@0.2.1:
@@ -8634,6 +9105,21 @@ snapshots:
       sisteransi: 1.0.5
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.6.0
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -8833,6 +9319,15 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+
   robust-predicates@3.0.3: {}
 
   rollup@4.60.2:
@@ -8895,7 +9390,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  semver-compare@1.0.0: {}
+
   semver@6.3.1: {}
+
+  semver@7.8.1: {}
 
   send@1.2.1:
     dependencies:
@@ -8912,6 +9411,10 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   serve-static@2.2.1:
     dependencies:
@@ -8969,6 +9472,37 @@ snapshots:
       - supports-color
       - typescript
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.1
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -9021,6 +9555,8 @@ snapshots:
   source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
@@ -9182,6 +9718,8 @@ snapshots:
   tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
+
+  type-fest@0.13.1: {}
 
   type-fest@5.6.0:
     dependencies:

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -207,11 +207,31 @@ export function AiInputBar() {
     if (it) onPickItem(it);
   };
 
-  const voiceLabel = c.voice.recording
-    ? "Listening…"
-    : c.voice.transcribing
-      ? "Transcribing…"
-      : null;
+  // Stable key based on the *state*, not the text. The download text updates
+  // many times per second; using `voiceLabel` as the AnimatePresence key would
+  // remount the row on every progress tick and replay the height animation.
+  const voiceLabelKey = c.voice.isLocalLoading
+    ? "loading"
+    : c.voice.recording
+      ? "recording"
+      : c.voice.transcribing
+        ? "transcribing"
+        : null;
+
+  const voiceLabel = c.voice.isLocalLoading
+    ? (() => {
+        const s = c.voice.transcriberState;
+        if (s.kind !== "loading") return "Loading model…";
+        const total = s.total ?? 0;
+        if (total <= 0) return "Loading model…";
+        const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(0)} MB`;
+        return `Downloading model · ${mb(s.loaded ?? 0)} / ${mb(total)}`;
+      })()
+    : c.voice.recording
+      ? "Listening…"
+      : c.voice.transcribing
+        ? "Transcribing…"
+        : null;
 
   return (
     <div className="shrink-0 border-t border-border/60 bg-card/40 px-3 py-2">
@@ -319,7 +339,7 @@ export function AiInputBar() {
         <AnimatePresence initial={false}>
           {voiceLabel && (
             <motion.div
-              key={voiceLabel}
+              key={voiceLabelKey ?? "voice"}
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -58,6 +58,14 @@ import { toggleFavoriteModel } from "../lib/modelPrefs";
 import { useChatStore } from "../store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 
+function formatProgress(state: { loaded?: number; total?: number; kind: string }): string {
+  if (state.kind !== "loading") return "";
+  const total = state.total ?? 0;
+  if (total <= 0) return "preparing…";
+  const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(0)} MB`;
+  return `${mb(state.loaded ?? 0)} / ${mb(total)}`;
+}
+
 const PROVIDER_ICON = {
   openai: ChatGptIcon,
   anthropic: ClaudeIcon,
@@ -125,26 +133,32 @@ export function AiStatusBarControls() {
       {c.voice.supported && (
         <IconBtn
           title={
-            !c.voice.hasKey
-              ? "Voice needs an OpenAI key"
-              : c.voice.recording
-                ? "Stop & transcribe"
-                : c.voice.transcribing
-                  ? "Transcribing…"
-                  : "Voice input"
+            c.voice.isLocalLoading
+              ? `Downloading model… ${formatProgress(c.voice.transcriberState)}`
+              : !c.voice.canRecord
+                ? c.voice.reasonUnavailable ?? "Voice input unavailable"
+                : c.voice.recording
+                  ? "Stop & transcribe"
+                  : c.voice.transcribing
+                    ? "Transcribing…"
+                    : "Voice input"
           }
           onClick={() =>
             c.voice.recording ? c.voice.stop() : void c.voice.start()
           }
-          disabled={c.isBusy || c.voice.transcribing || !c.voice.hasKey}
+          disabled={
+            c.isBusy ||
+            c.voice.transcribing ||
+            (!c.voice.canRecord && !c.voice.isLocalLoading)
+          }
           className={cn(
             c.voice.recording &&
-            "bg-destructive/10 text-destructive hover:bg-destructive/15",
+              "bg-destructive/10 text-destructive hover:bg-destructive/15",
           )}
         >
           {c.voice.recording ? (
             <span className="size-2 animate-pulse rounded-full bg-destructive" />
-          ) : c.voice.transcribing ? (
+          ) : c.voice.transcribing || c.voice.isLocalLoading ? (
             <Spinner className="size-3" />
           ) : (
             <HugeiconsIcon icon={Mic01Icon} size={13} strokeWidth={1.75} />

--- a/src/modules/ai/hooks/useWhisperRecording.ts
+++ b/src/modules/ai/hooks/useWhisperRecording.ts
@@ -1,7 +1,11 @@
-import { createOpenAI } from "@ai-sdk/openai";
-import { experimental_transcribe as transcribe } from "ai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useChatStore } from "../store/chatStore";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  createTranscriber,
+  type Transcriber,
+  type TranscriberState,
+} from "../lib/transcribers";
 
 const MIME_CANDIDATES = [
   "audio/webm;codecs=opus",
@@ -18,17 +22,7 @@ function pickMime(): string | undefined {
   return undefined;
 }
 
-async function transcribeBlob(blob: Blob, apiKey: string): Promise<string> {
-  const openai = createOpenAI({ apiKey });
-  const buf = new Uint8Array(await blob.arrayBuffer());
-  const { text } = await transcribe({
-    model: openai.transcription("whisper-1"),
-    audio: buf,
-  });
-  return text;
-}
-
-type State = "idle" | "recording" | "transcribing";
+type RecordingState = "idle" | "recording" | "transcribing";
 
 export function useWhisperRecording({
   onResult,
@@ -36,10 +30,36 @@ export function useWhisperRecording({
   onResult: (text: string) => void;
 }) {
   const apiKey = useChatStore((s) => s.apiKeys.openai);
-  const [state, setState] = useState<State>("idle");
+  const voiceProvider = usePreferencesStore((s) => s.voiceProvider);
+  const localModel = usePreferencesStore((s) => s.localWhisperModel);
+  const localLanguage = usePreferencesStore((s) => s.localWhisperLanguage);
+
+  const [state, setState] = useState<RecordingState>("idle");
+  const [transcriberState, setTranscriberState] = useState<TranscriberState>({
+    kind: "idle",
+  });
+
   const recRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
+  const transcriberRef = useRef<Transcriber | null>(null);
+
+  // Recreate the transcriber whenever the selection changes.
+  useEffect(() => {
+    transcriberRef.current?.unload();
+    const t = createTranscriber(
+      voiceProvider === "local"
+        ? { kind: "local", model: localModel, language: localLanguage }
+        : { kind: "openai", apiKey: apiKey ?? null },
+    );
+    transcriberRef.current = t;
+    const unsub = t.subscribe(setTranscriberState);
+    return () => {
+      unsub();
+      t.unload();
+      if (transcriberRef.current === t) transcriberRef.current = null;
+    };
+  }, [voiceProvider, localModel, localLanguage, apiKey]);
 
   const supported =
     typeof navigator !== "undefined" &&
@@ -57,7 +77,13 @@ export function useWhisperRecording({
   }, []);
 
   const start = useCallback(async () => {
-    if (!supported || !apiKey || state !== "idle") return;
+    const t = transcriberRef.current;
+    if (!supported || !t || state !== "idle") return;
+    if (!t.ready()) return;
+
+    // Kick off model preload in parallel with capturing audio.
+    t.preload();
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
@@ -79,7 +105,9 @@ export function useWhisperRecording({
         }
         setState("transcribing");
         try {
-          const text = await transcribeBlob(blob, apiKey);
+          const active = transcriberRef.current;
+          if (!active) return;
+          const text = await active.transcribe(blob);
           if (text.trim()) onResult(text.trim());
         } catch (e) {
           console.error("whisper.transcribe", e);
@@ -95,7 +123,7 @@ export function useWhisperRecording({
       teardownStream();
       setState("idle");
     }
-  }, [apiKey, onResult, state, supported]);
+  }, [onResult, state, supported]);
 
   useEffect(() => {
     return () => {
@@ -104,6 +132,10 @@ export function useWhisperRecording({
     };
   }, []);
 
+  const provider = voiceProvider;
+  const reasonUnavailable =
+    transcriberRef.current?.unavailableReason() ?? null;
+
   return {
     state,
     recording: state === "recording",
@@ -111,6 +143,16 @@ export function useWhisperRecording({
     start,
     stop,
     supported,
-    hasKey: !!apiKey,
+    /** Backwards-compat alias used by current UI code paths. */
+    hasKey: provider === "openai" ? !!apiKey : true,
+    canRecord:
+      supported &&
+      (transcriberRef.current?.ready() ?? false),
+    reasonUnavailable,
+    /** The transcriber's own state (loading model / loaded / error). */
+    transcriberState,
+    provider,
+    isLocalLoading:
+      provider === "local" && transcriberState.kind === "loading",
   };
 }

--- a/src/modules/ai/lib/audio.test.ts
+++ b/src/modules/ai/lib/audio.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { blobToMonoPcm16k, downmixToMono, TARGET_SAMPLE_RATE } from "./audio";
+
+describe("downmixToMono", () => {
+  it("returns the single channel unchanged for mono input", () => {
+    const ch = new Float32Array([0.1, 0.2, 0.3]);
+    expect(downmixToMono([ch])).toEqual(ch);
+  });
+
+  it("averages channels for stereo input", () => {
+    const l = new Float32Array([0.0, 0.5, 1.0]);
+    const r = new Float32Array([1.0, 0.5, 0.0]);
+    expect(Array.from(downmixToMono([l, r]))).toEqual([0.5, 0.5, 0.5]);
+  });
+
+  it("averages all three channels for surround input", () => {
+    const a = new Float32Array([0, 3]);
+    const b = new Float32Array([0, 3]);
+    const c = new Float32Array([0, 3]);
+    expect(Array.from(downmixToMono([a, b, c]))).toEqual([0, 3]);
+  });
+});
+
+describe("blobToMonoPcm16k", () => {
+  it("uses OfflineAudioContext at the target sample rate", async () => {
+    const numFrames = 48_000;
+    const stereoBuffer = {
+      numberOfChannels: 1,
+      length: numFrames,
+      sampleRate: 48_000,
+      duration: 1,
+      getChannelData: () => new Float32Array(numFrames).fill(0.42),
+    };
+    const renderedFrames = 16_000;
+    const renderedBuffer = {
+      numberOfChannels: 1,
+      length: renderedFrames,
+      sampleRate: 16_000,
+      duration: 1,
+      getChannelData: () => new Float32Array(renderedFrames).fill(0.42),
+    };
+    const ctorCalls: Array<{ ch: number; len: number; rate: number }> = [];
+    class FakeOfflineCtx {
+      destination = {};
+      constructor(ch: number, len: number, rate: number) {
+        ctorCalls.push({ ch, len, rate });
+      }
+      createBufferSource() {
+        return {
+          buffer: null as null | unknown,
+          connect: () => {},
+          start: () => {},
+        };
+      }
+      createBuffer(ch: number, len: number, rate: number) {
+        return {
+          numberOfChannels: ch,
+          length: len,
+          sampleRate: rate,
+          copyToChannel: () => {},
+        };
+      }
+      decodeAudioData() {
+        return Promise.resolve(stereoBuffer);
+      }
+      startRendering() {
+        return Promise.resolve(renderedBuffer);
+      }
+    }
+    vi.stubGlobal("OfflineAudioContext", FakeOfflineCtx);
+
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "audio/webm" });
+    const out = await blobToMonoPcm16k(blob);
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(out.length).toBe(renderedFrames);
+    expect(TARGET_SAMPLE_RATE).toBe(16_000);
+    expect(ctorCalls[ctorCalls.length - 1].rate).toBe(16_000);
+    expect(ctorCalls[ctorCalls.length - 1].ch).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/modules/ai/lib/audio.ts
+++ b/src/modules/ai/lib/audio.ts
@@ -1,0 +1,59 @@
+/** Whisper's expected sample rate. The model is trained on 16 kHz mono. */
+export const TARGET_SAMPLE_RATE = 16_000;
+
+/**
+ * Average all channels into a single mono Float32Array. For mono input
+ * the channel is returned unchanged. Surround layouts are flattened to
+ * a centered mix, which is acceptable for speech transcription.
+ */
+export function downmixToMono(channels: Float32Array[]): Float32Array {
+  if (channels.length === 0) return new Float32Array(0);
+  if (channels.length === 1) return channels[0];
+  const len = channels[0].length;
+  const out = new Float32Array(len);
+  const n = channels.length;
+  for (let i = 0; i < len; i++) {
+    let s = 0;
+    for (let c = 0; c < n; c++) s += channels[c][i];
+    out[i] = s / n;
+  }
+  return out;
+}
+
+/**
+ * Decode a MediaRecorder blob (WebM/Opus, OGG, MP4, etc.) to a mono
+ * Float32 PCM array at TARGET_SAMPLE_RATE. Two OfflineAudioContexts:
+ * one for decode (native rate), one for high-quality resample (target rate).
+ */
+export async function blobToMonoPcm16k(blob: Blob): Promise<Float32Array> {
+  const ab = await blob.arrayBuffer();
+
+  // A short-lived OfflineAudioContext for decoding. The frame count and
+  // sample rate are irrelevant for decodeAudioData — they're just required
+  // by the constructor.
+  const decodeCtx = new OfflineAudioContext(1, 1, TARGET_SAMPLE_RATE);
+  const decoded = await decodeCtx.decodeAudioData(ab);
+
+  // Collect the decoded channels into an array of Float32Arrays.
+  const decodedChannels: Float32Array[] = [];
+  for (let c = 0; c < decoded.numberOfChannels; c++) {
+    decodedChannels.push(decoded.getChannelData(c));
+  }
+  const mono = downmixToMono(decodedChannels);
+
+  // If already at the right rate, skip the render pass.
+  if (decoded.sampleRate === TARGET_SAMPLE_RATE) return mono;
+
+  const frames = Math.ceil(decoded.duration * TARGET_SAMPLE_RATE);
+  const renderCtx = new OfflineAudioContext(1, frames, TARGET_SAMPLE_RATE);
+  const src = renderCtx.createBufferSource();
+  // Use renderCtx.createBuffer to route buffer creation through the context
+  // (compatible with test fakes and avoids a direct AudioBuffer constructor call).
+  const buf = renderCtx.createBuffer(1, mono.length, decoded.sampleRate);
+  buf.copyToChannel(mono, 0);
+  src.buffer = buf;
+  src.connect(renderCtx.destination);
+  src.start(0);
+  const rendered = await renderCtx.startRendering();
+  return rendered.getChannelData(0);
+}

--- a/src/modules/ai/lib/transcribers/index.ts
+++ b/src/modules/ai/lib/transcribers/index.ts
@@ -1,0 +1,39 @@
+import { createLocalTranscriber, type LocalTranscriber } from "./local";
+import { createOpenAITranscriber } from "./openai";
+
+export type TranscriberState =
+  | { kind: "idle" }
+  | { kind: "loading"; file?: string; loaded: number; total: number }
+  | { kind: "loaded"; backend: "gpu" | "cpu" }
+  | { kind: "error"; message: string };
+
+export interface Transcriber {
+  /** Whether the user can press the mic button right now. */
+  ready(): boolean;
+  /** Optional explanation when ready() is false. */
+  unavailableReason(): string | null;
+  /** Begin pre-loading any expensive setup (model download/warmup). No-op for OpenAI. */
+  preload(): void;
+  /** Run transcription. May await preload internally. */
+  transcribe(blob: Blob): Promise<string>;
+  /** Subscribe to state changes. */
+  subscribe(listener: (state: TranscriberState) => void): () => void;
+  getState(): TranscriberState;
+  /** Free any owned resources (worker, etc.). */
+  unload(): void;
+  /** True for the local provider — used by UI to gate "Unload" affordance. */
+  readonly isLocal: boolean;
+}
+
+export type TranscriberSelection =
+  | { kind: "openai"; apiKey: string | null }
+  | { kind: "local"; model: string; language: string };
+
+export function createTranscriber(sel: TranscriberSelection): Transcriber {
+  if (sel.kind === "openai") {
+    return createOpenAITranscriber({ apiKey: sel.apiKey });
+  }
+  return createLocalTranscriber({ model: sel.model, language: sel.language });
+}
+
+export type { LocalTranscriber };

--- a/src/modules/ai/lib/transcribers/local.ts
+++ b/src/modules/ai/lib/transcribers/local.ts
@@ -1,0 +1,133 @@
+import { blobToMonoPcm16k } from "../audio";
+import type { Transcriber, TranscriberState } from "./index";
+import type { WhisperWorkerIn, WhisperWorkerOut } from "../../workers/whisperWorker.types";
+
+export interface LocalTranscriber extends Transcriber {
+  /** Force-reload the worker (used after model change). */
+  reload(): void;
+}
+
+export function createLocalTranscriber(opts: {
+  model: string;
+  language: string;
+}): LocalTranscriber {
+  const listeners = new Set<(s: TranscriberState) => void>();
+  let state: TranscriberState = { kind: "idle" };
+  let worker: Worker | null = null;
+  let readyResolve: (() => void) | null = null;
+  let readyPromise: Promise<void> | null = null;
+  let pendingTranscribe:
+    | { resolve: (text: string) => void; reject: (e: Error) => void }
+    | null = null;
+
+  function setState(next: TranscriberState) {
+    state = next;
+    for (const l of listeners) l(state);
+  }
+
+  function ensureWorker() {
+    if (worker) return;
+    worker = new Worker(
+      new URL("../../workers/whisperWorker.ts", import.meta.url),
+      { type: "module" },
+    );
+    readyPromise = new Promise<void>((resolve) => {
+      readyResolve = resolve;
+    });
+
+    worker.onmessage = (ev: MessageEvent<WhisperWorkerOut>) => {
+      const m = ev.data;
+      if (m.kind === "progress") {
+        setState({
+          kind: "loading",
+          file: m.file,
+          loaded: m.loaded,
+          total: m.total,
+        });
+        return;
+      }
+      if (m.kind === "ready") {
+        setState({ kind: "loaded", backend: m.backend });
+        readyResolve?.();
+        return;
+      }
+      if (m.kind === "result") {
+        if (state.kind !== "loaded") {
+          // Worker shouldn't have sent result without ready, but stay defensive
+          setState({ kind: "loaded", backend: "cpu" });
+        }
+        const p = pendingTranscribe;
+        pendingTranscribe = null;
+        p?.resolve(m.text);
+        return;
+      }
+      if (m.kind === "error") {
+        setState({ kind: "error", message: m.message });
+        const p = pendingTranscribe;
+        pendingTranscribe = null;
+        p?.reject(new Error(m.message));
+      }
+    };
+    worker.onerror = (e) => {
+      setState({ kind: "error", message: String(e.message ?? e) });
+      const p = pendingTranscribe;
+      pendingTranscribe = null;
+      p?.reject(new Error(e.message || "worker error"));
+    };
+
+    const msg: WhisperWorkerIn = { kind: "load", model: opts.model };
+    worker.postMessage(msg);
+    setState({ kind: "loading", loaded: 0, total: 0 });
+  }
+
+  return {
+    isLocal: true,
+    ready: () => true,
+    unavailableReason: () => null,
+    preload: () => ensureWorker(),
+    async transcribe(blob) {
+      ensureWorker();
+      await readyPromise;
+      const pcm = await blobToMonoPcm16k(blob);
+      if (pcm.length < 16_000 * 0.2) {
+        return "";
+      }
+      return new Promise<string>((resolve, reject) => {
+        pendingTranscribe = { resolve, reject };
+        const msg: WhisperWorkerIn = {
+          kind: "transcribe",
+          pcm,
+          language: opts.language,
+        };
+        worker!.postMessage(msg, [pcm.buffer as ArrayBuffer]);
+      });
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    getState: () => state,
+    unload: () => {
+      const p = pendingTranscribe;
+      pendingTranscribe = null;
+      p?.reject(new Error("transcriber unloaded"));
+      worker?.terminate();
+      worker = null;
+      readyResolve = null;
+      readyPromise = null;
+      setState({ kind: "idle" });
+    },
+    reload: () => {
+      const p = pendingTranscribe;
+      pendingTranscribe = null;
+      p?.reject(new Error("transcriber unloaded"));
+      worker?.terminate();
+      worker = null;
+      readyResolve = null;
+      readyPromise = null;
+      setState({ kind: "idle" });
+      ensureWorker();
+    },
+  };
+}

--- a/src/modules/ai/lib/transcribers/openai.ts
+++ b/src/modules/ai/lib/transcribers/openai.ts
@@ -1,0 +1,47 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { experimental_transcribe as transcribe } from "ai";
+import type { Transcriber, TranscriberState } from "./index";
+
+export function createOpenAITranscriber(opts: { apiKey: string | null }): Transcriber {
+  const listeners = new Set<(s: TranscriberState) => void>();
+  let state: TranscriberState = opts.apiKey
+    ? { kind: "loaded", backend: "cpu" }
+    : { kind: "error", message: "OpenAI API key not configured" };
+
+  function setState(next: TranscriberState) {
+    state = next;
+    for (const l of listeners) l(state);
+  }
+
+  return {
+    isLocal: false,
+    ready: () => state.kind === "loaded",
+    unavailableReason: () => (state.kind === "error" ? state.message : null),
+    preload: () => {},
+    async transcribe(blob) {
+      if (!opts.apiKey) throw new Error("OpenAI API key not configured");
+      setState({ kind: "loading", loaded: 0, total: 0 });
+      try {
+        const openai = createOpenAI({ apiKey: opts.apiKey });
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        const { text } = await transcribe({
+          model: openai.transcription("whisper-1"),
+          audio: buf,
+        });
+        setState({ kind: "loaded", backend: "cpu" });
+        return text;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ kind: "error", message });
+        throw e;
+      }
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    getState: () => state,
+    unload: () => {},
+  };
+}

--- a/src/modules/ai/workers/whisperWorker.ts
+++ b/src/modules/ai/workers/whisperWorker.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { pipeline, env, type AutomaticSpeechRecognitionPipeline } from "@huggingface/transformers";
+import type { WhisperWorkerIn, WhisperWorkerOut } from "./whisperWorker.types";
+
+// Allow the library to fetch ONNX builds from the HF Hub.
+env.allowRemoteModels = true;
+env.allowLocalModels = false;
+
+let currentModel: string | null = null;
+let asr: AutomaticSpeechRecognitionPipeline | null = null;
+let loadingPromise: Promise<void> | null = null;
+let loadedBackend: "gpu" | "cpu" = "cpu";
+let generation = 0; // bumped on every load/unload to cancel stale in-flight loads
+
+function post(msg: WhisperWorkerOut, transfer?: Transferable[]) {
+  if (transfer) (self as any).postMessage(msg, transfer);
+  else (self as any).postMessage(msg);
+}
+
+async function ensureLoaded(model: string): Promise<void> {
+  if (asr && currentModel === model) return;
+  if (loadingPromise && currentModel === model) return loadingPromise;
+
+  const myGen = ++generation;
+  asr = null;
+  currentModel = model;
+
+  const progressCallback = (p: any) => {
+    if (p?.status === "progress") {
+      post({
+        kind: "progress",
+        file: p.file ?? "",
+        loaded: p.loaded ?? 0,
+        total: p.total ?? 0,
+      });
+    }
+  };
+
+  loadingPromise = (async () => {
+    let pipe: AutomaticSpeechRecognitionPipeline;
+    try {
+      pipe = (await pipeline("automatic-speech-recognition", model, {
+        device: "webgpu",
+        progress_callback: progressCallback,
+      })) as AutomaticSpeechRecognitionPipeline;
+      if (myGen !== generation) return; // superseded — discard
+      asr = pipe;
+      loadedBackend = "gpu";
+    } catch (e) {
+      console.warn("[whisper] WebGPU init failed, falling back to WASM:", e);
+      pipe = (await pipeline("automatic-speech-recognition", model, {
+        progress_callback: progressCallback,
+      })) as AutomaticSpeechRecognitionPipeline;
+      if (myGen !== generation) return; // superseded — discard
+      asr = pipe;
+      loadedBackend = "cpu";
+    }
+    post({ kind: "ready", model, backend: loadedBackend });
+  })();
+
+  try {
+    await loadingPromise;
+  } finally {
+    if (myGen === generation) loadingPromise = null;
+  }
+}
+
+self.onmessage = async (ev: MessageEvent<WhisperWorkerIn>) => {
+  const msg = ev.data;
+  try {
+    if (msg.kind === "load") {
+      await ensureLoaded(msg.model);
+      return;
+    }
+    if (msg.kind === "unload") {
+      generation++;
+      asr = null;
+      currentModel = null;
+      loadingPromise = null;
+      return;
+    }
+    if (msg.kind === "transcribe") {
+      if (!asr) {
+        post({ kind: "error", message: "Model not loaded" });
+        return;
+      }
+      const result: any = await asr(msg.pcm, {
+        language: msg.language && msg.language !== "auto" ? msg.language : undefined,
+        chunk_length_s: 30,
+        stride_length_s: 5,
+      });
+      const text = typeof result?.text === "string" ? result.text : "";
+      post({ kind: "result", text });
+      return;
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    post({ kind: "error", message });
+  }
+};

--- a/src/modules/ai/workers/whisperWorker.types.ts
+++ b/src/modules/ai/workers/whisperWorker.types.ts
@@ -1,0 +1,10 @@
+export type WhisperWorkerIn =
+  | { kind: "load"; model: string }
+  | { kind: "transcribe"; pcm: Float32Array; language?: string }
+  | { kind: "unload" };
+
+export type WhisperWorkerOut =
+  | { kind: "progress"; file: string; loaded: number; total: number }
+  | { kind: "ready"; model: string; backend: "gpu" | "cpu" }
+  | { kind: "result"; text: string }
+  | { kind: "error"; message: string };

--- a/src/modules/settings/openSettingsWindow.ts
+++ b/src/modules/settings/openSettingsWindow.ts
@@ -5,6 +5,7 @@ export type SettingsTab =
   | "themes"
   | "shortcuts"
   | "models"
+  | "voice"
   | "agents"
   | "about";
 

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -34,6 +34,16 @@ export const EDITOR_THEMES = [
 
 export type EditorThemeId = (typeof EDITOR_THEMES)[number];
 
+export const WHISPER_MODELS = [
+  { id: "onnx-community/whisper-tiny.en", label: "tiny.en", sizeMB: 75, multilingual: false },
+  { id: "onnx-community/whisper-base.en", label: "base.en", sizeMB: 140, multilingual: false },
+  { id: "onnx-community/whisper-base", label: "base", sizeMB: 140, multilingual: true },
+  { id: "onnx-community/whisper-small.en", label: "small.en", sizeMB: 460, multilingual: false },
+  { id: "onnx-community/whisper-small", label: "small", sizeMB: 460, multilingual: true },
+] as const;
+
+export type WhisperModelId = (typeof WHISPER_MODELS)[number]["id"];
+
 export const EDITOR_THEME_LABELS: Record<EditorThemeId, string> = {
   atomone: "Atom One",
   aura: "Aura",
@@ -85,6 +95,9 @@ export type Preferences = {
   zoomLevel: number;
   agentNotifications: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
+  voiceProvider: "openai" | "local";
+  localWhisperModel: string;
+  localWhisperLanguage: string;
 };
 
 const STORE_PATH = "terax-settings.json";
@@ -126,6 +139,9 @@ const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
 const KEY_SHORTCUTS = "shortcuts";
+const KEY_VOICE_PROVIDER = "voiceProvider";
+const KEY_LOCAL_WHISPER_MODEL = "localWhisperModel";
+const KEY_LOCAL_WHISPER_LANGUAGE = "localWhisperLanguage";
 
 export const TERMINAL_FONT_SIZE_DEFAULT = 14;
 export const TERMINAL_FONT_SIZE_MIN = 8;
@@ -180,6 +196,9 @@ export const DEFAULT_PREFERENCES: Preferences = {
   zoomLevel: 1.0,
   agentNotifications: true,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
+  voiceProvider: "local",
+  localWhisperModel: "onnx-community/whisper-base",
+  localWhisperLanguage: "auto",
 };
 
 const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
@@ -302,6 +321,15 @@ export async function loadPreferences(): Promise<Preferences> {
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
+    voiceProvider:
+      get<"openai" | "local">(KEY_VOICE_PROVIDER) ??
+      DEFAULT_PREFERENCES.voiceProvider,
+    localWhisperModel:
+      get<string>(KEY_LOCAL_WHISPER_MODEL) ??
+      DEFAULT_PREFERENCES.localWhisperModel,
+    localWhisperLanguage:
+      get<string>(KEY_LOCAL_WHISPER_LANGUAGE) ??
+      DEFAULT_PREFERENCES.localWhisperLanguage,
   };
 }
 
@@ -482,6 +510,18 @@ export async function setZoomLevel(value: number): Promise<void> {
   await writePref(KEY_ZOOM_LEVEL, value);
 }
 
+export async function setVoiceProvider(value: "openai" | "local"): Promise<void> {
+  await writePref(KEY_VOICE_PROVIDER, value);
+}
+
+export async function setLocalWhisperModel(value: string): Promise<void> {
+  await writePref(KEY_LOCAL_WHISPER_MODEL, value);
+}
+
+export async function setLocalWhisperLanguage(value: string): Promise<void> {
+  await writePref(KEY_LOCAL_WHISPER_LANGUAGE, value);
+}
+
 export async function setAgentNotifications(value: boolean): Promise<void> {
   await writePref(KEY_AGENT_NOTIFICATIONS, value);
 }
@@ -540,6 +580,9 @@ export async function onPreferencesChange(
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
     [KEY_SHORTCUTS]: "shortcuts",
+    [KEY_VOICE_PROVIDER]: "voiceProvider",
+    [KEY_LOCAL_WHISPER_MODEL]: "localWhisperModel",
+    [KEY_LOCAL_WHISPER_LANGUAGE]: "localWhisperLanguage",
   };
   // Same-process writes still fire onChange immediately; cross-window writes
   // arrive via the Tauri event emitted by writePref().

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -6,6 +6,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   AiScanIcon,
   InformationCircleIcon,
+  Mic01Icon,
   PaintBoardIcon,
   Settings01Icon,
   UserMultiple02Icon,
@@ -20,6 +21,7 @@ import { GeneralSection } from "./sections/GeneralSection";
 import { ModelsSection } from "./sections/ModelsSection";
 import { ShortcutsSection } from "./sections/ShortcutsSection";
 import { ThemesSection } from "./sections/ThemesSection";
+import { VoiceSection } from "./sections/VoiceSection";
 
 const TABS: { id: SettingsTab; label: string; icon: typeof Settings01Icon, component: () => JSX.Element }[] =
   [
@@ -27,6 +29,7 @@ const TABS: { id: SettingsTab; label: string; icon: typeof Settings01Icon, compo
     { id: "themes", label: "Themes", icon: PaintBoardIcon, component: ThemesSection },
     { id: "shortcuts", label: "Shortcuts", icon: KeyboardIcon, component: ShortcutsSection },
     { id: "models", label: "Models", icon: AiScanIcon, component: ModelsSection },
+    { id: "voice", label: "Voice", icon: Mic01Icon, component: VoiceSection },
     { id: "agents", label: "Agents", icon: UserMultiple02Icon, component: AgentsSection },
     { id: "about", label: "About", icon: InformationCircleIcon, component: AboutSection },
   ];
@@ -36,6 +39,7 @@ const VALID_TABS: SettingsTab[] = [
   "themes",
   "shortcuts",
   "models",
+  "voice",
   "agents",
   "about",
 ];

--- a/src/settings/sections/VoiceSection.tsx
+++ b/src/settings/sections/VoiceSection.tsx
@@ -1,0 +1,106 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  WHISPER_MODELS,
+  setVoiceProvider,
+  setLocalWhisperModel,
+  setLocalWhisperLanguage,
+  type WhisperModelId,
+} from "@/modules/settings/store";
+import { useChatStore } from "@/modules/ai/store/chatStore";
+import { SectionHeader } from "../components/SectionHeader";
+import { SettingRow } from "../components/SettingRow";
+
+export function VoiceSection() {
+  const voiceProvider = usePreferencesStore((s) => s.voiceProvider);
+  const localModel = usePreferencesStore((s) => s.localWhisperModel);
+  const localLanguage = usePreferencesStore((s) => s.localWhisperLanguage);
+  const openaiKey = useChatStore((s) => s.apiKeys.openai);
+
+  const isLocal = voiceProvider === "local";
+  const activeModel = WHISPER_MODELS.find((m) => m.id === localModel);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader
+        title="Voice input"
+        description="Transcribe speech to text in the composer. Choose a local model for offline use, or OpenAI's hosted Whisper for the lowest setup cost."
+      />
+
+      <div className="flex flex-col gap-2">
+        <SettingRow
+          title="Provider"
+          description={
+            voiceProvider === "openai" && !openaiKey
+              ? "OpenAI cloud needs an API key (configure in Models)."
+              : isLocal
+                ? "Local runs the model in-app — no internet, no API key."
+                : "OpenAI cloud — uses your OpenAI API key for transcription."
+          }
+        >
+          <Select
+            value={voiceProvider}
+            onValueChange={(v) => void setVoiceProvider(v as "openai" | "local")}
+          >
+            <SelectTrigger className="h-8 w-40 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="local">Local (in-app)</SelectItem>
+              <SelectItem value="openai">OpenAI cloud</SelectItem>
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        {isLocal && (
+          <>
+            <SettingRow
+              title="Model"
+              description={
+                activeModel
+                  ? `${activeModel.sizeMB} MB · ${activeModel.multilingual ? "multilingual" : "English only"} · downloads on first use`
+                  : undefined
+              }
+            >
+              <Select
+                value={localModel}
+                onValueChange={(v) => void setLocalWhisperModel(v as WhisperModelId)}
+              >
+                <SelectTrigger className="h-8 w-40 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {WHISPER_MODELS.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.label} · {m.sizeMB} MB
+                      {m.multilingual ? "" : " · EN"}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </SettingRow>
+
+            <SettingRow
+              title="Language"
+              description='ISO 639-1 code (e.g. "en", "de"). Use "auto" to let the model detect. Ignored by ".en" models.'
+            >
+              <Input
+                value={localLanguage}
+                onChange={(e) => void setLocalWhisperLanguage(e.target.value)}
+                placeholder="auto"
+                className="h-8 w-24 text-xs"
+              />
+            </SettingRow>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Voice input no longer requires an OpenAI key. By default it runs a Whisper model in-process via \`@huggingface/transformers\` in a Web Worker (WebGPU when available, WASM fallback). OpenAI cloud Whisper remains a user-selectable provider.

## Design

- New \`Voice\` tab in Settings. Provider switch (Local / OpenAI cloud), model selector (tiny.en/base.en/base/small.en/small), and language input.
- Web Worker hosts the ASR pipeline. A generation counter cancels stale loads when the user switches models mid-load (otherwise a delayed \`ready\` from the old model could stomp the new one).
- \`useWhisperRecording\` is refactored as a thin orchestrator behind a \`Transcriber\` interface (\`openai\` cloud / \`local\` worker impls).
- Audio is decoded + downmixed to mono + resampled to 16 kHz Float32 via \`OfflineAudioContext\` on the main thread before being transferred to the worker.
- Mic button + composer status bar render new "loading model", "downloading X / Y MB", and "preparing" states. AnimatePresence key is stable across progress ticks (otherwise each update remounts the row and replays the height animation).

## Trade-offs

- First-run downloads ~140 MB for \`whisper-base\` (the default). Cached by the browser's CacheStorage thereafter.
- WebGPU is available on macOS/Windows WebViews; Linux WebKitGTK falls back to WASM/CPU (slower, but works).

## Test Plan

- [ ] Without an OpenAI key configured, click the mic icon. Confirm the model downloads (progress shown in input bar), then speak. Transcription appears in the composer.
- [ ] Switch provider to OpenAI cloud in Settings → Voice. Confirm mic disabled if no key; with a key, confirm transcription via the cloud API.
- [ ] Switch model between \`base\` and \`tiny.en\` mid-session. Confirm fresh download triggers on next use; no stale "ready" event from the old model.
- [ ] Confirm 4 new vitest cases pass: \`pnpm test src/modules/ai/lib/audio.test.ts\`.

## Notes

This PR is independent of the other two open PRs. Order of merge doesn't matter; \`settings/store.ts\` is touched in a non-conflicting region (different from session restoration).