### PR TITLE
fix(pty): swap $ZDOTDIR while sourcing user zsh init

### DIFF
--- a/src-tauri/src/modules/pty/scripts/zlogin.zsh
+++ b/src-tauri/src/modules/pty/scripts/zlogin.zsh
@@ -4,10 +4,17 @@
 # exit status becomes `$?` for the very first prompt. Without the trailing `:`,
 # users without a personal ~/.zlogin (the common case) hit a non-zero $? on
 # first render — themes that condition prompt color on `%?` (robbyrussell etc.)
-# show a red error indicator on a clean shell start.
+# show a red error indicator on a clean shell start. See zshenv.zsh for the
+# ZDOTDIR swap rationale.
 {
   _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
-  [ -f "$_terax_user_zdotdir/.zlogin" ] && source "$_terax_user_zdotdir/.zlogin"
+  if [ -f "$_terax_user_zdotdir/.zlogin" ]; then
+    _terax_saved_zdotdir="$ZDOTDIR"
+    ZDOTDIR="$_terax_user_zdotdir"
+    source "$_terax_user_zdotdir/.zlogin"
+    ZDOTDIR="$_terax_saved_zdotdir"
+    unset _terax_saved_zdotdir
+  fi
   unset _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zprofile.zsh
+++ b/src-tauri/src/modules/pty/scripts/zprofile.zsh
@@ -1,9 +1,15 @@
 # terax-shell-integration (zprofile)
 #
-# See zshenv.zsh for the rationale on the trailing `:`.
+# See zshenv.zsh for the rationale on the trailing `:` and the ZDOTDIR swap.
 {
   _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
-  [ -f "$_terax_user_zdotdir/.zprofile" ] && source "$_terax_user_zdotdir/.zprofile"
+  if [ -f "$_terax_user_zdotdir/.zprofile" ]; then
+    _terax_saved_zdotdir="$ZDOTDIR"
+    ZDOTDIR="$_terax_user_zdotdir"
+    source "$_terax_user_zdotdir/.zprofile"
+    ZDOTDIR="$_terax_saved_zdotdir"
+    unset _terax_saved_zdotdir
+  fi
   unset _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zshenv.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshenv.zsh
@@ -3,9 +3,21 @@
 # Trailing `:` is load-bearing — without it, a missing user .zshenv leaves $?=1,
 # which propagates through the rest of init and ultimately into the first
 # prompt's `%?` (rendering robbyrussell's `➜` red on a clean shell start).
+#
+# $ZDOTDIR is swapped to the user's real config dir for the duration of the
+# sourced file. User configs commonly resolve paths via $ZDOTDIR (e.g.
+# `$ZDOTDIR/conf.d/*.zsh`); without the swap those globs land in the Terax
+# integration dir and zsh errors with `no matches found` (#526). Restored
+# afterwards so the next init phase still loads from the integration dir.
 {
   _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
-  [ -f "$_terax_user_zdotdir/.zshenv" ] && source "$_terax_user_zdotdir/.zshenv"
+  if [ -f "$_terax_user_zdotdir/.zshenv" ]; then
+    _terax_saved_zdotdir="$ZDOTDIR"
+    ZDOTDIR="$_terax_user_zdotdir"
+    source "$_terax_user_zdotdir/.zshenv"
+    ZDOTDIR="$_terax_saved_zdotdir"
+    unset _terax_saved_zdotdir
+  fi
   unset _terax_user_zdotdir
 }
 :

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -7,7 +7,13 @@
 
 {
   _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
-  [ -f "$_terax_user_zdotdir/.zshrc" ] && source "$_terax_user_zdotdir/.zshrc"
+  if [ -f "$_terax_user_zdotdir/.zshrc" ]; then
+    _terax_saved_zdotdir="$ZDOTDIR"
+    ZDOTDIR="$_terax_user_zdotdir"
+    source "$_terax_user_zdotdir/.zshrc"
+    ZDOTDIR="$_terax_saved_zdotdir"
+    unset _terax_saved_zdotdir
+  fi
   unset _terax_user_zdotdir
 }
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -262,6 +262,61 @@ mod unix {
             format!("rename {} -> {}: {e}", tmp.display(), path.display())
         })
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::process::Command;
+
+        fn zsh_available() -> bool {
+            Command::new("zsh")
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        }
+
+        // Regression test for #526: when Terax's injected .zshenv sources the
+        // user's .zshenv, the user's file must observe $ZDOTDIR pointing at
+        // their real config dir, not at Terax's integration dir. Otherwise
+        // common patterns like `for f in $ZDOTDIR/conf.d/*.zsh; do …; done`
+        // glob into the wrong directory and zsh errors with `no matches found`.
+        #[test]
+        fn user_zshenv_sees_user_zdotdir() {
+            if !zsh_available() {
+                eprintln!("skipping: zsh not on PATH");
+                return;
+            }
+            let integ = tempfile::tempdir().expect("integ tempdir");
+            let user = tempfile::tempdir().expect("user tempdir");
+            fs::write(integ.path().join(".zshenv"), ZSHENV).expect("write integ .zshenv");
+            fs::write(
+                user.path().join(".zshenv"),
+                r#"if [[ "$ZDOTDIR" != "$TERAX_USER_ZDOTDIR" ]]; then
+  print -u2 "user .zshenv saw ZDOTDIR=$ZDOTDIR want=$TERAX_USER_ZDOTDIR"
+  exit 42
+fi
+"#,
+            )
+            .expect("write user .zshenv");
+
+            let status = Command::new("zsh")
+                .arg("-c")
+                .arg("exit 0")
+                .env_clear()
+                .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+                .env("HOME", user.path())
+                .env("ZDOTDIR", integ.path())
+                .env("TERAX_USER_ZDOTDIR", user.path())
+                .status()
+                .expect("spawn zsh");
+            assert!(
+                status.success(),
+                "zsh exited with {:?}; user .zshenv saw the wrong $ZDOTDIR",
+                status.code()
+            );
+        }
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## What
Swap `$ZDOTDIR` to the user's real config dir while sourcing their zsh init files, then restore it. Applies uniformly to all four injected scripts (`.zshenv`, `.zprofile`, `.zshrc`, `.zlogin`).

## Why
Fixes #526.

Terax sets `ZDOTDIR` to its integration dir so zsh picks up the shell-integration scripts. Inside those scripts, Terax sources the user's matching file from `$TERAX_USER_ZDOTDIR`, but `$ZDOTDIR` still points at Terax's integration dir during that source call. User configs that resolve paths via `$ZDOTDIR` (e.g. `for f in $ZDOTDIR/conf.d/*.zsh; do source $f; done`) glob into Terax's dir and zsh errors with `no matches found`. The user's normal terminal works fine; only Terax breaks.

## How
Swap pattern in each of the four scripts:

```zsh
{
  _terax_user_zdotdir="${TERAX_USER_ZDOTDIR:-$HOME}"
  if [ -f "$_terax_user_zdotdir/.zshenv" ]; then
    _terax_saved_zdotdir="$ZDOTDIR"
    ZDOTDIR="$_terax_user_zdotdir"
    source "$_terax_user_zdotdir/.zshenv"
    ZDOTDIR="$_terax_saved_zdotdir"
    unset _terax_saved_zdotdir
  fi
  unset _terax_user_zdotdir
}
```

Restoring `$ZDOTDIR` after the source matters: the next init phase (`.zprofile` -> `.zshrc` -> `.zlogin`) must still load from Terax's integration dir.

## Testing
Reproduced on Arch Linux 7.0.8-arch1-1, zsh 5.9, with a minimal `~/.config/zsh/.zshenv` matching the issue. Confirmed `no matches found` error before the fix and clean startup after.

Added `modules::pty::shell_init::unix::tests::user_zshenv_sees_user_zdotdir`: hermetic (tempdirs only), uses the actual `ZSHENV` constant, and a probe `.zshenv` that exits 42 on contract violation. Verified the probe **does** exit 42 against the pre-fix script — the test is real, not a no-op. Skips gracefully when zsh isn't on PATH (Windows runners).

- [x] `cargo test --locked` clean
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] `pnpm exec tsc --noEmit` clean (not run locally; change is Rust-only, no frontend file touched — CI will run it)
- [x] Manual smoke-test: reproduced + verified fix on local zsh
- [x] Platforms tested: Linux (Arch)
- [x] Shells tested: zsh

## Notes for reviewer
- Scope kept tight to the swap pattern. Other shells (bash/fish/pwsh) don't have an equivalent `$ZDOTDIR` notion, so no parallel change is needed there.
- Don't have macOS to test; the unix path is shared so it should behave identically (the test will run on the macOS CI runner).