### PR TITLE
fix(terminal): paste image file path on drag-and-drop

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -85,6 +85,7 @@ import {
   findLeafCwd,
   hasLeaf,
   leafIds,
+  pasteIntoLeaf,
   respawnSession,
   TerminalStack,
   whenSessionReady,
@@ -223,6 +224,26 @@ export default function App() {
   const terminalRefs = useRef<Map<number, TerminalPaneHandle>>(new Map());
   const editorRefs = useRef<Map<number, EditorPaneHandle>>(new Map());
   const previewRefs = useRef<Map<number, PreviewPaneHandle>>(new Map());
+
+  // Drag-and-drop a file onto the terminal → inject its path into the focused
+  // terminal as a bracketed paste. Claude Code resolves an image path into an
+  // "[Image #N]" reference (matching Warp); a plain shell just receives the
+  // literal path. Tauri surfaces the absolute path that HTML5 drop cannot.
+  const dropRef = useRef<(paths: string[]) => void>(() => {});
+  dropRef.current = (paths) => {
+    if (!activeTerminalTab || activeLeafId === null || paths.length === 0)
+      return;
+    if (pasteIntoLeaf(activeLeafId, paths?.join(" ")))
+      terminalRefs?.current?.get(activeLeafId)?.focus();
+  };
+  useEffect(() => {
+    const un = getCurrentWebviewWindow?.()?.onDragDropEvent?.((e) => {
+      if (e?.payload?.type === "drop") dropRef?.current(e?.payload?.paths);
+    });
+    return () => {
+      void un?.then((f) => f());
+    };
+  }, []);
   const [activeEditorHandle, setActiveEditorHandle] =
     useState<EditorPaneHandle | null>(null);
   const [gitHistoryHandle, setGitHistoryHandle] =

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -1,5 +1,6 @@
 export { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 export { TerminalStack } from "./TerminalStack";
+export { pasteIntoLeaf } from "./lib/rendererPool";
 export {
   clearFocusedTerminal,
   disposeSession,

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -73,6 +73,20 @@ export function poolSize(): number {
   return slots.length;
 }
 
+/**
+ * Bracketed-paste `text` into the terminal currently bound to `leafId`. Routes
+ * through xterm's `paste()` (→ onData → writeToPty), so apps that enabled
+ * bracketed paste (e.g. Claude Code) receive it as a real paste — letting Claude
+ * resolve a dropped image path into an "[Image #N]" reference — while a plain
+ * shell just gets the literal text without stray ESC[200~ markers.
+ */
+export function pasteIntoLeaf(leafId: number, text: string): boolean {
+  const slot = slots?.find((s) => s?.currentLeafId === leafId);
+  if (!slot) return false;
+  slot?.term?.paste(text);
+  return true;
+}
+
 function getRecycler(): HTMLDivElement {
   if (recyclerEl && recyclerEl.isConnected) return recyclerEl;
   const el = document.createElement("div");


### PR DESCRIPTION
Dragging an image file onto the terminal now injects its path as a bracketed paste, so Claude Code (and similar TUIs) resolve it to an [Image #N] reference — matching Warp / macOS Terminal.app.

## What & why
Previously, dropping an image onto the terminal did nothing. Tauri captures OS file drops (HTML5 drop can't expose the absolute path), so the dropped file path was never delivered to the PTY.

## Changes
- `rendererPool.ts`: add `pasteIntoLeaf(leafId, text)` — bracketed-paste-aware injection via xterm `term.paste()` (routes through the existing onData → writeToPty chain), so bracketed-paste apps get a real paste while a plain shell receives the literal path.
- `App.tsx`: subscribe to the Tauri `onDragDropEvent`; on drop, inject the dropped file path(s) into the focused terminal (only when a terminal tab is active).
- `terminal/index.ts`: export `pasteIntoLeaf`.

## Scope
Handles OS file drops (Finder, saved screenshots). In-app/browser image drags that carry no file path are out of scope.