### PR TITLE
feat(ai): support multiple OpenAI-compatible endpoints

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -440,6 +440,7 @@ export default function App() {
     customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0);
   const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
 
+  const prefsHydrated = usePreferencesStore((s) => s.hydrated);
   const [keysLoaded, setKeysLoaded] = useState(false);
   useEffect(() => {
     let alive = true;
@@ -449,6 +450,7 @@ export default function App() {
         setApiKeys(keys);
         setKeysLoaded(true);
       });
+      if (!prefsHydrated) return;
       void getAllCustomEndpointKeys(
         usePreferencesStore.getState().customEndpoints,
       ).then((epKeys) => {
@@ -462,13 +464,12 @@ export default function App() {
       alive = false;
       void unlistenP.then((fn) => fn());
     };
-  }, [setApiKeys, setCustomEndpointKeys]);
+  }, [setApiKeys, setCustomEndpointKeys, prefsHydrated]);
 
   // Hydrate the cross-window preference store and mirror the default model
   // into chatStore so the dropdown reflects what the user picked in Settings.
   const initPrefs = usePreferencesStore((s) => s.init);
   const prefDefaultModel = usePreferencesStore((s) => s.defaultModelId);
-  const prefsHydrated = usePreferencesStore((s) => s.hydrated);
   useEffect(() => {
     void initPrefs();
   }, [initPrefs]);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -25,6 +25,7 @@ import {
   AiInputBarConnect,
   AiMiniWindow,
   getAllKeys,
+  getAllCustomEndpointKeys,
   hasAnyKey,
   LocalAgentNotificationsBridge,
   SelectionAskAi,
@@ -392,6 +393,7 @@ export default function App() {
   const panelOpen = useChatStore((s) => s.panelOpen);
   const apiKeys = useChatStore((s) => s.apiKeys);
   const setApiKeys = useChatStore((s) => s.setApiKeys);
+  const setCustomEndpointKeys = useChatStore((s) => s.setCustomEndpointKeys);
   const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
   const setLive = useChatStore((s) => s.setLive);
   const respondToApproval = useChatStore((s) => s.respondToApproval);
@@ -411,12 +413,14 @@ export default function App() {
   const openaiCompatibleBaseURL = usePreferencesStore(
     (s) => s.openaiCompatibleBaseURL,
   );
+  const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
   const hasLocalModel =
     (lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0) ||
     (mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0) ||
     (ollamaBaseURL.trim().length > 0 && ollamaModelId.trim().length > 0) ||
     (openaiCompatibleBaseURL.trim().length > 0 &&
-      openaiCompatibleModelId.trim().length > 0);
+      openaiCompatibleModelId.trim().length > 0) ||
+    customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0);
   const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
 
   const [keysLoaded, setKeysLoaded] = useState(false);
@@ -428,6 +432,12 @@ export default function App() {
         setApiKeys(keys);
         setKeysLoaded(true);
       });
+      void getAllCustomEndpointKeys(
+        usePreferencesStore.getState().customEndpoints,
+      ).then((epKeys) => {
+        if (!alive) return;
+        setCustomEndpointKeys(epKeys);
+      });
     };
     reload();
     const unlistenP = onKeysChanged(reload);
@@ -435,7 +445,7 @@ export default function App() {
       alive = false;
       void unlistenP.then((fn) => fn());
     };
-  }, [setApiKeys]);
+  }, [setApiKeys, setCustomEndpointKeys]);
 
   // Hydrate the cross-window preference store and mirror the default model
   // into chatStore so the dropdown reflects what the user picked in Settings.

