### PR TITLE
feat(explorer): integrate Git status into FileExplorer and TreeRow components

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1430,6 +1430,7 @@ export default function App() {
                       <FileExplorer
                         ref={explorerRef}
                         rootPath={explorerRoot}
+                        gitStatus={sourceControl.status}
                         onOpenFile={handleOpenFile}
                         onPathRenamed={handlePathRenamed}
                         onPathDeleted={handlePathDeleted}

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -31,7 +31,9 @@ import { copyToClipboard, revealInFinder } from "./lib/contextActions";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
+import { useGitStatus } from "./lib/useGitStatus";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
+import type { GitStatusSnapshot } from "@/modules/ai/lib/native";
 
 export type FileExplorerHandle = {
   focus: () => void;
@@ -46,6 +48,7 @@ type Props = {
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
+  gitStatus?: GitStatusSnapshot | null;
 };
 
 type Row =
@@ -153,10 +156,12 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       onRevealInTerminal,
       onAttachToAgent,
       onOpenMarkdownPreview,
+      gitStatus,
     },
     ref,
   ) {
     const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
+    const { lookup: lookupGitStatus } = useGitStatus(rootPath, gitStatus);
     const [selectedPath, setSelectedPath] = useState<string | null>(null);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const [isSearchActive, setIsSearchActive] = useState(false);
@@ -343,6 +348,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
               onRevealInTerminal={onRevealInTerminal}
               onAttachToAgent={onAttachToAgent}
               onOpenMarkdownPreview={onOpenMarkdownPreview}
+              gitStatusCode={lookupGitStatus(row.path)}
             />
           );
         }

--- a/src/modules/explorer/GitStatusBadge.tsx
+++ b/src/modules/explorer/GitStatusBadge.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+import type { GitStatusCode } from "./lib/gitStatusUtils";
+
+type Props = {
+  code: GitStatusCode;
+  isDir?: boolean;
+};
+
+const TEXT_CLASS: Record<GitStatusCode, string> = {
+  M: "text-amber-600 dark:text-amber-400",
+  A: "text-emerald-600 dark:text-emerald-400",
+  D: "text-rose-600 dark:text-rose-400",
+  U: "text-green-600 dark:text-green-400",
+};
+
+const FOLDER_DOT_CLASS = "bg-amber-500/30";
+
+export function GitStatusBadge({ code, isDir = false }: Props) {
+  if (isDir) {
+    return (
+      <span
+        className={cn("ml-auto size-2 shrink-0 rounded-full", FOLDER_DOT_CLASS)}
+        aria-hidden
+      />
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "ml-auto shrink-0 text-[10px] font-semibold tabular-nums",
+        TEXT_CLASS[code],
+      )}
+      aria-hidden
+    >
+      {code}
+    </span>
+  );
+}

--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -15,6 +15,8 @@ import {
   relativePath,
   revealInFinder,
 } from "./lib/contextActions";
+import { GitStatusBadge } from "./GitStatusBadge";
+import type { GitStatusCode } from "./lib/gitStatusUtils";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import type { useFileTree } from "./lib/useFileTree";
@@ -36,6 +38,7 @@ export type EntryRowProps = {
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
+  gitStatusCode?: GitStatusCode | null;
 };
 
 function isMarkdownPath(path: string): boolean {
@@ -58,6 +61,7 @@ function EntryRowImpl(props: EntryRowProps) {
     onRevealInTerminal,
     onAttachToAgent,
     onOpenMarkdownPreview,
+    gitStatusCode,
   } = props;
 
   const [isConfirming, setIsConfirming] = useState(false);
@@ -123,6 +127,9 @@ function EntryRowImpl(props: EntryRowProps) {
               <span className="size-4 shrink-0" />
             )}
             <span className="min-w-0 flex-1 truncate">{name}</span>
+            {gitStatusCode ? (
+              <GitStatusBadge code={gitStatusCode} isDir={isDir} />
+            ) : null}
           </button>
         )}
       </ContextMenuTrigger>

