### PR TITLE
feat(terminal): improve split pane focus and clear shortcut UX

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1012,6 +1012,12 @@ export default function App() {
     handleClose(activeId);
   }, [activeId, closeActivePane, handleClose]);
 
+  const clearActiveTerminal = useCallback(() => {
+    if (!document.activeElement?.closest(".xterm")) return;
+    if (!activeTerminalTab || activeLeafId === null) return;
+    terminalRefs.current.get(activeLeafId)?.write("\x0c");
+  }, [activeTerminalTab, activeLeafId]);
+
   const shortcutHandlers = useMemo<ShortcutHandlers>(
     () => ({
       "tab.new": openNewTab,
@@ -1030,6 +1036,7 @@ export default function App() {
       "search.focus": () => searchInlineRef.current?.focus(),
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
+      "terminal.clearActive": clearActiveTerminal,
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
       "settings.open": () => void openSettingsWindow(),
       "sidebar.toggle": toggleSidebar,
@@ -1050,6 +1057,7 @@ export default function App() {
       selectByIndex,
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
+      clearActiveTerminal,
       toggleSourceControl,
       togglePanelAndFocus,
       askFromSelection,
@@ -1075,6 +1083,11 @@ export default function App() {
         if (!inTerminal) return false;
         const sel = captureActiveSelection();
         return !sel || !sel.trim();
+      }
+      if (id === "terminal.clearActive") {
+        const target =
+          (e.target as HTMLElement | null) ?? document.activeElement;
+        return !target?.closest?.(".xterm");
       }
       return false;
     },

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -5,6 +5,7 @@ import { IS_MAC, MOD_PROP } from "@/lib/platform";
  */
 
 export type ShortcutId =
+  | "terminal.clearActive"
   | "tab.new"
   | "tab.newPrivate"
   | "tab.newPreview"
@@ -71,6 +72,12 @@ export const SHORTCUTS: Shortcut[] = [
     defaultBindings: [{ [MOD_PROP]: true, key: "k" }],
   },
   {
+    id: "terminal.clearActive",
+    label: "Clear active terminal",
+    group: "Panes",
+    defaultBindings: [{ [MOD_PROP]: true, key: ";" }],
+  },
+  {
     id: "tab.new",
     label: "New tab",
     group: "Tabs",
@@ -123,7 +130,7 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Focus previous pane",
     group: "Panes",
     defaultBindings: [{ [MOD_PROP]: true, key: "[" }],
-  },  
+  },
   {
     id: "pane.source",
     label: "Toggle source panel",

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -67,15 +67,34 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       [session],
     );
 
+    const overlayColor = focused
+      ? "var(--terminal-last-active-pane-overlay)"
+      : "var(--terminal-inactive-pane-overlay)";
+
     return (
       <div
-        ref={containerRef}
-        className="zoom-exempt h-full w-full"
+        className="group/terminal-pane relative h-full w-full"
         style={{
           visibility: visible ? "visible" : "hidden",
           pointerEvents: visible ? "auto" : "none",
         }}
-      />
+      >
+        <div
+          ref={containerRef}
+          className="zoom-exempt h-full w-full"
+        />
+        <div
+          className={[
+            "pointer-events-none absolute inset-0 z-10 transition-opacity",
+            focused ? "group-focus-within/terminal-pane:hidden" : "",
+          ].join(" ")}
+          style={{
+            backgroundColor: overlayColor,
+            boxShadow:
+              "inset 0 0 0 1px var(--terminal-inactive-pane-edge), inset 0 1px 0 var(--terminal-inactive-pane-top-edge)",
+          }}
+        />
+      </div>
     );
   },
 );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -142,6 +142,10 @@
   --terminal-foreground: var(--foreground);
   --terminal-cursor: var(--foreground);
   --terminal-cursor-accent: var(--background);
+  --terminal-inactive-pane-edge: rgba(255,255,255,0.08);
+  --terminal-inactive-pane-overlay: rgba(148,163,184,0.12);
+  --terminal-last-active-pane-overlay: rgba(148,163,184,0.06);
+  --terminal-inactive-pane-top-edge: rgba(255,255,255,0.06);
   --terminal-selection: var(--accent);
   --terminal-ansi-black: #18181b;
   --terminal-ansi-red: #ef4444;


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Improves split terminal focus visibility with subtle inactive-pane overlays. Adds a customizable `Cmd/Ctrl + ;` shortcut to clear only the focused terminal pane without having to use `clear` or `cls`.

## Why

Closes https://github.com/crynta/terax-ai/issues/537


## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo check` clean
- [x] (If UI) tested in `pnpm tauri dev`

## Screenshots / GIFs

<details>
    <summary>1. One focused split pane</summary>

<img width="1624" height="981" alt="Screenshot 2026-05-27 at 1 30 30 AM" src="https://github.com/user-attachments/assets/6846d121-b81d-4259-abdd-b497e6ceee41" />

</details>

<details>
    <summary>2. Out of of focus split panes</summary>

<img width="1624" height="981" alt="Screenshot 2026-05-27 at 1 30 43 AM" src="https://github.com/user-attachments/assets/a3ae437d-3e52-4c3f-a334-d5fca8c50c41" />

</details>

## Notes for reviewer
- Would you suggest a better way of rendering overlays on top of inactive terminal split panes?
- Does it make sense to keep the opacity of the overlays as configurable?