### PR TITLE
feat(workspace): support workspace state, layouts persistence, and folder selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-autostart": "~2.5.1",
+    "@tauri-apps/plugin-dialog": "~2.2.0",
     "@tauri-apps/plugin-log": "~2.8.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@tauri-apps/plugin-autostart':
         specifier: ~2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ~2.2.0
+        version: 2.2.2
       '@tauri-apps/plugin-log':
         specifier: ~2.8.0
         version: 2.8.0
@@ -2111,6 +2114,9 @@ packages:
 
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-dialog@2.2.2':
+    resolution: {integrity: sha512-Pm9qnXQq8ZVhAMFSEPwxvh+nWb2mk7LASVlNEHYaksHvcz8P6+ElR5U5dNL9Ofrm+uwhh1/gYKWswK8JJJAh6A==}
 
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
@@ -6475,6 +6481,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
   '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-dialog@2.2.2':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3963,6 +3963,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,6 +5055,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5356,6 +5422,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -5541,6 +5608,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ shared_child = "1"
 tauri-plugin-log = "2"
 tauri-plugin-os = "2"
 tauri-plugin-store = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
 tauri-plugin-notification = "2"
 reqwest = { version = "0.12", default-features = false, features = [

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "os:default",
     "notification:default",
     "store:default",
+    "dialog:default",
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
         )
         .plugin(tauri_plugin_autostart::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -107,6 +107,7 @@ import {
   getWslHome,
   LOCAL_WORKSPACE,
   useWorkspaceEnvStore,
+  useWorkspaceStore,
   type WorkspaceEnv,
 } from "@/modules/workspace";
 import { invoke } from "@tauri-apps/api/core";
@@ -202,7 +203,7 @@ export default function App() {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
-    resetWorkspace,
+    setWorkspaceLayout,
   } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -343,6 +344,61 @@ export default function App() {
       .catch(() => setHome(null));
   }, []);
 
+  const workspaceStoreInit = useWorkspaceStore((s) => s.init);
+  const activeWorkspacePath = useWorkspaceStore((s) => s.activeWorkspacePath);
+  const workspaceLayouts = useWorkspaceStore((s) => s.layouts);
+  const workspaceStoreHydrated = useWorkspaceStore((s) => s.hydrated);
+  const saveLayout = useWorkspaceStore((s) => s.saveLayout);
+
+  const openWorkspaceFolder = useCallback(
+    async (path: string, env: WorkspaceEnv = workspaceEnv) => {
+      const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
+      if (dirty) {
+        window.alert("Save or close unsaved editor tabs before switching workspace.");
+        return;
+      }
+
+      if (activeWorkspacePath) {
+        await saveLayout(activeWorkspacePath, { tabs: tabsRef.current, activeId });
+      }
+
+      for (const id of liveLeavesRef.current) disposeSession(id);
+      searchAddons.current.clear();
+      terminalRefs.current.clear();
+      editorRefs.current.clear();
+      previewRefs.current.clear();
+      setActiveSearchAddon(null);
+      setActiveEditorHandle(null);
+
+      if (
+        env.kind !== workspaceEnv.kind ||
+        (env.kind === "wsl" && workspaceEnv.kind === "wsl" && env.distro !== workspaceEnv.distro)
+      ) {
+        setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
+      }
+
+      const cleanPath = path.replace(/\\/g, "/");
+      await useWorkspaceStore.getState().openWorkspace(cleanPath, env);
+      setHome(cleanPath);
+      setLaunchCwd(cleanPath);
+
+      if (cleanPath) {
+        try {
+          await native.workspaceAuthorize(cleanPath);
+        } catch {
+          // ignore
+        }
+      }
+
+      const nextLayouts = useWorkspaceStore.getState().layouts;
+      const savedLayout = nextLayouts[cleanPath];
+      setWorkspaceLayout(savedLayout ?? null, cleanPath);
+
+      void useChatStore.getState().hydrateSessions(true);
+    },
+    [activeWorkspacePath, workspaceEnv, setWorkspaceEnv, saveLayout, activeId, setWorkspaceLayout],
+  );
+
   const switchWorkspace = useCallback(
     async (env: WorkspaceEnv) => {
       if (
@@ -352,12 +408,6 @@ export default function App() {
       ) {
         return;
       }
-      const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
-      if (dirty) {
-        window.alert("Save or close unsaved editor tabs before switching workspace.");
-        return;
-      }
-
       let nextHome: string | null = null;
       try {
         if (env.kind === "wsl") {
@@ -370,27 +420,61 @@ export default function App() {
         return;
       }
 
-      for (const id of liveLeavesRef.current) disposeSession(id);
-      searchAddons.current.clear();
-      terminalRefs.current.clear();
-      editorRefs.current.clear();
-      previewRefs.current.clear();
-      setActiveSearchAddon(null);
-      setActiveEditorHandle(null);
-      setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
-      setHome(nextHome);
-      setLaunchCwd(nextHome);
       if (nextHome) {
-        try {
-          await native.workspaceAuthorize(nextHome);
-        } catch {
-          // Non-fatal — git panel will surface "not authorized" if needed.
-        }
+        await openWorkspaceFolder(nextHome, env);
       }
-      resetWorkspace(nextHome ?? undefined);
     },
-    [workspaceEnv, setWorkspaceEnv, resetWorkspace],
+    [workspaceEnv, openWorkspaceFolder],
   );
+
+  useEffect(() => {
+    if (launchCwdResolved && home && !workspaceStoreHydrated) {
+      const defaultPath = getLaunchDir() || launchCwd || home;
+      void workspaceStoreInit(defaultPath, workspaceEnv);
+    }
+  }, [launchCwdResolved, home, launchCwd, workspaceStoreInit, workspaceEnv, workspaceStoreHydrated]);
+
+  const initialLayoutLoaded = useRef(false);
+  useEffect(() => {
+    if (workspaceStoreHydrated && activeWorkspacePath && !initialLayoutLoaded.current) {
+      initialLayoutLoaded.current = true;
+      const cleanPath = activeWorkspacePath.replace(/\\/g, "/");
+      const savedLayout = workspaceLayouts[cleanPath];
+
+      const recent = useWorkspaceStore.getState().recentWorkspaces.find(
+        (w) => w.path.replace(/\\/g, "/") === cleanPath,
+      );
+      if (
+        recent &&
+        (recent.env.kind !== workspaceEnv.kind ||
+          (recent.env.kind === "wsl" &&
+            workspaceEnv.kind === "wsl" &&
+            recent.env.distro !== workspaceEnv.distro))
+      ) {
+        setWorkspaceEnv(recent.env);
+      }
+
+      setHome(cleanPath);
+      setLaunchCwd(cleanPath);
+      setWorkspaceLayout(savedLayout ?? null, cleanPath);
+      void useChatStore.getState().hydrateSessions(true);
+    }
+  }, [
+    workspaceStoreHydrated,
+    activeWorkspacePath,
+    workspaceLayouts,
+    setWorkspaceLayout,
+    setWorkspaceEnv,
+    workspaceEnv,
+  ]);
+
+  useEffect(() => {
+    if (!workspaceStoreHydrated || !activeWorkspacePath) return;
+    const timer = setTimeout(() => {
+      void saveLayout(activeWorkspacePath, { tabs, activeId });
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [tabs, activeId, activeWorkspacePath, workspaceStoreHydrated, saveLayout]);
   useEffect(() => {
     native
       .workspaceCurrentDir()
@@ -1487,6 +1571,7 @@ export default function App() {
                         onRevealInTerminal={cdInNewTab}
                         onAttachToAgent={handleAttachFileToAgent}
                         onOpenMarkdownPreview={openMarkdownPreview}
+                        onOpenWorkspaceFolder={openWorkspaceFolder}
                       />
                     ) : (
                       <SourceControlPanel

--- a/src/modules/ai/lib/sessions.ts
+++ b/src/modules/ai/lib/sessions.ts
@@ -6,6 +6,7 @@ export type SessionMeta = {
   title: string;
   createdAt: number;
   updatedAt: number;
+  workspacePath?: string;
 };
 
 const STORE_PATH = "terax-ai-sessions.json";

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -12,6 +12,7 @@ import {
   type ProviderId,
 } from "../config";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { useWorkspaceStore } from "@/modules/workspace";
 import { BUILTIN_AGENTS } from "../lib/agents";
 import { useAgentsStore } from "./agentsStore";
 import { usePlanStore } from "./planStore";
@@ -147,7 +148,7 @@ type StoreState = {
   sessionsHydrated: boolean;
   sessions: SessionMeta[];
   activeSessionId: string | null;
-  hydrateSessions: () => Promise<void>;
+  hydrateSessions: (force?: boolean) => Promise<void>;
   newSession: () => string;
   switchSession: (id: string) => void;
   deleteSession: (id: string) => void;
@@ -385,18 +386,30 @@ export const useChatStore = create<StoreState>((set, get) => ({
   sessions: [],
   activeSessionId: null,
 
-  hydrateSessions: async () => {
-    if (get().sessionsHydrated) return;
-    const { sessions } = await loadAll();
+  hydrateSessions: async (force = false) => {
+    if (get().sessionsHydrated && !force) return;
+    const { sessions, activeId: savedActiveId } = await loadAll();
+    const activeWorkspace = useWorkspaceStore.getState().activeWorkspacePath;
+    const cleanWorkspace = activeWorkspace ? activeWorkspace.replace(/\\/g, "/") : "";
 
-    // Reuse the most recent untitled "New chat" session if one exists from
-    // the previous run — no point stacking empty placeholder sessions every
-    // launch. Otherwise prepend a fresh one.
-    const reusable = sessions[0]?.title === "New chat" ? sessions[0] : null;
-    let nextSessions: SessionMeta[];
+    const otherWorkspaceSessions = sessions.filter(
+      (s) => (s.workspacePath ? s.workspacePath.replace(/\\/g, "/") : "") !== cleanWorkspace
+    );
+    const thisWorkspaceSessions = sessions.filter(
+      (s) => (s.workspacePath ? s.workspacePath.replace(/\\/g, "/") : "") === cleanWorkspace
+    );
+
+    let activeSession = thisWorkspaceSessions.find((s) => s.id === savedActiveId);
+    const reusable = thisWorkspaceSessions[0]?.title === "New chat" ? thisWorkspaceSessions[0] : null;
+
+    let nextThisSessions: SessionMeta[];
     let freshId: string;
-    if (reusable) {
-      nextSessions = sessions;
+
+    if (activeSession) {
+      nextThisSessions = thisWorkspaceSessions;
+      freshId = activeSession.id;
+    } else if (reusable) {
+      nextThisSessions = thisWorkspaceSessions;
       freshId = reusable.id;
     } else {
       freshId = newSessionId();
@@ -405,14 +418,15 @@ export const useChatStore = create<StoreState>((set, get) => ({
         title: "New chat",
         createdAt: Date.now(),
         updatedAt: Date.now(),
+        workspacePath: cleanWorkspace || undefined,
       };
-      nextSessions = [fresh, ...sessions];
-      void saveSessionsList(nextSessions);
+      nextThisSessions = [fresh, ...thisWorkspaceSessions];
+      void saveSessionsList([...otherWorkspaceSessions, ...nextThisSessions]);
     }
     void saveActiveId(freshId);
 
     set({
-      sessions: nextSessions,
+      sessions: nextThisSessions,
       activeSessionId: freshId,
       sessionsHydrated: true,
     });
@@ -420,15 +434,25 @@ export const useChatStore = create<StoreState>((set, get) => ({
 
   newSession: () => {
     const id = newSessionId();
+    const activeWorkspace = useWorkspaceStore.getState().activeWorkspacePath;
+    const cleanWorkspace = activeWorkspace ? activeWorkspace.replace(/\\/g, "/") : "";
+
     const meta: SessionMeta = {
       id,
       title: "New chat",
       createdAt: Date.now(),
       updatedAt: Date.now(),
+      workspacePath: cleanWorkspace || undefined,
     };
     const next = [meta, ...get().sessions];
     set({ sessions: next, activeSessionId: id, agentMeta: IDLE_META });
-    void saveSessionsList(next);
+
+    void loadAll().then(({ sessions }) => {
+      const other = sessions.filter(
+        (s) => (s.workspacePath ? s.workspacePath.replace(/\\/g, "/") : "") !== cleanWorkspace
+      );
+      void saveSessionsList([...other, ...next]);
+    });
     void saveActiveId(id);
     return id;
   },
@@ -437,8 +461,6 @@ export const useChatStore = create<StoreState>((set, get) => ({
     if (get().activeSessionId === id) return;
     if (!get().sessions.some((s) => s.id === id)) return;
 
-    // Lazily seed the chat with persisted messages the first time we open
-    // this session. Subsequent switches reuse the cached Chat instance.
     const flip = () => {
       set({ activeSessionId: id, agentMeta: IDLE_META });
       void saveActiveId(id);
@@ -454,6 +476,9 @@ export const useChatStore = create<StoreState>((set, get) => ({
   },
 
   deleteSession: (id) => {
+    const activeWorkspace = useWorkspaceStore.getState().activeWorkspacePath;
+    const cleanWorkspace = activeWorkspace ? activeWorkspace.replace(/\\/g, "/") : "";
+
     const remaining = get().sessions.filter((s) => s.id !== id);
     chats.get(id)?.stop();
     chats.delete(id);
@@ -466,24 +491,32 @@ export const useChatStore = create<StoreState>((set, get) => ({
     void deleteSessionData(id);
     void useTodosStore.getState().clearSession(id);
 
-    if (remaining.length === 0) {
-      const fresh: SessionMeta = {
-        id: newSessionId(),
-        title: "New chat",
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      };
-      set({ sessions: [fresh], activeSessionId: fresh.id });
-      void saveSessionsList([fresh]);
-      void saveActiveId(fresh.id);
-      return;
-    }
+    void loadAll().then(({ sessions }) => {
+      const other = sessions.filter(
+        (s) => (s.workspacePath ? s.workspacePath.replace(/\\/g, "/") : "") !== cleanWorkspace
+      );
+      if (remaining.length === 0) {
+        const fresh: SessionMeta = {
+          id: newSessionId(),
+          title: "New chat",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          workspacePath: cleanWorkspace || undefined,
+        };
+        set({ sessions: [fresh], activeSessionId: fresh.id });
+        void saveSessionsList([...other, fresh]);
+        void saveActiveId(fresh.id);
+        return;
+      }
+      void saveSessionsList([...other, ...remaining]);
+    });
 
-    const wasActive = get().activeSessionId === id;
-    const nextActive = wasActive ? remaining[0].id : get().activeSessionId;
-    set({ sessions: remaining, activeSessionId: nextActive });
-    void saveSessionsList(remaining);
-    if (wasActive) void saveActiveId(nextActive);
+    if (remaining.length > 0) {
+      const wasActive = get().activeSessionId === id;
+      const nextActive = wasActive ? remaining[0].id : get().activeSessionId;
+      set({ sessions: remaining, activeSessionId: nextActive });
+      if (wasActive) void saveActiveId(nextActive);
+    }
   },
 
   renameSession: (id, title) => {
@@ -491,11 +524,19 @@ export const useChatStore = create<StoreState>((set, get) => ({
       s.id === id ? { ...s, title, updatedAt: Date.now() } : s,
     );
     set({ sessions: next });
-    void saveSessionsList(next);
+
+    const activeWorkspace = useWorkspaceStore.getState().activeWorkspacePath;
+    const cleanWorkspace = activeWorkspace ? activeWorkspace.replace(/\\/g, "/") : "";
+
+    void loadAll().then(({ sessions }) => {
+      const other = sessions.filter(
+        (s) => (s.workspacePath ? s.workspacePath.replace(/\\/g, "/") : "") !== cleanWorkspace
+      );
+      void saveSessionsList([...other, ...next]);
+    });
   },
 
   persistMessages: (id, messages) => {
-    // Debounce the message-blob write so streaming doesn't pound the store.
     const existing = pendingPersist.get(id);
     if (existing) clearTimeout(existing.timer);
     const timer = setTimeout(() => {
@@ -506,9 +547,6 @@ export const useChatStore = create<StoreState>((set, get) => ({
     }, PERSIST_DEBOUNCE_MS);
     pendingPersist.set(id, { latest: messages, timer });
 
-    // Update zustand session list only when the derived title actually
-    // changes — otherwise we'd rewrite the sessions array (and trigger
-    // re-renders + a store write) on every token.
     const sessions = get().sessions;
     const meta = sessions.find((s) => s.id === id);
     if (!meta) return;
@@ -520,7 +558,16 @@ export const useChatStore = create<StoreState>((set, get) => ({
       s.id === id ? { ...s, title: nextTitle, updatedAt: Date.now() } : s,
     );
     set({ sessions: next });
-    void saveSessionsList(next);
+
+    const activeWorkspace = useWorkspaceStore.getState().activeWorkspacePath;
+    const cleanWorkspace = activeWorkspace ? activeWorkspace.replace(/\\/g, "/") : "";
+
+    void loadAll().then(({ sessions: allSessions }) => {
+      const other = allSessions.filter(
+        (s) => (s.workspacePath ? s.workspacePath.replace(/\\/g, "/") : "") !== cleanWorkspace
+      );
+      void saveSessionsList([...other, ...next]);
+    });
   },
 }));
 

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -1,3 +1,16 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  useWorkspaceStore,
+  type WorkspaceInfo,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
 import { Button } from "@/components/ui/button";
 import {
   ContextMenu,
@@ -12,6 +25,7 @@ import {
   FolderAddIcon,
   Refresh01Icon,
   Search01Icon,
+  ArrowDown01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -46,6 +60,7 @@ type Props = {
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
+  onOpenWorkspaceFolder?: (path: string, env?: WorkspaceEnv) => void;
 };
 
 type Row =
@@ -153,10 +168,39 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       onRevealInTerminal,
       onAttachToAgent,
       onOpenMarkdownPreview,
+      onOpenWorkspaceFolder,
     },
     ref,
   ) {
     const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
+    const recentWorkspaces = useWorkspaceStore((s) => s.recentWorkspaces);
+
+    const handleSelectFolder = async () => {
+      if (!onOpenWorkspaceFolder) return;
+      try {
+        const selected = await open({
+          directory: true,
+          multiple: false,
+          title: "Select Workspace Folder",
+        });
+        if (selected && typeof selected === "string") {
+          onOpenWorkspaceFolder(selected);
+        }
+      } catch (e) {
+        console.error("Failed to select folder:", e);
+      }
+    };
+
+    const handleOpenRecent = (w: WorkspaceInfo) => {
+      if (onOpenWorkspaceFolder) {
+        onOpenWorkspaceFolder(w.path, w.env);
+      }
+    };
+
+    const handleClearHistory = () => {
+      void useWorkspaceStore.getState().clearHistory();
+    };
+
     const [selectedPath, setSelectedPath] = useState<string | null>(null);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const [isSearchActive, setIsSearchActive] = useState(false);
@@ -370,19 +414,64 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
         onKeyDown={handleKeyDown}
       >
         <div className="flex h-8 shrink-0 items-center gap-1 border-b border-border/60 px-2">
-          <span
-            className="flex flex-1 items-center truncate text-xs font-medium text-foreground/80"
-            title={rootPath}
-          >
-            <img
-              src={folderIconUrl(basename(rootPath), false)}
-              alt=""
-              height={15}
-              width={15}
-              className="mx-1.5"
-            />
-            {basename(rootPath)}
-          </span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex flex-1 items-center justify-between min-w-0 rounded-sm px-1 py-0.5 hover:bg-accent text-left text-xs font-semibold text-foreground/80 outline-none focus:outline-none focus:bg-accent focus:text-foreground cursor-pointer"
+                title={rootPath || "Choose Workspace"}
+              >
+                <span className="flex items-center min-w-0 truncate">
+                  <img
+                    src={folderIconUrl(rootPath ? basename(rootPath) : "", false)}
+                    alt=""
+                    height={15}
+                    width={15}
+                    className="mx-1.5 shrink-0"
+                  />
+                  <span className="truncate">
+                    {rootPath ? basename(rootPath) : "Choose Workspace"}
+                  </span>
+                </span>
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  size={12}
+                  className="ml-1 shrink-0 opacity-60"
+                />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+              <DropdownMenuItem onSelect={handleSelectFolder} className="cursor-pointer">
+                Open Folder...
+              </DropdownMenuItem>
+              {recentWorkspaces.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <div className="px-2 py-1.5 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                    Recent Workspaces
+                  </div>
+                  {recentWorkspaces.map((w) => (
+                    <DropdownMenuItem
+                      key={w.path}
+                      onSelect={() => handleOpenRecent(w)}
+                      className="flex flex-col items-start py-1.5 cursor-pointer"
+                    >
+                      <span className="font-medium text-xs leading-none">
+                        {w.name}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground truncate w-full mt-0.5">
+                        {w.path}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onSelect={handleClearHistory} className="text-destructive focus:text-destructive cursor-pointer">
+                    Clear History
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           <Button
             variant="ghost"

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -794,6 +794,55 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     for (const lid of toDispose) disposeSession(lid);
   }, []);
 
+  const setWorkspaceLayout = useCallback(
+    (
+      layout: { tabs: Tab[]; activeId: number } | null,
+      defaultCwd?: string,
+    ) => {
+      let toDispose: number[] = [];
+      setTabs((curr) => {
+        toDispose = curr.flatMap((t) =>
+          t.kind === "terminal" ? leafIds(t.paneTree) : [],
+        );
+
+        if (layout && layout.tabs.length > 0) {
+          let maxId = 0;
+          for (const t of layout.tabs) {
+            if (t.id > maxId) maxId = t.id;
+            if (t.kind === "terminal") {
+              const leaves = leafIds(t.paneTree);
+              for (const lid of leaves) {
+                if (lid > maxId) maxId = lid;
+              }
+            }
+          }
+          nextIdRef.current = maxId + 1;
+          setActiveId(layout.activeId);
+          return layout.tabs;
+        } else {
+          const tabId = nextIdRef.current++;
+          const leafId = nextIdRef.current++;
+          setActiveId(tabId);
+          return [
+            {
+              id: tabId,
+              kind: "terminal",
+              title: "shell",
+              cwd: defaultCwd,
+              paneTree: { kind: "leaf", id: leafId, cwd: defaultCwd },
+              activeLeafId: leafId,
+            },
+          ];
+        }
+      });
+
+      setTimeout(() => {
+        for (const lid of toDispose) disposeSession(lid);
+      }, 100);
+    },
+    [],
+  );
+
   return {
     tabs,
     activeId,
@@ -821,5 +870,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
+    setWorkspaceLayout,
   };
 }

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -8,3 +8,8 @@ export {
   type WorkspaceEnv,
   type WslDistro,
 } from "./env";
+export {
+  useWorkspaceStore,
+  type WorkspaceInfo,
+  type WorkspaceLayout,
+} from "./workspaceStore";

--- a/src/modules/workspace/workspaceStore.ts
+++ b/src/modules/workspace/workspaceStore.ts
@@ -1,0 +1,136 @@
+import { create } from "zustand";
+import { LazyStore } from "@tauri-apps/plugin-store";
+import type { Tab } from "@/modules/tabs/lib/useTabs";
+import type { WorkspaceEnv } from "./env";
+
+export type WorkspaceInfo = {
+  path: string;
+  name: string;
+  lastOpened: number;
+  env: WorkspaceEnv;
+};
+
+export type WorkspaceLayout = {
+  tabs: Tab[];
+  activeId: number;
+};
+
+type WorkspaceState = {
+  activeWorkspacePath: string | null;
+  recentWorkspaces: WorkspaceInfo[];
+  layouts: Record<string, WorkspaceLayout>;
+  hydrated: boolean;
+  init: (defaultPath: string, defaultEnv: WorkspaceEnv) => Promise<void>;
+  openWorkspace: (path: string, env: WorkspaceEnv) => Promise<void>;
+  saveLayout: (path: string, layout: WorkspaceLayout) => Promise<void>;
+  removeRecentWorkspace: (path: string) => Promise<void>;
+  clearHistory: () => Promise<void>;
+};
+
+const STORE_PATH = "terax-workspaces.json";
+const KEY_ACTIVE = "activeWorkspacePath";
+const KEY_RECENTS = "recentWorkspaces";
+const KEY_LAYOUTS = "layouts";
+
+const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 200 });
+
+function getFolderBasename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : path;
+}
+
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
+  activeWorkspacePath: null,
+  recentWorkspaces: [],
+  layouts: {},
+  hydrated: false,
+
+  init: async (defaultPath, defaultEnv) => {
+    if (get().hydrated) return;
+
+    const entries = await store.entries();
+    let activePath: string | null = null;
+    let recents: WorkspaceInfo[] = [];
+    let layouts: Record<string, WorkspaceLayout> = {};
+
+    for (const [k, v] of entries) {
+      if (k === KEY_ACTIVE) activePath = v as string | null;
+      else if (k === KEY_RECENTS) recents = v as WorkspaceInfo[];
+      else if (k === KEY_LAYOUTS) layouts = v as Record<string, WorkspaceLayout>;
+    }
+
+    if (!activePath) {
+      activePath = defaultPath;
+    }
+
+    // Add initial/default path to recent list if not already present
+    const cleanPath = defaultPath.replace(/\\/g, "/");
+    const exists = recents.some((w) => w.path.replace(/\\/g, "/") === cleanPath);
+    if (!exists && defaultPath) {
+      const info: WorkspaceInfo = {
+        path: defaultPath,
+        name: getFolderBasename(defaultPath),
+        lastOpened: Date.now(),
+        env: defaultEnv,
+      };
+      recents = [info, ...recents];
+      void store.set(KEY_RECENTS, recents);
+    }
+
+    set({
+      activeWorkspacePath: activePath,
+      recentWorkspaces: recents,
+      layouts: layouts || {},
+      hydrated: true,
+    });
+    void store.set(KEY_ACTIVE, activePath);
+  },
+
+  openWorkspace: async (path, env) => {
+    const cleanPath = path.replace(/\\/g, "/");
+    const name = getFolderBasename(path);
+
+    // Update active workspace
+    set({ activeWorkspacePath: cleanPath });
+    void store.set(KEY_ACTIVE, cleanPath);
+
+    // Update recents list
+    let recents = get().recentWorkspaces.filter(
+      (w) => w.path.replace(/\\/g, "/") !== cleanPath,
+    );
+    const newWorkspace: WorkspaceInfo = {
+      path: cleanPath,
+      name,
+      lastOpened: Date.now(),
+      env,
+    };
+    recents = [newWorkspace, ...recents];
+    set({ recentWorkspaces: recents });
+    void store.set(KEY_RECENTS, recents);
+  },
+
+  saveLayout: async (path, layout) => {
+    const cleanPath = path.replace(/\\/g, "/");
+    const currentLayouts = { ...get().layouts, [cleanPath]: layout };
+    set({ layouts: currentLayouts });
+    void store.set(KEY_LAYOUTS, currentLayouts);
+  },
+
+  removeRecentWorkspace: async (path) => {
+    const cleanPath = path.replace(/\\/g, "/");
+    const recents = get().recentWorkspaces.filter(
+      (w) => w.path.replace(/\\/g, "/") !== cleanPath,
+    );
+    set({ recentWorkspaces: recents });
+    void store.set(KEY_RECENTS, recents);
+  },
+
+  clearHistory: async () => {
+    const active = get().activeWorkspacePath;
+    const recents = get().recentWorkspaces.filter(
+      (w) => w.path.replace(/\\/g, "/") === active,
+    );
+    set({ recentWorkspaces: recents });
+    void store.set(KEY_RECENTS, recents);
+  },
+}));


### PR DESCRIPTION


<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->
feat(workspace): support workspace state, layouts persistence, and folder selection

## What
<!-- One or two sentences describing the change. -->
Added support for workspace folder selection and automatic layout persistence. The application now saves the open tabs, active workspace path, and corresponding layout state across runs.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
Users need their session context, editor layouts, and terminal tabs saved per workspace folder. When they switch between different workspace directories, the application should restore their exact tab state and isolate their chat sessions to the active workspace.

## How
<!-- Brief notes on the approach, only if non-obvious. -->
1. Integrated the native `@tauri-apps/plugin-dialog` to provide a folder selection dialog.
2. Implemented `useWorkspaceStore` using `tauri-plugin-store` to persist recent folders, active workspace paths, and window layouts.
3. Updated the `FileExplorer` header to include a dropdown listing recent workspaces, an option to open a new folder, and an option to clear history.
4. Updated `App.tsx` and the `useTabs` hook to save layouts when changing workspaces and restore them via `setWorkspaceLayout`.
5. Modified `useChatStore` to store a `workspacePath` on chat sessions and filter the session list so chats are workspace-specific.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

Verified the implementation using the following steps:
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If UI) tested in `pnpm tauri dev`
- Platforms tested: Windows
- Shells tested: pwsh


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
Unit tests were run locally. All tests passed except the pre-existing `authorize_spawn_cwd_blocks_symlink_escape` test, which failed solely due to Windows OS restrictions on symlink creation under non-administrator developer environments.