--- a/src/modules/explorer/lib/gitStatusUtils.test.ts
+++ b/src/modules/explorer/lib/gitStatusUtils.test.ts
@@ -1,0 +1,214 @@
+import type { GitChangedFile, GitStatusSnapshot } from "@/modules/ai/lib/native";
+import { describe, expect, it } from "vitest";
+import {
+  bubbleUpDirectoryStatuses,
+  buildGitStatusMap,
+  lookupGitStatus,
+  repoCoversPath,
+  repoRelativePath,
+  statusCodeForFile,
+} from "./gitStatusUtils";
+
+function changedFile(
+  overrides: Partial<GitChangedFile> & Pick<GitChangedFile, "path">,
+): GitChangedFile {
+  return {
+    originalPath: null,
+    indexStatus: " ",
+    worktreeStatus: " ",
+    staged: false,
+    unstaged: false,
+    untracked: false,
+    statusLabel: "",
+    ...overrides,
+  };
+}
+
+function snapshot(
+  changedFiles: GitChangedFile[],
+  repoRoot = "/repo",
+): GitStatusSnapshot {
+  return {
+    repoRoot,
+    branch: "main",
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    isDetached: false,
+    truncated: false,
+    changedFiles,
+  };
+}
+
+describe("statusCodeForFile", () => {
+  it("returns U for untracked files", () => {
+    expect(
+      statusCodeForFile(
+        changedFile({
+          path: "new.txt",
+          untracked: true,
+          worktreeStatus: "?",
+          unstaged: true,
+        }),
+      ),
+    ).toBe("U");
+  });
+
+  it("returns U for unmerged files", () => {
+    expect(
+      statusCodeForFile(
+        changedFile({
+          path: "conflict.txt",
+          indexStatus: "U",
+          worktreeStatus: "U",
+          staged: true,
+          unstaged: true,
+        }),
+      ),
+    ).toBe("U");
+  });
+
+  it("prefers unstaged worktree over staged index", () => {
+    expect(
+      statusCodeForFile(
+        changedFile({
+          path: "file.ts",
+          indexStatus: "A",
+          worktreeStatus: "M",
+          staged: true,
+          unstaged: true,
+        }),
+      ),
+    ).toBe("M");
+  });
+
+  it("uses staged index when only staged", () => {
+    expect(
+      statusCodeForFile(
+        changedFile({
+          path: "file.ts",
+          indexStatus: "A",
+          worktreeStatus: " ",
+          staged: true,
+        }),
+      ),
+    ).toBe("A");
+  });
+
+  it("returns D for deleted files", () => {
+    expect(
+      statusCodeForFile(
+        changedFile({
+          path: "gone.txt",
+          worktreeStatus: "D",
+          unstaged: true,
+        }),
+      ),
+    ).toBe("D");
+  });
+});
+
+describe("bubbleUpDirectoryStatuses", () => {
+  it("bubbles child status to parent directories", () => {
+    const map = buildGitStatusMap(
+      snapshot([
+        changedFile({
+          path: "src/lib/util.ts",
+          worktreeStatus: "M",
+          unstaged: true,
+        }),
+      ]),
+    );
+    bubbleUpDirectoryStatuses(map);
+    expect(map.get("src/lib/util.ts")).toBe("M");
+    expect(map.get("src/lib")).toBe("M");
+    expect(map.get("src")).toBe("M");
+  });
+
+  it("merges sibling statuses by priority", () => {
+    const map = buildGitStatusMap(
+      snapshot([
+        changedFile({
+          path: "src/a.ts",
+          worktreeStatus: "A",
+          unstaged: true,
+        }),
+        changedFile({
+          path: "src/b.ts",
+          worktreeStatus: "D",
+          unstaged: true,
+        }),
+      ]),
+    );
+    bubbleUpDirectoryStatuses(map);
+    expect(map.get("src")).toBe("D");
+  });
+
+  it("prefers unmerged over deleted in parent merge", () => {
+    const map = buildGitStatusMap(
+      snapshot([
+        changedFile({
+          path: "pkg/a.ts",
+          worktreeStatus: "D",
+          unstaged: true,
+        }),
+        changedFile({
+          path: "pkg/b.ts",
+          indexStatus: "U",
+          worktreeStatus: "U",
+          staged: true,
+          unstaged: true,
+        }),
+      ]),
+    );
+    bubbleUpDirectoryStatuses(map);
+    expect(map.get("pkg")).toBe("U");
+  });
+});
+
+describe("lookupGitStatus", () => {
+  const repoRoot = "/repo";
+  let map: ReturnType<typeof buildGitStatusMap>;
+
+  it("returns null for paths outside the repo", () => {
+    map = buildGitStatusMap(
+      snapshot(
+        [changedFile({ path: "a.ts", worktreeStatus: "M", unstaged: true })],
+        repoRoot,
+      ),
+    );
+    bubbleUpDirectoryStatuses(map);
+    expect(lookupGitStatus(map, repoRoot, "/other/a.ts")).toBeNull();
+  });
+
+  it("looks up file and directory paths", () => {
+    map = buildGitStatusMap(
+      snapshot(
+        [
+          changedFile({
+            path: "src/deep/file.ts",
+            worktreeStatus: "M",
+            unstaged: true,
+          }),
+        ],
+        repoRoot,
+      ),
+    );
+    bubbleUpDirectoryStatuses(map);
+    expect(lookupGitStatus(map, repoRoot, "/repo/src/deep/file.ts")).toBe("M");
+    expect(lookupGitStatus(map, repoRoot, "/repo/src")).toBe("M");
+  });
+
+  it("handles trailing slashes and backslashes", () => {
+    map = buildGitStatusMap(
+      snapshot(
+        [changedFile({ path: "a.ts", worktreeStatus: "?", untracked: true, unstaged: true })],
+        "/repo/",
+      ),
+    );
+    bubbleUpDirectoryStatuses(map);
+    expect(repoCoversPath("/repo/", "/repo/sub")).toBe(true);
+    expect(repoRelativePath("\\repo\\", "\\repo\\a.ts")).toBe("a.ts");
+    expect(lookupGitStatus(map, "/repo/", "\\repo\\a.ts")).toBe("U");
+  });
+});