--- a/src/modules/ai/agents/runSubagent.ts
+++ b/src/modules/ai/agents/runSubagent.ts
@@ -13,7 +13,7 @@ type Args = {
   type: SubagentType;
   prompt: string;
   keys: ProviderKeys;
-  modelId: ModelId;
+  modelId: string;
   toolContext: ToolContext;
   lmstudioBaseURL?: string;
   onStep?: (label: string) => void;
@@ -47,9 +47,9 @@ export async function runSubagent({
   }
 
   const model = await buildLanguageModel(
-    getModel(modelId).provider,
+    getModel(modelId as ModelId).provider,
     keys,
-    getModel(modelId).id,
+    getModel(modelId as ModelId).id,
     { lmstudioBaseURL },
   );
 

--- a/src/modules/ai/components/AiMiniWindow.tsx
+++ b/src/modules/ai/components/AiMiniWindow.tsx
@@ -29,7 +29,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
 import { useEffect, useMemo } from "react";
-import { estimateCost, getModel, getModelContextLimit } from "../config";
+import { estimateCost, getModel, getModelContextLimit, type ModelId } from "../config";
 import type { ResizeDir } from "../lib/miniWindowGeometry";
 import type { SessionMeta } from "../lib/sessions";
 import { useMiniWindowGeometry } from "../lib/useMiniWindowGeometry";

--- a/src/modules/ai/components/AiMiniWindow.tsx
+++ b/src/modules/ai/components/AiMiniWindow.tsx
@@ -29,7 +29,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
 import { useEffect, useMemo } from "react";
-import { estimateCost, getModel, getModelContextLimit } from "../config";
+import { estimateCost, getModel, getModelContextLimit, type ModelId } from "../config";
 import type { SessionMeta } from "../lib/sessions";
 import { useAgentsStore } from "../store/agentsStore";
 import { getOrCreateChat, useChatStore } from "../store/chatStore";
@@ -298,7 +298,7 @@ function ContextIndicator({ messages }: { messages: UIMessage[] }) {
   const max = getModelContextLimit(modelId, openaiCompatibleContextLimit);
   const modelLabel = useMemo(() => {
     try {
-      return getModel(modelId).label;
+      return getModel(modelId as ModelId).label;
     } catch {
       return modelId;
     }

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -44,7 +44,10 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
 import { useMemo, useRef, useState } from "react";
 import {
+  compatModelIdForEndpoint,
+  getCompatModelInfo,
   getModel,
+  isCompatModelId,
   MODELS,
   providerNeedsKey,
   PROVIDERS,
@@ -212,31 +215,50 @@ function ModelDropdown() {
   const setSelected = useChatStore((s) => s.setSelectedModelId);
   const favoriteIds = usePreferencesStore((s) => s.favoriteModelIds);
   const recentIds = usePreferencesStore((s) => s.recentModelIds);
-  const current = getModel(selected);
+  const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+  const current = isCompatModelId(selected)
+    ? getCompatModelInfo(selected, customEndpoints)
+    : getModel(selected as ModelId);
   const [search, setSearch] = useState("");
-  const [activeProvider, setActiveProvider] = useState<ProviderId | null>(null);
+  const [activeProvider, setActiveProvider] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("all");
   const inputRef = useRef<HTMLInputElement>(null);
-  const currentProviderHasKey = providerNeedsKey(current.provider)
-    ? !!apiKeys[current.provider]
-    : true;
+  const currentProviderHasKey = isCompatModelId(selected)
+    ? true
+    : providerNeedsKey(current.provider)
+      ? !!apiKeys[current.provider]
+      : true;
 
   const hasKeyFor = (id: ProviderId) =>
     providerNeedsKey(id) ? !!apiKeys[id] : true;
+
+  const epModelInfos = useMemo(() => {
+    return customEndpoints.map((ep) =>
+      getCompatModelInfo(compatModelIdForEndpoint(ep.id), customEndpoints),
+    );
+  }, [customEndpoints]);
 
   const sortedProviders = useMemo(() => {
     const configured: (typeof PROVIDERS)[number][] = [];
     const unconfigured: (typeof PROVIDERS)[number][] = [];
     for (const p of PROVIDERS) {
+      if (p.id === "openai-compatible") continue;
       (hasKeyFor(p.id) ? configured : unconfigured).push(p);
     }
     return { configured, unconfigured };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiKeys]);
 
+  const allModels = useMemo(
+    () => [...MODELS, ...epModelInfos],
+    [epModelInfos],
+  );
+
+  const COMPAT_PROVIDER_ID = "__compat__";
+
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    let pool: readonly ModelInfo[] = MODELS;
+    let pool: readonly ModelInfo[] = allModels;
     if (tab === "favorites") {
       pool = pool.filter((m) => favoriteIds.includes(m.id));
     } else if (tab === "recent") {
@@ -246,7 +268,9 @@ function ModelDropdown() {
         .slice()
         .sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0));
     }
-    if (activeProvider !== null) {
+    if (activeProvider === COMPAT_PROVIDER_ID) {
+      pool = pool.filter((m) => isCompatModelId(m.id));
+    } else if (activeProvider !== null) {
       pool = pool.filter((m) => m.provider === activeProvider);
     }
     if (q) {
@@ -260,7 +284,7 @@ function ModelDropdown() {
       );
     }
     return pool;
-  }, [activeProvider, favoriteIds, recentIds, search, tab]);
+  }, [activeProvider, allModels, favoriteIds, recentIds, search, tab]);
 
   return (
     <DropdownMenu>
@@ -365,15 +389,32 @@ function ModelDropdown() {
                 />
               ),
             )}
+            {customEndpoints.length > 0 && (
+              <ProviderPill
+                icon={PlugIcon}
+                title="OpenAI Compatible"
+                active={activeProvider === COMPAT_PROVIDER_ID}
+                onClick={() => setActiveProvider(COMPAT_PROVIDER_ID)}
+              />
+            )}
           </div>
 
           {/* Models list */}
           <div className="min-h-0 flex-1 overflow-y-auto py-1">
-            {activeProvider !== null ? (
-              <ProviderHeader providerId={activeProvider} />
+            {activeProvider === COMPAT_PROVIDER_ID && (
+              <div className="flex items-center gap-1.5 px-3 pt-1 pb-1.5 text-[11px] font-medium tracking-tight text-muted-foreground/90">
+                <HugeiconsIcon icon={PlugIcon} size={13} strokeWidth={1.75} />
+                <span>OpenAI Compatible</span>
+              </div>
+            )}
+            {activeProvider !== null &&
+            activeProvider !== COMPAT_PROVIDER_ID ? (
+              <ProviderHeader providerId={activeProvider as ProviderId} />
             ) : null}
-            {activeProvider !== null && !hasKeyFor(activeProvider) ? (
-              <ProviderConfigureCTA providerId={activeProvider} />
+            {activeProvider !== null &&
+            activeProvider !== COMPAT_PROVIDER_ID &&
+            !hasKeyFor(activeProvider as ProviderId) ? (
+              <ProviderConfigureCTA providerId={activeProvider as ProviderId} />
             ) : null}
             {filtered.length === 0 ? (
               <div className="flex items-center justify-center px-4 py-10 text-xs text-muted-foreground/70">
@@ -389,15 +430,18 @@ function ModelDropdown() {
                   key={m.id}
                   model={m}
                   selected={m.id === selected}
-                  hasKey={hasKeyFor(m.provider)}
+                  hasKey={
+                    isCompatModelId(m.id) ||
+                    hasKeyFor(m.provider)
+                  }
                   favorite={favoriteIds.includes(m.id)}
                   showProviderIcon={activeProvider === null}
                   onPick={() => {
-                    if (!hasKeyFor(m.provider)) {
+                    if (!isCompatModelId(m.id) && !hasKeyFor(m.provider)) {
                       void openSettingsWindow("models");
                       return;
                     }
-                    setSelected(m.id as ModelId);
+                    setSelected(m.id);
                   }}
                   onToggleFavorite={() => void toggleFavoriteModel(m.id)}
                 />

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -120,6 +120,26 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   },
 ] as const;
 
+export type CustomEndpoint = {
+  id: string;
+  name: string;
+  baseURL: string;
+  modelId: string;
+  contextLimit: number;
+};
+
+export function compatModelIdForEndpoint(endpointId: string): string {
+  return `compat-${endpointId}`;
+}
+
+export function isCompatModelId(modelId: string): boolean {
+  return modelId.startsWith("compat-");
+}
+
+export function endpointIdFromCompatModel(modelId: string): string {
+  return modelId.startsWith("compat-") ? modelId.slice(7) : "";
+}
+
 export function getProvider(id: ProviderId): ProviderInfo {
   const p = PROVIDERS.find((x) => x.id === id);
   if (!p) throw new Error(`Unknown provider: ${id}`);
@@ -489,6 +509,33 @@ export const MODELS = [
 
 export type ModelId = (typeof MODELS)[number]["id"];
 
+export function getCompatModelInfo(
+  modelId: string,
+  endpoints: readonly CustomEndpoint[],
+): ModelInfo {
+  const eid = endpointIdFromCompatModel(modelId);
+  const ep = endpoints.find((e) => e.id === eid);
+  const name = ep?.name || "Custom endpoint";
+  return {
+    id: modelId,
+    provider: "openai-compatible",
+    label: ep?.modelId || name,
+    hint: name,
+    description: ep ? `${name} — ${ep.baseURL}` : "Custom OpenAI-compatible endpoint",
+    capabilities: { intelligence: 3, speed: 3, cost: 3 },
+  };
+}
+
+export function resolveModel(
+  modelId: string,
+  endpoints: readonly CustomEndpoint[] = [],
+): ModelInfo {
+  if (isCompatModelId(modelId)) return getCompatModelInfo(modelId, endpoints);
+  const m = MODELS.find((x) => x.id === modelId);
+  if (!m) throw new Error(`Unknown model: ${modelId}`);
+  return m;
+}
+
 export function getModel(id: ModelId): ModelInfo {
   const m = MODELS.find((x) => x.id === id);
   if (!m) throw new Error(`Unknown model: ${id}`);
@@ -561,6 +608,7 @@ export function getModelContextLimit(
   compatOverride?: number,
 ): number {
   if (!modelId) return 128_000;
+  if (isCompatModelId(modelId)) return compatOverride ?? 128_000;
   if (modelId === "openai-compatible-custom" && compatOverride)
     return compatOverride;
   return MODEL_CONTEXT_LIMITS[modelId] ?? 128_000;

--- a/src/modules/ai/index.ts
+++ b/src/modules/ai/index.ts
@@ -10,11 +10,13 @@ export { LocalAgentNotificationsBridge } from "./components/LocalAgentNotificati
 export {
   EMPTY_PROVIDER_KEYS,
   getAllKeys,
+  getAllCustomEndpointKeys,
   getKey,
   setKey,
   clearKey,
   hasAnyKey,
   type ProviderKeys,
+  type CustomEndpointKeys,
 } from "./lib/keyring";
 export {
   getActiveProviderKey,

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_MODEL_ID,
   getModel,
   getModelContextLimit,
+  isCompatModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
   MAX_AGENT_STEPS,
   MLX_DEFAULT_BASE_URL,
@@ -18,12 +19,13 @@ import {
   OLLAMA_DEFAULT_BASE_URL,
   providerNeedsKey,
   selectSystemPrompt,
+  type CustomEndpoint,
   type ModelId,
   type ProviderId,
 } from "../config";
 import { buildTools, type ToolContext } from "../tools/tools";
 import { compactModelMessagesDetailed } from "./compact";
-import type { ProviderKeys } from "./keyring";
+import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
 import { createProxyFetch } from "./proxyFetch";
 
 const localProxyFetch = createProxyFetch({ allowPrivateNetwork: true });
@@ -76,6 +78,7 @@ export async function buildLanguageModel(
   keys: ProviderKeys,
   resolvedModelId: string,
   options: BuildModelOptions = {},
+  customEndpointKey?: string | null,
 ): Promise<LanguageModel> {
   if (providerNeedsKey(provider) && !keys[provider]) {
     throw new Error(
@@ -87,7 +90,8 @@ export async function buildLanguageModel(
   const mlxURL = options.mlxBaseURL ?? MLX_DEFAULT_BASE_URL;
   const ollamaURL = options.ollamaBaseURL ?? OLLAMA_DEFAULT_BASE_URL;
   const compatURL = options.openaiCompatibleBaseURL ?? "";
-  const cacheKey = `${provider} ${key} ${resolvedModelId} ${lmstudioURL} ${mlxURL} ${ollamaURL} ${compatURL}`;
+  const epKey = customEndpointKey ?? "";
+  const cacheKey = `${provider} ${key} ${epKey} ${resolvedModelId} ${lmstudioURL} ${mlxURL} ${ollamaURL} ${compatURL}`;
   const hit = modelCache.get(cacheKey);
   if (hit) return hit;
 
@@ -168,7 +172,7 @@ export async function buildLanguageModel(
       built = createOpenAICompatible({
         name: "openai-compatible",
         baseURL: compatURL,
-        apiKey: key || undefined,
+        apiKey: epKey || key || undefined,
         fetch: localProxyFetch,
       })(resolvedModelId);
       break;
@@ -222,14 +226,33 @@ export type LocalProviderConfig = {
   openaiCompatibleBaseURL?: string;
   openaiCompatibleModelId?: string;
   openrouterModelId?: string;
+  customEndpoints?: readonly CustomEndpoint[];
+  customEndpointKeys?: CustomEndpointKeys;
 };
 
 export function buildConfiguredLanguageModel(
-  modelId: ModelId,
+  modelId: string,
   keys: ProviderKeys,
   local: LocalProviderConfig = {},
 ): Promise<LanguageModel> {
-  const m = getModel(modelId);
+  if (isCompatModelId(modelId)) {
+    const eid = modelId.slice(7);
+    const ep = local.customEndpoints?.find((e) => e.id === eid);
+    if (!ep) throw new Error(`Custom endpoint not found: ${eid}`);
+    if (!ep.modelId.trim()) {
+      throw new Error(
+        `${ep.name}: no model id set. Open Settings → Models.`,
+      );
+    }
+    return buildLanguageModel(
+      "openai-compatible",
+      keys,
+      ep.modelId.trim(),
+      { openaiCompatibleBaseURL: ep.baseURL },
+      local.customEndpointKeys?.[eid],
+    );
+  }
+  const m = getModel(modelId as ModelId);
   let resolvedId: string = m.id;
   if (m.id === "lmstudio-local") {
     if (!local.lmstudioModelId?.trim()) {
@@ -279,12 +302,15 @@ const PLAN_MODE_PROMPT = `## PLAN MODE — ACTIVE
 Mutating tools (write_file, edit, multi_edit, create_directory) will queue their changes for the user to review as a single diff. Do NOT execute bash_run or bash_background while plan mode is active — restrict yourself to reads (read_file, grep, glob, list_directory) and the queued mutations. After queueing the full set of edits, stop and return a brief summary; do not continue acting until the user has accepted/rejected.`;
 
 function buildStableSystem(
-  modelId: ModelId,
+  modelId: string,
   persona: { name: string; instructions: string } | null,
   customInstructions: string | undefined,
   projectMemory: string | null,
 ): string {
-  const base = selectSystemPrompt(getModel(modelId).id);
+  const resolvedId = isCompatModelId(modelId)
+    ? "openai-compatible-custom"
+    : modelId;
+  const base = selectSystemPrompt(resolvedId as ModelId);
   const personaBlock = persona?.instructions.trim()
     ? `\n\n## ACTIVE AGENT — ${persona.name}\n${persona.instructions.trim()}`
     : "";
@@ -339,7 +365,7 @@ const EMPTY_USAGE: AgentUsage = {
 
 export type RunAgentOptions = {
   keys: ProviderKeys;
-  modelId?: ModelId;
+  modelId?: string;
   customInstructions?: string;
   agentPersona?: { name: string; instructions: string } | null;
   toolContext: ToolContext;
@@ -357,6 +383,8 @@ export type RunAgentOptions = {
   openaiCompatibleModelId?: string;
   openaiCompatibleContextLimit?: number;
   openrouterModelId?: string;
+  customEndpoints?: readonly CustomEndpoint[];
+  customEndpointKeys?: CustomEndpointKeys;
   planMode?: boolean;
   projectMemory?: string | null;
   uiMessages: UIMessage[];
@@ -375,28 +403,34 @@ export async function runAgentStream(opts: RunAgentOptions) {
     openaiCompatibleBaseURL: opts.openaiCompatibleBaseURL,
     openaiCompatibleModelId: opts.openaiCompatibleModelId,
     openrouterModelId: opts.openrouterModelId,
+    customEndpoints: opts.customEndpoints,
+    customEndpointKeys: opts.customEndpointKeys,
   });
-  const provider = getModel(modelId).provider;
+  const provider = isCompatModelId(modelId)
+    ? "openai-compatible" as ProviderId
+    : getModel(modelId as ModelId).provider;
 
   const stableSystem = buildStableSystem(
-    modelId,
+    modelId as ModelId,
     opts.agentPersona ?? null,
     opts.customInstructions,
     opts.projectMemory ?? null,
   );
 
   const history = await convertToModelMessages(opts.uiMessages);
+  const keepsReasoning = isCompatModelId(modelId)
+    || modelKeepsReasoning(modelId as ModelId);
   const prunedHistory = pruneMessages({
     messages: history,
-    reasoning: modelKeepsReasoning(modelId) ? "none" : "before-last-message",
+    reasoning: keepsReasoning ? "none" : "before-last-message",
     emptyMessages: "remove",
   });
+  const compatCtxOverride = isCompatModelId(modelId)
+    ? opts.customEndpoints?.find((e) => e.id === modelId.slice(7))?.contextLimit
+    : opts.openaiCompatibleContextLimit;
   const compact = compactModelMessagesDetailed(
     prunedHistory,
-    getModelContextLimit(
-      getModel(modelId).id,
-      opts.openaiCompatibleContextLimit,
-    ),
+    getModelContextLimit(modelId, compatCtxOverride),
   );
   const compactedHistory = compact.messages;
   if (compact.compacted) {

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -4,10 +4,12 @@ import {
   KEYRING_SERVICE,
   PROVIDERS,
   providerSupportsKey,
+  type CustomEndpoint,
   type ProviderId,
 } from "../config";
 
 export type ProviderKeys = Record<ProviderId, string | null>;
+export type CustomEndpointKeys = Record<string, string | null>;
 
 export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   openai: null,
@@ -87,4 +89,69 @@ export async function getAllKeys(): Promise<ProviderKeys> {
 
 export function hasAnyKey(keys: ProviderKeys): boolean {
   return PROVIDERS.some((p) => providerSupportsKey(p.id) && !!keys[p.id]);
+}
+
+function compatKeyringAccount(endpointId: string): string {
+  return `compat-${endpointId}-api-key`;
+}
+
+export async function getCustomEndpointKey(
+  endpointId: string,
+): Promise<string | null> {
+  try {
+    const v = await invoke<string | null>("secrets_get", {
+      service: KEYRING_SERVICE,
+      account: compatKeyringAccount(endpointId),
+    });
+    return v && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setCustomEndpointKey(
+  endpointId: string,
+  key: string,
+): Promise<void> {
+  const trimmed = key.trim();
+  if (!trimmed) throw new Error("API key is empty");
+  await invoke("secrets_set", {
+    service: KEYRING_SERVICE,
+    account: compatKeyringAccount(endpointId),
+    password: trimmed,
+  });
+}
+
+export async function clearCustomEndpointKey(
+  endpointId: string,
+): Promise<void> {
+  try {
+    await invoke("secrets_delete", {
+      service: KEYRING_SERVICE,
+      account: compatKeyringAccount(endpointId),
+    });
+  } catch {}
+}
+
+export async function getAllCustomEndpointKeys(
+  endpoints: readonly CustomEndpoint[],
+): Promise<CustomEndpointKeys> {
+  if (endpoints.length === 0) return {};
+  const out: CustomEndpointKeys = {};
+  try {
+    const accounts = endpoints.map((e) => compatKeyringAccount(e.id));
+    const results = await invoke<(string | null)[]>("secrets_get_all", {
+      service: KEYRING_SERVICE,
+      accounts,
+    });
+    endpoints.forEach((e, i) => {
+      const v = results[i];
+      out[e.id] = v && v.length > 0 ? v : null;
+    });
+  } catch {
+    for (const e of endpoints) {
+      out[e.id] = await getCustomEndpointKey(e.id);
+    }
+  }
+  return out;
 }

--- a/src/modules/ai/lib/transport.ts
+++ b/src/modules/ai/lib/transport.ts
@@ -1,7 +1,7 @@
 import type { UIMessage } from "@ai-sdk/react";
-import { type ModelId } from "../config";
+import { type CustomEndpoint } from "../config";
 import { runAgentStream, type AgentUsageDelta } from "./agent";
-import type { ProviderKeys } from "./keyring";
+import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
 import { native } from "./native";
 import type { ToolContext } from "../tools/tools";
 
@@ -42,7 +42,7 @@ type LiveSnapshot = {
 type Deps = {
   getKeys: () => ProviderKeys;
   toolContext: ToolContext;
-  getModelId: () => ModelId;
+  getModelId: () => string;
   getCustomInstructions: () => string;
   getAgentPersona: () => { name: string; instructions: string } | null;
   getLive: () => LiveSnapshot;
@@ -56,6 +56,8 @@ type Deps = {
   getOpenaiCompatibleModelId?: () => string | undefined;
   getOpenaiCompatibleContextLimit?: () => number | undefined;
   getOpenrouterModelId?: () => string | undefined;
+  getCustomEndpoints?: () => readonly CustomEndpoint[];
+  getCustomEndpointKeys?: () => CustomEndpointKeys;
   onStep?: (step: string | null) => void;
   onUsage?: (delta: AgentUsageDelta) => void;
   onCompact?: (info: { droppedCount: number }) => void;
@@ -97,6 +99,8 @@ export function createContextAwareTransport(deps: Deps) {
       openaiCompatibleModelId: deps.getOpenaiCompatibleModelId?.(),
       openaiCompatibleContextLimit: deps.getOpenaiCompatibleContextLimit?.(),
       openrouterModelId: deps.getOpenrouterModelId?.(),
+      customEndpoints: deps.getCustomEndpoints?.(),
+      customEndpointKeys: deps.getCustomEndpointKeys?.(),
       planMode: deps.getPlanMode?.(),
       projectMemory,
       uiMessages: messagesForRun,

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -7,6 +7,7 @@ import { create } from "zustand";
 import {
   DEFAULT_MODEL_ID,
   getModel,
+  isCompatModelId,
   providerNeedsKey,
   type ModelId,
   type ProviderId,
@@ -17,7 +18,7 @@ import { useAgentsStore } from "./agentsStore";
 import { usePlanStore } from "./planStore";
 import { useTodosStore } from "./todoStore";
 import type { AgentUsage } from "../lib/agent";
-import { EMPTY_PROVIDER_KEYS, type ProviderKeys } from "../lib/keyring";
+import { EMPTY_PROVIDER_KEYS, type ProviderKeys, type CustomEndpointKeys } from "../lib/keyring";
 import {
   deleteSessionData,
   deriveTitle,
@@ -117,8 +118,11 @@ type StoreState = {
   setApiKeys: (keys: ProviderKeys) => void;
   setApiKey: (provider: ProviderId, key: string | null) => void;
 
-  selectedModelId: ModelId;
-  setSelectedModelId: (id: ModelId) => void;
+  customEndpointKeys: CustomEndpointKeys;
+  setCustomEndpointKeys: (keys: CustomEndpointKeys) => void;
+
+  selectedModelId: string;
+  setSelectedModelId: (id: string) => void;
 
   mini: MiniState;
   openMini: () => void;
@@ -270,6 +274,10 @@ function makeChat(sessionId: string): Chat<UIMessage> {
       usePreferencesStore.getState().openaiCompatibleContextLimit,
     getOpenrouterModelId: () =>
       usePreferencesStore.getState().openrouterModelId,
+    getCustomEndpoints: () =>
+      usePreferencesStore.getState().customEndpoints,
+    getCustomEndpointKeys: () =>
+      useChatStore.getState().customEndpointKeys,
     onStep: (step) => {
       useChatStore.getState().patchAgentMeta({ step });
     },
@@ -328,6 +336,9 @@ export const useChatStore = create<StoreState>((set, get) => ({
   setApiKey: (provider, key) => {
     set({ apiKeys: { ...get().apiKeys, [provider]: key } });
   },
+
+  customEndpointKeys: {},
+  setCustomEndpointKeys: (keys) => set({ customEndpointKeys: keys }),
 
   selectedModelId: DEFAULT_MODEL_ID,
   setSelectedModelId: (id) => {
@@ -529,13 +540,20 @@ export function getAgentMeta(): AgentMeta {
 }
 
 export function getActiveProviderKey(): string | null {
-  const { selectedModelId, apiKeys } = useChatStore.getState();
-  return apiKeys[getModel(selectedModelId).provider] ?? null;
+  const { selectedModelId, apiKeys, customEndpointKeys } = useChatStore.getState();
+  if (isCompatModelId(selectedModelId)) {
+    const eid = selectedModelId.slice(7);
+    return customEndpointKeys[eid] ?? null;
+  }
+  return apiKeys[getModel(selectedModelId as ModelId).provider] ?? null;
 }
 
-export function hasKeyForModel(modelId: ModelId): boolean {
+export function hasKeyForModel(modelId: string): boolean {
   const { apiKeys } = useChatStore.getState();
-  const provider = getModel(modelId).provider;
+  if (isCompatModelId(modelId)) {
+    return true;
+  }
+  const provider = getModel(modelId as ModelId).provider;
   return providerNeedsKey(provider) ? !!apiKeys[provider] : true;
 }
 
@@ -560,7 +578,7 @@ export async function sendMessage(text: string): Promise<boolean> {
   const state = useChatStore.getState();
   const sessionId = state.activeSessionId;
   if (!sessionId) return false;
-  if (providerNeedsKey(getModel(state.selectedModelId).provider) && !getActiveProviderKey()) return false;
+  if (providerNeedsKey(getModel(state.selectedModelId as ModelId).provider) && !getActiveProviderKey()) return false;
   const c = getOrCreateChat(sessionId);
   await c.sendMessage({ text });
   return true;

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -7,6 +7,7 @@ import {
   OLLAMA_DEFAULT_BASE_URL,
   OPENAI_COMPATIBLE_DEFAULT_BASE_URL,
   type AutocompleteProviderId,
+  type CustomEndpoint,
   type ModelId,
 } from "@/modules/ai/config";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
@@ -71,6 +72,7 @@ export type Preferences = {
   openaiCompatibleBaseURL: string;
   openaiCompatibleModelId: string;
   openaiCompatibleContextLimit: number;
+  customEndpoints: CustomEndpoint[];
   openrouterModelId: string;
   favoriteModelIds: string[];
   recentModelIds: string[];
@@ -111,6 +113,7 @@ const KEY_OLLAMA_MODEL_ID = "ollamaModelId";
 const KEY_OPENAI_COMPAT_BASE_URL = "openaiCompatibleBaseURL";
 const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
 const KEY_OPENAI_COMPAT_CONTEXT_LIMIT = "openaiCompatibleContextLimit";
+const KEY_CUSTOM_ENDPOINTS = "customEndpoints";
 const KEY_OPENROUTER_MODEL_ID = "openrouterModelId";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
@@ -166,6 +169,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   openaiCompatibleBaseURL: OPENAI_COMPATIBLE_DEFAULT_BASE_URL,
   openaiCompatibleModelId: "",
   openaiCompatibleContextLimit: 128_000,
+  customEndpoints: [],
   openrouterModelId: "",
   favoriteModelIds: [],
   recentModelIds: [],
@@ -261,6 +265,25 @@ export async function loadPreferences(): Promise<Preferences> {
     openaiCompatibleContextLimit:
       get<number>(KEY_OPENAI_COMPAT_CONTEXT_LIMIT) ??
       DEFAULT_PREFERENCES.openaiCompatibleContextLimit,
+    customEndpoints: (() => {
+      const stored = get<CustomEndpoint[]>(KEY_CUSTOM_ENDPOINTS);
+      if (stored && stored.length > 0) return stored;
+      const oldURL = get<string>(KEY_OPENAI_COMPAT_BASE_URL) ?? "";
+      const oldModel = get<string>(KEY_OPENAI_COMPAT_MODEL_ID) ?? "";
+      const oldLimit = get<number>(KEY_OPENAI_COMPAT_CONTEXT_LIMIT) ?? 128_000;
+      if (oldURL.trim() && oldModel.trim()) {
+        return [
+          {
+            id: crypto.randomUUID().slice(0, 8),
+            name: "Custom endpoint",
+            baseURL: oldURL,
+            modelId: oldModel,
+            contextLimit: oldLimit,
+          },
+        ];
+      }
+      return [];
+    })(),
     openrouterModelId:
       get<string>(KEY_OPENROUTER_MODEL_ID) ??
       DEFAULT_PREFERENCES.openrouterModelId,
@@ -419,6 +442,12 @@ export async function setOpenaiCompatibleContextLimit(
   await writePref(KEY_OPENAI_COMPAT_CONTEXT_LIMIT, clamped);
 }
 
+export async function setCustomEndpoints(
+  value: CustomEndpoint[],
+): Promise<void> {
+  await writePref(KEY_CUSTOM_ENDPOINTS, value);
+}
+
 export async function setOpenrouterModelId(value: string): Promise<void> {
   await writePref(KEY_OPENROUTER_MODEL_ID, value);
 }
@@ -526,6 +555,7 @@ export async function onPreferencesChange(
     [KEY_OPENAI_COMPAT_BASE_URL]: "openaiCompatibleBaseURL",
     [KEY_OPENAI_COMPAT_MODEL_ID]: "openaiCompatibleModelId",
     [KEY_OPENAI_COMPAT_CONTEXT_LIMIT]: "openaiCompatibleContextLimit",
+    [KEY_CUSTOM_ENDPOINTS]: "customEndpoints",
     [KEY_OPENROUTER_MODEL_ID]: "openrouterModelId",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -6,7 +6,7 @@ import {
   type GitStatusSnapshot,
 } from "@/modules/ai/lib/native";
 import { useChatStore } from "@/modules/ai/store/chatStore";
-import { getModel, providerNeedsKey } from "@/modules/ai/config";
+import { getModel, providerNeedsKey, type ModelId } from "@/modules/ai/config";
 import {
   invalidateDiff,
   invalidateRepoDiffs,
@@ -369,7 +369,7 @@ export function useSourceControlPanel(
   const selectedModelId = useChatStore((state) => state.selectedModelId);
   const agentStatus = useChatStore((state) => state.agentMeta.status);
   const hasApiKeyForSelected = useChatStore((state) => {
-    const model = getModel(state.selectedModelId);
+    const model = getModel(state.selectedModelId as ModelId);
     return !providerNeedsKey(model.provider) || !!state.apiKeys[model.provider];
   });
   const lmstudioModelId = usePreferencesStore((state) => state.lmstudioModelId);
@@ -462,7 +462,7 @@ export function useSourceControlPanel(
 
   const allClean = stagedEntries.length === 0 && unstagedEntries.length === 0;
   const canPush = !!status?.upstream && status.behind === 0;
-  const selectedModel = getModel(selectedModelId);
+  const selectedModel = getModel(selectedModelId as ModelId);
   const aiBusy = agentStatus !== "idle" && agentStatus !== "error";
   const anyActionBusy = localActionBusy !== null || summary.busyAction !== null;
   const aiUnavailableReason = useMemo(() => {

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -17,17 +17,27 @@ import {
   getModel,
   getProvider,
   providerNeedsKey,
+  type CustomEndpoint,
   type ModelId,
   type ProviderId,
   type ProviderInfo,
 } from "@/modules/ai/config";
-import { clearKey, getAllKeys, setKey } from "@/modules/ai/lib/keyring";
+import {
+  clearKey,
+  clearCustomEndpointKey,
+  getAllKeys,
+  getAllCustomEndpointKeys,
+  setKey,
+  setCustomEndpointKey,
+  type CustomEndpointKeys,
+} from "@/modules/ai/lib/keyring";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   emitKeysChanged,
   setAutocompleteEnabled,
   setAutocompleteModelId,
   setAutocompleteProvider,
+  setCustomEndpoints,
   setDefaultModel,
   setLmstudioBaseURL,
   setLmstudioModelId,
@@ -46,6 +56,7 @@ import {
   ArrowUpRight01Icon,
   Cancel01Icon,
   CheckmarkCircle02Icon,
+  ChevronDown,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
@@ -115,6 +126,7 @@ const LOCAL_META: Partial<Record<ProviderId, LocalMeta>> = {
 
 export function ModelsSection() {
   const [keys, setKeys] = useState<KeysMap | null>(null);
+  const [epKeys, setEpKeys] = useState<CustomEndpointKeys>({});
   const [adding, setAdding] = useState<Set<ProviderId>>(new Set());
 
   const defaultModel = usePreferencesStore((s) => s.defaultModelId);
@@ -130,10 +142,15 @@ export function ModelsSection() {
     (s) => s.openaiCompatibleContextLimit,
   );
   const openrouterModelId = usePreferencesStore((s) => s.openrouterModelId);
+  const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
 
   useEffect(() => {
     void getAllKeys().then(setKeys);
   }, []);
+
+  useEffect(() => {
+    void getAllCustomEndpointKeys(customEndpoints).then(setEpKeys);
+  }, [customEndpoints]);
 
   const onSaveKey = async (provider: ProviderId, value: string) => {
     await setKey(provider, value);
@@ -145,6 +162,48 @@ export function ModelsSection() {
     await clearKey(provider);
     setKeys((prev) => (prev ? { ...prev, [provider]: null } : prev));
     await emitKeysChanged();
+  };
+
+  const onSaveEndpointKey = async (endpointId: string, value: string) => {
+    await setCustomEndpointKey(endpointId, value);
+    setEpKeys((prev) => ({ ...prev, [endpointId]: value }));
+    await emitKeysChanged();
+  };
+
+  const onClearEndpointKey = async (endpointId: string) => {
+    await clearCustomEndpointKey(endpointId);
+    setEpKeys((prev) => ({ ...prev, [endpointId]: null }));
+    await emitKeysChanged();
+  };
+
+  const addCustomEndpoint = async () => {
+    const ep: CustomEndpoint = {
+      id: crypto.randomUUID().slice(0, 8),
+      name: "",
+      baseURL: "",
+      modelId: "",
+      contextLimit: 128_000,
+    };
+    await setCustomEndpoints([...customEndpoints, ep]);
+  };
+
+  const updateCustomEndpoint = async (
+    id: string,
+    patch: Partial<CustomEndpoint>,
+  ) => {
+    await setCustomEndpoints(
+      customEndpoints.map((e) => (e.id === id ? { ...e, ...patch } : e)),
+    );
+  };
+
+  const removeCustomEndpoint = async (id: string) => {
+    await clearCustomEndpointKey(id);
+    setEpKeys((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    await setCustomEndpoints(customEndpoints.filter((e) => e.id !== id));
   };
 
   const localConfig = (id: ProviderId): LocalConfig | null => {
@@ -212,8 +271,12 @@ export function ModelsSection() {
   );
   const visibleIds = new Set<ProviderId>(configuredIds);
   for (const id of adding) visibleIds.add(id);
-  const visibleProviders = PROVIDERS.filter((p) => visibleIds.has(p.id));
-  const addableProviders = PROVIDERS.filter((p) => !visibleIds.has(p.id));
+  const visibleProviders = PROVIDERS.filter(
+    (p) => p.id !== "openai-compatible" && visibleIds.has(p.id),
+  );
+  const addableProviders = PROVIDERS.filter(
+    (p) => p.id !== "openai-compatible" && !visibleIds.has(p.id),
+  );
 
   const removeProvider = (id: ProviderId) => {
     if (id === "openrouter") {
@@ -259,33 +322,41 @@ export function ModelsSection() {
           <AddProviderMenu
             providers={addableProviders}
             onAdd={addProvider}
+            onAddCompat={addCustomEndpoint}
           />
         </div>
 
-        {visibleProviders.length === 0 ? (
+        {visibleProviders.length === 0 && customEndpoints.length === 0 ? (
           <div className="rounded-lg border border-dashed border-border/60 bg-card/40 px-4 py-8 text-center">
             <p className="text-[12px] text-muted-foreground">
               No providers connected yet.
             </p>
             <p className="mt-0.5 text-[10.5px] text-muted-foreground/70">
-              Click “Add provider” to connect a cloud or local model source.
+              Click "Add provider" to connect a cloud or local model source.
             </p>
           </div>
         ) : (
           <div className="flex flex-col gap-2">
             {visibleProviders.map((p) =>
-              isLocalProvider(p.id) || p.id === "openrouter" ? (
+              p.id === "openrouter" ? (
                 <LocalProviderCard
                   key={p.id}
                   provider={p}
                   configured={configuredIds.has(p.id)}
                   config={localConfig(p.id)!}
                   meta={LOCAL_META[p.id]!}
-                  compatKey={
-                    p.id === "openai-compatible" || p.id === "openrouter"
-                      ? keys[p.id]
-                      : undefined
-                  }
+                  compatKey={keys[p.id]}
+                  onSaveKey={(v) => onSaveKey(p.id, v)}
+                  onClearKey={() => onClearKey(p.id)}
+                  onRemove={() => removeProvider(p.id)}
+                />
+              ) : isLocalProvider(p.id) ? (
+                <LocalProviderCard
+                  key={p.id}
+                  provider={p}
+                  configured={configuredIds.has(p.id)}
+                  config={localConfig(p.id)!}
+                  meta={LOCAL_META[p.id]!}
                   onSaveKey={(v) => onSaveKey(p.id, v)}
                   onClearKey={() => onClearKey(p.id)}
                   onRemove={() => removeProvider(p.id)}
@@ -301,6 +372,17 @@ export function ModelsSection() {
                 />
               ),
             )}
+            {customEndpoints.map((ep) => (
+              <CustomEndpointCard
+                key={ep.id}
+                endpoint={ep}
+                endpointKey={epKeys[ep.id] ?? null}
+                onSaveKey={(v) => onSaveEndpointKey(ep.id, v)}
+                onClearKey={() => onClearEndpointKey(ep.id)}
+                onUpdate={(patch) => updateCustomEndpoint(ep.id, patch)}
+                onRemove={() => removeCustomEndpoint(ep.id)}
+              />
+            ))}
           </div>
         )}
       </div>
@@ -321,13 +403,14 @@ type LocalConfig = {
 function AddProviderMenu({
   providers,
   onAdd,
+  onAddCompat,
 }: {
   providers: readonly ProviderInfo[];
   onAdd: (id: ProviderId) => void;
+  onAddCompat: () => void;
 }) {
   const cloud = providers.filter((p) => !isLocalProvider(p.id));
-  const local = providers.filter((p) => isLocalProvider(p.id));
-  const disabled = providers.length === 0;
+  const local = providers.filter((p) => isLocalProvider(p.id) && p.id !== "openai-compatible");
 
   return (
     <DropdownMenu>
@@ -335,7 +418,6 @@ function AddProviderMenu({
         <Button
           size="sm"
           variant="outline"
-          disabled={disabled}
           className="h-7 gap-1.5 px-2.5 text-[11px]"
         >
           <HugeiconsIcon icon={Add01Icon} size={12} strokeWidth={2} />
@@ -353,16 +435,19 @@ function AddProviderMenu({
             ))}
           </>
         ) : null}
-        {local.length > 0 ? (
-          <>
-            <DropdownMenuLabel className="px-2 text-[10px] tracking-wide text-muted-foreground uppercase">
-              Local & custom
-            </DropdownMenuLabel>
-            {local.map((p) => (
-              <ProviderMenuItem key={p.id} provider={p} onAdd={onAdd} />
-            ))}
-          </>
-        ) : null}
+        <DropdownMenuLabel className="px-2 text-[10px] tracking-wide text-muted-foreground uppercase">
+          Local & custom
+        </DropdownMenuLabel>
+        {local.map((p) => (
+          <ProviderMenuItem key={p.id} provider={p} onAdd={onAdd} />
+        ))}
+        <DropdownMenuItem
+          onSelect={() => onAddCompat()}
+          className="flex items-center gap-2 text-[12px]"
+        >
+          <ProviderIcon provider="openai-compatible" size={13} />
+          <span>OpenAI Compatible</span>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -825,6 +910,226 @@ function LocalProviderCard({
           </p>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function CustomEndpointCard({
+  endpoint,
+  endpointKey,
+  onSaveKey,
+  onClearKey,
+  onUpdate,
+  onRemove,
+}: {
+  endpoint: CustomEndpoint;
+  endpointKey: string | null;
+  onSaveKey: (v: string) => Promise<void>;
+  onClearKey: () => Promise<void>;
+  onUpdate: (patch: Partial<CustomEndpoint>) => Promise<void>;
+  onRemove: () => void;
+}) {
+  const [expanded, setExpanded] = useState(!endpoint.baseURL.trim());
+  const [nameDraft, setNameDraft] = useState(endpoint.name);
+  const [urlDraft, setUrlDraft] = useState(endpoint.baseURL);
+  const [modelDraft, setModelDraft] = useState(endpoint.modelId);
+  const [contextDraft, setContextDraft] = useState(
+    String(endpoint.contextLimit ?? ""),
+  );
+  const [keyDraft, setKeyDraft] = useState("");
+  const [testStatus, setTestStatus] = useState<
+    "idle" | "testing" | "ok" | "fail"
+  >("idle");
+
+  useEffect(() => setNameDraft(endpoint.name), [endpoint.name]);
+  useEffect(() => setUrlDraft(endpoint.baseURL), [endpoint.baseURL]);
+  useEffect(() => setModelDraft(endpoint.modelId), [endpoint.modelId]);
+  useEffect(
+    () => setContextDraft(String(endpoint.contextLimit ?? "")),
+    [endpoint.contextLimit],
+  );
+
+  const configured =
+    !!endpoint.baseURL.trim() && !!endpoint.modelId.trim();
+
+  const test = async () => {
+    setTestStatus("testing");
+    try {
+      const status = await invoke<number>("lm_ping", { baseUrl: urlDraft });
+      setTestStatus(status > 0 ? "ok" : "fail");
+    } catch {
+      setTestStatus("fail");
+    }
+  };
+
+  return (
+    <div className="flex flex-col rounded-lg border border-border/60 bg-card/60">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-2 px-3 py-2 text-left"
+      >
+        <HugeiconsIcon
+          icon={ChevronDown}
+          size={12}
+          strokeWidth={2}
+          className={cn(
+            "shrink-0 text-muted-foreground/60 transition-transform",
+            !expanded && "-rotate-90",
+          )}
+        />
+        <ProviderIcon provider="openai-compatible" size={15} />
+        <span className="text-[12.5px] font-medium truncate">
+          {endpoint.name || "OpenAI Compatible"}
+        </span>
+        {endpoint.modelId.trim() && (
+          <span className="text-[10.5px] text-muted-foreground truncate font-mono">
+            {endpoint.modelId}
+          </span>
+        )}
+        {configured ? (
+          <Badge
+            variant="outline"
+            className="ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal text-muted-foreground"
+          >
+            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={9} strokeWidth={2} />
+            Connected
+          </Badge>
+        ) : null}
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          title="Remove endpoint"
+          className="ml-auto size-7 text-muted-foreground hover:text-destructive"
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+        </Button>
+      </button>
+
+      {expanded && (
+        <div className="flex flex-col gap-2.5 border-t border-border/40 px-3 py-2.5">
+          <FieldRow label="Name">
+            <Input
+              value={nameDraft}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onBlur={() => {
+                const v = nameDraft.trim();
+                if (v !== endpoint.name) void onUpdate({ name: v });
+              }}
+              placeholder="My endpoint"
+              spellCheck={false}
+              className="h-8 flex-1 text-[11.5px]"
+            />
+          </FieldRow>
+
+          <FieldRow label="Base URL">
+            <div className="flex flex-1 gap-1.5">
+              <Input
+                value={urlDraft}
+                onChange={(e) => setUrlDraft(e.target.value)}
+                onBlur={() => {
+                  const v = urlDraft.trim();
+                  if (v !== endpoint.baseURL) void onUpdate({ baseURL: v });
+                }}
+                placeholder="https://api.example.com/v1"
+                spellCheck={false}
+                className="h-8 flex-1 font-mono text-[11.5px]"
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void test()}
+                disabled={!urlDraft.trim()}
+                className="h-8 px-3 text-[11px]"
+              >
+                Test
+              </Button>
+            </div>
+          </FieldRow>
+
+          <FieldRow label="Model ID">
+            <Input
+              value={modelDraft}
+              onChange={(e) => setModelDraft(e.target.value)}
+              onBlur={() => {
+                const v = modelDraft.trim();
+                if (v !== endpoint.modelId) void onUpdate({ modelId: v });
+              }}
+              placeholder="gpt-4o, qwen3-max, glm-4.6, …"
+              spellCheck={false}
+              className="h-8 font-mono text-[11.5px]"
+            />
+          </FieldRow>
+
+          <FieldRow label="Context">
+            <div className="flex flex-1 items-center gap-1.5">
+              <Input
+                value={contextDraft}
+                onChange={(e) => setContextDraft(e.target.value)}
+                onBlur={() => {
+                  const v = parseInt(contextDraft);
+                  if (Number.isFinite(v) && v >= 1000)
+                    void onUpdate({ contextLimit: v });
+                  else setContextDraft(String(endpoint.contextLimit ?? ""));
+                }}
+                placeholder="128000"
+                spellCheck={false}
+                className="h-8 w-28 font-mono text-[11.5px]"
+              />
+              <span className="text-[10.5px] text-muted-foreground">tokens</span>
+            </div>
+          </FieldRow>
+
+          <FieldRow label="API key">
+            {endpointKey ? (
+              <div className="flex flex-1 items-center gap-1.5">
+                <code className="flex-1 truncate rounded bg-muted/40 px-2 py-1 font-mono text-[11px] text-muted-foreground">
+                  {`${endpointKey.slice(0, 4)}${"•".repeat(8)}${endpointKey.slice(-4)}`}
+                </code>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => void onClearKey()}
+                  title="Remove key"
+                  className="size-7 text-muted-foreground hover:text-destructive"
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex flex-1 gap-1.5">
+                <Input
+                  type="password"
+                  value={keyDraft}
+                  onChange={(e) => setKeyDraft(e.target.value)}
+                  placeholder="Optional — leave empty for unauthenticated endpoints"
+                  spellCheck={false}
+                  className="h-8 flex-1 font-mono text-[11.5px]"
+                />
+                <Button
+                  size="sm"
+                  onClick={async () => {
+                    const v = keyDraft.trim();
+                    if (!v) return;
+                    await onSaveKey(v);
+                    setKeyDraft("");
+                  }}
+                  disabled={!keyDraft.trim()}
+                  className="h-8 px-3 text-[11px]"
+                >
+                  Save
+                </Button>
+              </div>
+            )}
+          </FieldRow>
+
+          <StatusLine status={testStatus} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Allow users to add multiple named OpenAI-compatible endpoints via Settings > Models > Add provider. Each endpoint has its own name, base URL, model ID, context limit, and optional API key stored in the OS keychain. Endpoints appear as named models in the model picker grouped under a single OpenAI Compatible sidebar entry. Existing single-endpoint config auto-migrates on first load.

Closes #496