### PR TITLE
feat(window): open new window via Cmd+N, File menu, and multi-window support

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Capability for the main window",
   "windows": [
     "main",
+    "main-*",
     "settings"
   ],
   "permissions": [

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -7,6 +7,7 @@
   ],
   "windows": [
     "main",
+    "main-*",
     "settings"
   ],
   "permissions": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,14 @@
 pub mod modules;
 
 use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_window_state::StateFlags;
+
+// Monotonic counter for new-window labels ("main-2", "main-3", …).
+// Starts at 2 so the primary window's label "main" is never shadowed.
+static WINDOW_COUNTER: AtomicU32 = AtomicU32::new(2);
 
 /// Drained on first read so HMR / re-mounts can't replay the launch dir.
 #[derive(Default)]
@@ -26,6 +31,53 @@ fn parse_launch_dir() -> Option<String> {
         return Some(crate::modules::fs::to_canon(&canon));
     }
     None
+}
+
+#[tauri::command]
+async fn open_new_window(app: tauri::AppHandle) -> Result<(), String> {
+    let idx = WINDOW_COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
+    let label = format!("main-{idx}");
+
+    let builder =
+        WebviewWindowBuilder::new(&app, &label, WebviewUrl::App("index.html".into()))
+            .title("Terax")
+            .inner_size(800.0, 600.0)
+            .min_inner_size(420.0, 280.0)
+            .resizable(true)
+            .visible(false);
+
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true);
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    let builder = builder.decorations(false).transparent(true);
+
+    let window = builder.build().map_err(|e| e.to_string())?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = window.set_decorations(false);
+    }
+    let _ = window;
+
+    // Belt-and-suspenders: show the window from Rust after a short delay.
+    // The frontend (main.tsx) also calls show() after 50ms, but in Tauri v2
+    // dynamically-created windows may not have __TAURI_INTERNALS__ injected in
+    // time for getCurrentWindow().show() to target the right window.
+    let app_clone = app.clone();
+    std::thread::Builder::new()
+        .name(format!("terax-show-{label}"))
+        .spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            if let Some(w) = app_clone.get_webview_window(&label) {
+                let _ = w.show();
+            }
+        })
+        .ok();
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -83,6 +135,54 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+fn build_app_menu(
+    app: &tauri::AppHandle,
+) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
+    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
+
+    let terax_sub = Submenu::with_items(
+        app,
+        "Terax",
+        true,
+        &[
+            &PredefinedMenuItem::about(app, None::<&str>, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &MenuItem::with_id(app, "settings", "Settings\u{2026}", true, Some("Cmd+,"))?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::quit(app, None::<&str>)?,
+        ],
+    )?;
+
+    let file_sub = Submenu::with_items(
+        app,
+        "File",
+        true,
+        &[
+            &MenuItem::with_id(app, "new_window", "New Window", true, Some("Cmd+N"))?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None::<&str>)?,
+        ],
+    )?;
+
+    let edit_sub = Submenu::with_items(
+        app,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app, None::<&str>)?,
+            &PredefinedMenuItem::redo(app, None::<&str>)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None::<&str>)?,
+            &PredefinedMenuItem::copy(app, None::<&str>)?,
+            &PredefinedMenuItem::paste(app, None::<&str>)?,
+            &PredefinedMenuItem::select_all(app, None::<&str>)?,
+        ],
+    )?;
+
+    Menu::with_items(app, &[&terax_sub, &file_sub, &edit_sub])
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let cli_dir = parse_launch_dir();
@@ -122,6 +222,38 @@ pub fn run() {
             registry
         })
         .manage(LaunchDir(Mutex::new(cli_dir)))