--- a/src/modules/explorer/lib/gitStatusUtils.ts
+++ b/src/modules/explorer/lib/gitStatusUtils.ts
@@ -1,0 +1,109 @@
+import type { GitChangedFile, GitStatusSnapshot } from "@/modules/ai/lib/native";
+
+export type GitStatusCode = "M" | "A" | "D" | "U";
+
+const PRIORITY: Record<GitStatusCode, number> = {
+  U: 5,
+  D: 4,
+  M: 3,
+  A: 2,
+};
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function normalizeStatusCode(status: string): GitStatusCode {
+  const code = status.trim().toUpperCase();
+  switch (code) {
+    case "?":
+      return "U";
+    case "A":
+      return "A";
+    case "M":
+      return "M";
+    case "D":
+      return "D";
+    case "R":
+      return "M";
+    case "C":
+      return "A";
+    case "U":
+      return "U";
+    default:
+      return "M";
+  }
+}
+
+export function statusCodeForFile(file: GitChangedFile): GitStatusCode {
+  if (file.untracked) return "U";
+  if (file.indexStatus === "U" || file.worktreeStatus === "U") return "U";
+
+  const primary = file.unstaged ? file.worktreeStatus : file.indexStatus;
+  const fallback = file.unstaged ? file.indexStatus : file.worktreeStatus;
+  return normalizeStatusCode(primary !== " " ? primary : fallback);
+}
+
+export function buildGitStatusMap(
+  status: GitStatusSnapshot,
+): Map<string, GitStatusCode> {
+  const map = new Map<string, GitStatusCode>();
+  for (const file of status.changedFiles) {
+    map.set(file.path, statusCodeForFile(file));
+  }
+  return map;
+}
+
+function parentSegments(relPath: string): string[] {
+  const parts = relPath.split("/").filter(Boolean);
+  parts.pop();
+  const parents: string[] = [];
+  for (let i = parts.length; i > 0; i--) {
+    parents.push(parts.slice(0, i).join("/"));
+  }
+  return parents;
+}
+
+export function bubbleUpDirectoryStatuses(
+  map: Map<string, GitStatusCode>,
+): void {
+  for (const [path, code] of [...map.entries()]) {
+    for (const parent of parentSegments(path)) {
+      const existing = map.get(parent);
+      if (!existing || PRIORITY[code] > PRIORITY[existing]) {
+        map.set(parent, code);
+      }
+    }
+  }
+}
+
+export function repoCoversPath(
+  repoRoot: string,
+  path: string | null,
+): boolean {
+  if (!path) return false;
+  const repo = normalizePath(repoRoot);
+  const target = normalizePath(path);
+  return target === repo || target.startsWith(`${repo}/`);
+}
+
+export function repoRelativePath(
+  repoRoot: string,
+  absolutePath: string,
+): string | null {
+  const repo = normalizePath(repoRoot);
+  const abs = normalizePath(absolutePath);
+  if (abs === repo) return "";
+  if (abs.startsWith(`${repo}/`)) return abs.slice(repo.length + 1);
+  return null;
+}
+
+export function lookupGitStatus(
+  map: Map<string, GitStatusCode>,
+  repoRoot: string,
+  absolutePath: string,
+): GitStatusCode | null {
+  const rel = repoRelativePath(repoRoot, absolutePath);
+  if (rel === null) return null;
+  return map.get(rel) ?? null;
+}

