### PR TITLE
Feat/media-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@uiw/codemirror-themes": "^4.25.9",
     "@uiw/react-codemirror": "^4.25.9",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-image": "0.9.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-image':
+        specifier: 0.9.0
+        version: 0.9.0
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
@@ -2407,6 +2410,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-image@0.9.0':
+    resolution: {integrity: sha512-oYWA8/QAr5/Emwl1xL7WCoOqeG3IZfpzEz/OVq1j4Oi9934TQmHiyubClikRf0D/jL3JNiNuz/Lsqx0kXQ02BA==}
 
   '@xterm/addon-search@0.16.0':
     resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
@@ -6878,6 +6884,8 @@ snapshots:
       tinyrainbow: 1.2.0
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-image@0.9.0': {}
 
   '@xterm/addon-search@0.16.0': {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1903,6 +1903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +4908,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",
@@ -5335,6 +5342,7 @@ dependencies = [
 name = "terax"
 version = "0.7.3"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "dirs 5.0.1",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -46,6 +46,7 @@ futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"
 notify = "8.2.0"
+base64 = "0.22"
 
 [dev-dependencies]
 proptest = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run() {
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,
+            fs::file::fs_read_media,
             fs::file::fs_write_file,
             fs::file::fs_stat,
             fs::file::fs_canonicalize,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -6,9 +6,12 @@ use serde::Serialize;
 use tauri::Emitter;
 use tempfile::NamedTempFile;
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+const MAX_MEDIA_BYTES: u64 = 100 * 1024 * 1024; // 100 MB
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
 #[derive(Serialize)]
@@ -76,6 +79,47 @@ pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<Rea
         Ok(content) => Ok(ReadResult::Text { content, size }),
         Err(_) => Ok(ReadResult::Binary { size }),
     }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ReadMediaResult {
+    Ok {
+        data: String,
+        size: u64,
+    },
+    TooLarge {
+        size: u64,
+        limit: u64,
+    },
+}
+
+#[tauri::command]
+pub fn fs_read_media(path: String, workspace: Option<WorkspaceEnv>) -> Result<ReadMediaResult, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
+    let meta = std::fs::metadata(&p).map_err(|e| {
+        log::debug!("fs_read_media stat({}) failed: {e}", p.display());
+        e.to_string()
+    })?;
+
+    let size = meta.len();
+    if size > MAX_MEDIA_BYTES {
+        return Ok(ReadMediaResult::TooLarge {
+            size,
+            limit: MAX_MEDIA_BYTES,
+        });
+    }
+
+    let bytes = std::fs::read(&p).map_err(|e| {
+        log::debug!("fs_read_media read({}) failed: {e}", p.display());
+        e.to_string()
+    })?;
+
+    Ok(ReadMediaResult::Ok {
+        data: STANDARD.encode(bytes),
+        size,
+    })
 }
 
 #[derive(Serialize, Clone)]
@@ -164,6 +208,20 @@ pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_media_returns_base64_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("pic.png");
+        std::fs::write(&f, [0x89, b'P', b'N', b'G']).unwrap();
+        match fs_read_media(f.to_string_lossy().into_owned(), None).unwrap() {
+            ReadMediaResult::Ok { data, size } => {
+                assert_eq!(size, 4);
+                assert!(!data.is_empty());
+            }
+            _ => panic!("expected ok"),
+        }
+    }
 
     #[test]
     fn read_file_classifies_utf8_as_text() {

--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -61,4 +61,8 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
 
   _terax_precmd
 fi
+
+_terax_img="${XDG_CACHE_HOME:-$HOME/.cache}/terax/shell-integration/img.sh"
+[ -f "$_terax_img" ] && . "$_terax_img"
+unset _terax_img
 :

--- a/src-tauri/src/modules/pty/scripts/img.fish
+++ b/src-tauri/src/modules/pty/scripts/img.fish
@@ -1,0 +1,19 @@
+# terax-shell-integration (img) — iTerm inline image protocol (PNG, JPEG, GIF first frame).
+if set -q TERAX_TERMINAL
+    if not set -q __TERAX_MEDIA_LOADED
+        set -g __TERAX_MEDIA_LOADED 1
+        function img
+            set -l file $argv[1]
+            if test -z "$file"
+                echo "usage: img <path>" >&2
+                return 1
+            end
+            if not test -f "$file"
+                echo "img: not found: $file" >&2
+                return 1
+            end
+            set -l b64 (base64 < "$file" | string replace -a '\n' '')
+            printf '\033]1337;File=inline=1:%s\a' "$b64"
+        end
+    end
+end

--- a/src-tauri/src/modules/pty/scripts/img.ps1
+++ b/src-tauri/src/modules/pty/scripts/img.ps1
@@ -1,0 +1,21 @@
+# terax-shell-integration (img) — iTerm inline image protocol (PNG, JPEG, GIF first frame).
+if (-not $global:__TERAX_MEDIA_LOADED) {
+    if ($env:TERAX_TERMINAL) {
+        $global:__TERAX_MEDIA_LOADED = $true
+        function global:img {
+            param(
+                [Parameter(Mandatory = $true, Position = 0)]
+                [string]$Path
+            )
+            $resolved = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
+            if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+                Write-Error "img: not found: $Path"
+                return
+            }
+            $bytes = [System.IO.File]::ReadAllBytes($resolved)
+            $b64 = [Convert]::ToBase64String($bytes)
+            $esc = [char]27
+            Write-Host -NoNewline "$esc]1337;File=inline=1:$b64$([char]7)"
+        }
+    }
+}

