### PR TITLE
feat(explorer): icon themes + search errors + macOS fullscreen fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",
     "@iconify-json/catppuccin": "^1.2.17",
+    "@iconify-json/material-icon-theme": "^1.2.66",
     "@lezer/highlight": "^1.2.3",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@replit/codemirror-vim": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@iconify-json/catppuccin':
         specifier: ^1.2.17
         version: 1.2.17
+      '@iconify-json/material-icon-theme':
+        specifier: ^1.2.66
+        version: 1.2.66
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
@@ -923,6 +926,9 @@ packages:
 
   '@iconify-json/catppuccin@1.2.17':
     resolution: {integrity: sha512-l1pFOADEUlw+j7V+yfFzBowdE4deeMuI4amqfKaN+7uTI9B0Ho24C86DitQk5zb62NkEM9poOyfuG7WS2bw6jg==}
+
+  '@iconify-json/material-icon-theme@1.2.66':
+    resolution: {integrity: sha512-TxWgH1twATqzvdMOafXf3V7NtgdLGkg77ySoEUo0uKv4cmzsy/8fHUZWNn6t9s7ZAzAjxf41ZIDdWIwxIsMrbQ==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -5321,6 +5327,10 @@ snapshots:
       react: 19.2.5
 
   '@iconify-json/catppuccin@1.2.17':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/material-icon-theme@1.2.66':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run() {
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,
+            fs::file::fs_read_bytes,
             fs::file::fs_write_file,
             fs::file::fs_stat,
             fs::file::fs_canonicalize,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -9,6 +9,7 @@ use tempfile::NamedTempFile;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+const MAX_MEDIA_BYTES: u64 = 200 * 1024 * 1024; // 200 MB
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
 #[derive(Serialize)]
@@ -76,6 +77,30 @@ pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<Rea
         Ok(content) => Ok(ReadResult::Text { content, size }),
         Err(_) => Ok(ReadResult::Binary { size }),
     }
+}
+
+/// Read raw bytes from a file. Used by the media viewer to display
+/// images, video and audio via blob URLs. Tauri serialises Vec<u8> as
+/// base64 automatically.
+#[tauri::command]
+pub fn fs_read_bytes(path: String, workspace: Option<WorkspaceEnv>) -> Result<Vec<u8>, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
+    let meta = std::fs::metadata(&p).map_err(|e| {
+        log::debug!("fs_read_bytes stat({}) failed: {e}", p.display());
+        e.to_string()
+    })?;
+    if meta.len() > MAX_MEDIA_BYTES {
+        return Err(format!(
+            "file too large ({} bytes, limit is {} bytes)",
+            meta.len(),
+            MAX_MEDIA_BYTES
+        ));
+    }
+    std::fs::read(&p).map_err(|e| {
+        log::debug!("fs_read_bytes read({}) failed: {e}", p.display());
+        e.to_string()
+    })
 }
 
 #[derive(Serialize, Clone)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; media-src 'self' asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' asset: https://asset.localhost ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
     }
   },
   "bundle": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,6 +62,7 @@ import {
   type SearchTarget,
 } from "@/modules/header";
 import { MarkdownStack } from "@/modules/markdown";