--- a/src/modules/explorer/lib/useGitStatus.ts
+++ b/src/modules/explorer/lib/useGitStatus.ts
@@ -1,0 +1,88 @@
+import { native, type GitStatusSnapshot } from "@/modules/ai/lib/native";
+import { useWorkspaceEnvStore, workspaceScopeKey } from "@/modules/workspace";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildGitStatusMap,
+  bubbleUpDirectoryStatuses,
+  lookupGitStatus,
+  repoCoversPath,
+  type GitStatusCode,
+} from "./gitStatusUtils";
+
+type GitStatusState = {
+  repoRoot: string | null;
+  statusMap: Map<string, GitStatusCode>;
+};
+
+const EMPTY_MAP = new Map<string, GitStatusCode>();
+
+export function useGitStatus(
+  workspaceRoot: string | null,
+  sharedStatus?: GitStatusSnapshot | null,
+) {
+  const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
+  const workspaceKey = workspaceScopeKey(workspaceEnv);
+  const requestIdRef = useRef(0);
+  const [fetched, setFetched] = useState<GitStatusState>({
+    repoRoot: null,
+    statusMap: EMPTY_MAP,
+  });
+
+  const sharedCoversRoot =
+    !!workspaceRoot &&
+    !!sharedStatus &&
+    repoCoversPath(sharedStatus.repoRoot, workspaceRoot);
+
+  const sharedState = useMemo<GitStatusState | null>(() => {
+    if (!sharedCoversRoot || !sharedStatus) return null;
+    const statusMap = buildGitStatusMap(sharedStatus);
+    bubbleUpDirectoryStatuses(statusMap);
+    return {
+      repoRoot: sharedStatus.repoRoot,
+      statusMap,
+    };
+  }, [sharedCoversRoot, sharedStatus]);
+
+  useEffect(() => {
+    requestIdRef.current++;
+    setFetched({ repoRoot: null, statusMap: EMPTY_MAP });
+  }, [workspaceKey]);
+
+  useEffect(() => {
+    if (!workspaceRoot || sharedCoversRoot) return;
+
+    const requestId = ++requestIdRef.current;
+
+    void native
+      .gitPanelSnapshot(workspaceRoot)
+      .then((snapshot) => {
+        if (requestId !== requestIdRef.current) return;
+        if (!snapshot.repo || !snapshot.status) {
+          setFetched({ repoRoot: null, statusMap: EMPTY_MAP });
+          return;
+        }
+        const statusMap = buildGitStatusMap(snapshot.status);
+        bubbleUpDirectoryStatuses(statusMap);
+        setFetched({
+          repoRoot: snapshot.repo.repoRoot,
+          statusMap,
+        });
+      })
+      .catch(() => {
+        if (requestId !== requestIdRef.current) return;
+        setFetched({ repoRoot: null, statusMap: EMPTY_MAP });
+      });
+  }, [workspaceRoot, sharedCoversRoot, workspaceKey]);
+
+  const { repoRoot, statusMap } = sharedState ?? fetched;
+
+  const lookup = useCallback(
+    (path: string): GitStatusCode | null => {
+      if (!repoRoot) return null;
+      return lookupGitStatus(statusMap, repoRoot, path);
+    },
+    [repoRoot, statusMap],
+  );
+
+  return { repoRoot, statusMap, lookup };
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
Adds VS Code-style git status decorations to the file explorer. Modified, added, deleted, and untracked files now show a colored letter badge (`M` / `A` / `D` / `U`) right-aligned on each row. Dirty directories bubble up — if any file inside a folder is changed, the folder shows an amber dot indicator.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
The file explorer gave no visual indication of which files had changed. To check git status you had to open the Source Control panel separately, breaking the flow of navigating the project. This brings the file tree in line with what developers expect from a modern editor.

Closes #511 

## How
<!-- Brief notes on the approach, only if non-obvious. -->
- **No new Rust command** — reuses the existing `GitStatusSnapshot` already produced by the Source Control module (`sourceControl.status`), passed down as a `gitStatus` prop to `FileExplorer`. Zero duplicate invocations.
- `gitStatusUtils.ts` — pure utility functions: `buildGitStatusMap` converts the snapshot's `changedFiles` array into a `Map<relativePath, GitStatusCode>`, `bubbleUpDirectoryStatuses` walks every file path and propagates statuses up to parent directories using a priority order (`U > D > M > A`), and `lookupGitStatus` resolves an absolute explorer path against the repo root with trailing-slash and Windows backslash normalisation.
- `useGitStatus.ts` — thin hook that memoises the map derivation and exposes a `lookup(path)` function for `FileExplorer` to call per row.
- `GitStatusBadge.tsx` — small presentational component. Files get a 10px semibold letter in the status colour; directories get a 2×2 amber dot (`aria-hidden` on both). Colours follow VS Code conventions: amber = modified, emerald = added, rose = deleted, amber dot = dirty dir, green = untracked/unmerged.
- `TreeRow` receives `gitStatusCode?: GitStatusCode | null` and renders the badge after the filename truncation span, so the badge never causes layout shift.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
  - Opened a project with modified, staged, untracked, and deleted files — all show correct badges
  - Parent folders show amber dot when any child is dirty
  - Non-git directory opens with no badges and no errors in console
  - Source Control panel and explorer badges stay in sync after staging / unstaging a file
  - Verified on a repo with files in nested subdirectories (bubble-up to grandparent dirs)
- [x] `cargo check` clean — no Rust changes in this PR
- [x] Tested in `pnpm tauri dev`
- [x] Unit tests added — `gitStatusUtils.test.ts` covers `statusCodeForFile`, `bubbleUpDirectoryStatuses` (including priority merging of sibling statuses), and `lookupGitStatus` (out-of-repo paths, file + directory lookup, trailing slash / backslash normalisation on Windows)

## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->
<img width="1958" height="1103" alt="image" src="https://github.com/user-attachments/assets/d17e4eb0-a0a9-42d2-afa4-f7a83e392fa8" />

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
