### PR TITLE
fix(ai): add reasoning tag to deepseek-v4-flash

### DIFF
--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -337,7 +337,7 @@ export const MODELS = [
     hint: "Fast",
     description: "Cheap and fast everyday tier.",
     capabilities: { intelligence: 4, speed: 5, cost: 5 },
-    tags: ["tools"],
+    tags: ["reasoning", "tools"],
   },
   {
     id: "deepseek-reasoner",


### PR DESCRIPTION
## What changed
Added `"reasoning"` to the `tags` array for `deepseek-v4-flash` in `src/modules/ai/config.ts`.

## Why
`deepseek-v4-flash` is a DeepSeek reasoning/thinking model but was missing the `"reasoning"` tag. This caused `modelKeepsReasoning()` to return `false`, which made `pruneMessages()` use `"before-last-message"` mode and strip `reasoning_content` from assistant messages. DeepSeek's API rejects follow-up calls after tool steps when prior `reasoning_content` is missing — producing errors like:

> The `reasoning_content` in the thinking mode must be passed back to the API.

The other DeepSeek reasoning models (`deepseek-v4-pro`, `deepseek-reasoner`) already have this tag.

Fixes #438

## How tested
- `pnpm exec tsc --noEmit` — no new errors
- `pnpm test` — 78/78 tests pass
- Build + local test