### PR TITLE
fix(explorer): open file on double-click, move rename to context menu and F2

### DIFF
--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -320,6 +320,12 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
           else onOpenFile(row.path);
           break;
         }
+        case "F2": {
+          if (currentIdx < 0) return;
+          e.preventDefault();
+          tree.beginRename(entryPaths[currentIdx]);
+          break;
+        }
       }
     };
 

--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -97,7 +97,7 @@ function EntryRowImpl(props: EntryRowProps) {
             type="button"
             data-fs-path={path}
             onClick={handleClick}
-            onDoubleClick={() => !isDir && tree.beginRename(path)}
+            onDoubleClick={() => !isDir && onOpenFile(path, true)}
             className={cn(
               "group flex h-6 w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 text-left text-[13px] text-foreground/85 transition-colors hover:bg-accent/70",
               isSelected && "bg-accent text-foreground",
@@ -196,6 +196,12 @@ function EntryRowImpl(props: EntryRowProps) {
           Attach to Agent
         </ContextMenuItem>
         <ContextMenuSeparator />
+        <ContextMenuItem
+          className={COMPACT_ITEM}
+          onSelect={() => tree.beginRename(path)}
+        >
+          Rename
+        </ContextMenuItem>
         <ContextMenuItem
           className={COMPACT_ITEM}
           variant="destructive"


### PR DESCRIPTION
## What
Double-clicking a file now opens it (pinned) instead of starting an inline rename. Rename is now triggered via a new "Rename" context-menu item and the F2 key on the selected row. Single-click and Enter still open files.

## Why
Double-click-to-rename is surprising — file managers and editors open on double-click. Rename also had no other entry point (no context-menu item, no F2), which #588 noted as well. Closes #541.

## How tested
- `pnpm exec tsc --noEmit`: clean
- `pnpm test`: 78/78 pass
- Manually in `pnpm tauri dev`: double-click opens the file; right-click → Rename and F2 both start the inline rename; single-click and Enter unchanged.