+        .setup(|app| {
+            #[cfg(target_os = "macos")]
+            {
+                let menu = build_app_menu(&app.handle())?;
+                app.set_menu(menu)?;
+                // Register listener on the app handle — the correct scope for
+                // app-level menu events on macOS per Tauri v2 examples.
+                let handle = app.handle().clone();
+                app.on_menu_event(move |_app, event| {
+                    match event.id().0.as_str() {
+                        "new_window" => {
+                            let h = handle.clone();
+                            tauri::async_runtime::spawn(async move {
+                                if let Err(e) = open_new_window(h).await {
+                                    log::error!("new_window menu: {e}");
+                                }
+                            });
+                        }
+                        "settings" => {
+                            let h = handle.clone();
+                            tauri::async_runtime::spawn(async move {
+                                if let Err(e) = open_settings_window(h, None).await {
+                                    log::error!("settings menu: {e}");
+                                }
+                            });
+                        }
+                        _ => {}
+                    }
+                });
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             pty::pty_open,
             pty::pty_write,
@@ -175,6 +307,7 @@ pub fn run() {
             workspace::workspace_authorize,
             workspace::workspace_current_dir,
             get_launch_dir,
+            open_new_window,
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/modules/header";
 import { MarkdownStack } from "@/modules/markdown";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
+import { openNewWindow } from "@/lib/openNewWindow";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { onKeysChanged, setThemeId as persistThemeId } from "@/modules/settings/store";
@@ -1034,6 +1035,7 @@ export default function App() {
 
   const shortcutHandlers = useMemo<ShortcutHandlers>(
     () => ({
+      "window.new": () => void openNewWindow(),
       "tab.new": openNewTab,
       "tab.newPrivate": openNewPrivateTab,
       "tab.newPreview": () => openPreviewTab(""),
@@ -1454,6 +1456,7 @@ export default function App() {
             onActivateAgent={onActivateAgent}
             onActivateLocalAgent={onActivateLocalAgent}
             onOpenSettings={() => void openSettingsWindow()}
+            onNewWindow={() => void openNewWindow()}
             searchTarget={searchTarget}
             searchRef={searchInlineRef}
           />

--- a/src/lib/openNewWindow.ts
+++ b/src/lib/openNewWindow.ts
@@ -1,0 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export async function openNewWindow(): Promise<void> {
+  await invoke("open_new_window");
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,12 @@ if (USE_CUSTOM_WINDOW_CONTROLS) {
 }
 
 // Reap PTY sessions orphaned by a prior webview load before any tab spawns.
-await invoke("pty_close_all").catch(() => {});
+// Only do this on the original "main" window — secondary windows (main-2, …)
+// have no orphaned sessions, and calling pty_close_all would kill sessions
+// that belong to other open windows.
+if (getCurrentWindow().label === "main") {
+  await invoke("pty_close_all").catch(() => {});
+}
 
 // Seed before first paint so default tab mounts at target cwd (no flicker).
 await initLaunchDir();

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -50,6 +50,7 @@ type Props = {
   onActivateAgent: (tabId: number, leafId: number) => void;
   onActivateLocalAgent: () => void;
   onOpenSettings: () => void;
+  onNewWindow: () => void;
   searchTarget: SearchTarget;
   searchRef: RefObject<SearchInlineHandle | null>;
 };
@@ -73,6 +74,7 @@ export function Header({
   onActivateAgent,
   onActivateLocalAgent,
   onOpenSettings,
+  onNewWindow,
   searchTarget,
   searchRef,
 }: Props) {
@@ -123,6 +125,25 @@ export function Header({
       }`}
     >
       <div className="flex shrink-0 items-center gap-0.5">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 shrink-0 rounded-md px-2 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              File
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-44">
+            <DropdownMenuItem onSelect={onNewWindow}>
+              <span className="flex-1">New Window</span>
+              <span className="text-xs text-muted-foreground">
+                {tokensFor("window.new")}
+              </span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button
           onClick={onToggleSidebar}
           title="Toggle sidebar"

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -5,6 +5,7 @@ import { IS_MAC, MOD_PROP } from "@/lib/platform";
  */
 
 export type ShortcutId =
+  | "window.new"
   | "tab.new"
   | "tab.newPrivate"
   | "tab.newPreview"
@@ -60,6 +61,12 @@ export type Shortcut = {
 };
 
 export const SHORTCUTS: Shortcut[] = [
+  {
+    id: "window.new",
+    label: "New window",
+    group: "General",
+    defaultBindings: [{ [MOD_PROP]: true, key: "n" }],
+  },
   {
     id: "settings.open",
     label: "Open settings",


### PR DESCRIPTION
## Summary

Adds **multi-window support** to Terax. A new `open_new_window` Tauri command spawns secondary windows (`main-2`, `main-3`, …) that match the primary window's chrome, reachable three ways:

- **Shortcut** — `window.new` bound to <kbd>Cmd/Ctrl</kbd>+<kbd>N</kbd>
- **Header** — a "File ▸ New Window" dropdown
- **Native macOS menu bar** — Terax / File / Edit submenus registered at startup (File ▸ New Window, ⌘N)

## Changes

- **`src-tauri/src/lib.rs`** — `open_new_window` command using an atomic label counter starting at `2` (so the primary `main` label is never shadowed); the new window is built hidden and shown shortly after (belt-and-suspenders with the frontend `show()`, since dynamically-created Tauri v2 windows may not have internals injected immediately). Adds a native macOS app menu (`build_app_menu`) wired via `on_menu_event` to the new-window and settings commands.
- **`src/main.tsx`** — run `pty_close_all` only on the original `main` window, so opening a new window no longer reaps other windows' PTY sessions.
- **`src-tauri/capabilities/{default,desktop}.json`** — permit `main-*` windows.
- **`src/lib/openNewWindow.ts`**, **`src/modules/shortcuts/shortcuts.ts`**, **`src/app/App.tsx`**, **`src/modules/header/Header.tsx`** — register the `window.new` shortcut and wire the UI entry points to the command.

## Test plan

- `tsc --noEmit` passes; `pnpm tauri build` (release) compiles cleanly.
- Built and ran locally on macOS (Apple Silicon, macOS 26): ⌘N, the File menu, and the native menu bar all open a new functional window; PTY sessions in existing windows survive opening a new one.

> Independent of #582 (tab-drag-reorder); branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
