### PR TITLE
feat(window): dynamic title from project folder + active terminal

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "core:window:allow-internal-toggle-maximize",
     "core:window:allow-show",
     "core:window:allow-set-focus",
+    "core:window:allow-set-title",
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "opener:default",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -79,7 +79,7 @@ import {
   useSourceControl,
 } from "@/modules/source-control";
 import { StatusBar } from "@/modules/statusbar";
-import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
+import { MAX_PANES_PER_TAB, useTabs, useWindowTitle, useWorkspaceCwd } from "@/modules/tabs";
 import {
   clearFocusedTerminal,
   disposeSession,
@@ -634,6 +634,8 @@ export default function App() {
     tabs,
     launchCwd ?? home,
   );
+
+  useWindowTitle(activeTab, explorerRoot);
 
   useEffect(() => {
     setActiveSearchAddon(

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -15,3 +15,4 @@ export {
   type TabPatch,
 } from "./lib/useTabs";
 export { useWorkspaceCwd } from "./lib/useWorkspaceCwd";
+export { useWindowTitle } from "./lib/useWindowTitle";

--- a/src/modules/tabs/lib/useWindowTitle.ts
+++ b/src/modules/tabs/lib/useWindowTitle.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { findLeafCwd } from "@/modules/terminal/lib/panes";
+import type { Tab } from "./useTabs";
+
+const APP_NAME = "Terax";
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : "/";
+}
+
+/** Label of the focused tab — for terminals, the active pane's folder. */
+function tabLabel(tab: Tab | undefined): string {
+  if (!tab) return "";
+  if (tab.kind === "terminal") {
+    const cwd = findLeafCwd(tab.paneTree, tab.activeLeafId) ?? tab.cwd;
+    return cwd ? basename(cwd) : tab.title;
+  }
+  return tab.title;
+}
+
+/**
+ * Drives the OS window title from the focused tab + project folder, the way
+ * Spotify shows the current track instead of just the app name. Without this
+ * the window keeps the build-time default ("Tauri App" on Linux).
+ *
+ * Format: `<project> — <tab>` (e.g. `terax-ai — src`), collapsing to just the
+ * project when the focused terminal sits at the project root. Falls back to the
+ * app name when there's nothing to show.
+ */
+export function useWindowTitle(
+  activeTab: Tab | undefined,
+  explorerRoot: string | null,
+): void {
+  const project = explorerRoot ? basename(explorerRoot) : "";
+  const label = tabLabel(activeTab);
+
+  useEffect(() => {
+    let title: string;
+    if (project && label && label !== project) title = `${project} — ${label}`;
+    else title = project || label || APP_NAME;
+
+    document.title = title;
+    void getCurrentWindow()
+      .setTitle(title)
+      .catch(() => {});
+  }, [project, label]);
+}


### PR DESCRIPTION
## Summary
Sets a dynamic window title derived from the project folder name and the active terminal's working directory, instead of a static title.

## Changes
- `src/modules/tabs/lib/useWindowTitle.ts` (new): hook that updates the window title from the active tab + explorer root, following the focused terminal pane's cwd.
- Wires `useWindowTitle(activeTab, explorerRoot)` into `App.tsx` and exports it from the tabs module.
- `src-tauri/capabilities/default.json`: adds the `core:window:allow-set-title` permission required to set the title from the frontend.

## Notes
- `tsc` clean. Self-contained — only depends on existing `findLeafCwd`.
