### PR TITLE
fix(linux) Not showing a cursor change to indicate that you can resize the window

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -78,6 +78,8 @@ import {
   useSourceControl,
 } from "@/modules/source-control";
 import { StatusBar } from "@/modules/statusbar";
+import { USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { WindowResizeHandles } from "@/components/WindowResizeHandles";
 import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
 import {
   clearFocusedTerminal,
@@ -1434,6 +1436,7 @@ export default function App() {
     <ThemeProvider>
       <TooltipProvider>
         <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
+          {USE_CUSTOM_WINDOW_CONTROLS && <WindowResizeHandles />}
           <Header
             tabs={tabs}
             activeId={activeId}

--- a/src/components/WindowResizeHandles.tsx
+++ b/src/components/WindowResizeHandles.tsx
@@ -1,0 +1,51 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useCallback } from "react";
+
+type ResizeDir = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+const DIR_MAP: Record<
+  ResizeDir,
+  "North" | "South" | "East" | "West" | "NorthEast" | "NorthWest" | "SouthEast" | "SouthWest"
+> = {
+  n: "North",
+  s: "South",
+  e: "East",
+  w: "West",
+  ne: "NorthEast",
+  nw: "NorthWest",
+  se: "SouthEast",
+  sw: "SouthWest",
+};
+
+const HANDLE_CLASS: Record<ResizeDir, string> = {
+  n: "top-0 left-2 right-2 h-1 cursor-ns-resize",
+  s: "bottom-0 left-2 right-2 h-1 cursor-ns-resize",
+  w: "top-2 bottom-2 left-0 w-1 cursor-ew-resize",
+  e: "top-2 bottom-2 right-0 w-1 cursor-ew-resize",
+  nw: "top-0 left-0 size-2 cursor-nwse-resize",
+  ne: "top-0 right-0 size-2 cursor-nesw-resize",
+  sw: "bottom-0 left-0 size-2 cursor-nesw-resize",
+  se: "bottom-0 right-0 size-2 cursor-nwse-resize",
+};
+
+const DIRS: ResizeDir[] = ["n", "s", "e", "w", "ne", "nw", "se", "sw"];
+
+export function WindowResizeHandles() {
+  const startResize = useCallback((dir: ResizeDir) => (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void getCurrentWindow().startResizeDragging(DIR_MAP[dir]);
+  }, []);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50">
+      {DIRS.map((dir) => (
+        <div
+          key={dir}
+          onPointerDown={startResize(dir)}
+          className={`pointer-events-auto absolute ${HANDLE_CLASS[dir]}`}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Add invisible window edge resize handles for the decorations-less main window on Linux/Windows.

## Why
On Linux, `tauri.linux.conf.json` sets `decorations: false`, which strips all OS window chrome — including native resize handles and their cursor icons. The cursor never changed at the window edge, and edge-drag resize was impossible.

## How
Renders 8 invisible `<div>` hit zones (4 edges + 4 corners) overlaying the window perimeter with the correct CSS cursor classes (`cursor-ns-resize`, `cursor-ew-resize`, etc.). On `pointerdown`, calls Tauri's `window.startResizeDragging(direction)` which hands off the resize gesture to the OS window manager — no custom pointer math needed.

Pattern mirrors the existing `AiMiniWindow` resize handles but delegates to Tauri IPC instead of manual DOM geometry.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm tauri build` succeeds (`.deb` / `.rpm` / `.AppImage` produced)
- [x] Platforms tested: Linux

## Notes for reviewer

The `startResizeDragging` API is available in Tauri v2 `@tauri-apps/api` (the `ResizeDirection` type is `'North'|'South'|'East'|'West'|'NorthEast'|'NorthWest'|'SouthEast'|'SouthWest'`). This component is only rendered when `USE_CUSTOM_WINDOW_CONTROLS` is true (non-macOS). On macOS the native window chrome handles resize normally.

