### PR TITLE
Feat/zen mode

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -65,7 +65,10 @@ import { MarkdownStack } from "@/modules/markdown";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import { onKeysChanged, setThemeId as persistThemeId } from "@/modules/settings/store";
+import {
+  onKeysChanged,
+  setThemeId as persistThemeId,
+} from "@/modules/settings/store";
 import {
   ShortcutsDialog,
   useGlobalShortcuts,
@@ -73,10 +76,7 @@ import {
   type ShortcutId,
 } from "@/modules/shortcuts";
 import { SidebarRail, type SidebarViewId } from "@/modules/sidebar";
-import {
-  SourceControlPanel,
-  useSourceControl,
-} from "@/modules/source-control";
+import { SourceControlPanel, useSourceControl } from "@/modules/source-control";
 import { StatusBar } from "@/modules/statusbar";
 import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
 import {
@@ -91,7 +91,10 @@ import {
   type TerminalPaneHandle,
 } from "@/modules/terminal";
 import { ThemeProvider } from "@/modules/theme";
-import { listCustomThemes, saveCustomTheme } from "@/modules/theme/customThemes";
+import {
+  listCustomThemes,
+  saveCustomTheme,
+} from "@/modules/theme/customThemes";
 import {
   isThemeFilePath,
   onThemeEdit,
@@ -211,13 +214,22 @@ export default function App() {
   const [gitHistoryHandle, setGitHistoryHandle] =
     useState<GitHistorySearchHandle | null>(null);
   const { zoomIn, zoomOut, zoomReset } = useZoom();
+  const [zenMode, setZenMode] = useState(false);
+
+  useEffect(() => {
+    if (zenMode) {
+      sidebarRef.current?.collapse();
+    }
+  }, [zenMode]);
+
   const explorerRef = useRef<FileExplorerHandle>(null);
   const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
 
   const sidebarRef = useRef<PanelImperativeHandle | null>(null);
   const sidebarWidthRef = useRef(readSidebarWidth());
   const sidebarWidthWriteTimerRef = useRef(0);
-  const [sidebarView, setSidebarViewState] = useState<SidebarViewId>(readSidebarView);
+  const [sidebarView, setSidebarViewState] =
+    useState<SidebarViewId>(readSidebarView);
   const persistSidebarView = useCallback((view: SidebarViewId) => {
     setSidebarViewState(view);
     try {
@@ -337,7 +349,9 @@ export default function App() {
       }
       const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
       if (dirty) {
-        window.alert("Save or close unsaved editor tabs before switching workspace.");
+        window.alert(
+          "Save or close unsaved editor tabs before switching workspace.",
+        );
         return;
       }
 
@@ -488,20 +502,21 @@ export default function App() {
 
   useEffect(() => {
     type FileWrittenPayload = { path: string; source?: string };
-    const unlistenPromise = getCurrentWebviewWindow().listen<FileWrittenPayload>(
-      "fs:file-written",
-      (event) => {
-        if (event.payload.source === "editor") return;
-        const normalizedPath = event.payload.path.replace(/\\/g, "/");
-        const currentTabs = tabsRef.current;
-        for (const t of currentTabs) {
-          if (t.kind !== "editor") continue;
-          if (t.path.replace(/\\/g, "/") === normalizedPath) {
-            editorRefs.current.get(t.id)?.reload();
+    const unlistenPromise =
+      getCurrentWebviewWindow().listen<FileWrittenPayload>(
+        "fs:file-written",
+        (event) => {
+          if (event.payload.source === "editor") return;
+          const normalizedPath = event.payload.path.replace(/\\/g, "/");
+          const currentTabs = tabsRef.current;
+          for (const t of currentTabs) {
+            if (t.kind !== "editor") continue;
+            if (t.path.replace(/\\/g, "/") === normalizedPath) {
+              editorRefs.current.get(t.id)?.reload();
+            }
           }
-        }
-      },
-    );
+        },
+      );
     return () => {
       void unlistenPromise.then((un) => un());
     };
@@ -544,30 +559,32 @@ export default function App() {
   // the code editor. Saving it re-ingests into the runtime store + applies live.
   useEffect(() => {
     type FileWrittenPayload = { path: string; source?: string };
-    const unlistenPromise = getCurrentWebviewWindow().listen<FileWrittenPayload>(
-      "fs:file-written",
-      (event) => {
-        if (event.payload.source !== "editor") return;
-        if (!isThemeFilePath(event.payload.path)) return;
-        void (async () => {
-          try {
-            const res = await invoke<{ kind: string; content?: string }>(
-              "fs_read_file",
-              { path: event.payload.path, workspace: currentWorkspaceEnv() },
-            );
-            if (res.kind !== "text" || typeof res.content !== "string") return;
-            const parsed = parseThemeFile(res.content);
-            if (!parsed.ok) {
-              console.warn("[terax] theme not applied:", parsed.error);
-              return;
+    const unlistenPromise =
+      getCurrentWebviewWindow().listen<FileWrittenPayload>(
+        "fs:file-written",
+        (event) => {
+          if (event.payload.source !== "editor") return;
+          if (!isThemeFilePath(event.payload.path)) return;
+          void (async () => {
+            try {
+              const res = await invoke<{ kind: string; content?: string }>(
+                "fs_read_file",
+                { path: event.payload.path, workspace: currentWorkspaceEnv() },
+              );
+              if (res.kind !== "text" || typeof res.content !== "string")
+                return;
+              const parsed = parseThemeFile(res.content);
+              if (!parsed.ok) {
+                console.warn("[terax] theme not applied:", parsed.error);
+                return;
+              }
+              await saveCustomTheme(parsed.theme);
+            } catch (e) {
+              console.warn("[terax] theme ingest failed:", e);
             }
-            await saveCustomTheme(parsed.theme);
-          } catch (e) {
-            console.warn("[terax] theme ingest failed:", e);
-          }
-        })();
-      },
-    );
+          })();
+        },
+      );
     return () => {
       void unlistenPromise.then((un) => un());
     };
@@ -609,7 +626,9 @@ export default function App() {
 
   useEffect(() => {
     setActiveSearchAddon(
-      activeLeafId !== null ? (searchAddons.current.get(activeLeafId) ?? null) : null,
+      activeLeafId !== null
+        ? (searchAddons.current.get(activeLeafId) ?? null)
+        : null,
     );
     setActiveEditorHandle(editorRefs.current.get(activeId) ?? null);
   }, [activeId, activeLeafId]);
@@ -935,8 +954,7 @@ export default function App() {
       ),
     [tabs],
   );
-  const sourceControlActive =
-    hasOpenGitTab || sidebarView === "source-control";
+  const sourceControlActive = hasOpenGitTab || sidebarView === "source-control";
   // Stable per-session path so switching tabs / cd-ing in a shell does NOT
   // re-fire git IPC for the badge. The active panel resolves the current
   // context path on its own when the user actually opens git.
@@ -1037,6 +1055,7 @@ export default function App() {
       "view.zoomIn": zoomIn,
       "view.zoomOut": zoomOut,
       "view.zoomReset": zoomReset,
+      "view.zenMode": () => setZenMode((v) => !v),
       "editor.undo": () => editorRefs.current.get(activeId)?.undo(),
       "editor.redo": () => editorRefs.current.get(activeId)?.redo(),
     }),
@@ -1058,6 +1077,7 @@ export default function App() {
       zoomIn,
       zoomOut,
       zoomReset,
+      setZenMode,
     ],
   );
 
@@ -1205,7 +1225,11 @@ export default function App() {
     const findCwd = () => {
       const active = tabs.find((x) => x.id === activeId);
       if (active?.kind === "terminal") {
-        return findLeafCwd(active.paneTree, active.activeLeafId) ?? active.cwd ?? null;
+        return (
+          findLeafCwd(active.paneTree, active.activeLeafId) ??
+          active.cwd ??
+          null
+        );
       }
       for (let i = tabs.length - 1; i >= 0; i--) {
         const t = tabs[i];
@@ -1251,8 +1275,12 @@ export default function App() {
         const oneLine = prompt.replace(/\s*\r?\n\s*/g, " ").trim();
         if (!oneLine) return null;
         const cwd = findCwd();
-        const short = oneLine.length > 32 ? `${oneLine.slice(0, 32)}…` : oneLine;
-        const { tabId, leafId } = newAgentTab(cwd ?? undefined, `claude · ${short}`);
+        const short =
+          oneLine.length > 32 ? `${oneLine.slice(0, 32)}…` : oneLine;
+        const { tabId, leafId } = newAgentTab(
+          cwd ?? undefined,
+          `claude · ${short}`,
+        );
         useManagedAgentsStore
           .getState()
           .register({ leafId, tabId, sessionId, task: oneLine, cwd });
@@ -1382,30 +1410,35 @@ export default function App() {
   const shell = (
     <ThemeProvider>
       <TooltipProvider>
-        <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
-          <Header
-            tabs={tabs}
-            activeId={activeId}
-            onSelect={setActiveId}
-            onNew={openNewTab}
-            onNewPrivate={openNewPrivateTab}
-            onNewPreview={() => openPreviewTab("")}
-            onNewEditor={() => setNewEditorOpen(true)}
-            onNewGitGraph={openGitGraphFromContext}
-            onClose={handleClose}
-            onPin={pinTab}
-            onToggleSidebar={toggleSidebar}
-            onSplit={splitActivePaneInActiveTab}
-            canSplit={
-              activeTerminalTab !== null &&
-              leafIds(activeTerminalTab.paneTree).length < MAX_PANES_PER_TAB
-            }
-            onActivateAgent={onActivateAgent}
-            onActivateLocalAgent={onActivateLocalAgent}
-            onOpenSettings={() => void openSettingsWindow()}
-            searchTarget={searchTarget}
-            searchRef={searchInlineRef}
-          />
+        <div
+          className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground"
+          data-zen-mode={zenMode || undefined}
+        >
+          <div className={cn(zenMode && "hidden")}>
+            <Header
+              tabs={tabs}
+              activeId={activeId}
+              onSelect={setActiveId}
+              onNew={openNewTab}
+              onNewPrivate={openNewPrivateTab}
+              onNewPreview={() => openPreviewTab("")}
+              onNewEditor={() => setNewEditorOpen(true)}
+              onNewGitGraph={openGitGraphFromContext}
+              onClose={handleClose}
+              onPin={pinTab}
+              onToggleSidebar={toggleSidebar}
+              onSplit={splitActivePaneInActiveTab}
+              canSplit={
+                activeTerminalTab !== null &&
+                leafIds(activeTerminalTab.paneTree).length < MAX_PANES_PER_TAB
+              }
+              onActivateAgent={onActivateAgent}
+              onActivateLocalAgent={onActivateLocalAgent}
+              onOpenSettings={() => void openSettingsWindow()}
+              searchTarget={searchTarget}
+              searchRef={searchInlineRef}
+            />
+          </div>
 
           <main className="zoom-content flex min-h-0 flex-1 flex-col">
             <ResizablePanelGroup
@@ -1469,7 +1502,7 @@ export default function App() {
                         opacity: panelOpen ? 1 : 0,
                       }}
                       transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
-                      className="overflow-hidden"
+                      className={cn("overflow-hidden", zenMode && "hidden")}
                       aria-hidden={!panelOpen}
                     >
                       {hasComposer ? (
@@ -1486,18 +1519,20 @@ export default function App() {
             </ResizablePanelGroup>
           </main>
 
-          <StatusBar
-            cwd={activeCwd}
-            filePath={activeFilePath}
-            home={home}
-            onCd={sendCd}
-            onWorkspaceChange={switchWorkspace}
-            onOpenMini={openMini}
-            hasComposer={hasComposer}
-            privateActive={
-              activeTab?.kind === "terminal" && activeTab.private === true
-            }
-          />
+          <div className={cn(zenMode && "hidden")}>
+            <StatusBar
+              cwd={activeCwd}
+              filePath={activeFilePath}
+              home={home}
+              onCd={sendCd}
+              onWorkspaceChange={switchWorkspace}
+              onOpenMini={openMini}
+              hasComposer={hasComposer}
+              privateActive={
+                activeTab?.kind === "terminal" && activeTab.private === true
+              }
+            />
+          </div>
 
           <AgentNotificationsBridge
             tabs={tabs}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -219,6 +219,8 @@ export default function App() {
   useEffect(() => {
     if (zenMode) {
       sidebarRef.current?.collapse();
+    } else {
+      sidebarRef.current?.expand();
     }
   }, [zenMode]);
 
@@ -1414,31 +1416,38 @@ export default function App() {
           className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground"
           data-zen-mode={zenMode || undefined}
         >
-          <div className={cn(zenMode && "hidden")}>
-            <Header
-              tabs={tabs}
-              activeId={activeId}
-              onSelect={setActiveId}
-              onNew={openNewTab}
-              onNewPrivate={openNewPrivateTab}
-              onNewPreview={() => openPreviewTab("")}
-              onNewEditor={() => setNewEditorOpen(true)}
-              onNewGitGraph={openGitGraphFromContext}
-              onClose={handleClose}
-              onPin={pinTab}
-              onToggleSidebar={toggleSidebar}
-              onSplit={splitActivePaneInActiveTab}
-              canSplit={
-                activeTerminalTab !== null &&
-                leafIds(activeTerminalTab.paneTree).length < MAX_PANES_PER_TAB
-              }
-              onActivateAgent={onActivateAgent}
-              onActivateLocalAgent={onActivateLocalAgent}
-              onOpenSettings={() => void openSettingsWindow()}
-              searchTarget={searchTarget}
-              searchRef={searchInlineRef}
-            />
-          </div>
+          <AnimatePresence>
+            {!zenMode && (
+              <motion.div
+                exit={{ height: 0, opacity: 0, overflow: "hidden" }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+              >
+                <Header
+                  tabs={tabs}
+                  activeId={activeId}
+                  onSelect={setActiveId}
+                  onNew={openNewTab}
+                  onNewPrivate={openNewPrivateTab}
+                  onNewPreview={() => openPreviewTab("")}
+                  onNewEditor={() => setNewEditorOpen(true)}
+                  onNewGitGraph={openGitGraphFromContext}
+                  onClose={handleClose}
+                  onPin={pinTab}
+                  onToggleSidebar={toggleSidebar}
+                  onSplit={splitActivePaneInActiveTab}
+                  canSplit={
+                    activeTerminalTab !== null &&
+                    leafIds(activeTerminalTab.paneTree).length < MAX_PANES_PER_TAB
+                  }
+                  onActivateAgent={onActivateAgent}
+                  onActivateLocalAgent={onActivateLocalAgent}
+                  onOpenSettings={() => void openSettingsWindow()}
+                  searchTarget={searchTarget}
+                  searchRef={searchInlineRef}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           <main className="zoom-content flex min-h-0 flex-1 flex-col">
             <ResizablePanelGroup
@@ -1498,12 +1507,12 @@ export default function App() {
                       data-ai-input-bar
                       initial={false}
                       animate={{
-                        height: panelOpen ? "auto" : 0,
-                        opacity: panelOpen ? 1 : 0,
+                        height: panelOpen && !zenMode ? "auto" : 0,
+                        opacity: panelOpen && !zenMode ? 1 : 0,
                       }}
                       transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
-                      className={cn("overflow-hidden", zenMode && "hidden")}
-                      aria-hidden={!panelOpen}
+                      className="overflow-hidden"
+                      aria-hidden={!panelOpen || zenMode}
                     >
                       {hasComposer ? (
                         <AiInputBar />
@@ -1519,20 +1528,27 @@ export default function App() {
             </ResizablePanelGroup>
           </main>
 
-          <div className={cn(zenMode && "hidden")}>
-            <StatusBar
-              cwd={activeCwd}
-              filePath={activeFilePath}
-              home={home}
-              onCd={sendCd}
-              onWorkspaceChange={switchWorkspace}
-              onOpenMini={openMini}
-              hasComposer={hasComposer}
-              privateActive={
-                activeTab?.kind === "terminal" && activeTab.private === true
-              }
-            />
-          </div>
+          <AnimatePresence>
+            {!zenMode && (
+              <motion.div
+                exit={{ height: 0, opacity: 0, overflow: "hidden" }}
+                transition={{ duration: 0.2, ease: "easeInOut" }}
+              >
+                <StatusBar
+                  cwd={activeCwd}
+                  filePath={activeFilePath}
+                  home={home}
+                  onCd={sendCd}
+                  onWorkspaceChange={switchWorkspace}
+                  onOpenMini={openMini}
+                  hasComposer={hasComposer}
+                  privateActive={
+                    activeTab?.kind === "terminal" && activeTab.private === true
+                  }
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           <AgentNotificationsBridge
             tabs={tabs}

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -24,6 +24,7 @@ export type ShortcutId =
   | "view.zoomIn"
   | "view.zoomOut"
   | "view.zoomReset"
+  | "view.zenMode"
   | "ai.toggle"
   | "ai.askSelection"
   | "shortcuts.open"
@@ -209,6 +210,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Reset zoom",
     group: "View",
     defaultBindings: [{ [MOD_PROP]: true, key: "0" }],
+  },
+  {
+    id: "view.zenMode",
+    label: "Toggle zen mode",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "z" }],
   },
   // Editor entries are display-only: CodeMirror's historyKeymap binds these
   // keys natively. We register them here so the shortcuts dialog can surface

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -347,3 +347,8 @@ html *::-webkit-scrollbar {
 .terax-collapsible-content[data-state="closed"] {
   animation: terax-collapsible-up 160ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+/* Zen mode sidebar collapse/expand transition */
+[data-zen-mode] [data-slot="resizable-panel"] {
+  transition: flex-basis 0.3s ease;
+}


### PR DESCRIPTION
## What
Add a **zen mode** that hides all UI elements (Except for the AI Chat Interface) so only the terminal/editor/preview content is visible

## Why
Provides a **distraction free** editing experience, useful for focused coding, or screen sharing

## How
- New `view.zenMode` shortcut `Ctrl+Shift+Z` registered in the existing shortcut system
- `zenMode` state toggled via the shortcut handler in `App.tsx`, header and status bar wrapped in `AnimatePresence`
- CSS transition on `[data-zen-mode] [data-slot="resizable-panel"]` for smooth sidebar collapse/expand

## Testing
- Toggle zen mode in terminal, editor, and preview tabs

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- Platforms tested: Windows (Should work fine with other platforms)
- Shells tested (if relevant): pwsh


## Screenshots / GIFs
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/a9176bf7-4969-47d6-8e3e-c685aac5a44c" />

## Note Review
This was like 15 or 20 line change, but i forgot to deactivate the formatter so it just formatted every thing by accident 🙂