--- a/src-tauri/src/modules/pty/scripts/img.sh
+++ b/src-tauri/src/modules/pty/scripts/img.sh
@@ -1,0 +1,9 @@
+# terax-shell-integration (img) — iTerm inline image protocol (PNG, JPEG, GIF first frame).
+if [ -n "$TERAX_TERMINAL" ] && [ -z "$__TERAX_MEDIA_LOADED" ]; then
+  __TERAX_MEDIA_LOADED=1
+  img() {
+    local file="${1:?usage: img <path>}"
+    [ -f "$file" ] || { echo "img: not found: $file" >&2; return 1; }
+    printf '\033]1337;File=inline=1:%s\a' "$(base64 < "$file" | tr -d '\n')"
+  }
+fi

--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -49,3 +49,8 @@ function __terax_preexec --on-event fish_preexec
     set -l cmd (string replace -ra '[\x00-\x1f\x7f]' ' ' -- "$argv")
     printf '\e]133;C;%s\e\\' (string sub -l 256 -- "$cmd")
 end
+
+set -l _terax_img "$HOME/.cache/terax/shell-integration/img.fish"
+if test -f "$_terax_img"
+    source "$_terax_img"
+end

--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -60,3 +60,6 @@ function global:prompt {
     $global:LASTEXITCODE = $lec
     "$oscD$oscA$osc7${original}${oscB}"
 }
+
+$__teraxImg = Join-Path $env:USERPROFILE '.cache\terax\shell-integration\img.ps1'
+if (Test-Path -LiteralPath $__teraxImg) { . $__teraxImg }

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -67,4 +67,8 @@ if [[ -z "$__TERAX_HOOKS_LOADED" ]]; then
 
   _terax_precmd
 fi
+
+_terax_img="${XDG_CACHE_HOME:-$HOME/.cache}/terax/shell-integration/img.sh"
+[ -f "$_terax_img" ] && . "$_terax_img"
+unset _terax_img
 :

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -4,6 +4,10 @@ use portable_pty::CommandBuilder;
 
 use crate::modules::workspace::{self, WorkspaceEnv};
 
+const IMG_SH: &str = include_str!("scripts/img.sh");
+const IMG_FISH: &str = include_str!("scripts/img.fish");
+const IMG_PS1: &str = include_str!("scripts/img.ps1");
+
 #[cfg(windows)]
 const BASHRC_SCRIPT: &str = include_str!("scripts/bashrc.bash");
 #[cfg(windows)]
@@ -217,6 +221,9 @@ mod unix {
         let home = dirs::home_dir().ok_or_else(|| "could not resolve home dir".to_string())?;
         let root = home.join(".cache").join("terax").join("shell-integration");
         fs::create_dir_all(&root).map_err(|e| format!("create {}: {e}", root.display()))?;
+        write_if_changed(&root.join("img.sh"), super::IMG_SH)?;
+        write_if_changed(&root.join("img.fish"), super::IMG_FISH)?;
+        write_if_changed(&root.join("img.ps1"), super::IMG_PS1)?;
         Ok(root)
     }
 
