### PR TITLE
fix(linux): avoid WebKitGTK Wayland NVIDIA crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Latest installers are on the [Releases](https://github.com/crynta/terax-ai/relea
 ### Linux notes
 
 - **Arch / AUR:** `yay -S terax-bin` (or `paru`, etc.). Tracks the latest release.
-- **AppImage:** needs FUSE. Without it: `./Terax_*.AppImage --appimage-extract-and-run`. On Wayland with rendering glitches, try `WEBKIT_DISABLE_DMABUF_RENDERER=1`. Otherwise the `.deb` / `.rpm` packages link against the system GTK stack and tend to be smoother.
+- **AppImage:** needs FUSE. Without it: `./Terax_*.AppImage --appimage-extract-and-run`. On NVIDIA + Wayland, Terax applies a WebKitGTK explicit-sync workaround that keeps DMABUF rendering enabled for lower terminal latency. Otherwise the `.deb` / `.rpm` packages link against the system GTK stack and tend to be smoother.
 
 ## Configure AI
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,29 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(target_os = "linux")]
+fn configure_linux_webkit_env() {
+    const NV_EXPLICIT_SYNC: &str = "__NV_DISABLE_EXPLICIT_SYNC";
+    const TERAX_SET_NV_EXPLICIT_SYNC: &str = "TERAX_SET_NV_DISABLE_EXPLICIT_SYNC";
+
+    let is_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some()
+        || std::env::var("XDG_SESSION_TYPE")
+            .is_ok_and(|session| session.eq_ignore_ascii_case("wayland"));
+    let has_nvidia_driver = std::path::Path::new("/sys/module/nvidia").exists();
+
+    if is_wayland && has_nvidia_driver && std::env::var_os(NV_EXPLICIT_SYNC).is_none() {
+        // On NVIDIA/Wayland, WebKitGTK can crash with GDK protocol errors when
+        // explicit sync is enabled. This keeps WebKit's DMABUF renderer active,
+        // avoiding the input/render latency caused by disabling DMABUF.
+        std::env::set_var(NV_EXPLICIT_SYNC, "1");
+        std::env::set_var(TERAX_SET_NV_EXPLICIT_SYNC, "1");
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_linux_webkit_env() {}
+
 fn main() {
+    configure_linux_webkit_env();
     terax_lib::run()
 }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -86,6 +86,7 @@ fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     cmd.env("TERAX_TERMINAL", "1");
+    remove_internal_graphics_env(cmd);
     ensure_utf8_locale(cmd);
 
     let resolved_cwd = cwd
@@ -102,6 +103,20 @@ fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
         log::warn!("pty cwd: no usable directory, inheriting from process");
     }
 }
+
+#[cfg(target_os = "linux")]
+fn remove_internal_graphics_env(cmd: &mut CommandBuilder) {
+    const NV_EXPLICIT_SYNC: &str = "__NV_DISABLE_EXPLICIT_SYNC";
+    const TERAX_SET_NV_EXPLICIT_SYNC: &str = "TERAX_SET_NV_DISABLE_EXPLICIT_SYNC";
+
+    if std::env::var_os(TERAX_SET_NV_EXPLICIT_SYNC).is_some() {
+        cmd.env_remove(NV_EXPLICIT_SYNC);
+        cmd.env_remove(TERAX_SET_NV_EXPLICIT_SYNC);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_internal_graphics_env(_cmd: &mut CommandBuilder) {}
 
 #[cfg(unix)]
 mod unix {

--- a/src-tauri/src/modules/shell/mod.rs
+++ b/src-tauri/src/modules/shell/mod.rs
@@ -301,6 +301,7 @@ pub(crate) fn build_oneshot_command(
     {
         let mut cmd = Command::new("/bin/sh");
         cmd.arg("-c").arg(command);
+        remove_internal_graphics_env(&mut cmd);
         Ok(cmd)
     }
     #[cfg(windows)]
@@ -320,6 +321,20 @@ pub(crate) fn build_oneshot_command(
         Ok(cmd)
     }
 }
+
+#[cfg(target_os = "linux")]
+fn remove_internal_graphics_env(cmd: &mut Command) {
+    const NV_EXPLICIT_SYNC: &str = "__NV_DISABLE_EXPLICIT_SYNC";
+    const TERAX_SET_NV_EXPLICIT_SYNC: &str = "TERAX_SET_NV_DISABLE_EXPLICIT_SYNC";
+
+    if std::env::var_os(TERAX_SET_NV_EXPLICIT_SYNC).is_some() {
+        cmd.env_remove(NV_EXPLICIT_SYNC);
+        cmd.env_remove(TERAX_SET_NV_EXPLICIT_SYNC);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn remove_internal_graphics_env(_cmd: &mut Command) {}
 
 fn drain<R: Read>(reader: &mut R) -> (Vec<u8>, bool) {
     let mut out = Vec::new();


### PR DESCRIPTION
## Summary
- apply an NVIDIA Wayland explicit-sync workaround before Tauri/WebKitGTK initializes
- keep WebKitGTK DMABUF rendering enabled to avoid the terminal latency caused by WEBKIT_DISABLE_DMABUF_RENDERER=1
- strip the internally-set workaround from spawned PTY and shell commands so child processes do not inherit it
- update Linux notes to describe the lower-latency workaround

## Testing
- pnpm exec tsc --noEmit
- cd src-tauri && cargo check --locked
- cd src-tauri && cargo test --locked
- GDK_BACKEND=wayland pnpm tauri dev (smoke test: app stayed alive and opened PTY until timeout)