### PR TITLE
fix(source-control): fix incomplete border class on commit message textarea

### DIFF
--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -567,7 +567,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                   placeholder="Commit message"
                   rows={3}
                   className={cn(
-                    "min-h-[72px] border-  resize-none rounded-lg  bg-transparent px-3 pb-7 pt-2.5 text-[12.5px] leading-snug shadow-none placeholder:text-muted-foreground/65 focus-visible:ring-0 focus:border-0",
+                    "min-h-[72px] border-border resize-none rounded-lg bg-transparent px-3 pb-7 pt-2.5 text-[12.5px] leading-snug shadow-none placeholder:text-muted-foreground/65 focus-visible:ring-0 focus:border-0",
                   )}
                 />
                 <div className="pointer-events-none absolute inset-x-3 bottom-1.5 flex items-center justify-between p-1 gap-2 text-[10px] tabular-nums text-muted-foreground/55">


### PR DESCRIPTION
## What

Fixes the commit message textarea's `border-` class to consistent `border-border` pattern, and clean up extra spaces. 


## Why

The Textarea component applies `border border-transparent` by default. 
The original `border-` was an incomplete class that did nothing.
Changing it to `border-border` making it consistent with every other border in this files. 

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test: border appears as expected in commit message textarea
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows


## Screenshots / GIFs

N/A, looks almost identical (--border color is a very subtle gray)