@@ -480,6 +487,7 @@ mod windows {
     }
 
     fn prepare_wsl_integration_dir(distro: &str, shell: &str) -> Result<(String, PathBuf), String> {
+        write_wsl_media_scripts(distro)?;
         let home = crate::modules::workspace::wsl_home(distro.to_string())?;
         let linux_dir = format!(
             "{}/.cache/terax/shell-integration/{shell}",
@@ -488,6 +496,20 @@ mod windows {
         let unc_dir = crate::modules::workspace::wsl_path_to_unc(distro, &linux_dir);
         fs::create_dir_all(&unc_dir).map_err(|e| format!("create {}: {e}", unc_dir.display()))?;
         Ok((linux_dir, unc_dir))
+    }
+
+    fn write_wsl_media_scripts(distro: &str) -> Result<(), String> {
+        let home = crate::modules::workspace::wsl_home(distro.to_string())?;
+        let linux_root = format!(
+            "{}/.cache/terax/shell-integration",
+            home.trim_end_matches('/')
+        );
+        let unc_root = crate::modules::workspace::wsl_path_to_unc(distro, &linux_root);
+        fs::create_dir_all(&unc_root).map_err(|e| format!("create {}: {e}", unc_root.display()))?;
+        write_if_changed(&unc_root.join("img.sh"), &normalize_script(super::IMG_SH))?;
+        write_if_changed(&unc_root.join("img.fish"), &normalize_script(super::IMG_FISH))?;
+        write_if_changed(&unc_root.join("img.ps1"), &normalize_script(super::IMG_PS1))?;
+        Ok(())
     }
 
     fn normalize_script(content: &str) -> String {
@@ -525,6 +547,7 @@ mod windows {
     }
 
     fn prepare_wsl_fish_conf_d(distro: &str) -> Result<(), String> {
+        write_wsl_media_scripts(distro)?;
         let home = crate::modules::workspace::wsl_home(distro.to_string())?;
         let linux_dir = format!("{}/.config/fish/conf.d", home.trim_end_matches('/'));
         let unc_dir = crate::modules::workspace::wsl_path_to_unc(distro, &linux_dir);
@@ -539,6 +562,9 @@ mod windows {
         let home = dirs::home_dir().ok_or_else(|| "could not resolve home dir".to_string())?;
         let root = home.join(".cache").join("terax").join("shell-integration");
         fs::create_dir_all(&root).map_err(|e| format!("create {}: {e}", root.display()))?;
+        write_if_changed(&root.join("img.sh"), super::IMG_SH)?;
+        write_if_changed(&root.join("img.fish"), super::IMG_FISH)?;
+        write_if_changed(&root.join("img.ps1"), super::IMG_PS1)?;
         Ok(root)
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,16 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https: http://localhost:* http://127.0.0.1:*; frame-src 'self' http: https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'"
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": [
+            "$HOME/**",
+            "$DOWNLOAD/**"
+          ]
+        }
+      },
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: blob:; media-src 'self' asset: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://api.example.com http://localhost:* http://127.0.0.1:*; frame-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
     }
   },
   "bundle": {

--- a/src/lib/mediaPath.test.ts
+++ b/src/lib/mediaPath.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMediaKind,
+  isMediaPath,
+  MEDIA_EXTENSIONS,
+} from "./mediaPath";
+
+describe("mediaPath", () => {
+  it("exports the expected extension lists", () => {
+    expect(MEDIA_EXTENSIONS.image).toContain("png");
+    expect(MEDIA_EXTENSIONS.image).toContain("svg");
+    expect(MEDIA_EXTENSIONS.video).toContain("avi");
+    expect(MEDIA_EXTENSIONS.video).toContain("mkv");
+    expect(MEDIA_EXTENSIONS.audio).toContain("m4a");
+  });
+
+  it("detects common image extensions", () => {
+    expect(getMediaKind("/photos/cat.PNG")).toBe("image");
+    expect(getMediaKind("x.gif")).toBe("image");
+    expect(getMediaKind("icon.svg")).toBe("image");
+  });
+
+  it("detects video and audio extensions", () => {
+    expect(getMediaKind("clip.mp4")).toBe("video");
+    expect(getMediaKind("clip.webm")).toBe("video");
+    expect(getMediaKind("legacy.avi")).toBe("video");
+    expect(getMediaKind("song.mp3")).toBe("audio");
+  });
+
+  it("returns null for non-media paths", () => {
+    expect(getMediaKind("main.rs")).toBeNull();
+    expect(isMediaPath("README.md")).toBe(false);
+  });
+});