+import { MediaStack } from "@/modules/media";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -467,6 +468,7 @@ export default function App() {
   const isGitDiffTab =
     activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
   const isGitHistoryTab = activeTab?.kind === "git-history";
+  const isMediaTab = activeTab?.kind === "media";
 
   // When an AI diff is approved (write_file applied to disk), reload any
   // open editor tabs for that path so the user sees the new content. We
@@ -1375,6 +1377,15 @@ export default function App() {
         aria-hidden={!isGitDiffTab}
       >
         <GitDiffStack tabs={tabs} activeId={activeId} />
+      </div>
+      <div
+        className={cn(
+          "absolute inset-0",
+          !isMediaTab && "invisible pointer-events-none",
+        )}
+        aria-hidden={!isMediaTab}
+      >
+        <MediaStack tabs={tabs} activeId={activeId} />
       </div>
       <div
         className={cn(

--- a/src/lib/useIsFullscreen.ts
+++ b/src/lib/useIsFullscreen.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+// Tracks the current Tauri window's fullscreen state. Used to remove the
+// macOS traffic-light gutter when the window goes fullscreen (the OS hides
+// the traffic lights so the reserved left padding becomes wasted space).
+export function useIsFullscreen(): boolean {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    let alive = true;
+
+    void win.isFullscreen().then((v) => {
+      if (alive) setIsFullscreen(v);
+    });
+
+    const unlistenPromise = win.onResized(() => {
+      void win.isFullscreen().then((v) => {
+        if (alive) setIsFullscreen(v);
+      });
+    });
+
+    return () => {
+      alive = false;
+      void unlistenPromise.then((un) => un());
+    };
+  }, []);
+
+  return isFullscreen;
+}

--- a/src/modules/ai/components/FilePicker.tsx
+++ b/src/modules/ai/components/FilePicker.tsx
@@ -2,6 +2,7 @@ import { PopoverContent } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { useEffect, useRef } from "react";
 
 type Props = {
@@ -25,6 +26,7 @@ export function FilePickerContent({
 }: Props) {
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const listRef = useRef<HTMLDivElement | null>(null);
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
 
   useEffect(() => {
     const el = itemRefs.current[activeIndex];
@@ -80,7 +82,7 @@ export function FilePickerContent({
                   )}
                 >
                   <img
-                    src={fileIconUrl(name)}
+                    src={fileIconUrl(name, iconTheme)}
                     alt=""
                     className="size-4 shrink-0"
                   />

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -23,6 +23,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { fileIconUrl } from "./lib/iconResolver";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
@@ -76,6 +77,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searching, setSearching] = useState(false);
   const [truncated, setTruncated] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastKeyboardNavAt = useRef(0);
@@ -95,6 +97,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
       setSelectedIndex(0);
       setSearching(false);
       setTruncated(false);
+      setSearchError(null);
     }
   }, [open]);
 
@@ -105,9 +108,11 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
       setSelectedIndex(0);
       setSearching(false);
       setTruncated(false);
+      setSearchError(null);
       return;
     }
     setSearching(true);
+    setSearchError(null);
     let alive = true;
     const handle = setTimeout(async () => {
       try {
@@ -122,13 +127,16 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
           setResults(res.hits);
           setTruncated(res.truncated);
           setSelectedIndex(0);
+          setSearchError(null);
         }
       } catch (e) {
         if (alive) {
-          console.error("fs_search failed:", e);
+          const message = e instanceof Error ? e.message : String(e);
           setResults([]);
           setTruncated(false);
           setSelectedIndex(0);
+          setSearchError(message);
+          toast.error("Search failed", { description: message });
         }
       } finally {
         if (alive) setSearching(false);
@@ -231,6 +239,10 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
             {searching && results.length === 0 ? (
               <div className="px-3 py-2 text-[11px] text-muted-foreground">
                 Searching…
+              </div>
+            ) : searchError ? (
+              <div className="px-3 py-2 text-[11px] text-destructive">
+                Search failed: {searchError}
               </div>
             ) : results.length === 0 ? (
               <div className="px-3 py-2 text-[11px] text-muted-foreground">

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -72,6 +72,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   ref,
 ) {
   const showHidden = usePreferencesStore((s) => s.showHidden);
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchHit[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -250,7 +251,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
               </div>
             ) : (
               results.map((hit, index) => {
-                const url = hit.is_dir ? null : fileIconUrl(hit.name);
+                const url = hit.is_dir ? null : fileIconUrl(hit.name, iconTheme);
                 const isSelected = index === selectedIndex;
                 return (
                   <ContextMenu key={hit.path}>

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -29,6 +29,7 @@ import { EntryRow, PendingRow, StatusRow } from "./TreeRow";
 import { InlineInput } from "./InlineInput";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
@@ -157,6 +158,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
     ref,
   ) {
     const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
+    const iconTheme = usePreferencesStore((s) => s.iconTheme);
     const [selectedPath, setSelectedPath] = useState<string | null>(null);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const [isSearchActive, setIsSearchActive] = useState(false);
@@ -375,7 +377,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
             title={rootPath}
           >
             <img
-              src={folderIconUrl(basename(rootPath), false)}
+              src={folderIconUrl(basename(rootPath), false, iconTheme)}
               alt=""
               height={15}
               width={15}
@@ -451,8 +453,8 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
                     <img
                       src={
                         pendingAtRoot.kind === "dir"
-                          ? folderIconUrl("", false)
-                          : fileIconUrl("untitled")
+                          ? folderIconUrl("", false, iconTheme)
+                          : fileIconUrl("untitled", iconTheme)
                       }
                       alt=""
                       className="size-4 shrink-0 opacity-70"

--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -18,6 +18,7 @@ import {
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import type { useFileTree } from "./lib/useFileTree";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 
 type Tree = ReturnType<typeof useFileTree>;
 
@@ -61,7 +62,8 @@ function EntryRowImpl(props: EntryRowProps) {
   } = props;
 
   const [isConfirming, setIsConfirming] = useState(false);
-  const iconUrl = isDir ? folderIconUrl(name, isExpanded) : fileIconUrl(name);
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
+  const iconUrl = isDir ? folderIconUrl(name, isExpanded, iconTheme) : fileIconUrl(name, iconTheme);
   const createTarget = isDir ? path : path.slice(0, path.lastIndexOf("/")) || rootPath;
   const paddingLeft = 6 + depth * 12;
 
@@ -226,6 +228,7 @@ export type PendingRowProps = {
 };
 
 export function PendingRow({ depth, kind, onCommit, onCancel }: PendingRowProps) {
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
   return (
     <div
       className="flex h-6 w-full min-w-0 items-center gap-2 px-1.5 text-[13px]"
@@ -233,7 +236,7 @@ export function PendingRow({ depth, kind, onCommit, onCancel }: PendingRowProps)
     >
       <span className="size-3.5 shrink-0" />
       <img
-        src={kind === "dir" ? folderIconUrl("", false) : fileIconUrl("untitled")}
+        src={kind === "dir" ? folderIconUrl("", false, iconTheme) : fileIconUrl("untitled", iconTheme)}
         alt=""
         className="size-4 shrink-0 opacity-70"
       />

--- a/src/modules/explorer/lib/iconResolver.ts
+++ b/src/modules/explorer/lib/iconResolver.ts
@@ -1,4 +1,6 @@
 import catppuccinIcons from "@iconify-json/catppuccin/icons.json";
+import materialIcons from "@iconify-json/material-icon-theme/icons.json";
+import type { IconThemeId } from "@/modules/settings/store";
 import { EXT_TO_LANGUAGE_ID } from "./constants";
 import * as fileIconsMod from "./fileIcons";
 import * as folderIconsMod from "./folderIcons";
@@ -9,51 +11,201 @@ const catLanguageIds = fileIconsMod.languageIds as Record<string, string>;
 const catFolderNames = folderIconsMod.folderNames as Record<string, string>;
 
 type IconifySet = {
-  icons: Record<string, { body: string }>;
+  icons: Record<
+    string,
+    { body: string; width?: number; height?: number; left?: number; top?: number }
+  >;
   aliases?: Record<string, { parent: string }>;
   width?: number;
   height?: number;
+  left?: number;
+  top?: number;
 };
 
-const cat = catppuccinIcons as unknown as IconifySet;
-const CAT_W = cat.width ?? 16;
-const CAT_H = cat.height ?? 16;
+const SETS: Record<IconThemeId, IconifySet> = {
+  catppuccin: catppuccinIcons as unknown as IconifySet,
+  material: materialIcons as unknown as IconifySet,
+};
 
-const DEFAULT_FILE = "file";
-const DEFAULT_FOLDER = "folder";
-const DEFAULT_FOLDER_OPEN = "folder-open";
+// Per-theme generic fallback slugs. Catppuccin uses `file` / `folder` /
+// `folder-open`; Material publishes `document` / `folder-base` /
+// `folder-base-open` (matches Material Icon Theme upstream).
+const DEFAULT_FILE: Record<IconThemeId, string> = {
+  catppuccin: "file",
+  material: "document",
+};
+const DEFAULT_FOLDER: Record<IconThemeId, string> = {
+  catppuccin: "folder",
+  material: "folder-base",
+};
+const DEFAULT_FOLDER_OPEN: Record<IconThemeId, string> = {
+  catppuccin: "folder-open",
+  material: "folder-base-open",
+};
 
-const dataUrlCache = new Map<string, string>();
+// fileIcons.ts targets are written against the Catppuccin slug vocabulary.
+// Material uses different names for some common icons; remap on lookup so a
+// Catppuccin-named target still resolves to the right Material slug.
+const MATERIAL_SLUG_OVERRIDES: Record<string, string> = {
+  "typescript-react": "react-ts",
+  "javascript-react": "react",
+  "typescript-config": "tsconfig",
+  "typescript-test": "test-ts",
+  "javascript-test": "test-js",
+  "javascript-map": "javascript",
+  "javascript-config": "jsconfig",
+  "json-schema": "json",
+  "css-map": "css",
+  "c-header": "cppheader",
+  "cpp-header": "cppheader",
+  "ms-excel": "excel",
+  "ms-word": "word",
+  "ms-powerpoint": "powerpoint",
+  "java-class": "java",
+  "java-jar": "jar",
+  "go-template": "go",
+  "ruby-gem": "gemfile",
+  "ruby-gem-lock": "gemfile",
+  "npm-lock": "npm",
+  "yarn-lock": "yarn",
+  "pnpm-lock": "pnpm",
+  "bun-lock": "bun",
+  "cargo-lock": "cargo",
+  "python-config": "python",
+  "python-compiled": "python",
+  "nix-lock": "nix",
+  "dart-generated": "dart",
+  "godot-assets": "godot",
+  "code-of-conduct": "conduct",
+  "code-climate": "codeclimate",
+  "circle-ci": "circleci",
+  "docker-compose": "docker",
+  "docker-ignore": "docker",
+  "git-cliff": "git",
+  "markdown-mdx": "mdx",
+  "package-json": "nodejs",
+  "panda-css": "panda",
+  "pre-commit": "settings",
+  "prettier-ignore": "prettier",
+  "eslint-ignore": "eslint",
+  "stylelint-ignore": "stylelint",
+  "stylua-ignore": "stylua",
+  "semgrep-ignore": "semgrep",
+  "cursor-ignore": "cursor",
+  "nuxt-ignore": "nuxt",
+  "tauri-ignore": "tauri",
+  "vscode-ignore": "vscode",
+  "vercel-ignore": "vercel",
+  "vs-codium": "vscode",
+  "sonar-cloud": "sonarcloud",
+  "rust-config": "rust",
+  "web-assembly": "webassembly",
+  "ansible-lint": "ansible",
+  "lint-staged": "lintstaged",
+  "adobe-ae": "after-effects",
+  "adobe-ai": "illustrator",
+  "adobe-id": "indesign",
+  "adobe-ps": "photoshop",
+  "adobe-xd": "adobe",
+  "super-collider": "supercollider",
+  "storybook-svelte": "storybook",
+  "storybook-vue": "storybook",
+  "vue-config": "vue",
+  "svelte-config": "svelte",
+  "pesde-lock": "pesde",
+  "pixi-lock": "pixi",
+  "poetry-lock": "poetry",
+};
 
-// Catppuccin's manifest emits names like `folder_src`/`typescript-react`, but
-// the iconify export normalizes everything to hyphenated slugs.
-function toIconifySlug(name: string): string {
+function resolveSlug(theme: IconThemeId, name: string): string {
+  if (theme === "material") {
+    return MATERIAL_SLUG_OVERRIDES[name] ?? name.replace(/_/g, "-");
+  }
   return name.replace(/_/g, "-");
 }
 
-function catBody(iconName: string): string | null {
-  const slug = toIconifySlug(iconName);
-  const direct = cat.icons[slug];
-  if (direct) return direct.body;
-  const alias = cat.aliases?.[slug];
+const dataUrlCacheByTheme = new Map<IconThemeId, Map<string, string>>();
+
+function getCache(theme: IconThemeId): Map<string, string> {
+  let m = dataUrlCacheByTheme.get(theme);
+  if (!m) {
+    m = new Map<string, string>();
+    dataUrlCacheByTheme.set(theme, m);
+  }
+  return m;
+}
+
+type ResolvedIcon = {
+  body: string;
+  width?: number;
+  height?: number;
+  left?: number;
+  top?: number;
+};
+
+function bodyFromSet(set: IconifySet, slug: string): ResolvedIcon | null {
+  const direct = set.icons[slug];
+  if (direct) {
+    return {
+      body: direct.body,
+      width: direct.width,
+      height: direct.height,
+      left: direct.left,
+      top: direct.top,
+    };
+  }
+  const alias = set.aliases?.[slug];
   if (alias) {
-    const parent = cat.icons[alias.parent];
-    if (parent) return parent.body;
+    const parent = set.icons[alias.parent];
+    if (parent) {
+      return {
+        body: parent.body,
+        width: parent.width,
+        height: parent.height,
+        left: parent.left,
+        top: parent.top,
+      };
+    }
   }
   return null;
 }
 
-function buildDataUrl(iconName: string): string | null {
-  const cached = dataUrlCache.get(iconName);
+function buildDataUrl(theme: IconThemeId, name: string): string | null {
+  const cache = getCache(theme);
+  const cached = cache.get(name);
   if (cached !== undefined) return cached || null;
-  const body = catBody(iconName);
-  if (!body) {
-    dataUrlCache.set(iconName, "");
+
+  const set = SETS[theme];
+  let resolved = bodyFromSet(set, resolveSlug(theme, name));
+
+  // Fall back to per-theme default slug if specific icon is missing.
+  if (!resolved) {
+    const isFolderOpen = name === "folder-open" || name.endsWith("-open");
+    const isFolder = name === "folder" || name.startsWith("folder-") || isFolderOpen;
+    const fallback = isFolderOpen
+      ? DEFAULT_FOLDER_OPEN[theme]
+      : isFolder
+        ? DEFAULT_FOLDER[theme]
+        : DEFAULT_FILE[theme];
+    resolved = bodyFromSet(set, fallback);
+  }
+
+  if (!resolved) {
+    cache.set(name, "");
     return null;
   }
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${CAT_W} ${CAT_H}">${body}</svg>`;
+
+  // Iconify allows per-icon dimensions and viewBox origin (left/top); fall
+  // back to set-level (defaults: 0 0 16 16). Material mixes 16/24/32-px and
+  // Material-Design coordinate systems (e.g. JSON path uses left=0, top=-960,
+  // 960x960) so honouring left/top is required for non-cropped rendering.
+  const w = resolved.width ?? set.width ?? 16;
+  const h = resolved.height ?? set.height ?? 16;
+  const x = resolved.left ?? set.left ?? 0;
+  const y = resolved.top ?? set.top ?? 0;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${x} ${y} ${w} ${h}">${resolved.body}</svg>`;
   const url = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
-  dataUrlCache.set(iconName, url);
+  cache.set(name, url);
   return url;
 }
 
@@ -64,12 +216,12 @@ function extOf(name: string): string {
   return lower.slice(dot + 1);
 }
 
-export function fileIconUrl(name: string): string {
+export function fileIconUrl(name: string, theme: IconThemeId = "catppuccin"): string {
   const lower = name.toLowerCase();
 
   const byName = catFileNames[lower];
   if (byName) {
-    const url = buildDataUrl(byName);
+    const url = buildDataUrl(theme, byName);
     if (url) return url;
   }
 
@@ -77,14 +229,14 @@ export function fileIconUrl(name: string): string {
   while (ext) {
     const iconName = catFileExtensions[ext];
     if (iconName) {
-      const url = buildDataUrl(iconName);
+      const url = buildDataUrl(theme, iconName);
       if (url) return url;
     }
     const langId = EXT_TO_LANGUAGE_ID[ext];
     if (langId) {
       const iconByLang = catLanguageIds[langId];
       if (iconByLang) {
-        const url = buildDataUrl(iconByLang);
+        const url = buildDataUrl(theme, iconByLang);
         if (url) return url;
       }
     }
@@ -93,19 +245,26 @@ export function fileIconUrl(name: string): string {
     ext = ext.slice(nextDot + 1);
   }
 
-  return buildDataUrl(DEFAULT_FILE) ?? "";
+  return buildDataUrl(theme, DEFAULT_FILE[theme]) ?? "";
 }
 
-export function folderIconUrl(name: string, expanded: boolean): string {
+export function folderIconUrl(
+  name: string,
+  expanded: boolean,
+  theme: IconThemeId = "catppuccin",
+): string {
   const lower = name.toLowerCase();
 
   const mapped = catFolderNames[lower];
   if (mapped) {
-    const slug = toIconifySlug(mapped);
+    const slug = mapped.replace(/_/g, "-");
     const target = expanded ? `${slug}-open` : slug;
-    const url = buildDataUrl(target);
+    const url = buildDataUrl(theme, target);
     if (url) return url;
   }
 
-  return buildDataUrl(expanded ? DEFAULT_FOLDER_OPEN : DEFAULT_FOLDER) ?? "";
+  return buildDataUrl(
+    theme,
+    expanded ? DEFAULT_FOLDER_OPEN[theme] : DEFAULT_FOLDER[theme],
+  ) ?? "";
 }

--- a/src/modules/git-history/GitHistoryPane.tsx
+++ b/src/modules/git-history/GitHistoryPane.tsx
@@ -13,6 +13,7 @@ import {
   type GitLogEntry,
 } from "@/modules/ai/lib/native";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   Copy01Icon,
   File02Icon,
@@ -982,7 +983,8 @@ const FileRow = memo(function FileRow({
 }) {
   const fileName = basename(file.path);
   const dir = dirname(file.path);
-  const iconUrl = fileIconUrl(fileName);
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
+  const iconUrl = fileIconUrl(fileName, iconTheme);
   return (
     <button
       type="button"

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { WindowControls } from "@/components/WindowControls";
 import { IS_MAC, KEY_SEP, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { useIsFullscreen } from "@/lib/useIsFullscreen";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   getBindingTokens,
@@ -79,6 +80,7 @@ export function Header({
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
   const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+  const isFullscreen = useIsFullscreen();
 
   const tokensFor = (id: ShortcutId): string => {
     const s = SHORTCUTS.find((s) => s.id === id);
@@ -119,7 +121,7 @@ export function Header({
       ref={rootRef}
       data-tauri-drag-region
       className={`flex h-10 shrink-0 items-center gap-2 border-b border-border/60 bg-card select-none ${
-        IS_MAC ? "pr-2 pl-20" : "pr-0 pl-2"
+        IS_MAC ? (isFullscreen ? "pr-2 pl-2" : "pr-2 pl-20") : "pr-0 pl-2"
       }`}
     >
       <div className="flex shrink-0 items-center gap-0.5">

--- a/src/modules/media/MediaStack.tsx
+++ b/src/modules/media/MediaStack.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+import type { MediaTab, Tab } from "@/modules/tabs";
+import { MediaPane } from "./components/MediaPane";
+
+type Props = {
+  tabs: Tab[];
+  activeId: number;
+};
+
+export function MediaStack({ tabs, activeId }: Props) {
+  const medias = tabs.filter((t): t is MediaTab => t.kind === "media");
+  if (medias.length === 0) return null;
+  return (
+    <div className="relative h-full w-full">
+      {medias.map((t) => {
+        const visible = t.id === activeId;
+        return (
+          <div
+            key={t.id}
+            className={cn(
+              "absolute inset-0",
+              !visible && "invisible pointer-events-none",
+            )}
+            aria-hidden={!visible}
+          >
+            <MediaPane
+              path={t.path}
+              mediaKind={t.mediaKind}
+              visible={visible}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/modules/media/components/MediaPane.tsx
+++ b/src/modules/media/components/MediaPane.tsx
@@ -1,0 +1,249 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { guessMime } from "@/modules/media/lib/mime";
+
+type Props = {
+  path: string;
+  mediaKind: "image" | "video" | "audio";
+  visible: boolean;
+};
+
+export function MediaPane({ path, mediaKind, visible }: Props) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [hasVideoTrack, setHasVideoTrack] = useState<boolean | null>(null);
+  const blobRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+
+    if (blobRef.current) {
+      URL.revokeObjectURL(blobRef.current);
+      blobRef.current = null;
+    }
+
+    setSrc(null);
+    setErrorMsg(null);
+    setHasVideoTrack(null);
+
+    const timer = setTimeout(() => {
+      invoke<number[]>("fs_read_bytes", { path })
+        .then((arr) => {
+          if (!alive) return;
+          const bytes = new Uint8Array(arr);
+          const mime = guessMime(path, mediaKind);
+          const blob = new Blob([bytes], { type: mime });
+          const url = URL.createObjectURL(blob);
+          blobRef.current = url;
+          setSrc(url);
+        })
+        .catch((e) => {
+          const msg = typeof e === "string" ? e : String(e);
+          if (alive) setErrorMsg(msg);
+        });
+    }, 50);
+
+    return () => {
+      alive = false;
+      clearTimeout(timer);
+    };
+  }, [path, mediaKind]);
+
+  // Called when <video> fires loadedmetadata — check if there's actually a
+  // video track. Some .mp4 / .mov files are audio-only containers.
+  const handleVideoMetadata = useCallback(
+    (e: React.SyntheticEvent<HTMLVideoElement>) => {
+      const el = e.currentTarget;
+      // videoWidth > 0 means a decoded video frame exists.
+      setHasVideoTrack(el.videoWidth > 0 && el.videoHeight > 0);
+    },
+    [],
+  );
+
+  if (!visible) {
+    return <div className="hidden h-full w-full" aria-hidden />;
+  }
+
+  if (errorMsg) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2">
+        <p className="text-[12px] text-muted-foreground">Failed to load media</p>
+        <p className="max-w-md px-4 text-center text-[11px] text-muted-foreground/70">
+          {errorMsg}
+        </p>
+      </div>
+    );
+  }
+
+  if (!src) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <p className="text-[12px] text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  // Image
+  if (mediaKind === "image") {
+    return (
+      <div className="flex h-full w-full items-center justify-center overflow-auto bg-background/50 p-4">
+        <img
+          src={src}
+          alt={path}
+          className="max-h-full max-w-full object-contain"
+          draggable={false}
+        />
+      </div>
+    );
+  }
+
+  // Video — might be audio-only; detect on metadata load
+  if (mediaKind === "video") {
+    return (
+      <div className="flex h-full w-full items-center justify-center overflow-auto bg-background/50 p-4">
+        {/* Hidden probe: load metadata to detect video track */}
+        {hasVideoTrack === null && (
+          <video
+            src={src}
+            onLoadedMetadata={handleVideoMetadata}
+            className="hidden"
+          />
+        )}
+        {hasVideoTrack === true && (
+          <video src={src} controls className="max-h-full max-w-full" />
+        )}
+        {hasVideoTrack === false && (
+          <AudioPlayer src={src} />
+        )}
+      </div>
+    );
+  }
+
+  // Audio
+  return (
+    <div className="flex h-full w-full items-center justify-center overflow-auto bg-background/50 p-4">
+      <AudioPlayer src={src} />
+    </div>
+  );
+}
+
+// --- Audio Player ----------------------------------------------------------
+
+function AudioPlayer({ src }: { src: string }) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const [current, setCurrent] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+
+  const toggle = useCallback(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    if (el.paused) {
+      void el.play();
+      setPlaying(true);
+    } else {
+      el.pause();
+      setPlaying(false);
+    }
+  }, []);
+
+  const seek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const el = audioRef.current;
+    if (!el) return;
+    const t = Number(e.target.value);
+    el.currentTime = t;
+    setCurrent(t);
+  }, []);
+
+  const changeVolume = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const el = audioRef.current;
+    if (!el) return;
+    const v = Number(e.target.value);
+    el.volume = v;
+    setVolume(v);
+  }, []);
+
+  return (
+    <div className="flex w-full max-w-md flex-col items-center gap-2 rounded-lg bg-card/80 p-4 shadow-sm">
+      <audio
+        ref={audioRef}
+        src={src}
+        onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
+        onTimeUpdate={(e) => {
+          // Throttle: only update every ~250ms to avoid excessive re-renders.
+          const t = e.currentTarget.currentTime;
+          setCurrent((prev) => (Math.abs(t - prev) < 0.25 ? prev : t));
+        }}
+        onEnded={() => setPlaying(false)}
+        onPause={() => setPlaying(false)}
+        onPlay={() => setPlaying(true)}
+      />
+
+      {/* Seek bar */}
+      <div className="flex w-full items-center gap-2">
+        <span className="w-10 text-right text-[10px] text-muted-foreground tabular-nums">
+          {fmtTime(current)}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={current}
+          onChange={seek}
+          className="h-1 w-full cursor-pointer accent-primary"
+        />
+        <span className="w-10 text-[10px] text-muted-foreground tabular-nums">
+          {fmtTime(duration)}
+        </span>
+      </div>
+
+      {/* Controls row */}
+      <div className="flex w-full items-center justify-between">
+        {/* Play/Pause */}
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/80"
+        >
+          {playing ? (
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+              <rect x="2" y="1" width="3.5" height="12" rx="1" />
+              <rect x="8.5" y="1" width="3.5" height="12" rx="1" />
+            </svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
+              <path d="M3 1.5v11l9-5.5z" />
+            </svg>
+          )}
+        </button>
+
+        {/* Volume */}
+        <div className="flex items-center gap-1.5">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted-foreground">
+            <path d="M11 5L6 9H2v6h4l5 4V5z" />
+            {volume > 0 && <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />}
+            {volume > 0.5 && <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />}
+          </svg>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={volume}
+            onChange={changeVolume}
+            className="h-1 w-16 cursor-pointer accent-primary"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function fmtTime(s: number): string {
+  if (!Number.isFinite(s)) return "0:00";
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${sec.toString().padStart(2, "0")}`;
+}

--- a/src/modules/media/index.ts
+++ b/src/modules/media/index.ts
@@ -1,0 +1,2 @@
+export { MediaStack } from "./MediaStack";
+export { detectMediaKind, type MediaKind } from "./lib/mime";

--- a/src/modules/media/lib/mime.ts
+++ b/src/modules/media/lib/mime.ts
@@ -1,0 +1,69 @@
+export type MediaKind = "image" | "video" | "audio" | null;
+
+const IMAGE_EXTS = new Set([
+  "png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif", "apng",
+]);
+
+const VIDEO_EXTS = new Set([
+  "mp4", "webm", "mov", "mkv", "avi", "m4v", "ogv",
+]);
+
+const AUDIO_EXTS = new Set([
+  "mp3", "wav", "ogg", "flac", "aac", "m4a", "opus",
+]);
+
+const IMAGE_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  avif: "image/avif",
+  apng: "image/apng",
+};
+
+const VIDEO_MIME: Record<string, string> = {
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  m4v: "video/mp4",
+  ogv: "video/ogg",
+  mkv: "video/x-matroska",
+  avi: "video/x-msvideo",
+};
+
+const AUDIO_MIME: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  flac: "audio/flac",
+  aac: "audio/aac",
+  m4a: "audio/mp4",
+  opus: "audio/opus",
+};
+
+export function ext(path: string): string {
+  const dot = path.lastIndexOf(".");
+  return dot === -1 ? "" : path.slice(dot + 1).toLowerCase();
+}
+
+export function detectMediaKind(path: string): MediaKind {
+  const e = ext(path);
+  if (IMAGE_EXTS.has(e)) return "image";
+  if (VIDEO_EXTS.has(e)) return "video";
+  if (AUDIO_EXTS.has(e)) return "audio";
+  return null;
+}
+
+export function guessMime(
+  path: string,
+  kind: "image" | "video" | "audio",
+): string {
+  const e = ext(path);
+  if (kind === "image") return IMAGE_MIME[e] ?? "application/octet-stream";
+  if (kind === "video") return VIDEO_MIME[e] ?? "video/mp4";
+  return AUDIO_MIME[e] ?? "audio/mpeg";
+}

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -34,6 +34,15 @@ export const EDITOR_THEMES = [
 
 export type EditorThemeId = (typeof EDITOR_THEMES)[number];
 
+export const ICON_THEMES = ["catppuccin", "material"] as const;
+
+export type IconThemeId = (typeof ICON_THEMES)[number];
+
+export const ICON_THEME_LABELS: Record<IconThemeId, string> = {
+  catppuccin: "Catppuccin",
+  material: "Material",
+};
+
 export const EDITOR_THEME_LABELS: Record<EditorThemeId, string> = {
   atomone: "Atom One",
   aura: "Aura",
@@ -56,6 +65,7 @@ export type Preferences = {
   backgroundBlur: number;
   defaultModelId: ModelId;
   editorTheme: EditorThemeId;
+  iconTheme: IconThemeId;
   customInstructions: string;
   autostart: boolean;
   restoreWindowState: boolean;
@@ -98,6 +108,7 @@ const KEY_BG_OPACITY = "backgroundOpacity";
 const KEY_BG_BLUR = "backgroundBlur";
 const KEY_DEFAULT_MODEL = "defaultModelId";
 const KEY_EDITOR_THEME = "editorTheme";
+const KEY_ICON_THEME = "iconTheme";
 const KEY_CUSTOM_INSTRUCTIONS = "customInstructions";
 const KEY_AUTOSTART = "autostart";
 const KEY_RESTORE_WINDOW = "restoreWindowState";
@@ -155,6 +166,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   backgroundBlur: 0,
   defaultModelId: DEFAULT_MODEL_ID,
   editorTheme: "atomone",
+  iconTheme: "catppuccin",
   customInstructions: "",
   autostart: false,
   restoreWindowState: true,
@@ -230,6 +242,12 @@ export async function loadPreferences(): Promise<Preferences> {
     })(),
     editorTheme:
       get<EditorThemeId>(KEY_EDITOR_THEME) ?? DEFAULT_PREFERENCES.editorTheme,
+    iconTheme: ((): IconThemeId => {
+      const stored = get<string>(KEY_ICON_THEME);
+      return stored && (ICON_THEMES as readonly string[]).includes(stored)
+        ? (stored as IconThemeId)
+        : DEFAULT_PREFERENCES.iconTheme;
+    })(),
     customInstructions:
       get<string>(KEY_CUSTOM_INSTRUCTIONS) ??
       DEFAULT_PREFERENCES.customInstructions,
@@ -363,6 +381,10 @@ export async function setDefaultModel(value: ModelId): Promise<void> {
 
 export async function setEditorTheme(value: EditorThemeId): Promise<void> {
   await writePref(KEY_EDITOR_THEME, value);
+}
+
+export async function setIconTheme(value: IconThemeId): Promise<void> {
+  await writePref(KEY_ICON_THEME, value);
 }
 
 export async function setCustomInstructions(value: string): Promise<void> {
@@ -537,6 +559,7 @@ export async function onPreferencesChange(
     [KEY_BG_BLUR]: "backgroundBlur",
     [KEY_DEFAULT_MODEL]: "defaultModelId",
     [KEY_EDITOR_THEME]: "editorTheme",
+    [KEY_ICON_THEME]: "iconTheme",
     [KEY_CUSTOM_INSTRUCTIONS]: "customInstructions",
     [KEY_AUTOSTART]: "autostart",
     [KEY_RESTORE_WINDOW]: "restoreWindowState",

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   AiContentGenerator02Icon,
   Alert02Icon,
@@ -912,7 +913,8 @@ const EntryRow = memo(function EntryRow({
   const entry = row.entry;
   const isSelected = selectedPath === entry.path;
   const fileName = basename(entry.path);
-  const iconUrl = fileIconUrl(fileName);
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
+  const iconUrl = fileIconUrl(fileName, iconTheme);
   const pathLabel = entryPathLabel(entry);
   const showDiscard = entry.unstaged;
   const isStageBusy =

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -11,15 +11,18 @@ import { cn } from "@/lib/utils";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
+  AudioWave01Icon,
   Cancel01Icon,
   Clock01Icon,
   ComputerTerminal02Icon,
   GitBranchIcon,
   GitCompareIcon,
   Globe02Icon,
+  Image01Icon,
   IncognitoIcon,
   PencilEdit02Icon,
   PlusSignIcon,
+  Video01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef } from "react";
@@ -256,6 +259,22 @@ function TabIcon({ tab }: { tab: Tab }) {
       />
     );
   }
+  if (tab.kind === "media") {
+    const icon =
+      tab.mediaKind === "video"
+        ? Video01Icon
+        : tab.mediaKind === "audio"
+          ? AudioWave01Icon
+          : Image01Icon;
+    return (
+      <HugeiconsIcon
+        icon={icon}
+        size={14}
+        strokeWidth={2}
+        className="shrink-0"
+      />
+    );
+  }
   if (tab.kind === "git-diff" || tab.kind === "git-commit-file") {
     return (
       <HugeiconsIcon
@@ -294,6 +313,7 @@ function labelFor(t: Tab): string {
   if (t.kind === "git-diff") return t.title;
   if (t.kind === "git-history") return t.title;
   if (t.kind === "git-commit-file") return t.title;
+  if (t.kind === "media") return t.title;
   if (!t.cwd) return t.title;
   const parts = t.cwd.split(/[\\/]/).filter(Boolean);
   return parts.length ? parts[parts.length - 1] : "/";

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fmtShortcut, MOD_KEY } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   Cancel01Icon,
   Clock01Icon,
@@ -220,8 +221,9 @@ export function TabBar({
 }
 
 function TabIcon({ tab }: { tab: Tab }) {
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
   if (tab.kind === "editor" || tab.kind === "markdown") {
-    const url = fileIconUrl(tab.title);
+    const url = fileIconUrl(tab.title, iconTheme);
     return url ? <img src={url} alt="" className="size-3.5 shrink-0" /> : null;
   }
   if (tab.kind === "preview") {

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -11,6 +11,7 @@ export {
   type GitDiffTab,
   type GitHistoryTab,
   type GitCommitFileDiffTab,
+  type MediaTab,
   type AiDiffStatus,
   type TabPatch,
 } from "./lib/useTabs";

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -12,6 +12,7 @@ import {
   type SplitDir,
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
+import { detectMediaKind } from "@/modules/media/lib/mime";
 
 // Matches the renderer slot pool size — over this we'd evict an active leaf.
 export const MAX_PANES_PER_TAB = 4;
@@ -100,6 +101,14 @@ export type GitCommitFileDiffTab = {
   originalPath: string | null;
 };
 
+export type MediaTab = {
+  id: number;
+  kind: "media";
+  title: string;
+  path: string;
+  mediaKind: "image" | "video" | "audio";
+};
+
 export type Tab =
   | TerminalTab
   | EditorTab
@@ -108,7 +117,8 @@ export type Tab =
   | AiDiffTab
   | GitDiffTab
   | GitHistoryTab
-  | GitCommitFileDiffTab;
+  | GitCommitFileDiffTab
+  | MediaTab;
 
 export type TabPatch = Partial<{
   title: string;
@@ -224,8 +234,32 @@ export function useTabs(initial?: Partial<TerminalTab>) {
    *   otherwise the current preview slot is replaced with the new path.
    */
   const openFileTab = useCallback((path: string, pin = true) => {
+    const mediaKind = detectMediaKind(path);
     let targetId: number | null = null;
     setTabs((curr) => {
+      // Media files get their own tab kind (image/video/audio viewer).
+      if (mediaKind) {
+        const existing = curr.find(
+          (t) => t.kind === "media" && t.path === path,
+        );
+        if (existing) {
+          targetId = existing.id;
+          return curr;
+        }
+        const id = nextIdRef.current++;
+        targetId = id;
+        return [
+          ...curr,
+          {
+            id,
+            kind: "media",
+            title: basename(path),
+            path,
+            mediaKind,
+          } satisfies MediaTab,
+        ];
+      }
+
       if (pin) {
         // Persistent open: find any existing editor tab, pin it if needed.
         const existing = curr.find(

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,7 +1,9 @@
 import { useTheme } from "@/modules/theme";
 import type { SearchAddon } from "@xterm/addon-search";
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import { quoteShellArg } from "@/lib/shellQuote";
 import { useTerminalSession } from "./lib/useTerminalSession";
+import { useTerminalDragDrop } from "./lib/useTerminalDragDrop";
 
 export type TerminalPaneHandle = {
   write: (data: string) => void;
@@ -56,6 +58,16 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       return () => cancelAnimationFrame(id);
     }, [resolvedMode, themeId, customThemes, session]);
 
+    const handleDrop = useCallback(
+      (paths: string[]) => {
+        const quoted = paths.map((p) => quoteShellArg(p)).join(" ");
+        session.write(quoted + " ");
+      },
+      [session],
+    );
+
+    const dropHovering = useTerminalDragDrop(containerRef, handleDrop);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -70,12 +82,20 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
     return (
       <div
         ref={containerRef}
-        className="zoom-exempt h-full w-full"
+        className="zoom-exempt relative h-full w-full"
         style={{
           visibility: visible ? "visible" : "hidden",
           pointerEvents: visible ? "auto" : "none",
         }}
-      />
+      >
+        {dropHovering && (
+          <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded border-2 border-dashed border-ring/70 bg-primary/10">
+            <span className="rounded-md bg-card/90 px-3 py-1.5 text-[12px] font-medium text-foreground shadow-sm">
+              Drop files here
+            </span>
+          </div>
+        )}
+      </div>
     );
   },
 );

--- a/src/modules/terminal/lib/useTerminalDragDrop.ts
+++ b/src/modules/terminal/lib/useTerminalDragDrop.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import type { DragDropEvent } from "@tauri-apps/api/webview";
+import type { Event } from "@tauri-apps/api/event";
+
+/**
+ * Listens to Tauri's OS-level file drag-drop events and calls `onDrop` when
+ * files are dropped inside the given container. Returns `true` while the user
+ * is hovering files over this specific pane so the caller can render a
+ * drop-highlight.
+ *
+ * Tauri reports positions in physical pixels (CSS × devicePixelRatio). We
+ * convert to CSS pixels before comparing with getBoundingClientRect().
+ */
+export function useTerminalDragDrop(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  onDrop: (paths: string[]) => void,
+): boolean {
+  const [hovering, setHovering] = useState(false);
+  const onDropRef = useRef(onDrop);
+  onDropRef.current = onDrop;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    let alive = true;
+
+    const unlistenPromise = getCurrentWebview().onDragDropEvent(
+      (event: Event<DragDropEvent>) => {
+        if (!alive) return;
+
+        // PhysicalPosition → CSS pixel conversion.
+        const dpr = window.devicePixelRatio || 1;
+        const pos =
+          event.payload.type === "over" || event.payload.type === "drop"
+            ? {
+                x: event.payload.position.x / dpr,
+                y: event.payload.position.y / dpr,
+              }
+            : null;
+
+        if (!pos) {
+          // "enter" or "cancel" — just clear hover.
+          setHovering(false);
+          return;
+        }
+
+        const rect = el.getBoundingClientRect();
+        const inside =
+          pos.x >= rect.left &&
+          pos.x <= rect.right &&
+          pos.y >= rect.top &&
+          pos.y <= rect.bottom;
+
+        if (event.payload.type === "over") {
+          setHovering(inside);
+        } else if (event.payload.type === "drop" && inside) {
+          setHovering(false);
+          const paths = event.payload.paths;
+          if (paths.length > 0) {
+            onDropRef.current(paths);
+          }
+        } else {
+          setHovering(false);
+        }
+      },
+    );
+
+    return () => {
+      alive = false;
+      void unlistenPromise.then((un) => un());
+    };
+  }, [containerRef]);
+
+  return hovering;
+}

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -1,6 +1,7 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { WindowControls } from "@/components/WindowControls";
 import { IS_MAC, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { useIsFullscreen } from "@/lib/useIsFullscreen";
 import type { SettingsTab } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
@@ -54,6 +55,7 @@ export function SettingsApp() {
   const [active, setActive] = useState<SettingsTab>(readInitialTab);
   const init = usePreferencesStore((s) => s.init);
   const ActiveSection = TABS.find(t => t.id === active)?.component;
+  const isFullscreen = useIsFullscreen();
 
   useEffect(() => {
     void init();
@@ -82,7 +84,7 @@ export function SettingsApp() {
     <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground select-none">
       <header
         data-tauri-drag-region
-        className={`flex h-11 shrink-0 items-center border-b border-border/60 bg-card/60 ${IS_MAC ? "pr-3 pl-22" : "pr-0 pl-3"
+        className={`flex h-11 shrink-0 items-center border-b border-border/60 bg-card/60 ${IS_MAC ? (isFullscreen ? "pr-3 pl-3" : "pr-3 pl-22") : "pr-0 pl-3"
           }`}
       >
         <Tabs

--- a/src/settings/sections/ThemesSection.tsx
+++ b/src/settings/sections/ThemesSection.tsx
@@ -1,12 +1,23 @@
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import type { IconThemeId } from "@/modules/settings/store";
 import {
+  ICON_THEMES,
+  ICON_THEME_LABELS,
   setBackgroundBlur,
   setBackgroundImageId,
   setBackgroundKind,
   setBackgroundOpacity,
+  setIconTheme,
 } from "@/modules/settings/store";
 import { useTheme } from "@/modules/theme";
 import {
@@ -55,6 +66,7 @@ export function ThemesSection() {
   const backgroundImageId = usePreferencesStore((s) => s.backgroundImageId);
   const backgroundOpacity = usePreferencesStore((s) => s.backgroundOpacity);
   const backgroundBlur = usePreferencesStore((s) => s.backgroundBlur);
+  const iconTheme = usePreferencesStore((s) => s.iconTheme);
 
   const handleThemeFiles = async (files: FileList | null) => {
     setImportError(null);
@@ -251,6 +263,30 @@ export function ThemesSection() {
             );
           })}
         </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <Label>File icons</Label>
+          <Select
+            value={iconTheme}
+            onValueChange={(v) => void setIconTheme(v as IconThemeId)}
+          >
+            <SelectTrigger size="sm" className="h-7 w-32 text-[11px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {ICON_THEMES.map((id) => (
+                <SelectItem key={id} value={id} className="text-[12px]">
+                  {ICON_THEME_LABELS[id]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Icon set used in the file explorer, tabs, source control, and AI file picker.
+        </p>
       </div>
 
       <div


### PR DESCRIPTION
What

  Combines three UI improvements: a file icon theme selector (Catppuccin
   + Material), inline error surfacing for explorer search failures, and
   a fix for the macOS fullscreen header indentation caused by the
  traffic-light gutter.

  Why

  - Icon theme selector: Users had no way to switch file icon sets.
  Material Icon Theme is a popular alternative to Catppuccin and was not
   available.
  - Search error surfacing: fs_search errors were silently swallowed —
  the results panel just showed "No matches" even when the search had
  actually failed, leaving users confused.
  - Fullscreen gutter fix: macOS hides the native traffic-light buttons
  in fullscreen, but the ~80px left padding reserved for them remained,
  creating a visibly indented header in both the main window and the
  settings window.

  How

  - Icon themes: Added @iconify-json/material-icon-theme dependency.
  iconResolver now maintains per-theme caches and routes Catppuccin slug
   names through a Material override table so existing
  fileIcons/folderIcons mappings work for both themes. A Select dropdown
   in ThemesSection lets users pick between Catppuccin (default) and
  Material. Components subscribe to preferences.iconTheme.
  - Search errors: ExplorerSearch now catches fs_search errors, stores
  the message in state, renders a destructive-colored inline message in
  the results panel, and fires a Sonner toast with details.
  - Fullscreen fix: New useIsFullscreen hook (Tauri
  window.isFullscreen() + onResized listener). Both Header and
  SettingsApp gate the macOS pl-20/pl-22 padding on !isFullscreen,
  falling back to pl-2/pl-3 when fullscreen.

  Testing

  - pnpm exec tsc --noEmit clean
  - Manual smoke-test of the affected feature
  - UI tested in pnpm tauri dev
  - Platforms tested: macOS
  - Verified icon theme switching updates explorer, tabs, source control
   panel, git history, and AI file picker
  - Verified search errors now show inline message + toast instead of
  silent "No matches"
  - Verified header padding collapses correctly in macOS fullscreen
  (Mission Control + titleBarStyle:Overlay)



  Notes for reviewer

  - The Material icon set uses mixed viewBox sizes (16/24/32px) and some
   entries have non-zero left/top offsets (e.g. json, rollup, snowpack).
   The SVG emitter now reads per-icon dimensions instead of hardcoding 0
   0 16 16 — worth double-checking a few Material icons at different
  sizes.
  - useIsFullscreen listens to onResized and re-queries isFullscreen()
  on each resize event. This is slightly indirect (no dedicated
  fullscreen-changed event in Tauri v2), but works reliably in practice.
  - The MATERIAL_SLUG_OVERRIDES table maps ~40 Catppuccin slugs to their
   Material equivalents. If new file icons are added to
  fileIcons.ts/folderIcons.ts in the future, they may need a Material
  override entry too.