### PR TITLE
feat(editor): add markdown preview shortcut and notebook view

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,6 +62,7 @@ import {
   type SearchTarget,
 } from "@/modules/header";
 import { MarkdownStack } from "@/modules/markdown";
+import { NotebookStack, type NotebookPaneHandle } from "@/modules/notebook";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -78,7 +79,13 @@ import {
   useSourceControl,
 } from "@/modules/source-control";
 import { StatusBar } from "@/modules/statusbar";
-import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
+import {
+  defaultFileViewForPath,
+  isMarkdownPreviewPath,
+  MAX_PANES_PER_TAB,
+  useTabs,
+  useWorkspaceCwd,
+} from "@/modules/tabs";
 import {
   clearFocusedTerminal,
   disposeSession,
@@ -188,6 +195,7 @@ export default function App() {
     pinTab,
     newPreviewTab,
     newMarkdownTab,
+    newNotebookTab,
     openAiDiffTab,
     closeAiDiffTab,
     openGitDiffTab,
@@ -222,6 +230,7 @@ export default function App() {
   const searchInlineRef = useRef<SearchInlineHandle | null>(null);
   const terminalRefs = useRef<Map<number, TerminalPaneHandle>>(new Map());
   const editorRefs = useRef<Map<number, EditorPaneHandle>>(new Map());
+  const notebookRefs = useRef<Map<number, NotebookPaneHandle>>(new Map());
   const previewRefs = useRef<Map<number, PreviewPaneHandle>>(new Map());
   const [activeEditorHandle, setActiveEditorHandle] =
     useState<EditorPaneHandle | null>(null);
@@ -479,6 +488,7 @@ export default function App() {
   const isEditorTab = activeTab?.kind === "editor";
   const isPreviewTab = activeTab?.kind === "preview";
   const isMarkdownTab = activeTab?.kind === "markdown";
+  const isNotebookTab = activeTab?.kind === "notebook";
   const isAiDiffTab = activeTab?.kind === "ai-diff";
   const isGitDiffTab =
     activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
@@ -496,9 +506,10 @@ export default function App() {
       if (appliedDiffsRef.current.has(t.approvalId)) continue;
       appliedDiffsRef.current.add(t.approvalId);
       for (const e of tabs) {
-        if (e.kind !== "editor") continue;
+        if (!("path" in e)) continue;
         if (e.path !== t.path) continue;
-        editorRefs.current.get(e.id)?.reload();
+        if (e.kind === "editor") editorRefs.current.get(e.id)?.reload();
+        if (e.kind === "notebook") notebookRefs.current.get(e.id)?.reload();
       }
     }
   }, [tabs]);
@@ -512,9 +523,10 @@ export default function App() {
         const normalizedPath = event.payload.path.replace(/\\/g, "/");
         const currentTabs = tabsRef.current;
         for (const t of currentTabs) {
-          if (t.kind !== "editor") continue;
+          if (t.kind !== "editor" && t.kind !== "notebook") continue;
           if (t.path.replace(/\\/g, "/") === normalizedPath) {
-            editorRefs.current.get(t.id)?.reload();
+            if (t.kind === "editor") editorRefs.current.get(t.id)?.reload();
+            else notebookRefs.current.get(t.id)?.reload();
           }
         }
       },
@@ -524,16 +536,20 @@ export default function App() {
     };
   }, []);
 
-  const editorWatchRef = useRef<Set<string>>(new Set());
+  const documentWatchRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     const want = new Set<string>();
-    for (const t of tabs) if (t.kind === "editor") want.add(parentDir(t.path));
-    const prev = editorWatchRef.current;
+    for (const t of tabs) {
+      if (t.kind === "editor" || t.kind === "notebook") {
+        want.add(parentDir(t.path));
+      }
+    }
+    const prev = documentWatchRef.current;
     const toAdd = [...want].filter((d) => !prev.has(d));
     const toRemove = [...prev].filter((d) => !want.has(d));
     watchAdd(toAdd);
     watchRemove(toRemove);
