### PR TITLE
feat(explorer): fix Windows drive-root and permission errors, add drive-selector dropdown

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,7 @@ pub fn run() {
             pty::pty_close_all,
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
+            fs::tree::fs_list_drives,
             fs::file::fs_read_file,
             fs::file::fs_write_file,
             fs::file::fs_stat,

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -48,7 +48,13 @@ pub fn fs_read_dir(
             // silently drop them from the listing.
             let (meta, was_symlink) = match std::fs::metadata(entry.path()) {
                 Ok(m) => (Some(m), false),
-                Err(_) => (entry.metadata().ok(), true),
+                Err(_) => match entry.metadata() {
+                    Ok(m) => {
+                        let is_sym = m.file_type().is_symlink();
+                        (Some(m), is_sym)
+                    }
+                    Err(_) => (None, false),
+                },
             };
             let meta = meta?;
 

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -134,3 +134,22 @@ pub fn list_subdirs(
     dirs.sort_by_key(|a| a.to_lowercase());
     Ok(dirs)
 }
+
+#[tauri::command]
+pub fn fs_list_drives() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        let mut drives = Vec::new();
+        for letter in b'A'..=b'Z' {
+            let drive = format!("{}:\\", letter as char);
+            if std::path::Path::new(&drive).exists() {
+                drives.push(format!("{}:/", letter as char));
+            }
+        }
+        drives
+    }
+    #[cfg(not(windows))]
+    {
+        Vec::new()
+    }
+}

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -236,9 +236,16 @@ pub struct WslDistro {
 
 #[cfg(windows)]
 pub fn resolve_path(path: &str, workspace: &WorkspaceEnv) -> PathBuf {
+    let mut normalized = path.replace('\\', "/");
+    if normalized.starts_with('/') && normalized.len() >= 3 {
+        let chars: Vec<char> = normalized.chars().collect();
+        if chars[1].is_ascii_alphabetic() && chars[2] == ':' {
+            normalized = normalized[1..].to_string();
+        }
+    }
     match workspace {
-        WorkspaceEnv::Local => PathBuf::from(path),
-        WorkspaceEnv::Wsl { distro } => wsl_path_to_host(distro, path),
+        WorkspaceEnv::Local => PathBuf::from(normalized),
+        WorkspaceEnv::Wsl { distro } => wsl_path_to_host(distro, &normalized),
     }
 }
 
@@ -573,6 +580,18 @@ mod tests {
         assert_eq!(
             resolve_path(path, &WorkspaceEnv::Local),
             PathBuf::from(path)
+        );
+    }
+
+    #[test]
+    fn resolve_path_normalizes_leading_slash_on_windows() {
+        assert_eq!(
+            resolve_path("/D:/Documents", &WorkspaceEnv::Local),
+            PathBuf::from("D:/Documents")
+        );
+        assert_eq!(
+            resolve_path("/C:/", &WorkspaceEnv::Local),
+            PathBuf::from("C:/")
         );
     }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1489,6 +1489,7 @@ export default function App() {
                         onRevealInTerminal={cdInNewTab}
                         onAttachToAgent={handleAttachFileToAgent}
                         onOpenMarkdownPreview={openMarkdownPreview}
+                        onCd={sendCd}
                       />
                     ) : (
                       <SourceControlPanel

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -138,7 +138,9 @@ function dirname(path: string | null): string | null {
   const normalized = path.replace(/\\/g, "/");
   const idx = normalized.lastIndexOf("/");
   if (idx <= 0) return normalized;
-  return normalized.slice(0, idx);
+  const res = normalized.slice(0, idx);
+  if (/^[A-Za-z]:$/.test(res)) return `${res}/`;
+  return res;
 }
 
 const SIDEBAR_DEFAULT_WIDTH = 260;

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -7,12 +7,20 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   FileAddIcon,
   Folder01Icon,
   FolderAddIcon,
   Refresh01Icon,
   Search01Icon,
+  ArrowDown01Icon,
 } from "@hugeicons/core-free-icons";
+import { invoke } from "@tauri-apps/api/core";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -46,6 +54,7 @@ type Props = {
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
+  onCd?: (path: string) => void;
 };
 
 type Row =
@@ -153,6 +162,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       onRevealInTerminal,
       onAttachToAgent,
       onOpenMarkdownPreview,
+      onCd,
     },
     ref,
   ) {
@@ -160,6 +170,13 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
     const [selectedPath, setSelectedPath] = useState<string | null>(null);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const [isSearchActive, setIsSearchActive] = useState(false);
+    const [drives, setDrives] = useState<string[]>([]);
+
+    useEffect(() => {
+      invoke<string[]>("fs_list_drives")
+        .then(setDrives)
+        .catch(() => {});
+    }, []);
     const searchRef = useRef<ExplorerSearchHandle>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -370,19 +387,52 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
         onKeyDown={handleKeyDown}
       >
         <div className="flex h-8 shrink-0 items-center gap-1 border-b border-border/60 px-2">
-          <span
-            className="flex flex-1 items-center truncate text-xs font-medium text-foreground/80"
-            title={rootPath}
-          >
-            <img
-              src={folderIconUrl(basename(rootPath), false)}
-              alt=""
-              height={15}
-              width={15}
-              className="mx-1.5"
-            />
-            {basename(rootPath)}
-          </span>
+          {drives.length > 1 ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex flex-1 items-center truncate text-xs font-medium text-foreground/80 hover:bg-accent/40 rounded px-1.5 py-0.5 cursor-pointer outline-none min-w-0"
+                  title={rootPath}
+                >
+                  <img
+                    src={folderIconUrl(basename(rootPath), false)}
+                    alt=""
+                    height={15}
+                    width={15}
+                    className="mr-1.5 shrink-0"
+                  />
+                  <span className="truncate mr-1">{basename(rootPath)}</span>
+                  <HugeiconsIcon icon={ArrowDown01Icon} size={11} className="opacity-60 shrink-0" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="min-w-[120px]">
+                {drives.map((drv) => (
+                  <DropdownMenuItem
+                    key={drv}
+                    onSelect={() => onCd?.(drv)}
+                    className="gap-1.5 cursor-pointer"
+                  >
+                    <HugeiconsIcon icon={Folder01Icon} size={12} className="text-muted-foreground" />
+                    {drv}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <span
+              className="flex flex-1 items-center truncate text-xs font-medium text-foreground/80 px-1.5"
+              title={rootPath}
+            >
+              <img
+                src={folderIconUrl(basename(rootPath), false)}
+                alt=""
+                height={15}
+                width={15}
+                className="mr-1.5 shrink-0"
+              />
+              <span className="truncate">{basename(rootPath)}</span>
+            </span>
+          )}
 
           <Button
             variant="ghost"

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -32,7 +32,9 @@ export function joinPath(parent: string, name: string): string {
 export function dirname(path: string): string {
   const i = path.lastIndexOf("/");
   if (i <= 0) return "/";
-  return path.slice(0, i);
+  const res = path.slice(0, i);
+  if (/^[A-Za-z]:$/.test(res)) return `${res}/`;
+  return res;
 }
 
 const EXPANSION_CACHE_LIMIT = 8;

--- a/src/modules/git-history/GitHistoryPane.tsx
+++ b/src/modules/git-history/GitHistoryPane.tsx
@@ -93,7 +93,9 @@ function dirname(path: string): string {
   const normalized = path.replace(/\\/g, "/");
   const index = normalized.lastIndexOf("/");
   if (index <= 0) return "";
-  return normalized.slice(0, index);
+  const res = normalized.slice(0, index);
+  if (/^[A-Za-z]:$/.test(res)) return `${res}/`;
+  return res;
 }
 
 function normalizeError(error: unknown): string {

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -90,7 +90,9 @@ function dirname(path: string): string {
   const normalized = path.replace(/\\/g, "/");
   const index = normalized.lastIndexOf("/");
   if (index <= 0) return "";
-  return normalized.slice(0, index);
+  const res = normalized.slice(0, index);
+  if (/^[A-Za-z]:$/.test(res)) return `${res}/`;
+  return res;
 }
 
 function entryPathLabel(entry: SourceControlFileEntry): string {

--- a/src/modules/statusbar/CwdBreadcrumb.tsx
+++ b/src/modules/statusbar/CwdBreadcrumb.tsx
@@ -36,7 +36,9 @@ type Props = {
 function dirname(path: string): string {
   const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   if (i <= 0) return "/";
-  return path.slice(0, i);
+  const res = path.slice(0, i);
+  if (/^[A-Za-z]:$/.test(res)) return `${res}/`;
+  return res;
 }
 
 function basename(path: string): string {


### PR DESCRIPTION
## What
This PR fixes critical Windows filesystem bugs where the sidebar explorer failed to access drive roots or threw `Access is denied (os error 5)` on restricted directories. Additionally, it implements a platform-safe drive-selector dropdown in the explorer sidebar header on Windows to let users switch between mounted drives (e.g. `C:/`, `D:/`) directly inside the IDE.

## Why
1. **Windows Drive Root Paths**: Windows treats relative drive paths like `D:` as resolving to the active CWD of that drive for the process rather than the absolute drive root (`D:/`). Slicing paths to a drive letter without the trailing slash broke navigation and watches.
2. **Leading Slashes**: Slashes in paths like `/D:/` caused Windows filesystem path canonicalization to fail with `Invalid Filename (os error 123)`.
3. **Reparse Point / Permission Handling**: Accessing restricted directories (like `System Volume Information`) threw permission errors that were incorrectly classified as broken symlinks, breaking rendering of the surrounding folder tree.
4. **Drive Navigation**: Windows users had no UI control to switch between different disk drives in the sidebar without typing `cd D:\` in the terminal.

## How
- **Drive Root Slicing**: Updated `dirname` in frontend modules (`useFileTree.ts`, `CwdBreadcrumb.tsx`, `App.tsx`, `SourceControlPanel.tsx`, `GitHistoryPane.tsx`) to check for Windows drive letters (`^[A-Za-z]:$`) and append a trailing `/` to ensure it is treated as an absolute drive root.
- **Path Normalization**: Refactored `resolve_path` in `src-tauri/src/modules/workspace.rs` to strip leading slashes before drive letters on Windows.
- **Permission Errors**: Refactored `fs_read_dir` in `src-tauri/src/modules/fs/tree.rs` to check the actual symlink status via `entry.metadata()` rather than assuming all metadata failures are broken symlinks.
- **Drive-Selector UI**: 
  - Implemented the `fs_list_drives` command in the backend to query active drives A–Z on Windows.
  - Replaced the static explorer sidebar folder header in `FileExplorer.tsx` with a `DropdownMenu` when multiple drives are detected. Selecting a drive calls `onCd` to update the active CWD and sidebar. On macOS and Linux, it falls back to the default static header.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows 11
- [x] Shells tested (if relevant): PowerShell

## Screenshots / GIFs
<img width="389" height="163" alt="image" src="https://github.com/user-attachments/assets/c336c92e-f6d9-4c03-95b2-c0b9185d7072" />
<img width="678" height="133" alt="image" src="https://github.com/user-attachments/assets/3e2e6145-b9db-44b6-a4ce-5c068f94e798" />


## Notes for reviewer
- The new `fs_list_drives` Tauri command signature was added and successfully registered in the backend application router (`lib.rs`).
- On non-Windows platforms, the UI behaves identically to previous versions with zero impact or changes.