--- a/src/lib/mediaPath.ts
+++ b/src/lib/mediaPath.ts
@@ -1,0 +1,67 @@
+export const MEDIA_EXTENSIONS = {
+  image: [
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "webp",
+    "svg",
+    "bmp",
+    "ico",
+    "avif",
+  ],
+  video: ["mp4", "webm", "mov", "mkv", "avi", "ogv", "m4v"],
+  audio: ["mp3", "wav", "ogg", "flac", "aac", "m4a"],
+} as const;
+
+export type MediaKind = keyof typeof MEDIA_EXTENSIONS;
+
+export type MediaExtension =
+  | (typeof MEDIA_EXTENSIONS)["image"][number]
+  | (typeof MEDIA_EXTENSIONS)["video"][number]
+  | (typeof MEDIA_EXTENSIONS)["audio"][number];
+
+const IMAGE_EXT = new Set<string>(MEDIA_EXTENSIONS.image);
+const VIDEO_EXT = new Set<string>(MEDIA_EXTENSIONS.video);
+const AUDIO_EXT = new Set<string>(MEDIA_EXTENSIONS.audio);
+
+export function getMediaKind(path: string): MediaKind | null {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  if (IMAGE_EXT.has(ext)) return "image";
+  if (VIDEO_EXT.has(ext)) return "video";
+  if (AUDIO_EXT.has(ext)) return "audio";
+  return null;
+}
+
+export function isMediaPath(path: string): boolean {
+  return getMediaKind(path) !== null;
+}
+
+export function mimeForMediaKind(kind: MediaKind, path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  switch (kind) {
+    case "image":
+      if (ext === "svg") return "image/svg+xml";
+      if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
+      if (ext === "gif") return "image/gif";
+      if (ext === "webp") return "image/webp";
+      if (ext === "avif") return "image/avif";
+      if (ext === "bmp") return "image/bmp";
+      if (ext === "ico") return "image/x-icon";
+      return "image/png";
+    case "video":
+      if (ext === "webm") return "video/webm";
+      if (ext === "ogv") return "video/ogg";
+      if (ext === "mov") return "video/quicktime";
+      if (ext === "avi") return "video/x-msvideo";
+      if (ext === "mkv") return "video/x-matroska";
+      return "video/mp4";
+    case "audio":
+      if (ext === "wav") return "audio/wav";
+      if (ext === "ogg") return "audio/ogg";
+      if (ext === "flac") return "audio/flac";
+      if (ext === "m4a") return "audio/mp4";
+      if (ext === "aac") return "audio/aac";
+      return "audio/mpeg";
+  }
+}