-    editorWatchRef.current = want;
+    documentWatchRef.current = want;
   }, [tabs]);
 
   useEffect(() => {
@@ -542,9 +558,10 @@ export default function App() {
     void listenFsChanged((paths) => {
       const changed = new Set(paths.map((p) => p.replace(/\\/g, "/")));
       for (const t of tabsRef.current) {
-        if (t.kind !== "editor") continue;
+        if (t.kind !== "editor" && t.kind !== "notebook") continue;
         if (changed.has(t.path.replace(/\\/g, "/"))) {
-          editorRefs.current.get(t.id)?.reload();
+          if (t.kind === "editor") editorRefs.current.get(t.id)?.reload();
+          else notebookRefs.current.get(t.id)?.reload();
         }
       }
     }).then((un) => {
@@ -645,6 +662,7 @@ export default function App() {
       // the effect below as the pane tree changes; only the tab-id-keyed
       // handles need explicit cleanup here.
       editorRefs.current.delete(id);
+      notebookRefs.current.delete(id);
       previewRefs.current.delete(id);
       closeTab(id);
     },
@@ -674,7 +692,10 @@ export default function App() {
   const handleClose = useCallback(
     (id: number) => {
       const t = tabs.find((x) => x.id === id);
-      if (t?.kind === "editor" && t.dirty) {
+      if (
+        (t?.kind === "editor" || t?.kind === "notebook") &&
+        t.dirty
+      ) {
         setPendingCloseTab(id);
         return;
       }
@@ -854,17 +875,27 @@ export default function App() {
 
   const handleOpenFile = useCallback(
     (path: string, pin?: boolean) => {
+      if (defaultFileViewForPath(path) === "notebook") {
+        newNotebookTab(path);
+        return;
+      }
       // Explorer defaults to preview (pin=false); explicit actions like
       // context-menu "Open" pass pin=true for a persistent tab.
       openFileTab(path, pin ?? false);
     },
-    [openFileTab],
+    [newNotebookTab, openFileTab],
   );
 
   const handlePathRenamed = useCallback(
     (from: string, to: string) => {
       for (const t of tabs) {
-        if (t.kind !== "editor") continue;
+        if (
+          t.kind !== "editor" &&
+          t.kind !== "markdown" &&
+          t.kind !== "notebook"
+        ) {
+          continue;
+        }
         if (t.path === from) {
           const i = to.lastIndexOf("/");
           updateTab(t.id, { path: to, title: i === -1 ? to : to.slice(i + 1) });
@@ -897,9 +928,18 @@ export default function App() {
     (path: string) => {
       const dirty: number[] = [];
       for (const t of tabs) {
-        if (t.kind !== "editor") continue;
+        if (
+          t.kind !== "editor" &&
+          t.kind !== "markdown" &&
+          t.kind !== "notebook"
+        ) {
+          continue;
+        }
         if (t.path !== path && !t.path.startsWith(`${path}/`)) continue;
-        if (t.dirty) {
+        if (
+          (t.kind === "editor" || t.kind === "notebook") &&
+          t.dirty
+        ) {
           dirty.push(t.id);
         } else {
           disposeTab(t.id);
@@ -918,7 +958,13 @@ export default function App() {
       : null;
 
   const activeFilePath = (() => {
-    if (activeTab?.kind === "editor") return activeTab.path;
+    if (
+      activeTab?.kind === "editor" ||
+      activeTab?.kind === "markdown" ||
+      activeTab?.kind === "notebook"
+    ) {
+      return activeTab.path;
+    }
     if (activeTab?.kind === "git-diff") {
       if (/^([A-Za-z]:|\/|\\)/.test(activeTab.path)) return activeTab.path;
       const root = activeTab.repoRoot.replace(/[\\/]+$/, "");
@@ -939,7 +985,13 @@ export default function App() {
     if (activeTab?.kind === "terminal") {
       return activeTerminalLeafCwd ?? explorerRoot ?? workspaceFallbackPath;
     }
-    if (activeTab?.kind === "editor") return dirname(activeTab.path);
+    if (
+      activeTab?.kind === "editor" ||
+      activeTab?.kind === "markdown" ||
+      activeTab?.kind === "notebook"
+    ) {
+      return dirname(activeTab.path);
+    }
     if (activeTab?.kind === "git-diff") return activeTab.repoRoot;
     if (activeTab?.kind === "git-commit-file") return activeTab.repoRoot;
     if (activeTab?.kind === "git-history") return activeTab.repoRoot;
@@ -1051,6 +1103,12 @@ export default function App() {
         clearFocusedTerminal();
       },
       "search.focus": () => searchInlineRef.current?.focus(),
+      "markdown.preview": () => {
+        const t = tabsRef.current.find((x) => x.id === activeId);
+        if (t?.kind === "editor" && isMarkdownPreviewPath(t.path)) {
+          newMarkdownTab(t.path);
+        }
+      },
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
@@ -1070,6 +1128,7 @@ export default function App() {
       openNewTab,
       openNewPrivateTab,
       openPreviewTab,
+      newMarkdownTab,
       selectByIndex,
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
@@ -1106,9 +1165,13 @@ export default function App() {
           (e.target as HTMLElement | null) ?? document.activeElement;
         return !(target as HTMLElement | null)?.closest?.(".xterm");
       }
+      if (id === "markdown.preview") {
+        const t = tabsRef.current.find((x) => x.id === activeId);
+        return !(t?.kind === "editor" && isMarkdownPreviewPath(t.path));
+      }
       return false;
     },
-    [activeTab],
+    [activeId, activeTab],
   );
 
   useGlobalShortcuts(shortcutHandlers, { isDisabled: shortcutsDisabled });
@@ -1128,6 +1191,14 @@ export default function App() {
       if (id === activeId) setActiveEditorHandle(h);
     },
     [activeId],
+  );
+
+  const registerNotebookHandle = useCallback(
+    (id: number, h: NotebookPaneHandle | null) => {
+      if (h) notebookRefs.current.set(id, h);
+      else notebookRefs.current.delete(id);
+    },
+    [],
   );
 
   const registerPreviewHandle = useCallback(
@@ -1195,6 +1266,11 @@ export default function App() {
   );
 
   const handleEditorDirty = useCallback(
+    (id: number, dirty: boolean) => updateTab(id, { dirty }),
+    [updateTab],
+  );
+
+  const handleNotebookDirty = useCallback(
     (id: number, dirty: boolean) => updateTab(id, { dirty }),
     [updateTab],
   );
@@ -1271,7 +1347,14 @@ export default function App() {
       getWorkspaceRoot: () => explorerRoot ?? launchCwd ?? home ?? null,
       getActiveFile: () => {
         const t = tabs.find((x) => x.id === activeId);
-        return t?.kind === "editor" ? t.path : null;
+        if (
+          t?.kind === "editor" ||
+          t?.kind === "markdown" ||
+          t?.kind === "notebook"
+        ) {
+          return t.path;
+        }
+        return null;
       },
       openPreview: (url: string) => {
         openPreviewTab(url);
@@ -1389,6 +1472,20 @@ export default function App() {
         aria-hidden={!isMarkdownTab}
       >
         <MarkdownStack tabs={tabs} activeId={activeId} />
+      </div>
+      <div
+        className={cn(
+          "absolute inset-0 px-3 pt-2 pb-2",
+          !isNotebookTab && "invisible pointer-events-none",
+        )}
+        aria-hidden={!isNotebookTab}
+      >
+        <NotebookStack
+          tabs={tabs}
+          activeId={activeId}
+          registerHandle={registerNotebookHandle}
+          onDirtyChange={handleNotebookDirty}
+        />
       </div>
       <div
         className={cn(
@@ -1589,7 +1686,7 @@ export default function App() {
             open={newEditorOpen}
             onOpenChange={setNewEditorOpen}
             rootPath={explorerRoot ?? home}
-            onCreated={(path) => openFileTab(path)}
+            onCreated={(path) => handleOpenFile(path, true)}
           />
 
           <UpdaterDialog />

--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -17,6 +17,7 @@ import {
 } from "./lib/contextActions";
 import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
+import { isMarkdownPreviewPath } from "@/modules/tabs";
 import type { useFileTree } from "./lib/useFileTree";
 
 type Tree = ReturnType<typeof useFileTree>;
@@ -37,10 +38,6 @@ export type EntryRowProps = {
   onAttachToAgent?: (path: string) => void;
   onOpenMarkdownPreview?: (path: string) => void;
 };
-
-function isMarkdownPath(path: string): boolean {
-  return /\.(md|markdown|mdx)$/i.test(path);
-}
 
 function EntryRowImpl(props: EntryRowProps) {
   const {
@@ -140,7 +137,7 @@ function EntryRowImpl(props: EntryRowProps) {
             Open
           </ContextMenuItem>
         )}
-        {!isDir && isMarkdownPath(path) && onOpenMarkdownPreview && (
+        {!isDir && isMarkdownPreviewPath(path) && onOpenMarkdownPreview && (
           <ContextMenuItem
             className={COMPACT_ITEM}
             onSelect={() => onOpenMarkdownPreview(path)}

--- a/src/modules/notebook/NotebookPane.tsx
+++ b/src/modules/notebook/NotebookPane.tsx
@@ -1,0 +1,282 @@
+import { MarkdownCode } from "@/components/ai-elements/markdown-code";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { buildSharedExtensions } from "@/modules/editor/lib/extensions";
+import { EDITOR_THEME_EXT } from "@/modules/editor/lib/themes";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import type { Extension } from "@codemirror/state";
+import CodeMirror from "@uiw/react-codemirror";
+import { keymap } from "@codemirror/view";
+import { Streamdown } from "streamdown";
+import {
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import {
+  useNotebookDocument,
+  type NotebookDocumentState,
+} from "./lib/useNotebookDocument";
+import type { NotebookCell } from "./lib/ipynb";
+
+export type NotebookPaneHandle = {
+  focus: () => void;
+  reload: () => boolean;
+  save: () => Promise<void>;
+};
+
+type Props = {
+  path: string;
+  onDirtyChange?: (dirty: boolean) => void;
+};
+
+const markdownComponents = { code: MarkdownCode };
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : path;
+}
+
+function NotebookCellView({
+  cell,
+  onSourceChange,
+  editorExtensions,
+  theme,
+}: {
+  cell: NotebookCell;
+  onSourceChange: (source: string) => void;
+  editorExtensions: ReturnType<typeof buildSharedExtensions>;
+  theme: Extension;
+}) {
+  const [editing, setEditing] = useState(false);
+  const outputText = cell.outputs
+    .map((output) => output.text)
+    .filter((text) => text.trim().length > 0);
+
+  return (
+    <section
+      className="overflow-hidden rounded-md border border-border/60 bg-card"
+      onDoubleClick={() => setEditing(true)}
+    >
+      <div className="flex min-h-8 items-center gap-2 border-b border-border/50 px-3 text-[11px] text-muted-foreground">
+        <span className="min-w-14 font-mono">
+          {cell.type === "code" ? `[${cell.executionCount ?? " "}]` : ""}
+        </span>
+        <span className="uppercase tracking-normal">{cell.type}</span>
+        {editing ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="ml-auto h-6 px-2 text-[11px]"
+            onClick={() => setEditing(false)}
+          >
+            Done
+          </Button>
+        ) : null}
+      </div>
+
+      {editing ? (
+        <CodeMirror
+          value={cell.source}
+          onChange={onSourceChange}
+          theme={theme}
+          extensions={editorExtensions}
+          autoFocus
+          basicSetup={{
+            lineNumbers: cell.type === "code",
+            foldGutter: cell.type === "code",
+            bracketMatching: true,
+            closeBrackets: true,
+            autocompletion: true,
+            highlightActiveLine: true,
+            highlightSelectionMatches: true,
+            searchKeymap: true,
+          }}
+          className="min-h-24"
+        />
+      ) : (
+        <div className="px-4 py-3">
+          {cell.type === "markdown" ? (
+            <Streamdown
+              className="select-text prose-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+              components={markdownComponents}
+            >
+              {cell.source || " "}
+            </Streamdown>
+          ) : (
+            <pre
+              className={cn(
+                "m-0 overflow-x-auto whitespace-pre-wrap font-mono text-[13px] leading-6 text-foreground",
+                cell.type === "raw" && "text-muted-foreground",
+              )}
+            >
+              {cell.source}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {outputText.length > 0 ? (
+        <div className="border-t border-border/50 bg-muted/25 px-4 py-3">
+          {outputText.map((text, index) => (
+            <pre
+              key={`${cell.id}-output-${index}`}
+              className="m-0 overflow-x-auto whitespace-pre-wrap font-mono text-[12px] leading-5 text-muted-foreground"
+            >
+              {text}
+            </pre>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function NotebookBody({
+  state,
+  setCellSource,
+  editorExtensions,
+  theme,
+}: {
+  state: NotebookDocumentState;
+  setCellSource: (cellId: string, source: string) => void;
+  editorExtensions: ReturnType<typeof buildSharedExtensions>;
+  theme: Extension;
+}) {
+  if (state.status === "loading") {
+    return <p className="text-[12px] text-muted-foreground">Loading...</p>;
+  }
+  if (state.status === "error") {
+    return <p className="text-[12px] text-destructive">{state.message}</p>;
+  }
+  if (state.status === "binary") {
+    return (
+      <p className="text-[12px] text-muted-foreground">
+        Binary file, notebook preview not available.
+      </p>
+    );
+  }
+  if (state.status === "toolarge") {
+    return (
+      <p className="text-[12px] text-muted-foreground">
+        File is {formatBytes(state.size)}; limit {formatBytes(state.limit)}.
+      </p>
+    );
+  }
+
+  if (state.document.cells.length === 0) {
+    return <p className="text-[12px] text-muted-foreground">Empty notebook.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {state.document.cells.map((cell) => (
+        <NotebookCellView
+          key={cell.id}
+          cell={cell}
+          onSourceChange={(source) => setCellSource(cell.id, source)}
+          editorExtensions={editorExtensions}
+          theme={theme}
+        />
+      ))}
+    </div>
+  );
+}
+
+export const NotebookPane = forwardRef<NotebookPaneHandle, Props>(
+  function NotebookPane({ path, onDirtyChange }, ref) {
+    const { state, dirty, setCellSource, save, reload } = useNotebookDocument({
+      path,
+      onDirtyChange,
+    });
+    const containerRef = useRef<HTMLDivElement>(null);
+    const editorThemeId = usePreferencesStore((s) => s.editorTheme);
+    const theme = EDITOR_THEME_EXT[editorThemeId] ?? EDITOR_THEME_EXT.atomone;
+    const saveExtension = useMemo(
+      () =>
+        keymap.of([
+          {
+            key: "Mod-s",
+            preventDefault: true,
+            run: () => {
+              void save();
+              return true;
+            },
+          },
+        ]),
+      [save],
+    );
+    const editorExtensions = useMemo(
+      () => [...buildSharedExtensions(), saveExtension],
+      [saveExtension],
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => containerRef.current?.focus(),
+        reload,
+        save,
+      }),
+      [reload, save],
+    );
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        void save();
+      }
+    };
+
+    return (
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        className="flex h-full min-h-0 flex-col overflow-hidden rounded-md border border-border/60 bg-background outline-none"
+      >
+        <div className="flex h-10 shrink-0 items-center gap-3 border-b border-border/60 px-4">
+          <div className="min-w-0 flex-1 truncate text-xs font-medium">
+            {basename(path)}
+          </div>
+          {state.status === "ready" && state.document.languageName ? (
+            <span className="text-[11px] text-muted-foreground">
+              {state.document.languageName}
+            </span>
+          ) : null}
+          {dirty ? (
+            <span className="text-[11px] text-muted-foreground">Unsaved</span>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="h-7 px-2 text-xs"
+            disabled={!dirty}
+            onClick={() => void save()}
+          >
+            Save
+          </Button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
+          <NotebookBody
+            state={state}
+            setCellSource={setCellSource}
+            editorExtensions={editorExtensions}
+            theme={theme}
+          />
+        </div>
+      </div>
+    );
+  },
+);

--- a/src/modules/notebook/NotebookStack.tsx
+++ b/src/modules/notebook/NotebookStack.tsx
@@ -1,0 +1,87 @@
+import { cn } from "@/lib/utils";
+import type { NotebookTab, Tab } from "@/modules/tabs";
+import { useEffect, useRef } from "react";
+import { NotebookPane, type NotebookPaneHandle } from "./NotebookPane";
+
+type Props = {
+  tabs: Tab[];
+  activeId: number;
+  onDirtyChange: (id: number, dirty: boolean) => void;
+  registerHandle: (id: number, handle: NotebookPaneHandle | null) => void;
+};
+
+export function NotebookStack({
+  tabs,
+  activeId,
+  onDirtyChange,
+  registerHandle,
+}: Props) {
+  const notebooks = tabs.filter((t): t is NotebookTab => t.kind === "notebook");
+  const registerRef = useRef(registerHandle);
+  const dirtyRef = useRef(onDirtyChange);
+  useEffect(() => {
+    registerRef.current = registerHandle;
+  }, [registerHandle]);
+  useEffect(() => {
+    dirtyRef.current = onDirtyChange;
+  }, [onDirtyChange]);
+
+  const refCallbacks = useRef(
+    new Map<number, (handle: NotebookPaneHandle | null) => void>(),
+  );
+  const dirtyCallbacks = useRef(new Map<number, (dirty: boolean) => void>());
+
+  const getRefCallback = (id: number) => {
+    let callback = refCallbacks.current.get(id);
+    if (!callback) {
+      callback = (handle: NotebookPaneHandle | null) =>
+        registerRef.current(id, handle);
+      refCallbacks.current.set(id, callback);
+    }
+    return callback;
+  };
+
+  const getDirtyCallback = (id: number) => {
+    let callback = dirtyCallbacks.current.get(id);
+    if (!callback) {
+      callback = (dirty: boolean) => dirtyRef.current(id, dirty);
+      dirtyCallbacks.current.set(id, callback);
+    }
+    return callback;
+  };
+
+  useEffect(() => {
+    const live = new Set(notebooks.map((tab) => tab.id));
+    for (const id of refCallbacks.current.keys()) {
+      if (!live.has(id)) refCallbacks.current.delete(id);
+    }
+    for (const id of dirtyCallbacks.current.keys()) {
+      if (!live.has(id)) dirtyCallbacks.current.delete(id);
+    }
+  }, [notebooks]);
+
+  if (notebooks.length === 0) return null;
+  return (
+    <div className="relative h-full w-full">
+      {notebooks.map((tab) => {
+        const visible = tab.id === activeId;
+        return (
+          <div
+            key={tab.id}
+            className={cn(
+              "absolute inset-0",
+              !visible && "invisible pointer-events-none",
+            )}
+            aria-hidden={!visible}
+          >
+            <NotebookPane
+              ref={getRefCallback(tab.id)}
+              path={tab.path}
+              onDirtyChange={getDirtyCallback(tab.id)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/modules/notebook/NotebookStackLazy.tsx
+++ b/src/modules/notebook/NotebookStackLazy.tsx
@@ -1,0 +1,19 @@
+import { lazy, Suspense } from "react";
+import type { ComponentProps } from "react";
+import type { NotebookStack as NotebookStackType } from "./NotebookStack";
+
+const NotebookStackInner = lazy(() =>
+  import("./NotebookStack").then((module) => ({
+    default: module.NotebookStack,
+  })),
+);
+
+type Props = ComponentProps<typeof NotebookStackType>;
+
+export function NotebookStack(props: Props) {
+  return (
+    <Suspense fallback={null}>
+      <NotebookStackInner {...props} />
+    </Suspense>
+  );
+}

--- a/src/modules/notebook/index.ts
+++ b/src/modules/notebook/index.ts
@@ -1,0 +1,2 @@
+export { NotebookStack } from "./NotebookStackLazy";
+export type { NotebookPaneHandle } from "./NotebookPane";

--- a/src/modules/notebook/lib/ipynb.test.ts
+++ b/src/modules/notebook/lib/ipynb.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseNotebookDocument,
+  serializeNotebookDocument,
+  updateNotebookCellSource,
+} from "./ipynb";
+
+const sampleNotebook = {
+  cells: [
+    {
+      cell_type: "markdown",
+      metadata: {},
+      source: ["# Title\n", "Body"],
+    },
+    {
+      cell_type: "code",
+      execution_count: 2,
+      metadata: {},
+      outputs: [{ output_type: "stream", name: "stdout", text: ["1\n"] }],
+      source: "print(1)\n",
+    },
+    {
+      cell_type: "raw",
+      metadata: {},
+      source: ["plain"],
+    },
+  ],
+  metadata: { language_info: { name: "python" } },
+  nbformat: 4,
+  nbformat_minor: 5,
+};
+
+describe("parseNotebookDocument", () => {
+  it("normalizes notebook cells into stable editable records", () => {
+    const parsed = parseNotebookDocument(JSON.stringify(sampleNotebook));
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    expect(parsed.document.languageName).toBe("python");
+    expect(parsed.document.cells).toMatchObject([
+      { id: "cell-0", type: "markdown", source: "# Title\nBody" },
+      {
+        id: "cell-1",
+        type: "code",
+        source: "print(1)\n",
+        executionCount: 2,
+        outputs: [{ kind: "stream", text: "1\n" }],
+      },
+      { id: "cell-2", type: "raw", source: "plain" },
+    ]);
+  });
+
+  it("reports invalid JSON as a parse failure", () => {
+    const parsed = parseNotebookDocument("{not json");
+
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.message).toContain("Invalid notebook JSON");
+  });
+
+  it("accepts notebooks that start with a UTF-8 BOM", () => {
+    const parsed = parseNotebookDocument(`\uFEFF${JSON.stringify(sampleNotebook)}`);
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.document.cells[0]?.source).toBe("# Title\nBody");
+  });
+});
+
+describe("serializeNotebookDocument", () => {
+  it("updates only the requested cell and keeps original source shape", () => {
+    const parsed = parseNotebookDocument(JSON.stringify(sampleNotebook));
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    const updated = updateNotebookCellSource(
+      parsed.document,
+      "cell-0",
+      "# Updated\nSecond line\n",
+    );
+    const serialized = serializeNotebookDocument(updated);
+    const json = JSON.parse(serialized);
+
+    expect(json.cells[0].source).toEqual(["# Updated\n", "Second line\n"]);
+    expect(json.cells[1].source).toBe("print(1)\n");
+    expect(serialized.endsWith("\n")).toBe(true);
+  });
+});

--- a/src/modules/notebook/lib/ipynb.ts
+++ b/src/modules/notebook/lib/ipynb.ts
@@ -1,0 +1,183 @@
+export type NotebookCellType = "markdown" | "code" | "raw";
+
+export type NotebookOutput = {
+  kind: "stream" | "result" | "display" | "error" | "unknown";
+  text: string;
+};
+
+export type NotebookCell = {
+  id: string;
+  type: NotebookCellType;
+  source: string;
+  sourceFormat: "array" | "string";
+  executionCount: number | null;
+  outputs: NotebookOutput[];
+};
+
+export type NotebookDocument = {
+  raw: NotebookRaw;
+  cells: NotebookCell[];
+  languageName: string | null;
+};
+
+export type ParseNotebookResult =
+  | { ok: true; document: NotebookDocument }
+  | { ok: false; message: string };
+
+type JsonRecord = Record<string, unknown>;
+type NotebookRawCell = JsonRecord & {
+  cell_type?: unknown;
+  source?: unknown;
+  outputs?: unknown;
+  execution_count?: unknown;
+};
+type NotebookRaw = JsonRecord & { cells: NotebookRawCell[] };
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sourceToText(source: unknown): string {
+  if (typeof source === "string") return source;
+  if (Array.isArray(source)) return source.map((part) => String(part)).join("");
+  return "";
+}
+
+function textToSource(
+  text: string,
+  format: NotebookCell["sourceFormat"],
+): string | string[] {
+  if (format === "string") return text;
+  return text.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+}
+
+function normalizeCellType(value: unknown): NotebookCellType {
+  if (value === "markdown" || value === "code" || value === "raw") return value;
+  return "raw";
+}
+
+function outputText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map((part) => String(part)).join("");
+  return "";
+}
+
+function dataText(data: unknown): string {
+  if (!isRecord(data)) return "";
+  const plain = data["text/plain"];
+  const text = outputText(plain);
+  if (text) return text;
+  if (typeof data["image/png"] === "string") return "[image/png output]";
+  if (typeof data["image/jpeg"] === "string") return "[image/jpeg output]";
+  if (typeof data["text/html"] !== "undefined") return "[HTML output]";
+  return "";
+}
+
+function normalizeOutputs(outputs: unknown): NotebookOutput[] {
+  if (!Array.isArray(outputs)) return [];
+  return outputs.map((output): NotebookOutput => {
+    if (!isRecord(output)) return { kind: "unknown", text: "" };
+    const outputType = output.output_type;
+    if (outputType === "stream") {
+      return { kind: "stream", text: outputText(output.text) };
+    }
+    if (outputType === "execute_result") {
+      return { kind: "result", text: dataText(output.data) };
+    }
+    if (outputType === "display_data") {
+      return { kind: "display", text: dataText(output.data) };
+    }
+    if (outputType === "error") {
+      const traceback = outputText(output.traceback);
+      const fallback = [output.ename, output.evalue]
+        .filter(
+          (part): part is string =>
+            typeof part === "string" && part.length > 0,
+        )
+        .join(": ");
+      return { kind: "error", text: traceback || fallback };
+    }
+    return { kind: "unknown", text: "" };
+  });
+}
+
+function executionCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function languageName(raw: NotebookRaw): string | null {
+  const metadata = raw.metadata;
+  if (!isRecord(metadata)) return null;
+  const languageInfo = metadata.language_info;
+  if (isRecord(languageInfo) && typeof languageInfo.name === "string") {
+    return languageInfo.name;
+  }
+  const kernelspec = metadata.kernelspec;
+  if (isRecord(kernelspec) && typeof kernelspec.language === "string") {
+    return kernelspec.language;
+  }
+  return null;
+}
+
+function normalizeNotebook(raw: NotebookRaw): NotebookDocument {
+  return {
+    raw,
+    languageName: languageName(raw),
+    cells: raw.cells.map((cell, index) => ({
+      id: `cell-${index}`,
+      type: normalizeCellType(cell.cell_type),
+      source: sourceToText(cell.source),
+      sourceFormat: Array.isArray(cell.source) ? "array" : "string",
+      executionCount: executionCount(cell.execution_count),
+      outputs: normalizeOutputs(cell.outputs),
+    })),
+  };
+}
+
+export function parseNotebookDocument(content: string): ParseNotebookResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      content.charCodeAt(0) === 0xfeff ? content.slice(1) : content,
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Invalid notebook JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+
+  if (!isRecord(parsed)) {
+    return { ok: false, message: "Notebook JSON root must be an object." };
+  }
+  if (!Array.isArray(parsed.cells)) {
+    return { ok: false, message: "Notebook JSON must contain a cells array." };
+  }
+
+  const cells = parsed.cells.map((cell) =>
+    isRecord(cell) ? ({ ...cell } as NotebookRawCell) : ({ source: "" } as NotebookRawCell),
+  );
+  return { ok: true, document: normalizeNotebook({ ...parsed, cells }) };
+}
+
+export function updateNotebookCellSource(
+  document: NotebookDocument,
+  cellId: string,
+  source: string,
+): NotebookDocument {
+  const index = document.cells.findIndex((cell) => cell.id === cellId);
+  if (index === -1) return document;
+  const current = document.cells[index];
+  const cells = document.raw.cells.map((cell, cellIndex) =>
+    cellIndex === index
+      ? { ...cell, source: textToSource(source, current.sourceFormat) }
+      : cell,
+  );
+  return normalizeNotebook({ ...document.raw, cells });
+}
+
+export function serializeNotebookDocument(document: NotebookDocument): string {
+  return `${JSON.stringify(document.raw, null, 2)}\n`;
+}

--- a/src/modules/notebook/lib/useNotebookDocument.ts
+++ b/src/modules/notebook/lib/useNotebookDocument.ts
@@ -1,0 +1,195 @@
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  parseNotebookDocument,
+  serializeNotebookDocument,
+  updateNotebookCellSource,
+  type NotebookDocument,
+} from "./ipynb";
+
+type ReadResult =
+  | { kind: "text"; content: string; size: number }
+  | { kind: "binary"; size: number }
+  | { kind: "toolarge"; size: number; limit: number };
+
+export type NotebookDocumentState =
+  | { status: "loading" }
+  | { status: "ready"; document: NotebookDocument; size: number }
+  | { status: "binary"; size: number }
+  | { status: "toolarge"; size: number; limit: number }
+  | { status: "error"; message: string };
+
+type Options = {
+  path: string;
+  onDirtyChange?: (dirty: boolean) => void;
+};
+
+export function useNotebookDocument({ path, onDirtyChange }: Options) {
+  const [state, setState] = useState<NotebookDocumentState>({
+    status: "loading",
+  });
+  const [dirty, setDirty] = useState(false);
+  const autoSave = usePreferencesStore((s) => s.editorAutoSave);
+  const autoSaveDelay = usePreferencesStore((s) => s.editorAutoSaveDelay);
+  const savedRef = useRef("");
+  const documentRef = useRef<NotebookDocument | null>(null);
+  const dirtyRef = useRef(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoSaveRef = useRef({ autoSave, autoSaveDelay });
+  autoSaveRef.current = { autoSave, autoSaveDelay };
+
+  useEffect(() => {
+    dirtyRef.current = dirty;
+  }, [dirty]);
+
+  const clearAutoSaveTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const saveNow = useCallback(async () => {
+    const document = documentRef.current;
+    if (!document) return;
+    const content = serializeNotebookDocument(document);
+    await invoke("fs_write_file", {
+      path,
+      content,
+      workspace: currentWorkspaceEnv(),
+      source: "editor",
+    });
+    savedRef.current = content;
+    setDirty(false);
+  }, [path]);
+
+  const save = useCallback(async () => {
+    clearAutoSaveTimer();
+    if (!dirtyRef.current) return;
+    await saveNow();
+  }, [clearAutoSaveTimer, saveNow]);
+
+  const load = useCallback(
+    async (skipDirty: boolean): Promise<boolean> => {
+      if (skipDirty && dirtyRef.current) return false;
+      setState({ status: "loading" });
+      const res = await invoke<ReadResult>("fs_read_file", {
+        path,
+        workspace: currentWorkspaceEnv(),
+      });
+      if (res.kind === "text") {
+        const parsed = parseNotebookDocument(res.content);
+        if (!parsed.ok) {
+          documentRef.current = null;
+          setState({ status: "error", message: parsed.message });
+          setDirty(false);
+          return true;
+        }
+        savedRef.current = serializeNotebookDocument(parsed.document);
+        documentRef.current = parsed.document;
+        setState({
+          status: "ready",
+          document: parsed.document,
+          size: res.size,
+        });
+        setDirty(false);
+        return true;
+      }
+      documentRef.current = null;
+      if (res.kind === "binary") {
+        setState({ status: "binary", size: res.size });
+      } else {
+        setState({ status: "toolarge", size: res.size, limit: res.limit });
+      }
+      setDirty(false);
+      return true;
+    },
+    [path],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    setDirty(false);
+    documentRef.current = null;
+
+    invoke<ReadResult>("fs_read_file", { path, workspace: currentWorkspaceEnv() })
+      .then((res) => {
+        if (cancelled) return;
+        if (res.kind === "text") {
+          const parsed = parseNotebookDocument(res.content);
+          if (!parsed.ok) {
+            setState({ status: "error", message: parsed.message });
+            return;
+          }
+          savedRef.current = serializeNotebookDocument(parsed.document);
+          documentRef.current = parsed.document;
+          setState({
+            status: "ready",
+            document: parsed.document,
+            size: res.size,
+          });
+        } else if (res.kind === "binary") {
+          setState({ status: "binary", size: res.size });
+        } else {
+          setState({ status: "toolarge", size: res.size, limit: res.limit });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) setState({ status: "error", message: String(error) });
+      });
+
+    return () => {
+      cancelled = true;
+      clearAutoSaveTimer();
+    };
+  }, [path, clearAutoSaveTimer]);
+
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange;
+  }, [onDirtyChange]);
+  useEffect(() => {
+    onDirtyChangeRef.current?.(dirty);
+  }, [dirty]);
+
+  const setCellSource = useCallback(
+    (cellId: string, source: string) => {
+      setState((current) => {
+        if (current.status !== "ready") return current;
+        const document = updateNotebookCellSource(
+          current.document,
+          cellId,
+          source,
+        );
+        documentRef.current = document;
+        const nextContent = serializeNotebookDocument(document);
+        const nextDirty = nextContent !== savedRef.current;
+        setDirty(nextDirty);
+        clearAutoSaveTimer();
+        const { autoSave: active, autoSaveDelay: delay } = autoSaveRef.current;
+        if (active && nextDirty) {
+          timeoutRef.current = setTimeout(() => {
+            saveNow().catch((error) =>
+              console.error("[notebook autosave]", error),
+            );
+          }, delay);
+        }
+        return { ...current, document };
+      });
+    },
+    [clearAutoSaveTimer, saveNow],
+  );
+
+  const reload = useCallback((): boolean => {
+    if (dirtyRef.current) return false;
+    void load(true).catch((error) =>
+      setState({ status: "error", message: String(error) }),
+    );
+    return true;
+  }, [load]);
+
+  return { state, dirty, setCellSource, save, reload };
+}

--- a/src/modules/shortcuts/shortcuts.test.ts
+++ b/src/modules/shortcuts/shortcuts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { matchBinding, SHORTCUTS } from "./shortcuts";
+
+describe("markdown preview shortcut", () => {
+  it("uses Mod+Shift+V by default", () => {
+    const shortcut = SHORTCUTS.find((item) => item.id === "markdown.preview");
+
+    expect(shortcut?.defaultBindings).toEqual([
+      expect.objectContaining({ shift: true, key: "v" }),
+    ]);
+  });
+
+  it("matches Ctrl+Shift+V on Windows and Linux", () => {
+    const event = {
+      key: "v",
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      metaKey: false,
+    } as KeyboardEvent;
+
+    expect(
+      matchBinding(
+        event,
+        { ctrl: true, shift: true, key: "v" },
+        "markdown.preview",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -20,6 +20,7 @@ export type ShortcutId =
   | "pane.source"
   | "terminal.clear"
   | "search.focus"
+  | "markdown.preview"
   | "explorer.search"
   | "explorer.focus"
   | "view.zoomIn"
@@ -170,6 +171,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Find in terminal",
     group: "Search",
     defaultBindings: [{ [MOD_PROP]: true, key: "f" }],
+  },
+  {
+    id: "markdown.preview",
+    label: "Open Markdown preview",
+    group: "Editor",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "v" }],
   },
   {
     id: "ai.toggle",

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -127,7 +127,8 @@ export function TabBar({
                     <span className={cn("truncate", isPreview && "italic")}>
                       {labelFor(t)}
                     </span>
-                    {t.kind === "editor" && t.dirty ? (
+                    {((t.kind === "editor" || t.kind === "notebook") &&
+                      t.dirty) ? (
                       <span
                         aria-label="Unsaved changes"
                         className="size-1.5 shrink-0 rounded-full bg-foreground/70"
@@ -220,7 +221,11 @@ export function TabBar({
 }
 
 function TabIcon({ tab }: { tab: Tab }) {
-  if (tab.kind === "editor" || tab.kind === "markdown") {
+  if (
+    tab.kind === "editor" ||
+    tab.kind === "markdown" ||
+    tab.kind === "notebook"
+  ) {
     const url = fileIconUrl(tab.title);
     return url ? <img src={url} alt="" className="size-3.5 shrink-0" /> : null;
   }
@@ -288,6 +293,7 @@ function labelFor(t: Tab): string {
   if (t.kind === "editor") return t.title;
   if (t.kind === "preview") return t.title;
   if (t.kind === "markdown") return t.title;
+  if (t.kind === "notebook") return t.title;
   if (t.kind === "ai-diff") return t.title;
   if (t.kind === "git-diff") return t.title;
   if (t.kind === "git-history") return t.title;

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -7,6 +7,7 @@ export {
   type EditorTab,
   type PreviewTab,
   type MarkdownTab,
+  type NotebookTab,
   type AiDiffTab,
   type GitDiffTab,
   type GitHistoryTab,
@@ -15,3 +16,9 @@ export {
   type TabPatch,
 } from "./lib/useTabs";
 export { useWorkspaceCwd } from "./lib/useWorkspaceCwd";
+export {
+  defaultFileViewForPath,
+  isMarkdownPreviewPath,
+  isNotebookPath,
+  type DefaultFileView,
+} from "./lib/fileKinds";

--- a/src/modules/tabs/lib/fileKinds.test.ts
+++ b/src/modules/tabs/lib/fileKinds.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultFileViewForPath,
+  isMarkdownPreviewPath,
+  isNotebookPath,
+} from "./fileKinds";
+
+describe("file view routing", () => {
+  it("detects markdown files that can be previewed", () => {
+    expect(isMarkdownPreviewPath("README.md")).toBe(true);
+    expect(isMarkdownPreviewPath("docs/guide.markdown")).toBe(true);
+    expect(isMarkdownPreviewPath("C:\\work\\page.MDX")).toBe(true);
+    expect(isMarkdownPreviewPath("README.md.bak")).toBe(false);
+  });
+
+  it("detects notebooks case-insensitively", () => {
+    expect(isNotebookPath("analysis.ipynb")).toBe(true);
+    expect(isNotebookPath("C:\\work\\DATA.IPYNB")).toBe(true);
+    expect(isNotebookPath("analysis.ipynb.txt")).toBe(false);
+  });
+
+  it("routes notebooks to the built-in notebook view and leaves markdown editable", () => {
+    expect(defaultFileViewForPath("notes.md")).toBe("editor");
+    expect(defaultFileViewForPath("notebook.ipynb")).toBe("notebook");
+    expect(defaultFileViewForPath("src/app.tsx")).toBe("editor");
+  });
+});

--- a/src/modules/tabs/lib/fileKinds.ts
+++ b/src/modules/tabs/lib/fileKinds.ts
@@ -1,0 +1,13 @@
+export type DefaultFileView = "editor" | "notebook";
+
+export function isMarkdownPreviewPath(path: string): boolean {
+  return /\.(md|markdown|mdx)$/i.test(path);
+}
+
+export function isNotebookPath(path: string): boolean {
+  return /\.ipynb$/i.test(path);
+}
+
+export function defaultFileViewForPath(path: string): DefaultFileView {
+  return isNotebookPath(path) ? "notebook" : "editor";
+}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -55,6 +55,14 @@ export type MarkdownTab = {
   path: string;
 };
 
+export type NotebookTab = {
+  id: number;
+  kind: "notebook";
+  title: string;
+  path: string;
+  dirty: boolean;
+};
+
 export type AiDiffStatus = "pending" | "approved" | "rejected";
 
 export type AiDiffTab = {
@@ -105,6 +113,7 @@ export type Tab =
   | EditorTab
   | PreviewTab
   | MarkdownTab
+  | NotebookTab
   | AiDiffTab
   | GitDiffTab
   | GitHistoryTab
@@ -412,6 +421,27 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return targetId;
   }, []);
 
+  const newNotebookTab = useCallback((path: string) => {
+    let targetId: number | null = null;
+    setTabs((curr) => {
+      const existing = curr.find(
+        (t) => t.kind === "notebook" && t.path === path,
+      );
+      if (existing) {
+        targetId = existing.id;
+        return curr;
+      }
+      const id = nextIdRef.current++;
+      targetId = id;
+      return [
+        ...curr,
+        { id, kind: "notebook", title: basename(path), path, dirty: false },
+      ];
+    });
+    if (targetId !== null) setActiveId(targetId);
+    return targetId;
+  }, []);
+
   const openGitDiffTab = useCallback(
     (input: {
       path: string;
@@ -601,6 +631,15 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           return {
             ...x,
             ...(patch.title !== undefined && { title: patch.title }),
+            ...(patch.path !== undefined && { path: patch.path }),
+          };
+        }
+        if (x.kind === "notebook") {
+          return {
+            ...x,
+            ...(patch.title !== undefined && { title: patch.title }),
+            ...(patch.path !== undefined && { path: patch.path }),
+            ...(patch.dirty !== undefined && { dirty: patch.dirty }),
           };
         }
         // editor tab: auto-promote from preview the moment the file becomes dirty.
@@ -805,6 +844,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     pinTab,
     newPreviewTab,
     newMarkdownTab,
+    newNotebookTab,
     openAiDiffTab,
     openGitDiffTab,
     openCommitHistoryTab,

--- a/src/viteConfig.test.ts
+++ b/src/viteConfig.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const viteConfig = readFileSync(path.join(here, "..", "vite.config.ts"), "utf8");
+
+describe("Vite dev watch exclusions", () => {
+  it("does not reload the app when notebooks are saved from Terax", () => {
+    expect(viteConfig).toContain('"**/*.ipynb"');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,7 +81,7 @@ export default defineConfig(async ({ mode }) => ({
         }
       : undefined,
     watch: {
-      ignored: ["**/src-tauri/**"],
+      ignored: ["**/src-tauri/**", "**/*.ipynb"],
     },
   },
 }));


### PR DESCRIPTION
﻿## What

Adds built-in Markdown preview opening and a lightweight `.ipynb` notebook view/editor.

## Why

Closes #595. Markdown files should have a fast rendered preview path, and opening `.ipynb` files as raw JSON is hard to read or edit safely.

## How

- Adds file-kind routing for Markdown preview and `.ipynb` files.
- Adds a lightweight notebook parser/serializer that preserves cell source shape where possible and writes formatted notebook JSON.
- Adds a notebook tab surface with rendered Markdown/code/raw cells and double-click cell editing.
- Adds `Ctrl+Shift+V` as the Markdown preview shortcut.
- Ignores `.ipynb` writes in Vite watch mode so saving notebooks does not reload the dev app.

This intentionally does not add kernel execution, output recomputation, or full Jupyter runtime support.

## Testing

- [x] `pnpm exec tsc --noEmit` clean via `corepack pnpm exec tsc --noEmit`
- [x] `pnpm test` via `corepack pnpm test`, 10 files / 88 tests passed
- [x] Manual smoke-test of the affected feature
- [x] `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] If you changed a `#[tauri::command]` signature, called out below so the FE caller can be updated in lockstep
- [x] UI tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [x] Shells tested: pwsh for local verification commands

Manual smoke test:

- Opened a Markdown editor tab and used `Ctrl+Shift+V` to open the rendered preview.
- Opened an `.ipynb` file and verified it renders as notebook cells instead of raw JSON.
- Double-clicked a notebook cell, edited it, and saved.
- Verified saving `.ipynb` files no longer triggers a full dev app reload.

## Screenshots / GIFs

Not attached yet. This is opened as a draft PR for scope and direction feedback first.

## Notes for reviewer

The scope is intentionally limited to viewing, light editing, and formatted persistence. It avoids full Jupyter behavior because the project direction calls out full Jupyter notebooks as out of scope.
