### PR TITLE
feat(explorer-search): dedicated search view and resilient large-root scanning

### DIFF
--- a/.pnpm-build-override.json
+++ b/.pnpm-build-override.json
@@ -1,0 +1,1 @@
+{"esbuild":true,"msw":true}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:mac": "sh scripts/build-mac.sh",
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest run",

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Build Terax for macOS, re-sign with the stable local dev identity, install.
+#
+# Why: `tauri build` ad-hoc signs the bundle. Ad-hoc identity changes per build,
+# so the macOS Keychain re-prompts for the AI provider keys every launch. Signing
+# with a stable self-signed cert ("Terax Dev") lets "Always Allow" stick.
+#
+# One-time setup of the cert lives in scripts/setup-mac-signing.sh.
+set -e
+cd "$(dirname "$0")/.."
+
+IDENTITY="Terax Dev"
+APP="src-tauri/target/release/bundle/macos/Terax.app"
+
+if ! security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
+  echo "signing identity '$IDENTITY' not found — run scripts/setup-mac-signing.sh first" >&2
+  exit 1
+fi
+
+# tauri build exits non-zero only on updater-artifact signing (no private key set);
+# the .app bundle is already produced by that point, so guard on its presence instead.
+pnpm tauri build || true
+
+[ -d "$APP" ] || { echo "build failed: $APP not produced" >&2; exit 1; }
+
+codesign --force --deep --sign "$IDENTITY" --identifier app.crynta.terax "$APP"
+codesign --verify --deep --strict "$APP"
+
+rm -rf /Applications/Terax.app
+cp -R "$APP" /Applications/
+xattr -dr com.apple.quarantine /Applications/Terax.app 2>/dev/null || true
+echo "signed + installed: /Applications/Terax.app"

--- a/scripts/setup-mac-signing.sh
+++ b/scripts/setup-mac-signing.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# One-time: create a stable self-signed code-signing identity ("Terax Dev")
+# and import it into the login keychain. Re-runnable (skips if already present).
+#
+# This identity is local-dev only — it is NOT trusted by Gatekeeper (spctl will
+# report "rejected"), which is fine for a locally-built app launched from
+# /Applications. Its purpose is a *stable* signature so the macOS Keychain
+# "Always Allow" for the AI provider keys persists across rebuilds.
+set -e
+
+IDENTITY="Terax Dev"
+WORK="$HOME/.config/terax-signing"
+KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+
+if security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
+  echo "identity '$IDENTITY' already present"
+  exit 0
+fi
+
+mkdir -p "$WORK"
+cd "$WORK"
+
+cat > openssl.cnf <<'EOF'
+[req]
+distinguished_name = dn
+x509_extensions = v3
+prompt = no
+[dn]
+CN = Terax Dev
+[v3]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+EOF
+
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650 -nodes -config openssl.cnf
+# -legacy: macOS `security import` cannot read OpenSSL 3's default PKCS12 MAC.
+openssl pkcs12 -export -legacy -inkey key.pem -in cert.pem -out terax-dev.p12 -name "$IDENTITY" -passout pass:terax
+
+# -T grants codesign/security access to the private key without a GUI prompt.
+security import terax-dev.p12 -k "$KEYCHAIN" -P terax -T /usr/bin/codesign -T /usr/bin/security
+
+echo "identity '$IDENTITY' imported. Now run: scripts/build-mac.sh"

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -1,5 +1,8 @@
 use ignore::WalkBuilder;
 use serde::Serialize;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use super::to_canon;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
@@ -20,12 +23,31 @@ pub struct SearchResult {
     pub hits: Vec<SearchHit>,
     /// True if the scan stopped early (entry budget or hit cap reached).
     pub truncated: bool,
+    pub scanned: usize,
+    pub elapsed_ms: u64,
+    pub budget_exhausted: bool,
+    pub partial_reason: Option<String>,
 }
 
-/// Hard cap on entries the walker is allowed to visit before bailing. Protects
-/// against pathological roots like $HOME where there's no .gitignore and the
-/// tree is effectively unbounded.
-const MAX_SCANNED: usize = 50_000;
+fn build_globset(patterns: Option<&[String]>) -> Result<Option<GlobSet>, String> {
+    let Some(patterns) = patterns else {
+        return Ok(None);
+    };
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+    let mut b = GlobSetBuilder::new();
+    for p in patterns {
+        let g = Glob::new(p).map_err(|e| format!("bad glob {p:?}: {e}"))?;
+        b.add(g);
+    }
+    let set = b.build().map_err(|e| format!("globset build: {e}"))?;
+    Ok(Some(set))
+}
+
+/// Hard cap on entries for fast mode to keep UI responsive on huge roots.
+const FAST_MAX_SCANNED: usize = 20_000;
+const FAST_TIMEOUT_MS: u64 = 250;
 
 /// Directory names pruned unconditionally — they're rarely useful in a
 /// file-explorer search and they dominate scan time when present.
@@ -42,6 +64,8 @@ const PRUNE_DIRS: &[&str] = &[
     "__pycache__",
 ];
 