--- a/src/lib/mediaSrc.ts
+++ b/src/lib/mediaSrc.ts
@@ -1,0 +1,63 @@
+import { mimeForMediaKind, type MediaKind } from "@/lib/mediaPath";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+
+type FileStat = { size: number };
+
+type ReadMediaResult =
+  | { kind: "ok"; data: string; size: number }
+  | { kind: "toolarge"; size: number; limit: number };
+
+export type MediaUrlResult = {
+  src: string;
+  size: number;
+  revoke?: () => void;
+};
+
+function bytesFromBase64(data: string): Uint8Array {
+  const bin = atob(data);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function blobUrl(bytes: Uint8Array, mime: string, size: number): MediaUrlResult {
+  const buffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  const blob = new Blob([buffer], { type: mime });
+  const src = URL.createObjectURL(blob);
+  return { src, size, revoke: () => URL.revokeObjectURL(src) };
+}
+
+/**
+ * Load media through workspace-authenticated IPC (works on any drive/path).
+ * Falls back to `convertFileSrc` only when the file exceeds the IPC size cap.
+ */
+export async function resolveMediaUrl(
+  path: string,
+  kind: MediaKind,
+): Promise<MediaUrlResult> {
+  const mime = mimeForMediaKind(kind, path);
+  const res = await invoke<ReadMediaResult>("fs_read_media", {
+    path,
+    workspace: currentWorkspaceEnv(),
+  });
+
+  if (res.kind === "ok") {
+    return blobUrl(bytesFromBase64(res.data), mime, res.size);
+  }
+
+  const [canon, stat] = await Promise.all([
+    invoke<string>("fs_canonicalize", {
+      path,
+      workspace: currentWorkspaceEnv(),
+    }),
+    invoke<FileStat>("fs_stat", {
+      path,
+      workspace: currentWorkspaceEnv(),
+    }),
+  ]);
+  return { src: convertFileSrc(canon), size: stat.size };
+}

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -26,6 +26,8 @@ import {
 import { initVimGlobals, vimHandlersExtension } from "./lib/vim";
 
 initVimGlobals();
+import { isMediaPath } from "@/lib/mediaPath";
+import { MediaPreview } from "@/modules/media/MediaPreview";
 import { resolveLanguage } from "./lib/languageResolver";
 import { useDocument } from "./lib/useDocument";
 import { inlineCompletion } from "./lib/autocomplete/inlineExtension";
@@ -61,7 +63,16 @@ function formatBytes(n: number): string {
 }
 
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
-  function EditorPane({ path, onDirtyChange, onSaved, onClose }, ref) {
+  function EditorPane(props, ref) {
+    if (isMediaPath(props.path)) {
+      return <MediaPreview ref={ref} path={props.path} />;
+    }
+    return <TextEditorPane ref={ref} {...props} />;
+  },
+);
+
+const TextEditorPane = forwardRef<EditorPaneHandle, Props>(
+  function TextEditorPane({ path, onDirtyChange, onSaved, onClose }, ref) {
     const { doc, onChange, save, reload } = useDocument({ path, onDirtyChange });
     const reloadRef = useRef(reload);
     reloadRef.current = reload;

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -11,6 +11,8 @@ import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EDITOR_THEME_EXT } from "./lib/themes";
 import {
   forwardRef,
+  lazy,
+  Suspense,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -27,12 +29,16 @@ import { initVimGlobals, vimHandlersExtension } from "./lib/vim";
 
 initVimGlobals();
 import { isMediaPath } from "@/lib/mediaPath";
-import { MediaPreview } from "@/modules/media/MediaPreview";
 import { resolveLanguage } from "./lib/languageResolver";
 import { useDocument } from "./lib/useDocument";
 import { inlineCompletion } from "./lib/autocomplete/inlineExtension";
 import { getKey } from "@/modules/ai/lib/keyring";
 import { onKeysChanged } from "@/modules/settings/store";
+const MediaPreview = lazy(() =>
+  import("@/modules/media/MediaPreview").then((m) => ({
+    default: m.MediaPreview,
+  }))
+);
 
 export type EditorPaneHandle = {
   setQuery: (q: string) => void;
@@ -65,7 +71,11 @@ function formatBytes(n: number): string {
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
   function EditorPane(props, ref) {
     if (isMediaPath(props.path)) {
-      return <MediaPreview ref={ref} path={props.path} />;
+      return (
+        <Suspense fallback={<div className="flex-1 bg-background" />}>
+          <MediaPreview ref={ref} path={props.path} />
+        </Suspense>
+      );
     }
     return <TextEditorPane ref={ref} {...props} />;
   },

--- a/src/modules/editor/mediaEditorHandle.ts
+++ b/src/modules/editor/mediaEditorHandle.ts
@@ -1,0 +1,23 @@
+import type { EditorPaneHandle } from "./types";
+
+/** No-op stubs so media tabs satisfy `EditorPaneHandle` for search/editor callers. */
+export function createMediaEditorHandle(
+  path: string,
+  reload: () => void,
+): EditorPaneHandle {
+  return {
+    setQuery: () => {},
+    findNext: () => {},
+    findPrevious: () => {},
+    clearQuery: () => {},
+    focus: () => {},
+    getSelection: () => null,
+    getPath: () => path,
+    reload: () => {
+      reload();
+      return true;
+    },
+    undo: () => {},
+    redo: () => {},
+  };
+}

--- a/src/modules/editor/types.ts
+++ b/src/modules/editor/types.ts
@@ -1,0 +1,13 @@
+export type EditorPaneHandle = {
+  setQuery: (q: string) => void;
+  findNext: () => void;
+  findPrevious: () => void;
+  clearQuery: () => void;
+  focus: () => void;
+  getSelection: () => string | null;
+  getPath: () => string;
+  /** Re-read the file from disk. Skips silently if the buffer is dirty. */
+  reload: () => boolean;
+  undo: () => void;
+  redo: () => void;
+};

--- a/src/modules/media/MediaPreview.tsx
+++ b/src/modules/media/MediaPreview.tsx
@@ -1,0 +1,129 @@
+import { getMediaKind, mimeForMediaKind } from "@/lib/mediaPath";
+import { resolveMediaUrl } from "@/lib/mediaSrc";
+import { createMediaEditorHandle } from "@/modules/editor/mediaEditorHandle";
+import type { EditorPaneHandle } from "@/modules/editor/types";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "ready"; src: string; size: number; revoke?: () => void }
+  | { kind: "error"; message: string };
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+type Props = {
+  path: string;
+};
+
+export const MediaPreview = forwardRef<EditorPaneHandle, Props>(
+  function MediaPreview({ path }, ref) {
+    const mediaKind = getMediaKind(path);
+    const [status, setStatus] = useState<Status>({ kind: "loading" });
+    const [reloadKey, setReloadKey] = useState(0);
+
+    useEffect(() => {
+      if (!mediaKind) return;
+      let cancelled = false;
+      let revoke: (() => void) | undefined;
+      setStatus({ kind: "loading" });
+
+      void resolveMediaUrl(path, mediaKind)
+        .then(({ src, size, revoke: r }) => {
+          if (cancelled) {
+            r?.();
+            return;
+          }
+          revoke = r;
+          setStatus({ kind: "ready", src, size, revoke: r });
+        })
+        .catch((e) => {
+          if (!cancelled) {
+            setStatus({ kind: "error", message: String(e) });
+          }
+        });
+
+      return () => {
+        cancelled = true;
+        revoke?.();
+      };
+    }, [path, mediaKind, reloadKey]);
+
+    useImperativeHandle(
+      ref,
+      () =>
+        createMediaEditorHandle(path, () => {
+          setReloadKey((k) => k + 1);
+        }),
+      [path],
+    );
+
+    if (!mediaKind) {
+      return (
+        <div className="flex h-full items-center justify-center px-6 text-center text-xs text-muted-foreground">
+          Unsupported media type
+        </div>
+      );
+    }
+
+    if (status.kind === "loading") {
+      return (
+        <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+          Loading…
+        </div>
+      );
+    }
+
+    if (status.kind === "error") {
+      return (
+        <div className="flex h-full items-center justify-center px-6 text-center text-xs text-destructive">
+          {status.message}
+        </div>
+      );
+    }
+
+    const mime = mimeForMediaKind(mediaKind, path);
+
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <div className="flex shrink-0 items-center justify-between border-b border-border/60 px-3 py-1.5 text-[11px] text-muted-foreground">
+          <span className="truncate font-mono">{path.split(/[\\/]/).pop()}</span>
+          <span>{formatBytes(status.size)}</span>
+        </div>
+        <div className="relative min-h-0 flex-1 overflow-hidden bg-muted/20 p-4 flex items-center justify-center">
+          {mediaKind === "image" ? (
+            <img
+              src={status.src}
+              alt=""
+              className="max-h-full max-w-full object-contain select-none block"
+              draggable={false}
+            />
+          ) : mediaKind === "video" ? (
+            <video
+              src={status.src}
+              controls
+              playsInline
+                className="max-h-full max-w-full object-contain block"
+            >
+              <source src={status.src} type={mime} />
+            </video>
+          ) : (
+            <div className="w-full max-w-md">
+              <audio src={status.src} controls className="w-full">
+                <source src={status.src} type={mime} />
+              </audio>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  },
+);

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -3,6 +3,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
+import { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -42,6 +43,7 @@ export type Slot = {
   readonly searchAddon: SearchAddon;
   readonly serializeAddon: SerializeAddon;
   readonly host: HTMLDivElement;
+  imageAddon: ImageAddon;
   webglAddon: WebglAddon | null;
   webglCanvases: HTMLCanvasElement[];
   currentLeafId: number | null;
@@ -128,6 +130,13 @@ function createSlot(): Slot {
   term.loadAddon(
     new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
   );
+  const imageAddon = new ImageAddon({
+    enableSizeReports: true,
+    sixelSupport: true,
+    iipSupport: true,
+    iipSizeLimit: 50_000_000,
+  });
+  term.loadAddon(imageAddon);
 
   const host = document.createElement("div");
   host.style.cssText = "width:100%;height:100%;";
@@ -142,6 +151,7 @@ function createSlot(): Slot {
     searchAddon,
     serializeAddon,
     host,
+    imageAddon,
     webglAddon: null,
     webglCanvases: [],
     currentLeafId: null,


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
Adds inline media viewing to Terax. Images (PNG, JPEG, GIF, WebP, SVG, BMP, ICO), video (MP4, WebM, MOV, MKV, AVI), and audio (MP3, WAV, OGG, FLAC, AAC, M4A) now open in a dedicated `MediaPreview` component inside the existing editor tab slot instead of loading as garbage bytes in CodeMirror. Also adds an `img` shell command to all four supported shells that renders images inline in the terminal via the iTerm2 image protocol.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
Opening any non-text file from the file explorer previously attempted to load it in CodeMirror, which either rendered garbage or silently failed. There was no in-app way to preview assets without leaving Terax entirely.

Closes #571

## How
<!-- Brief notes on the approach, only if non-obvious. -->
**Frontend — zero new tab type, zero new store fields.**
`EditorPane` now forks on `isMediaPath(path)` (a new utility at `src/lib/mediaPath.ts`): media paths render `<MediaPreview>`, everything else falls through to `<TextEditorPane>` unchanged. `EditorPaneHandle` was extracted to `src/modules/editor/types.ts` to avoid a circular import.

`MediaPreview` resolves the file URL via `convertFileSrc()` from `@tauri-apps/api/core` — this streams directly from disk over the asset protocol with no IPC round-trip and no base64 serialization, keeping memory cost flat even for large video files. It satisfies the `EditorPaneHandle` ref interface with no-op stubs for editor-specific methods so all existing ref call-sites stay safe.

**Terminal inline images — `@xterm/addon-image`.**
`ImageAddon` is wired into `rendererPool.ts` with `sixelSupport: true` and `iipSupport: true`. All four shell init scripts (`zshrc.zsh`, `bashrc.bash`, `init.fish`, `profile.ps1`) now inject an `img <path>` shell function that encodes a file as base64 and emits it via `OSC 1337` (iTerm2 inline image protocol), so `img screenshot.png` renders the image directly in the terminal output.

**Tauri — asset protocol.**
- `tauri` is updated to include the `protocol-asset` feature in `Cargo.toml`.
- `tauri.conf.json` enables `assetProtocol` with `allow: ["**"]` scope so
- `convertFileSrc()` can resolve arbitrary project paths.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
  - Opened PNG, JPEG, WebP, SVG, BMP from the file explorer — all render correctly in an editor tab
  - Opened an animated GIF — plays inline without controls
  - Opened MP4 and WebM — renders `<video>` with native controls, plays correctly
  - Opened MP3 and WAV — renders `<audio>` with native controls
  - Opened a `.ts` and `.md` file after previewing media — CodeMirror loads normally, no regression
  - Ran `img screenshot.png` in the terminal (bash, zsh, fish, pwsh) — image renders inline via OSC 1337
  - Opened a non-git directory — no errors, no regressions in unrelated panels
  - Held a ref to a `MediaPreview` editor tab and called `focus()`, `reload()`, `undo()` — no crashes, no-ops as expected
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [x] Shells tested (if relevant): pwsh


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->
<img alt="media-support" src="https://github.com/user-attachments/assets/d445685a-4e5c-4bdb-ae49-200bd736947d" />


## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