+static LATEST_SEARCH_REQUEST_ID: AtomicU64 = AtomicU64::new(0);
+
 #[tauri::command]
 pub fn fs_search(
     root: String,
@@ -49,38 +73,66 @@ pub fn fs_search(
     limit: Option<usize>,
     workspace: Option<WorkspaceEnv>,
     show_hidden: Option<bool>,
+    include_paths: Option<Vec<String>>,
+    exclude_paths: Option<Vec<String>>,
+    pass_mode: Option<String>,
+    prune_heavy: Option<bool>,
+    deep_budget_profile: Option<String>,
+    request_id: Option<u64>,
 ) -> Result<SearchResult, String> {
     let q = query.trim().to_lowercase();
     if q.is_empty() {
         return Ok(SearchResult {
             hits: Vec::new(),
             truncated: false,
+            scanned: 0,
+            elapsed_ms: 0,
+            budget_exhausted: false,
+            partial_reason: None,
         });
     }
     let cap = limit.unwrap_or(200).min(1000);
+    let request_id = request_id.unwrap_or(0);
+    if request_id > 0 {
+        LATEST_SEARCH_REQUEST_ID.fetch_max(request_id, Ordering::Relaxed);
+    }
     let show_hidden = show_hidden.unwrap_or(false);
+    let mode = pass_mode.unwrap_or_else(|| "fast".to_string());
+    let deep = mode.eq_ignore_ascii_case("deep");
+    let deep_budget_profile = deep_budget_profile.unwrap_or_else(|| "strict".to_string());
+    let (deep_max_scanned, deep_timeout_ms): (usize, u64) =
+        if deep_budget_profile.eq_ignore_ascii_case("wide") {
+            (250_000, 3_000)
+        } else {
+            (60_000, 700)
+        };
+    let prune_heavy = prune_heavy.unwrap_or(!deep);
     let workspace = WorkspaceEnv::from_option(workspace);
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
     }
 
+    let include_set = build_globset(include_paths.as_deref())?;
+    let exclude_set = build_globset(exclude_paths.as_deref())?;
+
     let mut out: Vec<SearchHit> = Vec::with_capacity(cap.min(64));
     let mut scanned: usize = 0;
     let mut truncated = false;
+    let mut budget_exhausted = false;
+    let mut partial_reason: Option<String> = None;
+    let started = Instant::now();
 
     let walker = WalkBuilder::new(&root_path)
-        .hidden(!show_hidden)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
-        .ignore(true)
+        .hidden(!(show_hidden || deep))
+        .git_ignore(!deep)
+        .git_global(!deep)
+        .git_exclude(!deep)
+        .ignore(!deep)
         .parents(true)
         .follow_links(false)
-        .filter_entry(|dent| {
-            // Prune known-heavy dirs even when no .gitignore is present (e.g.
-            // searching from $HOME).
-            if dent.depth() == 0 {
+        .filter_entry(move |dent| {
+            if !prune_heavy || dent.depth() == 0 {
                 return true;
             }
             match dent.file_name().to_str() {
@@ -91,13 +143,40 @@ pub fn fs_search(
         .build();
 
     for dent in walker.flatten() {
-        scanned += 1;
-        if scanned > MAX_SCANNED {
+        if request_id > 0 && LATEST_SEARCH_REQUEST_ID.load(Ordering::Relaxed) != request_id {
             truncated = true;
+            budget_exhausted = true;
+            partial_reason = Some("cancelled".to_string());
+            break;
+        }
+        scanned += 1;
+        if deep {
+            if scanned > deep_max_scanned {
+                truncated = true;
+                budget_exhausted = true;
+                partial_reason = Some("budget_scanned".to_string());
+                break;
+            }
+            if started.elapsed().as_millis() as u64 > deep_timeout_ms {
+                truncated = true;
+                budget_exhausted = true;
+                partial_reason = Some("budget_timeout".to_string());
+                break;
+            }
+        }
+        if !deep && scanned > FAST_MAX_SCANNED {
+            truncated = true;
+            partial_reason = Some("max_scanned".to_string());
+            break;
+        }
+        if !deep && started.elapsed().as_millis() as u64 > FAST_TIMEOUT_MS {
+            truncated = true;
+            partial_reason = Some("fast_timeout".to_string());
             break;
         }
         if out.len() >= cap {
             truncated = true;
+            partial_reason = Some("max_hits".to_string());
             break;
         }
         let path = dent.path();
@@ -108,7 +187,18 @@ pub fn fs_search(
             Ok(r) => to_canon(r),
             Err(_) => continue,
         };
-        if !rel.to_lowercase().contains(&q) {
+        let abs = display_path(path, &root_path, &root, &workspace);
+        if let Some(set) = include_set.as_ref() {
+            if !set.is_match(&rel) && !set.is_match(&abs) {
+                continue;
+            }
+        }
+        if let Some(set) = exclude_set.as_ref() {
+            if set.is_match(&rel) || set.is_match(&abs) {
+                continue;
+            }
+        }
+        if !rel.to_lowercase().contains(&q) && !abs.to_lowercase().contains(&q) {
             continue;
         }
         let name = path
@@ -117,7 +207,7 @@ pub fn fs_search(
             .unwrap_or_default();
         let is_dir = dent.file_type().map(|t| t.is_dir()).unwrap_or(false);
         out.push(SearchHit {
-            path: display_path(path, &root_path, &root, &workspace),
+            path: abs,
             rel,
             name,
             is_dir,
@@ -134,6 +224,10 @@ pub fn fs_search(
     Ok(SearchResult {
         hits: out,
         truncated,
+        scanned,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        budget_exhausted,
+        partial_reason,
     })
 }
 
@@ -191,7 +285,7 @@ pub fn fs_list_files(
 
     for dent in walker.flatten() {
         scanned += 1;
-        if scanned > MAX_SCANNED {
+        if scanned > FAST_MAX_SCANNED {
             truncated = true;
             break;
         }

--- a/src-tauri/tests/fs_search.rs
+++ b/src-tauri/tests/fs_search.rs
@@ -18,6 +18,9 @@ fn grep_finds_matches_and_returns_relative_paths() {
         None,
         None,
         None,
+        None,
+        None,
+        None,
     )
     .expect("grep");
 
@@ -35,11 +38,11 @@ fn grep_case_insensitive_finds_mixed_case() {
     let fx = FsFixture::new();
     fx.write("a.txt", "Hello World\n");
 
-    let strict = fs_grep("hello".into(), fx.root_str(), None, Some(false), None, None)
+    let strict = fs_grep("hello".into(), fx.root_str(), None, Some(false), None, None, None, None, None)
         .expect("grep");
     assert!(strict.hits.is_empty());
 
-    let loose = fs_grep("hello".into(), fx.root_str(), None, Some(true), None, None)
+    let loose = fs_grep("hello".into(), fx.root_str(), None, Some(true), None, None, None, None, None)
         .expect("grep");
     assert_eq!(loose.hits.len(), 1);
 }
@@ -57,6 +60,9 @@ fn grep_glob_filter_restricts_files() {
         None,
         None,
         None,
+        None,
+        None,
+        None,
     )
     .expect("grep");
 
@@ -71,7 +77,7 @@ fn grep_max_results_truncates() {
         fx.write(&format!("f{i}.txt"), "needle\n");
     }
 
-    let res = fs_grep("needle".into(), fx.root_str(), None, None, Some(3), None)
+    let res = fs_grep("needle".into(), fx.root_str(), None, None, Some(3), None, None, None, None)
         .expect("grep");
 
     assert!(res.hits.len() <= 3);
@@ -81,7 +87,7 @@ fn grep_max_results_truncates() {
 #[test]
 fn grep_empty_pattern_errors() {
     let fx = FsFixture::new();
-    let err = fs_grep("".into(), fx.root_str(), None, None, None, None);
+    let err = fs_grep("".into(), fx.root_str(), None, None, None, None, None, None, None);
     assert!(err.is_err());
 }
 
@@ -90,6 +96,9 @@ fn grep_non_dir_root_errors() {
     let err = fs_grep(
         "x".into(),
         "/this/does/not/exist".into(),
+        None,
+        None,
+        None,
         None,
         None,
         None,
@@ -105,7 +114,7 @@ fn grep_respects_ignore_file() {
     fx.write("ignored.txt", "secret\n");
     fx.write("visible.txt", "secret\n");
 
-    let res = fs_grep("secret".into(), fx.root_str(), None, None, None, None)
+    let res = fs_grep("secret".into(), fx.root_str(), None, None, None, None, None, None, None)
         .expect("grep");
 
     let rels: Vec<&str> = res.hits.iter().map(|h| h.rel.as_str()).collect();
@@ -152,7 +161,7 @@ fn search_substring_matches_filename() {
     fx.write("src/lib.rs", "");
     fx.write("docs/main.md", "");
 
-    let res = fs_search(fx.root_str(), "main".into(), None, None, None).expect("search");
+    let res = fs_search(fx.root_str(), "main".into(), None, None, None, None, None, None, None, None, None).expect("search");
     let rels: Vec<&str> = res.hits.iter().map(|h| h.rel.as_str()).collect();
     assert!(rels.contains(&"src/main.rs"));
     assert!(rels.contains(&"docs/main.md"));
@@ -163,7 +172,7 @@ fn search_substring_matches_filename() {
 fn search_is_case_insensitive() {
     let fx = FsFixture::new();
     fx.write("README.md", "");
-    let res = fs_search(fx.root_str(), "readme".into(), None, None, None).expect("search");
+    let res = fs_search(fx.root_str(), "readme".into(), None, None, None, None, None, None, None, None, None).expect("search");
     assert_eq!(res.hits.len(), 1);
 }
 
@@ -171,7 +180,7 @@ fn search_is_case_insensitive() {
 fn search_empty_query_returns_empty() {
     let fx = FsFixture::new();
     fx.write("a.txt", "");
-    let res = fs_search(fx.root_str(), "   ".into(), None, None, None).expect("search");
+    let res = fs_search(fx.root_str(), "   ".into(), None, None, None, None, None, None, None, None, None).expect("search");
     assert!(res.hits.is_empty());
     assert!(!res.truncated);
 }
@@ -182,7 +191,7 @@ fn search_prunes_node_modules() {
     fx.write("node_modules/lodash/index.js", "");
     fx.write("src/index.js", "");
 
-    let res = fs_search(fx.root_str(), "index".into(), None, None, None).expect("search");
+    let res = fs_search(fx.root_str(), "index".into(), None, None, None, None, None, None, None, None, None).expect("search");
     let rels: Vec<&str> = res.hits.iter().map(|h| h.rel.as_str()).collect();
     assert!(rels.iter().any(|r| r.starts_with("src/")));
     assert!(!rels.iter().any(|r| r.starts_with("node_modules")));
@@ -194,7 +203,7 @@ fn search_ranks_filename_hits_before_path_hits() {
     fx.write("zeta/inner.txt", "");
     fx.write("beta/zeta.txt", "");
 
-    let res = fs_search(fx.root_str(), "zeta".into(), None, None, None).expect("search");
+    let res = fs_search(fx.root_str(), "zeta".into(), None, None, None, None, None, None, None, None, None).expect("search");
     let zeta_file = res
         .hits
         .iter()
@@ -209,6 +218,73 @@ fn search_ranks_filename_hits_before_path_hits() {
         zeta_file < inner_file,
         "filename hit should rank before path-only hit",
     );
+}
+
+#[test]
+fn search_deep_can_include_node_modules() {
+    let fx = FsFixture::new();
+    fx.write("node_modules/lodash/index.js", "");
+    let res = fs_search(
+        fx.root_str(),
+        "index".into(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("deep".into()),
+        Some(false),
+        None,
+        None,
+    )
+    .expect("search");
+    assert!(res.hits.iter().any(|h| h.rel == "node_modules/lodash/index.js"));
+}
+
+#[test]
+fn search_include_exclude_filters_apply() {
+    let fx = FsFixture::new();
+    fx.write("src/main.ts", "");
+    fx.write("src/skip/main.ts", "");
+    let res = fs_search(
+        fx.root_str(),
+        "main".into(),
+        None,
+        None,
+        None,
+        Some(vec!["src/**/*.ts".into()]),
+        Some(vec!["**/skip/**".into()]),
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("search");
+    let rels: Vec<&str> = res.hits.iter().map(|h| h.rel.as_str()).collect();
+    assert!(rels.contains(&"src/main.ts"));
+    assert!(!rels.contains(&"src/skip/main.ts"));
+}
+
+#[test]
+fn grep_include_exclude_filters_apply() {
+    let fx = FsFixture::new();
+    fx.write("src/a.txt", "needle");
+    fx.write("src/skip/b.txt", "needle");
+    let res = fs_grep(
+        "needle".into(),
+        fx.root_str(),
+        None,
+        None,
+        None,
+        None,
+        Some(vec!["src/**/*.txt".into()]),
+        Some(vec!["**/skip/**".into()]),
+        Some("deep".into()),
+    )
+    .expect("grep");
+    let rels: Vec<&str> = res.hits.iter().map(|h| h.rel.as_str()).collect();
+    assert!(rels.contains(&"src/a.txt"));
+    assert!(!rels.contains(&"src/skip/b.txt"));
 }
 
 #[test]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -49,7 +49,12 @@ import {
 import { getLaunchDir } from "@/lib/launchDir";
 import { quoteShellArg } from "@/lib/shellQuote";
 import { useZoom } from "@/lib/useZoom";
-import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
+import {
+  ExplorerPanelSearch,
+  type ExplorerSearchHandle,
+  FileExplorer,
+  type FileExplorerHandle,
+} from "@/modules/explorer";
 import {
   listenFsChanged,
   parentDir,
@@ -75,6 +80,7 @@ import {
 import { SidebarRail, type SidebarViewId } from "@/modules/sidebar";
 import {
   SourceControlPanel,
+  useChildRepos,
   useSourceControl,
 } from "@/modules/source-control";
 import { StatusBar } from "@/modules/statusbar";
@@ -153,7 +159,12 @@ function readSidebarWidth(): number {
 function readSidebarView(): SidebarViewId {
   try {
     const stored = window.localStorage.getItem(SIDEBAR_VIEW_STORAGE_KEY);
-    if (stored === "explorer" || stored === "source-control") return stored;
+    if (
+      stored === "explorer" ||
+      stored === "search" ||
+      stored === "source-control"
+    )
+      return stored;
   } catch {
     // ignore
   }
@@ -213,6 +224,7 @@ export default function App() {
     useState<GitHistorySearchHandle | null>(null);
   const { zoomIn, zoomOut, zoomReset } = useZoom();
   const explorerRef = useRef<FileExplorerHandle>(null);
+  const sidebarSearchRef = useRef<ExplorerSearchHandle>(null);
   const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
 
   const sidebarRef = useRef<PanelImperativeHandle | null>(null);
@@ -302,6 +314,14 @@ export default function App() {
     explorerReturnFocusRef.current =
       active instanceof HTMLElement && active !== document.body ? active : null;
     explorer.focus();
+  }, [persistSidebarView, sidebarView]);
+
+  const openSidebarSearch = useCallback(() => {
+    const panel = sidebarRef.current;
+    const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
+    if (panel && collapsed) panel.resize(`${sidebarWidthRef.current}px`);
+    if (sidebarView !== "search") persistSidebarView("search");
+    requestAnimationFrame(() => sidebarSearchRef.current?.focus());
   }, [persistSidebarView, sidebarView]);
 
   const [home, setHome] = useState<string | null>(null);
@@ -845,6 +865,31 @@ export default function App() {
     [openFileTab],
   );
 
+  const handleOpenSearchTextHit = useCallback(
+    (
+      path: string,
+      line: number,
+      query: string,
+      caseSensitive: boolean,
+      exactWord: boolean,
+    ) => {
+      const tabId = openFileTab(path, true);
+      if (tabId === null) return;
+      explorerRef.current?.revealPath(path);
+      const tryJump = (attempt: number) => {
+        const handle = editorRefs.current.get(tabId);
+        if (handle) {
+          handle.jumpToMatch(line, query, caseSensitive, exactWord);
+          return;
+        }
+        if (attempt >= 20) return;
+        window.setTimeout(() => tryJump(attempt + 1), 25);
+      };
+      tryJump(0);
+    },
+    [openFileTab],
+  );
+
   const handlePathRenamed = useCallback(
     (from: string, to: string) => {
       for (const t of tabs) {
@@ -941,13 +986,30 @@ export default function App() {
   );
   const sourceControlActive =
     hasOpenGitTab || sidebarView === "source-control";
+  const { repos: childRepos, isLoading: childReposLoading } = useChildRepos(
+    sourceControlContextPath,
+    true,
+  );
+  const [selectedRepoRoot, setSelectedRepoRoot] = useState<string | null>(null);
+  useEffect(() => {
+    setSelectedRepoRoot(null);
+  }, [sourceControlContextPath]);
+  useEffect(() => {
+    if (!selectedRepoRoot) return;
+    if (!childRepos.some((r) => r.repoRoot === selectedRepoRoot)) {
+      setSelectedRepoRoot(null);
+    }
+  }, [childRepos, selectedRepoRoot]);
+
+  const hasChildRepos = childRepos.length > 0;
+  const activeSourceRepoRoot = hasChildRepos ? selectedRepoRoot : null;
   // Stable per-session path so switching tabs / cd-ing in a shell does NOT
   // re-fire git IPC for the badge. The active panel resolves the current
   // context path on its own when the user actually opens git.
   const badgeContextPath = workspaceFallbackPath;
   const sourceControlPath = sourceControlActive
-    ? sourceControlContextPath
-    : badgeContextPath;
+    ? (activeSourceRepoRoot ?? (hasChildRepos ? null : sourceControlContextPath))
+    : (activeSourceRepoRoot ?? badgeContextPath);
   const sourceControl = useSourceControl(sourceControlPath, true);
 
   const toggleSourceControl = useCallback(() => {
@@ -1041,6 +1103,7 @@ export default function App() {
       "settings.open": () => void openSettingsWindow(),
       "sidebar.toggle": toggleSidebar,
       "explorer.focus": toggleExplorerFocus,
+      "explorer.search": openSidebarSearch,
       "view.zoomIn": zoomIn,
       "view.zoomOut": zoomOut,
       "view.zoomReset": zoomReset,
@@ -1062,6 +1125,7 @@ export default function App() {
       askFromSelection,
       toggleSidebar,
       toggleExplorerFocus,
+      openSidebarSearch,
       zoomIn,
       zoomOut,
       zoomReset,
@@ -1451,10 +1515,24 @@ export default function App() {
                         onAttachToAgent={handleAttachFileToAgent}
                         onOpenMarkdownPreview={openMarkdownPreview}
                       />
+                    ) : sidebarView === "search" ? (
+                      <ExplorerPanelSearch
+                        ref={sidebarSearchRef}
+                        rootPath={explorerRoot}
+                        onOpenFile={handleOpenFile}
+                        onOpenTextHit={handleOpenSearchTextHit}
+                        onRevealPath={(path) => explorerRef.current?.revealPath(path)}
+                        onRevealInTerminal={cdInNewTab}
+                        onAttachToAgent={handleAttachFileToAgent}
+                      />
                     ) : (
                       <SourceControlPanel
                         open
                         sourceControl={sourceControl}
+                        repoChoices={childRepos}
+                        repoChoiceLoading={childReposLoading}
+                        selectedRepoRoot={selectedRepoRoot}
+                        onSelectRepoRoot={setSelectedRepoRoot}
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}
                       />

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -103,6 +103,12 @@ export type GitLogEntry = {
   deletions: number;
 };
 
+export type GitChildRepoSummary = {
+  repoRoot: string;
+  name: string;
+  branch: string | null;
+};
+
 export type GitCommitFileChange = {
   path: string;
   originalPath: string | null;
@@ -355,6 +361,11 @@ export const native = {
     invoke<string | null>("git_remote_url", {
       repoRoot,
       name: name ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
+  gitListChildRepos: (contextPath: string) =>
+    invoke<GitChildRepoSummary[]>("git_list_child_repos", {
+      contextPath,
       workspace: currentWorkspaceEnv(),
     }),
 };

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -5,7 +5,8 @@ import {
   SearchQuery,
   setSearchQuery,
 } from "@codemirror/search";
-import { keymap } from "@codemirror/view";
+import { EditorSelection } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EDITOR_THEME_EXT } from "./lib/themes";
@@ -45,6 +46,13 @@ export type EditorPaneHandle = {
   /** Apply CodeMirror's undo/redo commands. */
   undo: () => void;
   redo: () => void;
+  jumpToLine: (line: number, column?: number) => void;
+  jumpToMatch: (
+    line: number,
+    query: string,
+    caseSensitive?: boolean,
+    exactWord?: boolean,
+  ) => void;
 };
 
 type Props = {
@@ -262,6 +270,51 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
         redo: () => {
           const view = cmRef.current?.view;
           if (view) redo(view);
+        },
+        jumpToLine: (line: number, _column = 1) => {
+          const view = cmRef.current?.view;
+          if (!view) return;
+          const doc = view.state.doc;
+          const targetLine = Math.max(1, Math.min(line, doc.lines));
+          const lineInfo = doc.line(targetLine);
+          view.dispatch({
+            selection: EditorSelection.range(lineInfo.from, lineInfo.to),
+            effects: EditorView.scrollIntoView(lineInfo.from, { y: "center" }),
+          });
+          view.focus();
+        },
+        jumpToMatch: (
+          line: number,
+          query: string,
+          caseSensitive = false,
+          exactWord = false,
+        ) => {
+          const view = cmRef.current?.view;
+          if (!view) return;
+          const doc = view.state.doc;
+          const targetLine = Math.max(1, Math.min(line, doc.lines));
+          const lineInfo = doc.line(targetLine);
+          const lineText = doc.sliceString(lineInfo.from, lineInfo.to);
+          const flags = caseSensitive ? "g" : "gi";
+          const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+          const pat = exactWord ? `\\b${escaped}\\b` : escaped;
+          const re = new RegExp(pat, flags);
+          const m = re.exec(lineText);
+          if (!m || typeof m.index !== "number") {
+            view.dispatch({
+              selection: EditorSelection.range(lineInfo.from, lineInfo.to),
+              effects: EditorView.scrollIntoView(lineInfo.from, { y: "center" }),
+            });
+            view.focus();
+            return;
+          }
+          const from = lineInfo.from + m.index;
+          const to = from + m[0].length;
+          view.dispatch({
+            selection: EditorSelection.range(from, to),
+            effects: EditorView.scrollIntoView(from, { y: "center" }),
+          });
+          view.focus();
         },
       }),
       [path],

--- a/src/modules/explorer/ExplorerPanelSearch.tsx
+++ b/src/modules/explorer/ExplorerPanelSearch.tsx
@@ -1,0 +1,59 @@
+import { FolderSearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { forwardRef } from "react";
+import { ExplorerSearch, type ExplorerSearchHandle } from "./ExplorerSearch";
+
+type Props = {
+  rootPath: string | null;
+  onOpenFile: (path: string, pin?: boolean) => void;
+  onOpenTextHit: (
+    path: string,
+    line: number,
+    query: string,
+    caseSensitive: boolean,
+    exactWord: boolean,
+  ) => void;
+  onRevealPath?: (path: string) => void;
+  onRevealInTerminal?: (path: string) => void;
+  onAttachToAgent?: (path: string) => void;
+};
+
+export const ExplorerPanelSearch = forwardRef<ExplorerSearchHandle, Props>(
+  function ExplorerPanelSearch(
+    { rootPath, onOpenFile, onOpenTextHit, onRevealPath, onRevealInTerminal, onAttachToAgent },
+    ref,
+  ) {
+    if (!rootPath) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+          <HugeiconsIcon
+            icon={FolderSearchIcon}
+            size={24}
+            strokeWidth={1.5}
+            className="text-muted-foreground"
+          />
+          <div className="text-xs text-muted-foreground">No current directory</div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="flex h-8 shrink-0 items-center gap-1 border-b border-border/60 px-2">
+          <span className="px-1.5 text-xs font-medium text-foreground/80">Search</span>
+        </div>
+        <ExplorerSearch
+          ref={ref}
+          rootPath={rootPath}
+          onOpenFile={onOpenFile}
+          onOpenTextHit={onOpenTextHit}
+          onRevealPath={onRevealPath}
+          open
+          onRequestClose={() => {}}
+          onRevealInTerminal={onRevealInTerminal}
+          onAttachToAgent={onAttachToAgent}
+        />
+      </div>
+    );
+  },
+);

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -8,6 +8,8 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
   Cancel01Icon,
   Folder01Icon,
   Search01Icon,
@@ -16,13 +18,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { motion } from "motion/react";
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { fileIconUrl } from "./lib/iconResolver";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
@@ -39,14 +35,42 @@ type SearchHit = {
 type SearchResult = {
   hits: SearchHit[];
   truncated: boolean;
+  scanned: number;
+  elapsed_ms: number;
+  budget_exhausted: boolean;
+  partial_reason: string | null;
 };
 
+type GrepHit = {
+  path: string;
+  rel: string;
+  line: number;
+  text: string;
+};
+
+type GrepResult = {
+  hits: GrepHit[];
+  truncated: boolean;
+  files_scanned: number;
+};
+
+type SearchTab = "files" | "text";
+
 const MIN_QUERY_LEN = 2;
-const DEBOUNCE_MS = 300;
+const DEEP_QUERY_MIN_LEN = 6;
+const SNIPPET_WINDOW = 40;
 
 type Props = {
   rootPath: string;
-  onOpenFile: (path: string) => void;
+  onOpenFile: (path: string, pin?: boolean) => void;
+  onOpenTextHit: (
+    path: string,
+    line: number,
+    query: string,
+    caseSensitive: boolean,
+    exactWord: boolean,
+  ) => void;
+  onRevealPath?: (path: string) => void;
   open: boolean;
   onRequestClose: () => void;
   onActiveChange?: (active: boolean) => void;
@@ -59,28 +83,100 @@ export type ExplorerSearchHandle = {
   isFocused: () => boolean;
 };
 
-export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function ExplorerSearch({
-  rootPath,
-  onOpenFile,
-  open,
-  onRequestClose,
-  onActiveChange,
-  onRevealInTerminal,
-  onAttachToAgent,
-}: Props,
+function parsePatterns(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findSnippetStart(text: string, query: string, caseSensitive: boolean, exactWord: boolean): number {
+  if (!query) return 0;
+  const flags = caseSensitive ? "g" : "gi";
+  const pat = exactWord ? `\\b${escapeRegex(query)}\\b` : escapeRegex(query);
+  const re = new RegExp(pat, flags);
+  const m = re.exec(text);
+  if (!m || typeof m.index !== "number") return 0;
+  return Math.max(0, m.index - SNIPPET_WINDOW);
+}
+
+function buildSnippet(text: string, query: string, caseSensitive: boolean, exactWord: boolean): string {
+  if (!text) return "";
+  const start = findSnippetStart(text, query, caseSensitive, exactWord);
+  const end = Math.min(text.length, start + SNIPPET_WINDOW * 2);
+  const body = text.slice(start, end);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < text.length ? "..." : "";
+  return `${prefix}${body}${suffix}`;
+}
+
+function splitWithHighlight(snippet: string, query: string, caseSensitive: boolean, exactWord: boolean): Array<{ text: string; hit: boolean }> {
+  if (!query || !snippet) return [{ text: snippet, hit: false }];
+  const flags = caseSensitive ? "g" : "gi";
+  const pat = exactWord ? `\\b${escapeRegex(query)}\\b` : escapeRegex(query);
+  const re = new RegExp(pat, flags);
+  const parts: Array<{ text: string; hit: boolean }> = [];
+  let last = 0;
+  for (const m of snippet.matchAll(re)) {
+    const idx = m.index ?? -1;
+    if (idx < 0) continue;
+    if (idx > last) parts.push({ text: snippet.slice(last, idx), hit: false });
+    parts.push({ text: m[0], hit: true });
+    last = idx + m[0].length;
+  }
+  if (last < snippet.length) parts.push({ text: snippet.slice(last), hit: false });
+  return parts.length > 0 ? parts : [{ text: snippet, hit: false }];
+}
+
+export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function ExplorerSearch(
+  {
+    rootPath,
+    onOpenFile,
+    onOpenTextHit,
+    onRevealPath,
+    open,
+    onRequestClose,
+    onActiveChange,
+    onRevealInTerminal,
+    onAttachToAgent,
+  }: Props,
   ref,
 ) {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchHit[]>([]);
+  const [submittedQuery, setSubmittedQuery] = useState("");
+  const [tab, setTab] = useState<SearchTab>("files");
+  const [submittedTab, setSubmittedTab] = useState<SearchTab>("files");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [exactWord, setExactWord] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [includeRaw, setIncludeRaw] = useState("");
+  const [excludeRaw, setExcludeRaw] = useState("");
+  const [submittedCaseSensitive, setSubmittedCaseSensitive] = useState(false);
+  const [submittedExactWord, setSubmittedExactWord] = useState(false);
+  const [submittedIncludeRaw, setSubmittedIncludeRaw] = useState("");
+  const [submittedExcludeRaw, setSubmittedExcludeRaw] = useState("");
+  const [runNonce, setRunNonce] = useState(0);
+  const [fileResults, setFileResults] = useState<SearchHit[]>([]);
+  const [textResults, setTextResults] = useState<GrepHit[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searching, setSearching] = useState(false);
   const [truncated, setTruncated] = useState(false);
+  const [deepBlocked, setDeepBlocked] = useState(false);
+  const [runningDeep, setRunningDeep] = useState(false);
+  const [partialReason, setPartialReason] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastKeyboardNavAt = useRef(0);
+  const requestId = useRef(0);
+  const forceDeepRef = useRef(false);
 
-  const active = query.trim().length > 0;
+  const active = submittedQuery.trim().length > 0;
+  const visibleCount = tab === "files" ? fileResults.length : textResults.length;
 
   useEffect(() => {
     onActiveChange?.(active);
@@ -89,57 +185,118 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   useEffect(() => {
     if (open) {
       inputRef.current?.focus();
-    } else {
-      setQuery("");
-      setResults([]);
-      setSelectedIndex(0);
-      setSearching(false);
-      setTruncated(false);
     }
   }, [open]);
 
   useEffect(() => {
-    const q = query.trim();
-    if (q.length < MIN_QUERY_LEN) {
-      setResults([]);
-      setSelectedIndex(0);
-      setSearching(false);
-      setTruncated(false);
+    const q = submittedQuery.trim();
+    if (q.length < MIN_QUERY_LEN || runNonce === 0) {
       return;
     }
+
+    const includePaths = parsePatterns(submittedIncludeRaw);
+    const excludePaths = parsePatterns(submittedExcludeRaw);
+    const id = ++requestId.current;
+    const forceDeep = forceDeepRef.current;
+    forceDeepRef.current = false;
     setSearching(true);
-    let alive = true;
-    const handle = setTimeout(async () => {
-      try {
-        const res = await invoke<SearchResult>("fs_search", {
+    setDeepBlocked(false);
+    setRunningDeep(false);
+    setPartialReason(null);
+
+    const runPass = async (mode: "fast" | "deep") => {
+      if (submittedTab === "files") {
+        return invoke<SearchResult>("fs_search", {
           root: rootPath,
           query: q,
-          limit: 200,
+          limit: 100,
           showHidden,
           workspace: currentWorkspaceEnv(),
+          includePaths,
+          excludePaths,
+          passMode: mode,
+          pruneHeavy: mode === "fast",
+          deepBudgetProfile: mode === "deep" && forceDeep ? "wide" : "strict",
+          requestId: id,
         });
-        if (alive) {
-          setResults(res.hits);
-          setTruncated(res.truncated);
-          setSelectedIndex(0);
-        }
-      } catch (e) {
-        if (alive) {
-          console.error("fs_search failed:", e);
-          setResults([]);
-          setTruncated(false);
-          setSelectedIndex(0);
-        }
-      } finally {
-        if (alive) setSearching(false);
       }
-    }, DEBOUNCE_MS);
-
-    return () => {
-      alive = false;
-      clearTimeout(handle);
+      const pattern = submittedExactWord ? `\\b${escapeRegex(q)}\\b` : escapeRegex(q);
+      return invoke<GrepResult>("fs_grep", {
+        pattern,
+        root: rootPath,
+        caseInsensitive: !submittedCaseSensitive,
+        maxResults: 100,
+        workspace: currentWorkspaceEnv(),
+        includePaths,
+        excludePaths,
+        passMode: mode,
+      });
     };
-  }, [query, rootPath, showHidden]);
+
+    void (async () => {
+      try {
+        const fast = await runPass("fast");
+        if (id !== requestId.current) return;
+        let finalRes = fast;
+        if (fast.truncated) {
+          const allowAutoDeep = q.length >= DEEP_QUERY_MIN_LEN;
+          if (forceDeep || allowAutoDeep) {
+            setRunningDeep(true);
+            finalRes = await runPass("deep");
+            if (id !== requestId.current) return;
+          } else {
+            setDeepBlocked(tab === "text");
+          }
+        }
+        if (submittedTab === "files") {
+          const raw = (finalRes as SearchResult).hits;
+          const needle = submittedCaseSensitive ? q : q.toLowerCase();
+          const exact = submittedExactWord
+            ? new RegExp(`\\b${escapeRegex(q)}\\b`, submittedCaseSensitive ? "" : "i")
+            : null;
+          const filtered = raw.filter((h) => {
+            const rel = submittedCaseSensitive ? h.rel : h.rel.toLowerCase();
+            const abs = submittedCaseSensitive ? h.path : h.path.toLowerCase();
+            if (exact) return exact.test(h.rel) || exact.test(h.path);
+            return rel.includes(needle) || abs.includes(needle);
+          });
+          setFileResults(filtered);
+          setTextResults([]);
+        } else {
+          setTextResults((finalRes as GrepResult).hits);
+          setFileResults([]);
+        }
+        setTruncated(finalRes.truncated);
+        if (submittedTab === "files") {
+          setPartialReason((finalRes as SearchResult).partial_reason ?? null);
+        }
+        setSelectedIndex(0);
+      } catch (e) {
+        if (id !== requestId.current) return;
+        console.error("explorer search failed:", e);
+        setFileResults([]);
+        setTextResults([]);
+        setTruncated(false);
+        setPartialReason(null);
+        setSelectedIndex(0);
+      } finally {
+        if (id === requestId.current) {
+          setSearching(false);
+          setRunningDeep(false);
+        }
+      }
+    })();
+  }, [
+    rootPath,
+    runNonce,
+    showHidden,
+    submittedExcludeRaw,
+    submittedIncludeRaw,
+    submittedCaseSensitive,
+    submittedExactWord,
+    submittedQuery,
+    submittedTab,
+  ]);
 
   useImperativeHandle(
     ref,
@@ -155,89 +312,213 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   );
 
   useEffect(() => {
-    if (active && results.length > 0) {
+    if (active && visibleCount > 0) {
       const el = scrollRef.current?.querySelector(`[data-index="${selectedIndex}"]`);
       el?.scrollIntoView({ block: "nearest" });
     }
-  }, [selectedIndex, results, active]);
+  }, [selectedIndex, visibleCount, active]);
 
-  const handleSelect = (hit: SearchHit) => {
-    if (!hit.is_dir) {
-      onOpenFile(hit.path);
+  const handleSelect = (index: number) => {
+    if (tab === "files") {
+      const hit = fileResults[index];
+      if (!hit || hit.is_dir) return;
+      onRevealPath?.(hit.path);
+      onOpenFile(hit.path, false);
+      return;
     }
+    const hit = textResults[index];
+    if (!hit) return;
+    onRevealPath?.(hit.path);
+    onOpenTextHit(
+      hit.path,
+      hit.line,
+      submittedQuery,
+      submittedCaseSensitive,
+      submittedExactWord,
+    );
+  };
+
+  const submitSearch = () => {
+    const nextQuery = query.trim();
+    if (nextQuery.length < MIN_QUERY_LEN) return false;
+    setSubmittedTab(tab);
+    setSubmittedQuery(nextQuery);
+    setSubmittedCaseSensitive(caseSensitive);
+    setSubmittedExactWord(exactWord);
+    setSubmittedIncludeRaw(includeRaw);
+    setSubmittedExcludeRaw(excludeRaw);
+    setRunNonce((n) => n + 1);
+    return true;
+  };
+
+  const hasUnsubmittedChanges =
+    query.trim() !== submittedQuery ||
+    caseSensitive !== submittedCaseSensitive ||
+    exactWord !== submittedExactWord ||
+    includeRaw !== submittedIncludeRaw ||
+    excludeRaw !== submittedExcludeRaw;
+
+  const runDeepAnyway = () => {
+    forceDeepRef.current = true;
+    setRunNonce((n) => n + 1);
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       {open ? (
         <motion.div
-          className="relative shrink-0 px-2 py-1.5"
+          className="shrink-0 border-b border-border/60 px-2 py-1.5"
           initial={{ opacity: 0, transform: "translateY(-15px)" }}
           animate={{ opacity: 1, transform: "translateY(0px)" }}
         >
-          <HugeiconsIcon
-            icon={Search01Icon}
-            size={13}
-            strokeWidth={2}
-            className="absolute top-1/2 left-4 -translate-y-1/2 text-muted-foreground"
-          />
-          <Input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                e.preventDefault();
-                e.stopPropagation();
-                onRequestClose();
-                return;
-              }
-              if (results.length > 0) {
-                if (e.key === "ArrowDown") {
-                  e.preventDefault();
-                  lastKeyboardNavAt.current = Date.now();
-                  setSelectedIndex((prev) => (prev + 1) % results.length);
-                } else if (e.key === "ArrowUp") {
-                  e.preventDefault();
-                  lastKeyboardNavAt.current = Date.now();
-                  setSelectedIndex(
-                    (prev) => (prev - 1 + results.length) % results.length,
-                  );
-                } else if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleSelect(results[selectedIndex]);
-                }
-              }
-            }}
-            placeholder="Search files…"
-            className="h-7 pr-7 pl-6.5 text-xs"
-          />
-          {query ? (
+          <div className="mb-1 flex items-center gap-1">
             <button
               type="button"
-              onClick={() => setQuery("")}
-              className="absolute top-1/2 right-3.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-              aria-label="Clear search"
+              className={cn(
+                "h-6 rounded px-2 text-xs",
+                tab === "files" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => setTab("files")}
             >
-              <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
+              Files
             </button>
-          ) : null}
+            <button
+              type="button"
+              className={cn(
+                "h-6 rounded px-2 text-xs",
+                tab === "text" ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => setTab("text")}
+            >
+              Text
+            </button>
+          </div>
+          <div className="relative">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              size={13}
+              strokeWidth={2}
+              className="absolute top-1/2 left-2.5 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onRequestClose();
+                  return;
+                }
+                if (visibleCount > 0) {
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    lastKeyboardNavAt.current = Date.now();
+                    setSelectedIndex((prev) => (prev + 1) % visibleCount);
+                  } else if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    lastKeyboardNavAt.current = Date.now();
+                    setSelectedIndex((prev) => (prev - 1 + visibleCount) % visibleCount);
+                  } else if (e.key === "Enter") {
+                    e.preventDefault();
+                    if (hasUnsubmittedChanges) submitSearch();
+                    else handleSelect(selectedIndex);
+                  }
+                } else if (e.key === "Enter") {
+                  e.preventDefault();
+                  submitSearch();
+                }
+              }}
+              placeholder={tab === "files" ? "Search files..." : "Search file contents..."}
+              className="h-7 pr-24 pl-6.5 text-[11px] placeholder:text-muted-foreground/45"
+            />
+            <div className="absolute top-1/2 right-7 flex -translate-y-1/2 items-center gap-0.5">
+              <button
+                type="button"
+                aria-label="Toggle case sensitive"
+                title="Case sensitive"
+                onClick={() => setCaseSensitive((v) => !v)}
+                className={cn(
+                  "rounded px-1 py-0.5 text-[9px] font-medium",
+                  caseSensitive ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                Aa
+              </button>
+              <button
+                type="button"
+                aria-label="Toggle exact word"
+                title="Exact word"
+                onClick={() => setExactWord((v) => !v)}
+                className={cn(
+                  "rounded px-1 py-0.5 text-[9px] font-medium",
+                  exactWord ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                W
+              </button>
+            </div>
+            {query ? (
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                className="absolute top-1/2 right-2.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                aria-label="Clear search"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
+              </button>
+            ) : null}
+          </div>
+          <div className="mt-1">
+            <button
+              type="button"
+              onClick={() => setFiltersOpen((v) => !v)}
+              className="flex h-6 w-full items-center gap-1 rounded px-1 text-[11px] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              aria-expanded={filtersOpen}
+            >
+              <HugeiconsIcon
+                icon={filtersOpen ? ArrowDown01Icon : ArrowRight01Icon}
+                size={10}
+                strokeWidth={2}
+              />
+              Filters
+            </button>
+            {filtersOpen ? (
+              <div className="mt-1 space-y-1">
+                <Input
+                  value={includeRaw}
+                  onChange={(e) => setIncludeRaw(e.target.value)}
+                  placeholder="Include globs"
+                  className="h-6 text-[10px] text-muted-foreground/70 placeholder:text-muted-foreground/45"
+                />
+                <Input
+                  value={excludeRaw}
+                  onChange={(e) => setExcludeRaw(e.target.value)}
+                  placeholder="Exclude globs"
+                  className="h-6 text-[10px] text-muted-foreground/70 placeholder:text-muted-foreground/45"
+                />
+              </div>
+            ) : null}
+          </div>
         </motion.div>
       ) : null}
 
       {active ? (
         <ScrollArea className="min-h-0 flex-1">
-          <div className="py-1" ref={scrollRef}>
-            {searching && results.length === 0 ? (
-              <div className="px-3 py-2 text-[11px] text-muted-foreground">
-                Searching…
-              </div>
-            ) : results.length === 0 ? (
-              <div className="px-3 py-2 text-[11px] text-muted-foreground">
-                No matches
-              </div>
-            ) : (
-              results.map((hit, index) => {
+          <div className="relative py-1" ref={scrollRef}>
+            {tab === "text" ? (
+              <div
+                className="pointer-events-none absolute top-0 right-0 bottom-0 w-px bg-border/60"
+                aria-hidden
+              />
+            ) : null}
+            {searching && visibleCount === 0 ? (
+              <div className="px-3 py-2 text-[11px] text-muted-foreground">Searching...</div>
+            ) : visibleCount === 0 ? (
+              <div className="px-3 py-2 text-[11px] text-muted-foreground">No matches</div>
+            ) : tab === "files" ? (
+              fileResults.map((hit, index) => {
                 const url = hit.is_dir ? null : fileIconUrl(hit.name);
                 const isSelected = index === selectedIndex;
                 return (
@@ -246,15 +527,13 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                       <button
                         type="button"
                         data-index={index}
-                        onClick={() => handleSelect(hit)}
+                        onClick={() => handleSelect(index)}
                         onMouseEnter={() => {
-                          if (Date.now() - lastKeyboardNavAt.current > 250) {
-                            setSelectedIndex(index);
-                          }
+                          if (Date.now() - lastKeyboardNavAt.current > 250) setSelectedIndex(index);
                         }}
                         className={cn(
                           "flex w-full items-center gap-1.5 px-2 py-1 text-left text-xs transition-colors",
-                          isSelected ? "bg-accent text-foreground" : "hover:bg-accent/50 text-foreground/80"
+                          isSelected ? "bg-accent text-foreground" : "text-foreground/80 hover:bg-accent/50",
                         )}
                         title={hit.path}
                       >
@@ -269,56 +548,130 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                           />
                         )}
                         <span className="truncate">{hit.name}</span>
-                        <span className="ml-auto truncate text-[10px] text-muted-foreground">
-                          {hit.rel}
-                        </span>
+                        <span className="ml-auto truncate text-[10px] text-muted-foreground">{hit.rel}</span>
                       </button>
                     </ContextMenuTrigger>
                     <ContextMenuContent className={COMPACT_CONTENT}>
                       {!hit.is_dir && (
-                        <ContextMenuItem
-                          className={COMPACT_ITEM}
-                          onSelect={() => onOpenFile(hit.path)}
-                        >
+                        <ContextMenuItem className={COMPACT_ITEM} onSelect={() => onOpenFile(hit.path, true)}>
                           Open
                         </ContextMenuItem>
                       )}
                       {hit.is_dir && onRevealInTerminal && (
-                        <ContextMenuItem
-                          className={COMPACT_ITEM}
-                          onSelect={() => onRevealInTerminal(hit.path)}
-                        >
+                        <ContextMenuItem className={COMPACT_ITEM} onSelect={() => onRevealInTerminal(hit.path)}>
                           Open in Terminal
                         </ContextMenuItem>
                       )}
-                      <ContextMenuItem
-                        className={COMPACT_ITEM}
-                        onSelect={() => void revealInFinder(hit.path)}
-                      >
+                      <ContextMenuItem className={COMPACT_ITEM} onSelect={() => void revealInFinder(hit.path)}>
                         Reveal in Finder
                       </ContextMenuItem>
                       <ContextMenuSeparator />
-                      <ContextMenuItem
-                        className={COMPACT_ITEM}
-                        onSelect={() => void copyToClipboard(hit.path)}
-                      >
+                      <ContextMenuItem className={COMPACT_ITEM} onSelect={() => void copyToClipboard(hit.path)}>
                         Copy Path
                       </ContextMenuItem>
                       <ContextMenuSeparator />
-                      <ContextMenuItem
-                        className={COMPACT_ITEM}
-                        onSelect={() => onAttachToAgent?.(hit.path)}
-                      >
+                      <ContextMenuItem className={COMPACT_ITEM} onSelect={() => onAttachToAgent?.(hit.path)}>
                         Attach to Agent
                       </ContextMenuItem>
                     </ContextMenuContent>
                   </ContextMenu>
                 );
               })
+            ) : (
+              textResults.map((hit, index) => {
+                const isSelected = index === selectedIndex;
+                const snippet = buildSnippet(
+                  hit.text,
+                  submittedQuery,
+                  submittedCaseSensitive,
+                  submittedExactWord,
+                );
+                const parts = splitWithHighlight(
+                  snippet,
+                  submittedQuery,
+                  submittedCaseSensitive,
+                  submittedExactWord,
+                );
+                return (
+                  <button
+                    key={`${hit.path}:${hit.line}:${index}`}
+                    type="button"
+                    data-index={index}
+                    onMouseDown={(e) => {
+                      // Keep this row behaving like a single clickable item,
+                      // not a text-selection target.
+                      e.preventDefault();
+                    }}
+                    onClick={() => handleSelect(index)}
+                    onMouseEnter={() => {
+                      if (Date.now() - lastKeyboardNavAt.current > 250) setSelectedIndex(index);
+                    }}
+                    className={cn(
+                      "flex w-full cursor-pointer select-none flex-col items-start gap-0.5 py-1.5 pr-0 pl-2 text-left text-[11px] transition-colors",
+                      isSelected ? "bg-accent text-foreground" : "text-foreground/80 hover:bg-accent/50",
+                    )}
+                    title={`${hit.path}:${hit.line}`}
+                  >
+                    <div className="relative w-full">
+                      <span className="block min-w-0 truncate pr-[210px] font-medium">
+                        {hit.rel}
+                      </span>
+                      <span
+                        className="absolute top-0 right-0 w-[200px] min-w-[88px] truncate text-right text-[10px] text-muted-foreground"
+                        dir="rtl"
+                        title={`${hit.rel}:${hit.line}`}
+                      >
+                        {hit.rel}:{hit.line}
+                      </span>
+                    </div>
+                    <span className="w-full truncate text-[11px] text-foreground/70">
+                      {parts.map((part, i) => (
+                        <span
+                          key={`${i}:${part.text}`}
+                          className={part.hit ? "rounded bg-yellow-400/30 text-foreground" : undefined}
+                        >
+                          {part.text}
+                        </span>
+                      ))}
+                    </span>
+                  </button>
+                );
+              })
             )}
-            {truncated && results.length > 0 ? (
+            {runningDeep ? (
+              <div className="px-3 py-1.5 text-[10px] text-muted-foreground">Running deep search...</div>
+            ) : null}
+            {tab === "files" && partialReason === "budget_timeout" ? (
               <div className="px-3 py-1.5 text-[10px] text-muted-foreground">
-                Showing partial results — refine your query.
+                Partial results: deep search hit time budget.
+              </div>
+            ) : null}
+            {tab === "text" && deepBlocked ? (
+              <div className="flex items-center gap-2 px-3 py-1.5 text-[10px] text-muted-foreground">
+                Query too short for auto deep search.
+                <button
+                  type="button"
+                  onClick={runDeepAnyway}
+                  className="rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-foreground hover:bg-accent"
+                >
+                  Run Deep Anyway
+                </button>
+              </div>
+            ) : null}
+            {truncated && visibleCount > 0 && !runningDeep ? (
+              <div className="flex items-center gap-2 px-3 py-1.5 text-[10px] text-muted-foreground">
+                <span>Showing first 100 results.</span>
+                {tab === "files" &&
+                (partialReason === "budget_timeout" ||
+                  partialReason === "budget_scanned") ? (
+                  <button
+                    type="button"
+                    onClick={runDeepAnyway}
+                    className="rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-foreground hover:bg-accent"
+                  >
+                    Search Deeper
+                  </button>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -11,7 +11,6 @@ import {
   Folder01Icon,
   FolderAddIcon,
   Refresh01Icon,
-  Search01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -24,18 +23,17 @@ import {
   useRef,
   useState,
 } from "react";
-import { ExplorerSearch, type ExplorerSearchHandle } from "./ExplorerSearch";
 import { EntryRow, PendingRow, StatusRow } from "./TreeRow";
 import { InlineInput } from "./InlineInput";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
-import { useGlobalShortcuts } from "@/modules/shortcuts";
 
 export type FileExplorerHandle = {
   focus: () => void;
   isFocused: () => boolean;
+  revealPath: (path: string) => void;
 };
 
 type Props = {
@@ -158,9 +156,6 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
   ) {
     const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
     const [selectedPath, setSelectedPath] = useState<string | null>(null);
-    const [isSearchOpen, setIsSearchOpen] = useState(false);
-    const [isSearchActive, setIsSearchActive] = useState(false);
-    const searchRef = useRef<ExplorerSearchHandle>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -198,6 +193,23 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       [entryIndexByPath, virtualizer],
     );
 
+    const revealPath = useCallback(
+      (path: string) => {
+        if (!rootPath || !path.startsWith(rootPath)) return;
+        const rel = path.slice(rootPath.length).replace(/^\/+/, "");
+        if (!rel) return;
+        const segments = rel.split("/").filter(Boolean);
+        let cursor = rootPath;
+        for (let i = 0; i < segments.length - 1; i++) {
+          cursor = tree.joinPath(cursor, segments[i]);
+          tree.expand(cursor);
+        }
+        setSelectedPath(path);
+        requestAnimationFrame(() => scrollEntryIntoView(path));
+      },
+      [rootPath, scrollEntryIntoView, tree],
+    );
+
     useImperativeHandle(
       ref,
       () => ({
@@ -215,20 +227,10 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
           const active = document.activeElement;
           return active instanceof Node && c.contains(active);
         },
+        revealPath,
       }),
-      [entryPaths, scrollEntryIntoView, selectedPath],
+      [entryPaths, revealPath, scrollEntryIntoView, selectedPath],
     );
-
-    useGlobalShortcuts({
-      "explorer.search": () => {
-        if (searchRef.current?.isFocused()) {
-          setIsSearchOpen(false);
-          return;
-        }
-        setIsSearchOpen(true);
-        searchRef.current?.focus();
-      },
-    });
 
     if (!rootPath) {
       return (
@@ -251,7 +253,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       tree.pendingCreate?.parentPath === rootPath ? tree.pendingCreate : null;
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (tree.renaming || tree.pendingCreate || isSearchOpen) return;
+      if (tree.renaming || tree.pendingCreate) return;
       const target = e.target as HTMLElement;
       if (
         target.tagName === "INPUT" ||
@@ -388,17 +390,6 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
             variant="ghost"
             size="icon"
             className="size-6 text-muted-foreground hover:text-foreground"
-            onClick={() => setIsSearchOpen((v) => !v)}
-            title="Search files"
-            aria-label="Search files"
-          >
-            <HugeiconsIcon icon={Search01Icon} size={13} strokeWidth={2} />
-          </Button>
-
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-6 text-muted-foreground hover:text-foreground"
             onClick={() => tree.beginCreate(rootPath, "file")}
             title="New file"
           >
@@ -424,19 +415,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
           </Button>
         </div>
 
-        <ExplorerSearch
-          ref={searchRef}
-          rootPath={rootPath}
-          onOpenFile={onOpenFile}
-          open={isSearchOpen}
-          onRequestClose={() => setIsSearchOpen(false)}
-          onActiveChange={setIsSearchActive}
-          onRevealInTerminal={onRevealInTerminal}
-          onAttachToAgent={onAttachToAgent}
-        />
-
-        {!isSearchActive ? (
-          <ContextMenu>
+        <ContextMenu>
             <ContextMenuTrigger asChild>
               <div
                 ref={scrollRef}
@@ -557,7 +536,6 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
               </ContextMenuItem>
             </ContextMenuContent>
           </ContextMenu>
-        ) : null}
       </div>
     );
   },

--- a/src/modules/explorer/index.ts
+++ b/src/modules/explorer/index.ts
@@ -1,2 +1,3 @@
 export { FileExplorer, type FileExplorerHandle } from "./FileExplorer";
-export { ExplorerSearch } from "./ExplorerSearch";
+export { ExplorerSearch, type ExplorerSearchHandle } from "./ExplorerSearch";
+export { ExplorerPanelSearch } from "./ExplorerPanelSearch";

--- a/src/modules/sidebar/SidebarRail.tsx
+++ b/src/modules/sidebar/SidebarRail.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { FolderGitTwoIcon, FolderTreeIcon } from "@hugeicons/core-free-icons";
+import { FolderGitTwoIcon, FolderSearchIcon, FolderTreeIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SidebarViewId } from "./types";
 
@@ -21,6 +21,7 @@ type Props = {
 export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
   const items: RailItem[] = [
     { id: "explorer", label: "Files", icon: FolderTreeIcon },
+    { id: "search", label: "Search", icon: FolderSearchIcon },
     {
       id: "source-control",
       label: "Source Control",

--- a/src/modules/sidebar/types.ts
+++ b/src/modules/sidebar/types.ts
@@ -1,1 +1,1 @@
-export type SidebarViewId = "explorer" | "source-control";
+export type SidebarViewId = "explorer" | "search" | "source-control";

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -47,6 +47,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import type { GitChildRepoSummary } from "@/modules/ai/lib/native";
 import type { SourceControlSummary } from "./useSourceControl";
 import {
   useSourceControlPanel,
@@ -57,6 +58,10 @@ import {
 type Props = {
   open: boolean;
   sourceControl: SourceControlSummary;
+  repoChoices?: GitChildRepoSummary[];
+  repoChoiceLoading?: boolean;
+  selectedRepoRoot?: string | null;
+  onSelectRepoRoot?: (repoRoot: string | null) => void;
   onOpenGitGraph?: () => void;
   onOpenDiff: (input: {
     path: string;

--- a/src/modules/source-control/index.ts
+++ b/src/modules/source-control/index.ts
@@ -1,4 +1,5 @@
 export { SourceControlPanel } from "./SourceControlPanelLazy";
+export { useChildRepos } from "./useChildRepos";
 export {
   getSourceControlRemoteIndicator,
   useSourceControl,

--- a/src/modules/source-control/useChildRepos.ts
+++ b/src/modules/source-control/useChildRepos.ts
@@ -1,0 +1,42 @@
+import { native, type GitChildRepoSummary } from "@/modules/ai/lib/native";
+import { useEffect, useRef, useState } from "react";
+
+export function useChildRepos(contextPath: string | null, enabled = true): {
+  repos: GitChildRepoSummary[];
+  isLoading: boolean;
+  error: string | null;
+} {
+  const [repos, setRepos] = useState<GitChildRepoSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reqIdRef = useRef(0);
+
+  useEffect(() => {
+    const reqId = ++reqIdRef.current;
+    if (!enabled || !contextPath) {
+      setRepos([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    native
+      .gitListChildRepos(contextPath)
+      .then((next) => {
+        if (reqId !== reqIdRef.current) return;
+        setRepos(next);
+      })
+      .catch((e) => {
+        if (reqId !== reqIdRef.current) return;
+        setRepos([]);
+        setError(typeof e === "string" ? e : String(e));
+      })
+      .finally(() => {
+        if (reqId !== reqIdRef.current) return;
+        setIsLoading(false);
+      });
+  }, [contextPath, enabled]);
+
+  return { repos, isLoading, error };
+}

--- a/tools.yaml
+++ b/tools.yaml
@@ -1,0 +1,937 @@
+---
+version: v1.2
+tools:
+  ## Access Groups
+  ## An access group is the equivalent of an Endpoint Group in Portainer.
+  ## ------------------------------------------------------------
+  - name: listAccessGroups
+    description: List all available access groups
+    annotations:
+      title: List Access Groups
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: createAccessGroup
+    description: Create a new access group. Use access groups when you want to define
+      accesses on more than one environment. Otherwise, define the accesses on
+      the environment level.
+    parameters:
+      - name: name
+        description: The name of the access group
+        type: string
+        required: true
+      - name: environmentIds
+        description: "The IDs of the environments that are part of the access group.
+          Must include all the environment IDs that are part of the group - this
+          includes new environments and the existing environments that are
+          already associated with the group. Example: [1, 2, 3]"
+        type: array
+        items:
+          type: number
+    annotations:
+      title: Create Access Group
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+  - name: updateAccessGroupName
+    description: Update the name of an existing access group.
+    parameters:
+      - name: id
+        description: The ID of the access group to update
+        type: number
+        required: true
+      - name: name
+        description: The name of the access group
+        type: string
+        required: true
+    annotations:
+      title: Update Access Group Name
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateAccessGroupUserAccesses
+    description: Update the user accesses of an existing access group.
+    parameters:
+      - name: id
+        description: The ID of the access group to update
+        type: number
+        required: true
+      - name: userAccesses
+        description: "The user accesses that are associated with all the environments in
+          the access group. The ID is the user ID of the user in Portainer.
+          Example: [{id: 1, access: 'environment_administrator'}, {id: 2,
+          access: 'standard_user'}]"
+        type: array
+        required: true
+        items:
+          type: object
+          properties:
+            id:
+              description: The ID of the user
+              type: number
+            access:
+              description: The access level of the user. Can be environment_administrator,
+                helpdesk_user, standard_user, readonly_user or operator_user
+              type: string
+              enum:
+                - environment_administrator
+                - helpdesk_user
+                - standard_user
+                - readonly_user
+                - operator_user
+    annotations:
+      title: Update Access Group User Accesses
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateAccessGroupTeamAccesses
+    description: Update the team accesses of an existing access group.
+    parameters:
+      - name: id
+        description: The ID of the access group to update
+        type: number
+        required: true
+      - name: teamAccesses
+        description: "The team accesses that are associated with all the environments in
+          the access group. The ID is the team ID of the team in Portainer.
+          Example: [{id: 1, access: 'environment_administrator'}, {id: 2,
+          access: 'standard_user'}]"
+        type: array
+        required: true
+        items:
+          type: object
+          properties:
+            id:
+              description: The ID of the team
+              type: number
+            access:
+              description: The access level of the team. Can be environment_administrator,
+                helpdesk_user, standard_user, readonly_user or operator_user
+              type: string
+              enum:
+                - environment_administrator
+                - helpdesk_user
+                - standard_user
+                - readonly_user
+                - operator_user
+    annotations:
+      title: Update Access Group Team Accesses
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: addEnvironmentToAccessGroup
+    description: Add an environment to an access group.
+    parameters:
+      - name: id
+        description: The ID of the access group to update
+        type: number
+        required: true
+      - name: environmentId
+        description: The ID of the environment to add to the access group
+        type: number
+        required: true
+    annotations:
+      title: Add Environment To Access Group
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: removeEnvironmentFromAccessGroup
+    description: Remove an environment from an access group.
+    parameters:
+      - name: id
+        description: The ID of the access group to update
+        type: number
+        required: true
+      - name: environmentId
+        description: The ID of the environment to remove from the access group
+        type: number
+        required: true
+    annotations:
+      title: Remove Environment From Access Group
+      readOnlyHint: false
+      destructiveHint: true
+      idempotentHint: true
+      openWorldHint: false
+  ## Environment
+  ## ------------------------------------------------------------
+  - name: listEnvironments
+    description: List all available environments
+    annotations:
+      title: List Environments
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateEnvironmentTags
+    description: Update the tags associated with an environment
+    parameters:
+      - name: id
+        description: The ID of the environment to update
+        type: number
+        required: true
+      - name: tagIds
+        description: >-
+          The IDs of the tags that are associated with the environment.
+          Must include all the tag IDs that should be associated with the environment - this includes new tags and existing tags.
+          Providing an empty array will remove all tags.
+          Example: [1, 2, 3]
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Update Environment Tags
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateEnvironmentUserAccesses
+    description: Update the user access policies of an environment
+    parameters:
+      - name: id
+        description: The ID of the environment to update
+        type: number
+        required: true
+      - name: userAccesses
+        description: >-
+          The user accesses that are associated with the environment.
+          The ID is the user ID of the user in Portainer.
+          Must include all the access policies for all users that should be associated with the environment.
+          Providing an empty array will remove all user accesses.
+          Example: [{id: 1, access: 'environment_administrator'}, {id: 2, access: 'standard_user'}]
+        type: array
+        required: true
+        items:
+          type: object
+          properties:
+            id:
+              description: The ID of the user
+              type: number
+            access:
+              description: The access level of the user
+              type: string
+              enum:
+                - environment_administrator
+                - helpdesk_user
+                - standard_user
+                - readonly_user
+                - operator_user
+    annotations:
+      title: Update Environment User Accesses
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateEnvironmentTeamAccesses
+    description: Update the team access policies of an environment
+    parameters:
+      - name: id
+        description: The ID of the environment to update
+        type: number
+        required: true
+      - name: teamAccesses
+        description: >-
+          The team accesses that are associated with the environment.
+          The ID is the team ID of the team in Portainer.
+          Must include all the access policies for all teams that should be associated with the environment.
+          Providing an empty array will remove all team accesses.
+          Example: [{id: 1, access: 'environment_administrator'}, {id: 2, access: 'standard_user'}]
+        type: array
+        required: true
+        items:
+          type: object
+          properties:
+            id:
+              description: The ID of the team
+              type: number
+            access:
+              description: The access level of the team
+              type: string
+              enum:
+                - environment_administrator
+                - helpdesk_user
+                - standard_user
+                - readonly_user
+                - operator_user
+    annotations:
+      title: Update Environment Team Accesses
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  ## Environment Groups
+  ## An environment group is the equivalent of an Edge Group in Portainer.
+  ## ------------------------------------------------------------
+  - name: createEnvironmentGroup
+    description: Create a new environment group. Environment groups are the equivalent of Edge Groups in Portainer.
+    parameters:
+      - name: name
+        description: The name of the environment group
+        type: string
+        required: true
+      - name: environmentIds
+        description: The IDs of the environments to add to the group
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Create Environment Group
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+  - name: listEnvironmentGroups
+    description: List all available environment groups. Environment groups are the equivalent of Edge Groups in Portainer.
+    annotations:
+      title: List Environment Groups
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateEnvironmentGroupName
+    description: Update the name of an environment group. Environment groups are the equivalent of Edge Groups in Portainer.
+    parameters:
+      - name: id
+        description: The ID of the environment group to update
+        type: number
+        required: true
+      - name: name
+        description: The new name for the environment group
+        type: string
+        required: true
+    annotations:
+      title: Update Environment Group Name
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateEnvironmentGroupEnvironments
+    description: Update the environments associated with an environment group. Environment groups are the equivalent of Edge Groups in Portainer.
+    parameters:
+      - name: id
+        description: The ID of the environment group to update
+        type: number
+        required: true
+      - name: environmentIds
+        description: >-
+          The IDs of the environments that should be part of the group.
+          Must include all environment IDs that should be associated with the group.
+          Providing an empty array will remove all environments from the group.
+          Example: [1, 2, 3]
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Update Environment Group Environments
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateEnvironmentGroupTags
+    description: Update the tags associated with an environment group. Environment groups are the equivalent of Edge Groups in Portainer.
+    parameters:
+      - name: id
+        description: The ID of the environment group to update
+        type: number
+        required: true
+      - name: tagIds
+        description: >-
+          The IDs of the tags that should be associated with the group.
+          Must include all tag IDs that should be associated with the group.
+          Providing an empty array will remove all tags from the group.
+          Example: [1, 2, 3]
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Update Environment Group Tags
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  ## Settings
+  ## ------------------------------------------------------------
+  - name: getSettings
+    description: Get the settings of the Portainer instance
+    annotations:
+      title: Get Settings
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  ## Stacks
+  ## ------------------------------------------------------------
+  - name: listStacks
+    description: List all available stacks
+    annotations:
+      title: List Stacks
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: getStackFile
+    description: Get the compose file for a specific stack ID
+    parameters:
+      - name: id
+        description: The ID of the stack to get the compose file for
+        type: number
+        required: true
+    annotations:
+      title: Get Stack File
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: createStack
+    description: Create a new stack
+    parameters:
+      - name: name
+        description: Name of the stack. Stack name must only consist of lowercase alpha
+          characters, numbers, hyphens, or underscores as well as start with a
+          lowercase character or number
+        type: string
+        required: true
+      - name: file
+        description: >-
+          Content of the stack file. The file must be a valid
+          docker-compose.yml file. example: services:
+           web:
+             image:nginx
+        type: string
+        required: true
+      - name: environmentGroupIds
+        description: "The IDs of the environment groups that the stack belongs to. Must
+          include at least one environment group ID. Example: [1, 2, 3]"
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Create Stack
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+  - name: updateStack
+    description: Update an existing stack
+    parameters:
+      - name: id
+        description: The ID of the stack to update
+        type: number
+        required: true
+      - name: file
+        description: >-
+          Content of the stack file. The file must be a valid
+          docker-compose.yml file. example: version: 3
+           services:
+             web:
+               image:nginx
+        type: string
+        required: true
+      - name: environmentGroupIds
+        description: "The IDs of the environment groups that the stack belongs to. Must
+          include at least one environment group ID. Example: [1, 2, 3]"
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Update Stack
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  ## Local Stacks (regular Docker Compose stacks, non-Edge)
+  ## ------------------------------------------------------------
+  - name: listLocalStacks
+    description: >-
+      List all local (non-edge) stacks deployed on Portainer environments.
+      Returns stack ID, name, status, type, environment ID, creation date,
+      and environment variables for each stack.
+    annotations:
+      title: List Local Stacks
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: getLocalStackFile
+    description: >-
+      Get the docker-compose file content for a specific local stack by its ID.
+      Returns the raw compose file as text.
+    parameters:
+      - name: id
+        description: The ID of the local stack to get the compose file for
+        type: number
+        required: true
+    annotations:
+      title: Get Local Stack File
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: createLocalStack
+    description: >-
+      Create a new local standalone Docker Compose stack on a specific environment.
+      Requires the environment ID, a stack name, and the compose file content.
+      Optionally accepts environment variables.
+    parameters:
+      - name: environmentId
+        description: The ID of the environment to deploy the stack to
+        type: number
+        required: true
+      - name: name
+        description: >-
+          Name of the stack. Stack name must only consist of lowercase alpha
+          characters, numbers, hyphens, or underscores as well as start with a
+          lowercase character or number
+        type: string
+        required: true
+      - name: file
+        description: >-
+          Content of the stack file. The file must be a valid
+          docker-compose.yml file. example: services:
+           web:
+             image: nginx
+        type: string
+        required: true
+      - name: env
+        description: >-
+          Optional environment variables for the stack. Each variable must have
+          a 'name' and 'value' field.
+          Example: [{"name": "DB_HOST", "value": "localhost"}]
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the environment variable
+            value:
+              type: string
+              description: The value of the environment variable
+    annotations:
+      title: Create Local Stack
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+  - name: updateLocalStack
+    description: >-
+      Update an existing local stack with new compose file content and/or
+      environment variables. Requires the stack ID and environment ID.
+    parameters:
+      - name: id
+        description: The ID of the local stack to update
+        type: number
+        required: true
+      - name: environmentId
+        description: The ID of the environment where the stack is deployed
+        type: number
+        required: true
+      - name: file
+        description: >-
+          Content of the stack file. The file must be a valid
+          docker-compose.yml file. example: services:
+           web:
+             image: nginx
+        type: string
+        required: true
+      - name: env
+        description: >-
+          Optional environment variables for the stack. Each variable must have
+          a 'name' and 'value' field.
+          Example: [{"name": "DB_HOST", "value": "localhost"}]
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the environment variable
+            value:
+              type: string
+              description: The value of the environment variable
+      - name: prune
+        description: >-
+          If true, services that are no longer in the compose file will be removed.
+          Default: false
+        type: boolean
+        required: false
+      - name: pullImage
+        description: >-
+          If true, images will be pulled before deploying. Default: false
+        type: boolean
+        required: false
+    annotations:
+      title: Update Local Stack
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: startLocalStack
+    description: >-
+      Start a stopped local stack. Brings up all containers defined in the
+      stack's compose file.
+    parameters:
+      - name: id
+        description: The ID of the local stack to start
+        type: number
+        required: true
+      - name: environmentId
+        description: The ID of the environment where the stack is deployed
+        type: number
+        required: true
+    annotations:
+      title: Start Local Stack
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: stopLocalStack
+    description: >-
+      Stop a running local stack. Stops all containers defined in the
+      stack's compose file.
+    parameters:
+      - name: id
+        description: The ID of the local stack to stop
+        type: number
+        required: true
+      - name: environmentId
+        description: The ID of the environment where the stack is deployed
+        type: number
+        required: true
+    annotations:
+      title: Stop Local Stack
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: deleteLocalStack
+    description: >-
+      Delete a local stack permanently. This removes the stack and all its
+      associated containers from the environment.
+    parameters:
+      - name: id
+        description: The ID of the local stack to delete
+        type: number
+        required: true
+      - name: environmentId
+        description: The ID of the environment where the stack is deployed
+        type: number
+        required: true
+    annotations:
+      title: Delete Local Stack
+      readOnlyHint: false
+      destructiveHint: true
+      idempotentHint: false
+      openWorldHint: false
+  ## Tags
+  ## ------------------------------------------------------------
+  - name: createEnvironmentTag
+    description: Create a new environment tag
+    parameters:
+      - name: name
+        description: The name of the tag
+        type: string
+        required: true
+    annotations:
+      title: Create Environment Tag
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+  - name: listEnvironmentTags
+    description: List all available environment tags
+    annotations:
+      title: List Environment Tags
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  ## Teams
+  ## ------------------------------------------------------------
+  - name: createTeam
+    description: Create a new team
+    parameters:
+      - name: name
+        description: The name of the team
+        type: string
+        required: true
+    annotations:
+      title: Create Team
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: false
+      openWorldHint: false
+  - name: listTeams
+    description: List all available teams
+    annotations:
+      title: List Teams
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateTeamName
+    description: Update the name of an existing team
+    parameters:
+      - name: id
+        description: The ID of the team to update
+        type: number
+        required: true
+      - name: name
+        description: The new name of the team
+        type: string
+        required: true
+    annotations:
+      title: Update Team Name
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateTeamMembers
+    description: Update the members of an existing team
+    parameters:
+      - name: id
+        description: The ID of the team to update
+        type: number
+        required: true
+      - name: userIds
+        description: "The IDs of the users that are part of the team. Must include all
+          the user IDs that are part of the team - this includes new users and
+          the existing users that are already associated with the team. Example:
+          [1, 2, 3]"
+        type: array
+        required: true
+        items:
+          type: number
+    annotations:
+      title: Update Team Members
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+
+  ## Users
+  ## ------------------------------------------------------------
+  - name: listUsers
+    description: List all available users
+    annotations:
+      title: List Users
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+  - name: updateUserRole
+    description: Update an existing user
+    parameters:
+      - name: id
+        description: The ID of the user to update
+        type: number
+        required: true
+      - name: role
+        description: The role of the user. Can be admin, user or edge_admin
+        type: string
+        required: true
+        enum:
+          - admin
+          - user
+          - edge_admin
+    annotations:
+      title: Update User Role
+      readOnlyHint: false
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false
+
+  ## Docker Proxy
+  ## ------------------------------------------------------------
+  - name: dockerProxy
+    description: Proxy Docker requests to a specific Portainer environment.
+      This tool can be used with any Docker API operation as documented in the Docker Engine API specification (https://docs.docker.com/reference/api/engine/version/v1.48/).
+      In read-only mode, only GET requests are allowed.
+    parameters:
+      - name: environmentId
+        description: The ID of the environment to proxy Docker requests to
+        type: number
+        required: true
+      - name: method
+        description: The HTTP method to use to proxy the Docker API operation
+        type: string
+        required: true
+        enum:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - HEAD
+      - name: dockerAPIPath
+        description: "The route of the Docker API operation to proxy. Must include the leading slash. Example: /containers/json"
+        type: string
+        required: true
+      - name: queryParams
+        description: "The query parameters to include in the Docker API operation. Must be an array of key-value pairs.
+          Example: [{key: 'all', value: 'true'}, {key: 'filter', value: 'dangling'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the query parameter
+            value:
+              type: string
+              description: The value of the query parameter
+      - name: headers
+        description: "The headers to include in the Docker API operation. Must be an array of key-value pairs.
+          Example: [{key: 'Content-Type', value: 'application/json'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the header
+            value:
+              type: string
+              description: The value of the header
+      - name: body
+        description: "The body of the Docker API operation to proxy. Must be a JSON string.
+          Example: {'Image': 'nginx:latest', 'Name': 'my-container'}"
+        type: string
+        required: false
+    annotations:
+      title: Docker Proxy
+      readOnlyHint: true
+      destructiveHint: true
+      idempotentHint: true
+      openWorldHint: false
+
+  ## Kubernetes Proxy
+  ## ------------------------------------------------------------
+  - name: kubernetesProxy
+    description: Proxy Kubernetes requests to a specific Portainer environment.
+      This tool can be used with any Kubernetes API operation as documented in the Kubernetes API specification (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/).
+      In read-only mode, only GET requests are allowed.
+    parameters:
+      - name: environmentId
+        description: The ID of the environment to proxy Kubernetes requests to
+        type: number
+        required: true
+      - name: method
+        description: The HTTP method to use to proxy the Kubernetes API operation
+        type: string
+        required: true
+        enum:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - HEAD
+      - name: kubernetesAPIPath
+        description: "The route of the Kubernetes API operation to proxy. Must include the leading slash. Example: /api/v1/namespaces/default/pods"
+        type: string
+        required: true
+      - name: queryParams
+        description: "The query parameters to include in the Kubernetes API operation. Must be an array of key-value pairs.
+          Example: [{key: 'watch', value: 'true'}, {key: 'fieldSelector', value: 'metadata.name=my-pod'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the query parameter
+            value:
+              type: string
+              description: The value of the query parameter
+      - name: headers
+        description: "The headers to include in the Kubernetes API operation. Must be an array of key-value pairs.
+          Example: [{key: 'Content-Type', value: 'application/json'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the header
+            value:
+              type: string
+              description: The value of the header
+      - name: body
+        description: "The body of the Kubernetes API operation to proxy. Must be a JSON string.
+          Example: {'apiVersion': 'v1', 'kind': 'Pod', 'metadata': {'name': 'my-pod'}}"
+        type: string
+        required: false
+    annotations:
+      title: Kubernetes Proxy
+      readOnlyHint: true
+      destructiveHint: true
+      idempotentHint: true
+      openWorldHint: false
+  - name: getKubernetesResourceStripped
+    description: >-
+      Proxy GET requests to a specific Portainer environment for Kubernetes resources,
+      and automatically strips verbose metadata fields (such as 'managedFields') from the API response
+      to reduce its size. This tool is intended for retrieving Kubernetes resource
+      information where a leaner payload is desired.
+      This tool can be used with any GET Kubernetes API operation as documented
+      in the Kubernetes API specification (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/).
+      For other methods (POST, PUT, DELETE, HEAD), use the 'kubernetesProxy' tool.
+    parameters:
+      - name: environmentId
+        description: The ID of the environment to proxy Kubernetes GET requests to
+        type: number
+        required: true
+      - name: kubernetesAPIPath
+        description: "The route of the Kubernetes API GET operation to proxy. Must include the leading slash. Example: /api/v1/namespaces/default/pods"
+        type: string
+        required: true
+      - name: queryParams
+        description: "The query parameters to include in the Kubernetes API operation. Must be an array of key-value pairs.
+          Example: [{key: 'watch', value: 'true'}, {key: 'fieldSelector', value: 'metadata.name=my-pod'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the query parameter
+            value:
+              type: string
+              description: The value of the query parameter
+      - name: headers
+        description: "The headers to include in the Kubernetes API operation. Must be an array of key-value pairs.
+          Example: [{key: 'Accept', value: 'application/json'}]"
+        type: array
+        required: false
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+              description: The key of the header
+            value:
+              type: string
+              description: The value of the header
+    annotations:
+      title: Get Kubernetes Resource (Stripped)
+      readOnlyHint: true
+      destructiveHint: false
+      idempotentHint: true
+      openWorldHint: false


### PR DESCRIPTION
## Summary
- add a dedicated sidebar **Search** view (separate from Files / Source Control)
- remove inline search from the Files tree panel
- improve search UX with Enter-to-search semantics and stable tab-specific submit behavior
- improve text-result interaction: full-row click, match-focused jump, and match-only highlight in editor
- improve text-result presentation: path-focused header row, muted filter controls, and compact result density
- harden `fs_search` for large roots with strict budgets and request supersession cancellation

## Why
The main goal is to make Explorer search easier to use and more consistent:
- separate search workflow from file-tree navigation
- improve result readability and click-to-context behavior
- reduce accidental re-search triggers when switching modes

As a supporting hardening change, `fs_search` now stops stale/over-budget scans earlier so search remains responsive on larger roots.

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `cd src-tauri && cargo test --locked --test fs_search`
