### PR TITLE
feat(ai): local CLI agent providers (Claude Code, Codex, cursor-agent, OpenCode)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, agent_cli, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -159,6 +159,7 @@ pub fn run() {
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())
         .manage(fs::watch::FsWatchState::default())
+        .manage(agent_cli::AgentCliState::default())
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
@@ -224,6 +225,9 @@ pub fn run() {
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,
+            agent_cli::agent_cli_which,
+            agent_cli::agent_cli_spawn,
+            agent_cli::agent_cli_kill,
             secrets::secrets_get,
             secrets::secrets_set,
             secrets::secrets_delete,

--- a/src-tauri/src/modules/agent_cli.rs
+++ b/src-tauri/src/modules/agent_cli.rs
@@ -1,0 +1,251 @@
+//! Headless wrapper around installed coding-agent CLIs (Claude Code, Codex,
+//! cursor-agent, OpenCode). The webview never spawns processes itself: it asks
+//! this module to detect which binaries exist and to run one in headless
+//! streaming mode, with stdout lines relayed verbatim over a Tauri `Channel`.
+//! Per-CLI event parsing lives on the frontend (one parser per CLI); Rust stays
+//! a generic, injection-safe spawner so adding a CLI never touches Rust.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+
+use serde::Serialize;
+use shared_child::SharedChild;
+use tauri::ipc::Channel;
+
+use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
+
+type ChildMap = Arc<Mutex<HashMap<u32, Arc<SharedChild>>>>;
+
+#[derive(Default)]
+pub struct AgentCliState {
+    children: ChildMap,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum AgentCliEvent {
+    /// One line of stdout (typically a single JSON event from the CLI).
+    Stdout { line: String },
+    /// One line of stderr (diagnostics, progress, auth prompts).
+    Stderr { line: String },
+    /// Process exited. `code` is None if terminated by signal.
+    Exit { code: Option<i32> },
+    /// Spawn or wiring failure before/while running.
+    Error { message: String },
+}
+
+/// PATH as seen by the user's login shell. A GUI-launched app inherits a
+/// minimal PATH that usually omits `~/.local/bin`, `~/.npm-global/bin`, nvm,
+/// etc. We resolve the real PATH once and reuse it for both detection and
+/// spawning so the agent (and the tools it shells out to) behave as in a
+/// terminal. Falls back to the inherited PATH if the probe fails.
+fn login_path() -> &'static str {
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        if let Some(p) = probe_login_path() {
+            let trimmed = p.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        std::env::var("PATH").unwrap_or_default()
+    })
+}
+
+#[cfg(unix)]
+fn probe_login_path() -> Option<String> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    let out = Command::new(shell)
+        .arg("-lc")
+        .arg("printf %s \"$PATH\"")
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+#[cfg(windows)]
+fn probe_login_path() -> Option<String> {
+    // Windows GUI apps inherit the full user+system PATH already.
+    None
+}
+
+#[cfg(windows)]
+fn executable_exts() -> Vec<String> {
+    std::env::var("PATHEXT")
+        .unwrap_or_else(|_| ".EXE;.CMD;.BAT;.COM".into())
+        .split(';')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_start_matches('.').to_ascii_lowercase())
+        .collect()
+}
+
+/// Resolve a bare binary name to an absolute path by scanning `login_path()`.
+/// Mirrors `command -v` semantics without spawning a shell per lookup.
+fn resolve_bin(bin: &str) -> Option<PathBuf> {
+    if bin.is_empty() {
+        return None;
+    }
+    // An explicit path is used as-is when it points at a real file.
+    if bin.contains('/') || bin.contains('\\') {
+        let p = PathBuf::from(bin);
+        return p.is_file().then_some(p);
+    }
+    let sep = if cfg!(windows) { ';' } else { ':' };
+    for dir in login_path().split(sep).filter(|s| !s.is_empty()) {
+        let base = PathBuf::from(dir).join(bin);
+        if base.is_file() {
+            return Some(base);
+        }
+        #[cfg(windows)]
+        for ext in executable_exts() {
+            let cand = PathBuf::from(dir).join(format!("{bin}.{ext}"));
+            if cand.is_file() {
+                return Some(cand);
+            }
+        }
+    }
+    None
+}
+
+/// Map each requested binary name to its absolute path, or `None` if not found.
+#[tauri::command]
+pub async fn agent_cli_which(bins: Vec<String>) -> HashMap<String, Option<String>> {
+    bins.into_iter()
+        .map(|b| {
+            let resolved = resolve_bin(&b).map(|p| p.to_string_lossy().into_owned());
+            (b, resolved)
+        })
+        .collect()
+}
+
+/// Spawn a CLI agent in headless mode. `argv[0]` is the binary (bare name or
+/// absolute path); the remaining entries are passed verbatim as separate
+/// arguments (no shell, so the prompt cannot inject). Streams stdout/stderr
+/// lines over `on_event` and resolves once the child has been launched; the
+/// `Exit` event marks completion. `id` is a frontend-chosen handle for cancel.
+#[tauri::command]
+pub async fn agent_cli_spawn(
+    id: u32,
+    argv: Vec<String>,
+    cwd: Option<String>,
+    workspace: Option<WorkspaceEnv>,
+    on_event: Channel<AgentCliEvent>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+    state: tauri::State<'_, AgentCliState>,
+) -> Result<(), String> {
+    let Some((bin, args)) = argv.split_first() else {
+        return Err("empty argv".into());
+    };
+    if bin.trim().is_empty() {
+        return Err("empty binary".into());
+    }
+
+    let workspace = WorkspaceEnv::from_option(workspace);
+    authorize_spawn_cwd(&registry, cwd.as_deref(), &workspace)?;
+
+    let program = resolve_bin(bin).ok_or_else(|| format!("{bin} not found on PATH"))?;
+
+    let mut cmd = Command::new(&program);
+    cmd.args(args)
+        .env("PATH", login_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(dir) = cwd.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        cmd.current_dir(dir);
+    }
+    crate::modules::proc::hide_console(&mut cmd);
+
+    let child = Arc::new(SharedChild::spawn(&mut cmd).map_err(|e| {
+        log::warn!("agent_cli_spawn failed for {bin}: {e}");
+        e.to_string()
+    })?);
+
+    let stdout_pipe = child.take_stdout();
+    let stderr_pipe = child.take_stderr();
+    state.children.lock().unwrap().insert(id, Arc::clone(&child));
+
+    if let Some(pipe) = stdout_pipe {
+        let ch = on_event.clone();
+        thread::spawn(move || stream_lines(pipe, &ch, true));
+    }
+    if let Some(pipe) = stderr_pipe {
+        let ch = on_event.clone();
+        thread::spawn(move || stream_lines(pipe, &ch, false));
+    }
+
+    let waiter = Arc::clone(&child);
+    let children = Arc::clone(&state.children);
+    thread::spawn(move || {
+        let code = waiter.wait().ok().and_then(|s| s.code());
+        let _ = on_event.send(AgentCliEvent::Exit { code });
+        children.lock().unwrap().remove(&id);
+    });
+
+    Ok(())
+}
+
+/// Kill a running agent by its spawn `id`. No-op if already gone.
+#[tauri::command]
+pub async fn agent_cli_kill(id: u32, state: tauri::State<'_, AgentCliState>) -> Result<(), String> {
+    let child = state.children.lock().unwrap().remove(&id);
+    if let Some(child) = child {
+        let _ = child.kill();
+    }
+    Ok(())
+}
+
+fn stream_lines<R: std::io::Read>(pipe: R, ch: &Channel<AgentCliEvent>, stdout: bool) {
+    let reader = BufReader::new(pipe);
+    for line in reader.lines() {
+        let Ok(line) = line else { break };
+        let event = if stdout {
+            AgentCliEvent::Stdout { line }
+        } else {
+            AgentCliEvent::Stderr { line }
+        };
+        if ch.send(event).is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn login_path_is_non_empty() {
+        // Either the login-shell probe or the inherited PATH must yield something.
+        assert!(!login_path().is_empty());
+    }
+
+    #[test]
+    fn resolve_bin_rejects_missing() {
+        assert!(resolve_bin("definitely-not-a-real-binary-zzz-9000").is_none());
+        assert!(resolve_bin("").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_bin_finds_path_binary() {
+        let p = resolve_bin("sh").expect("sh should resolve on PATH");
+        assert!(p.is_absolute());
+        assert!(p.is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_bin_honors_explicit_path() {
+        assert_eq!(resolve_bin("/bin/sh"), Some(PathBuf::from("/bin/sh")));
+        assert!(resolve_bin("/nonexistent/dir/nope").is_none());
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod agent_cli;
 pub mod fs;
 pub mod git;
 pub mod net;

--- a/src/modules/ai/cli/bridge.ts
+++ b/src/modules/ai/cli/bridge.ts
@@ -1,0 +1,71 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { CliSpawnEvent } from "./types";
+
+let nextSpawnId = 1;
+export function allocateSpawnId(): number {
+  // u32 on the Rust side; wrap well below the limit.
+  nextSpawnId = (nextSpawnId % 0x7fff_ffff) + 1;
+  return nextSpawnId;
+}
+
+/** Map of requested binary names to their resolved absolute path (or null). */
+export function detectCliAgents(
+  bins: string[],
+): Promise<Record<string, string | null>> {
+  return invoke<Record<string, string | null>>("agent_cli_which", { bins });
+}
+
+export function killCliAgent(id: number): Promise<void> {
+  return invoke<void>("agent_cli_kill", { id }).catch(() => {});
+}
+
+type RunHandlers = {
+  onStdout: (line: string) => void;
+  onStderr?: (line: string) => void;
+};
+
+/**
+ * Spawn a CLI agent and stream its line output. Resolves with the exit code
+ * once the process ends; rejects only if the spawn itself fails before any
+ * output. `id` should come from `allocateSpawnId()` so the caller can cancel.
+ */
+export function runCliAgent(
+  args: { id: number; argv: string[]; cwd: string | null },
+  handlers: RunHandlers,
+): Promise<{ code: number | null }> {
+  return new Promise((resolve, reject) => {
+    let started = false;
+    const channel = new Channel<CliSpawnEvent>();
+    channel.onmessage = (event) => {
+      switch (event.kind) {
+        case "stdout":
+          started = true;
+          handlers.onStdout(event.line);
+          break;
+        case "stderr":
+          started = true;
+          handlers.onStderr?.(event.line);
+          break;
+        case "exit":
+          resolve({ code: event.code });
+          break;
+        case "error":
+          if (started) resolve({ code: null });
+          else reject(new Error(event.message));
+          break;
+      }
+    };
+
+    invoke<void>("agent_cli_spawn", {
+      id: args.id,
+      argv: args.argv,
+      cwd: args.cwd ?? undefined,
+      workspace: currentWorkspaceEnv(),
+      onEvent: channel,
+    }).catch((e) => {
+      if (started) return;
+      reject(e instanceof Error ? e : new Error(String(e)));
+    });
+  });
+}

--- a/src/modules/ai/cli/index.ts
+++ b/src/modules/ai/cli/index.ts
@@ -1,0 +1,9 @@
+export { runCliAgentStream, type RunCliAgentOptions } from "./stream";
+export {
+  CLI_AGENTS,
+  CLI_AGENT_IDS,
+  CLI_AGENT_BINS,
+  type CliAgentDef,
+} from "./registry";
+export { detectCliAgents } from "./bridge";
+export type { CliAgentId, CliPermissionMode } from "./types";

--- a/src/modules/ai/cli/parsers/claude.ts
+++ b/src/modules/ai/cli/parsers/claude.ts
@@ -1,0 +1,105 @@
+import { ChunkEmitter, parseJsonLine, type CliParser } from "./emitter";
+
+type Block = { kind: string; id: string; name: string; json: string };
+
+/**
+ * Claude Code `--output-format stream-json --include-partial-messages`.
+ * Text and thinking stream as Anthropic SSE deltas inside `stream_event`;
+ * tool calls are assembled from `content_block_*` and finalized on stop;
+ * tool results arrive as `user` messages; `result` carries terminal status.
+ */
+export function createClaudeParser(emitter: ChunkEmitter): CliParser {
+  const blocks = new Map<number, Block>();
+
+  const onLine = (line: string) => {
+    const obj = parseJsonLine(line);
+    if (!obj) return;
+    const type = obj.type as string | undefined;
+
+    if (type === "stream_event") {
+      handleStreamEvent(obj.event as Record<string, unknown> | undefined);
+      return;
+    }
+    if (type === "user") {
+      handleToolResults(obj.message as Record<string, unknown> | undefined);
+      return;
+    }
+    if (type === "result" && obj.is_error === true) {
+      const msg =
+        typeof obj.result === "string" ? obj.result : "Claude run failed";
+      emitter.error(msg);
+    }
+  };
+
+  function handleStreamEvent(event?: Record<string, unknown>): void {
+    if (!event) return;
+    const etype = event.type as string | undefined;
+    switch (etype) {
+      case "content_block_start": {
+        const index = event.index as number;
+        const cb = (event.content_block ?? {}) as Record<string, unknown>;
+        blocks.set(index, {
+          kind: (cb.type as string) ?? "text",
+          id: (cb.id as string) ?? `tool-${index}`,
+          name: (cb.name as string) ?? "tool",
+          json: "",
+        });
+        break;
+      }
+      case "content_block_delta": {
+        const index = event.index as number;
+        const delta = (event.delta ?? {}) as Record<string, unknown>;
+        const dtype = delta.type as string | undefined;
+        if (dtype === "text_delta") emitter.textDelta(String(delta.text ?? ""));
+        else if (dtype === "thinking_delta")
+          emitter.reasoningDelta(String(delta.thinking ?? ""));
+        else if (dtype === "input_json_delta") {
+          const b = blocks.get(index);
+          if (b) b.json += String(delta.partial_json ?? "");
+        }
+        break;
+      }
+      case "content_block_stop": {
+        const index = event.index as number;
+        const b = blocks.get(index);
+        if (b && b.kind === "tool_use") {
+          let input: unknown = {};
+          try {
+            input = b.json ? JSON.parse(b.json) : {};
+          } catch {
+            input = { _raw: b.json };
+          }
+          emitter.tool(b.id, b.name, input);
+        }
+        blocks.delete(index);
+        break;
+      }
+    }
+  }
+
+  function handleToolResults(message?: Record<string, unknown>): void {
+    const content = message?.content;
+    if (!Array.isArray(content)) return;
+    for (const block of content) {
+      if (block && block.type === "tool_result") {
+        emitter.toolResult(block.tool_use_id, normalizeContent(block.content));
+      }
+    }
+  }
+
+  return { onLine };
+}
+
+function normalizeContent(content: unknown): unknown {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) =>
+        c && typeof c === "object" && "text" in c
+          ? String((c as { text: unknown }).text)
+          : JSON.stringify(c),
+      )
+      .join("\n");
+  }
+  return content ?? null;
+}

--- a/src/modules/ai/cli/parsers/codex.ts
+++ b/src/modules/ai/cli/parsers/codex.ts
@@ -1,0 +1,79 @@
+import { ChunkEmitter, parseJsonLine, type CliParser } from "./emitter";
+
+/**
+ * Codex `exec --json`. Emits a thread/turn/item event model. Items arrive as
+ * started/updated/completed; agent_message and reasoning carry cumulative
+ * text (we emit the growing suffix), command/file/mcp items render as tool
+ * cards. No token-level streaming, so text appears per item update.
+ */
+export function createCodexParser(emitter: ChunkEmitter): CliParser {
+  const textSeen = new Map<string, number>();
+  const reasoningSeen = new Map<string, number>();
+  const toolStarted = new Set<string>();
+
+  const onLine = (line: string) => {
+    const obj = parseJsonLine(line);
+    if (!obj) return;
+    const type = obj.type as string | undefined;
+
+    if (type === "item.started" || type === "item.updated" || type === "item.completed") {
+      handleItem(obj.item as Record<string, unknown> | undefined, type);
+      return;
+    }
+    if (type === "turn.failed" || type === "error") {
+      const err = obj.error as Record<string, unknown> | undefined;
+      emitter.error(
+        (err?.message as string) ?? (obj.message as string) ?? "Codex run failed",
+      );
+    }
+  };
+
+  function handleItem(item: Record<string, unknown> | undefined, phase: string): void {
+    if (!item) return;
+    const id = String(item.id ?? "item");
+    const itype = item.item_type ?? item.type;
+
+    if (itype === "agent_message") {
+      const full = String(item.text ?? "");
+      emitter.textDelta(full.slice(textSeen.get(id) ?? 0));
+      textSeen.set(id, full.length);
+      return;
+    }
+    if (itype === "reasoning") {
+      const full = String(item.text ?? "");
+      emitter.reasoningDelta(full.slice(reasoningSeen.get(id) ?? 0));
+      reasoningSeen.set(id, full.length);
+      return;
+    }
+    if (itype === "command_execution") {
+      if (!toolStarted.has(id)) {
+        emitter.tool(id, "shell", { command: item.command ?? "" });
+        toolStarted.add(id);
+      }
+      if (phase === "item.completed") {
+        emitter.toolResult(id, {
+          output: item.aggregated_output ?? item.output ?? "",
+          exit_code: item.exit_code ?? null,
+        });
+      }
+      return;
+    }
+    if (itype === "file_change" || itype === "patch") {
+      if (!toolStarted.has(id)) {
+        emitter.tool(id, "edit", item.changes ?? item);
+        toolStarted.add(id);
+      }
+      if (phase === "item.completed") emitter.toolResult(id, { status: item.status ?? "done" });
+      return;
+    }
+    if (itype === "mcp_tool_call") {
+      if (!toolStarted.has(id)) {
+        emitter.tool(id, String(item.tool ?? item.server ?? "mcp"), item.arguments ?? {});
+        toolStarted.add(id);
+      }
+      if (phase === "item.completed") emitter.toolResult(id, item.result ?? null);
+    }
+  }
+
+  return { onLine };
+}

--- a/src/modules/ai/cli/parsers/cursor.ts
+++ b/src/modules/ai/cli/parsers/cursor.ts
@@ -1,0 +1,63 @@
+import { ChunkEmitter, parseJsonLine, type CliParser } from "./emitter";
+
+/**
+ * cursor-agent `--output-format stream-json --stream-partial-output`.
+ * Shape mirrors Claude's stream-json but coarser: `assistant` events carry the
+ * cumulative message content (text grows across events); tool calls surface as
+ * `tool_call` content blocks; `result` carries terminal status.
+ */
+export function createCursorParser(emitter: ChunkEmitter): CliParser {
+  let emittedText = "";
+  const toolStarted = new Set<string>();
+
+  const onLine = (line: string) => {
+    const obj = parseJsonLine(line);
+    if (!obj) return;
+    const type = obj.type as string | undefined;
+
+    if (type === "assistant") {
+      const content = (obj.message as Record<string, unknown> | undefined)?.content;
+      if (Array.isArray(content)) for (const block of content) handleBlock(block);
+      return;
+    }
+    if (type === "result" && obj.is_error === true) {
+      emitter.error(
+        typeof obj.result === "string" ? obj.result : "cursor-agent run failed",
+      );
+    }
+  };
+
+  function handleBlock(block: unknown): void {
+    if (!block || typeof block !== "object") return;
+    const b = block as Record<string, unknown>;
+    const btype = b.type as string | undefined;
+
+    if (btype === "text") {
+      const text = String(b.text ?? "");
+      if (text === emittedText) return;
+      if (text.startsWith(emittedText)) {
+        emitter.textDelta(text.slice(emittedText.length));
+      } else {
+        emitter.textDelta(text);
+      }
+      emittedText = text;
+      return;
+    }
+    if (btype === "thinking" || btype === "reasoning") {
+      emitter.reasoningDelta(String(b.text ?? b.thinking ?? ""));
+      return;
+    }
+    if (btype === "tool_call" || btype === "tool_use") {
+      const id = String(b.id ?? b.tool_call_id ?? `tool-${toolStarted.size}`);
+      if (!toolStarted.has(id)) {
+        emitter.tool(id, String(b.name ?? b.tool ?? "tool"), b.input ?? b.arguments ?? {});
+        toolStarted.add(id);
+      }
+      if (b.result !== undefined || b.output !== undefined) {
+        emitter.toolResult(id, b.result ?? b.output);
+      }
+    }
+  }
+
+  return { onLine };
+}

--- a/src/modules/ai/cli/parsers/emitter.ts
+++ b/src/modules/ai/cli/parsers/emitter.ts
@@ -1,0 +1,113 @@
+import type { UIMessageStreamWriter } from "ai";
+
+/**
+ * Thin helper over a `UIMessageStreamWriter` that tracks open text/reasoning
+ * blocks and tool parts so parsers can emit well-formed chunk sequences
+ * (start -> delta* -> end) without bookkeeping. One emitter per CLI run.
+ */
+export class ChunkEmitter {
+  private seq = 0;
+  private textId: string | null = null;
+  private reasoningId: string | null = null;
+  private readonly openTools = new Set<string>();
+
+  constructor(private readonly writer: UIMessageStreamWriter) {}
+
+  private id(prefix: string): string {
+    this.seq += 1;
+    return `${prefix}-${this.seq}`;
+  }
+
+  textDelta(delta: string): void {
+    if (!delta) return;
+    this.endReasoning();
+    if (this.textId === null) {
+      this.textId = this.id("txt");
+      this.writer.write({ type: "text-start", id: this.textId });
+    }
+    this.writer.write({ type: "text-delta", id: this.textId, delta });
+  }
+
+  endText(): void {
+    if (this.textId === null) return;
+    this.writer.write({ type: "text-end", id: this.textId });
+    this.textId = null;
+  }
+
+  reasoningDelta(delta: string): void {
+    if (!delta) return;
+    this.endText();
+    if (this.reasoningId === null) {
+      this.reasoningId = this.id("rsn");
+      this.writer.write({ type: "reasoning-start", id: this.reasoningId });
+    }
+    this.writer.write({
+      type: "reasoning-delta",
+      id: this.reasoningId,
+      delta,
+    });
+  }
+
+  endReasoning(): void {
+    if (this.reasoningId === null) return;
+    this.writer.write({ type: "reasoning-end", id: this.reasoningId });
+    this.reasoningId = null;
+  }
+
+  /** Emit a fully-resolved tool call the CLI executed on its own. */
+  tool(toolCallId: string, toolName: string, input: unknown): void {
+    this.endText();
+    this.endReasoning();
+    this.writer.write({
+      type: "tool-input-available",
+      toolCallId,
+      toolName,
+      input: input ?? {},
+      providerExecuted: true,
+      dynamic: true,
+    });
+    this.openTools.add(toolCallId);
+  }
+
+  toolResult(toolCallId: string, output: unknown): void {
+    this.writer.write({
+      type: "tool-output-available",
+      toolCallId,
+      output: output ?? null,
+      providerExecuted: true,
+      dynamic: true,
+    });
+    this.openTools.delete(toolCallId);
+  }
+
+  error(errorText: string): void {
+    this.endText();
+    this.endReasoning();
+    this.writer.write({ type: "error", errorText });
+  }
+
+  /** Close any still-open blocks at end of run. */
+  finish(): void {
+    this.endText();
+    this.endReasoning();
+  }
+}
+
+export type CliParser = {
+  onLine(line: string): void;
+  onStderr?(line: string): void;
+  onExit?(code: number | null): void;
+};
+
+export type ParserFactory = (emitter: ChunkEmitter) => CliParser;
+
+/** Parse a JSONL line, returning null on blank/non-JSON noise. */
+export function parseJsonLine(line: string): Record<string, unknown> | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed[0] !== "{") return null;
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/src/modules/ai/cli/parsers/opencode.ts
+++ b/src/modules/ai/cli/parsers/opencode.ts
@@ -1,0 +1,56 @@
+import { ChunkEmitter, parseJsonLine, type CliParser } from "./emitter";
+
+/**
+ * OpenCode `run --format json`. Each line is `{ type, part }` where `part` is a
+ * message part keyed by `part.id`. Text and reasoning parts carry cumulative
+ * text (emit the growing suffix); tool parts carry `state.status` with input
+ * and output. Type strings appear in both dashed and underscored forms.
+ */
+export function createOpenCodeParser(emitter: ChunkEmitter): CliParser {
+  const textSeen = new Map<string, number>();
+  const reasoningSeen = new Map<string, number>();
+  const toolStarted = new Set<string>();
+
+  const onLine = (line: string) => {
+    const obj = parseJsonLine(line);
+    if (!obj) return;
+    const type = String(obj.type ?? "").replace(/-/g, "_");
+    const part = obj.part as Record<string, unknown> | undefined;
+
+    if (type === "error") {
+      emitter.error(String(obj.error ?? obj.message ?? "OpenCode run failed"));
+      return;
+    }
+    if (!part) return;
+
+    if (type === "text") {
+      const id = String(part.id ?? "text");
+      const full = String(part.text ?? "");
+      emitter.textDelta(full.slice(textSeen.get(id) ?? 0));
+      textSeen.set(id, full.length);
+      return;
+    }
+    if (type === "reasoning") {
+      const id = String(part.id ?? "reasoning");
+      const full = String(part.text ?? "");
+      emitter.reasoningDelta(full.slice(reasoningSeen.get(id) ?? 0));
+      reasoningSeen.set(id, full.length);
+      return;
+    }
+    if (type === "tool") {
+      const id = String(part.callID ?? part.id ?? `tool-${toolStarted.size}`);
+      const state = (part.state ?? {}) as Record<string, unknown>;
+      const name = String(part.tool ?? "tool");
+      if (!toolStarted.has(id)) {
+        emitter.tool(id, name, state.input ?? {});
+        toolStarted.add(id);
+      }
+      const status = state.status as string | undefined;
+      if (status === "completed" || status === "error") {
+        emitter.toolResult(id, state.output ?? state.error ?? null);
+      }
+    }
+  };
+
+  return { onLine };
+}

--- a/src/modules/ai/cli/registry.ts
+++ b/src/modules/ai/cli/registry.ts
@@ -1,0 +1,110 @@
+import type { ParserFactory } from "./parsers/emitter";
+import { createClaudeParser } from "./parsers/claude";
+import { createCodexParser } from "./parsers/codex";
+import { createCursorParser } from "./parsers/cursor";
+import { createOpenCodeParser } from "./parsers/opencode";
+import type { CliAgentId, CliPermissionMode } from "./types";
+
+export type CliAgentDef = {
+  id: CliAgentId;
+  label: string;
+  /** Binary name resolved against the user's login PATH on the Rust side. */
+  bin: string;
+  /** Where to get/authenticate the CLI (shown when not installed). */
+  docsUrl: string;
+  /** Build argv (binary first); cwd is passed out-of-band, never in argv. */
+  buildArgv: (
+    prompt: string,
+    opts: { model?: string; permission: CliPermissionMode },
+  ) => string[];
+  createParser: ParserFactory;
+};
+
+const CLAUDE_PERMISSION: Record<CliPermissionMode, string> = {
+  default: "plan",
+  acceptEdits: "acceptEdits",
+  full: "bypassPermissions",
+};
+
+const CODEX_SANDBOX: Record<CliPermissionMode, string> = {
+  default: "read-only",
+  acceptEdits: "workspace-write",
+  full: "danger-full-access",
+};
+
+export const CLI_AGENTS: Record<CliAgentId, CliAgentDef> = {
+  claude: {
+    id: "claude",
+    label: "Claude Code",
+    bin: "claude",
+    docsUrl: "https://docs.anthropic.com/en/docs/claude-code",
+    buildArgv: (prompt, { model, permission }) => {
+      const a = [
+        "claude",
+        "-p",
+        prompt,
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "--verbose",
+        "--permission-mode",
+        CLAUDE_PERMISSION[permission],
+      ];
+      if (permission === "full") a.push("--dangerously-skip-permissions");
+      if (model) a.push("--model", model);
+      return a;
+    },
+    createParser: createClaudeParser,
+  },
+  codex: {
+    id: "codex",
+    label: "Codex",
+    bin: "codex",
+    docsUrl: "https://github.com/openai/codex",
+    buildArgv: (prompt, { model, permission }) => {
+      const a = ["codex", "exec", "--json", "--skip-git-repo-check", "-s", CODEX_SANDBOX[permission]];
+      if (model) a.push("-m", model);
+      a.push(prompt);
+      return a;
+    },
+    createParser: createCodexParser,
+  },
+  cursor: {
+    id: "cursor",
+    label: "Cursor Agent",
+    bin: "cursor-agent",
+    docsUrl: "https://docs.cursor.com/cli",
+    buildArgv: (prompt, { model, permission }) => {
+      const a = [
+        "cursor-agent",
+        "-p",
+        prompt,
+        "--output-format",
+        "stream-json",
+        "--stream-partial-output",
+      ];
+      // Headless cannot answer trust/permission prompts; force-allow so the
+      // agent can act. Plan mode stays read-only.
+      a.push(permission === "default" ? "--plan" : "-f");
+      if (model) a.push("--model", model);
+      return a;
+    },
+    createParser: createCursorParser,
+  },
+  opencode: {
+    id: "opencode",
+    label: "OpenCode",
+    bin: "opencode",
+    docsUrl: "https://opencode.ai/docs",
+    buildArgv: (prompt, { model }) => {
+      const a = ["opencode", "run", "--format", "json"];
+      if (model) a.push("-m", model);
+      a.push(prompt);
+      return a;
+    },
+    createParser: createOpenCodeParser,
+  },
+};
+
+export const CLI_AGENT_IDS = Object.keys(CLI_AGENTS) as CliAgentId[];
+export const CLI_AGENT_BINS = CLI_AGENT_IDS.map((id) => CLI_AGENTS[id].bin);

--- a/src/modules/ai/cli/stream.ts
+++ b/src/modules/ai/cli/stream.ts
@@ -1,0 +1,87 @@
+import { createUIMessageStream, type UIMessage } from "ai";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { allocateSpawnId, killCliAgent, runCliAgent } from "./bridge";
+import { ChunkEmitter } from "./parsers/emitter";
+import { CLI_AGENTS } from "./registry";
+import type { CliAgentId, CliPermissionMode } from "./types";
+
+export type RunCliAgentOptions = {
+  cliId: CliAgentId;
+  uiMessages: UIMessage[];
+  cwd: string | null;
+  model?: string;
+  permission?: CliPermissionMode;
+  abortSignal?: AbortSignal;
+  onStep?: (step: string | null) => void;
+};
+
+/**
+ * Drive a wrapped CLI agent and expose it as the same `{ toUIMessageStream }`
+ * shape `runAgentStream` returns, so the chat transport is agnostic to whether
+ * the turn was served by an API model or a local CLI. The CLI runs its own
+ * tool loop end-to-end; we only relay its event stream into the chat UI.
+ */
+export function runCliAgentStream(opts: RunCliAgentOptions) {
+  const def = CLI_AGENTS[opts.cliId];
+  const prompt = messagesToPrompt(opts.uiMessages);
+
+  return {
+    toUIMessageStream: (_o?: { originalMessages?: UIMessage[] }) =>
+      createUIMessageStream({
+        execute: async ({ writer }) => {
+          const emitter = new ChunkEmitter(writer);
+          const parser = def.createParser(emitter);
+          const id = allocateSpawnId();
+          const onAbort = () => void killCliAgent(id);
+          opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
+          opts.onStep?.(`Running ${def.label}`);
+          try {
+            const permission =
+              opts.permission ??
+              usePreferencesStore.getState().cliAgentPermission;
+            const argv = def.buildArgv(prompt, { model: opts.model, permission });
+            await runCliAgent(
+              { id, argv, cwd: opts.cwd },
+              {
+                onStdout: (line) => parser.onLine(line),
+                onStderr: (line) => parser.onStderr?.(line),
+              },
+            );
+          } catch (e) {
+            emitter.error(e instanceof Error ? e.message : String(e));
+          } finally {
+            opts.abortSignal?.removeEventListener("abort", onAbort);
+            parser.onExit?.(null);
+            emitter.finish();
+            opts.onStep?.(null);
+          }
+        },
+        onError: (e) => (e instanceof Error ? e.message : String(e)),
+      }),
+  };
+}
+
+/** Flatten the chat history into a single prompt. CLIs take one prompt per
+ *  run and manage their own context, so we hand them a readable transcript. */
+function messagesToPrompt(messages: UIMessage[]): string {
+  const turns = messages
+    .map((m) => ({
+      role: m.role,
+      text: (m.parts ?? [])
+        .filter((p): p is { type: "text"; text: string } => p.type === "text")
+        .map((p) => p.text)
+        .join("")
+        .trim(),
+    }))
+    .filter((t) => t.text);
+
+  if (turns.length === 0) return "";
+  if (turns.length === 1) return turns[0].text;
+
+  const last = turns[turns.length - 1];
+  const history = turns
+    .slice(0, -1)
+    .map((t) => `${t.role === "user" ? "User" : "Assistant"}: ${t.text}`)
+    .join("\n\n");
+  return `Conversation so far:\n${history}\n\nCurrent request:\n${last.text}`;
+}

--- a/src/modules/ai/cli/types.ts
+++ b/src/modules/ai/cli/types.ts
@@ -1,0 +1,12 @@
+export type CliAgentId = "claude" | "codex" | "cursor" | "opencode";
+
+/** Mirror of the Rust `AgentCliEvent` (serde tag = "kind", camelCase). */
+export type CliSpawnEvent =
+  | { kind: "stdout"; line: string }
+  | { kind: "stderr"; line: string }
+  | { kind: "exit"; code: number | null }
+  | { kind: "error"; message: string };
+
+/** Permission posture passed to the wrapped CLI. CLIs run headless so they
+ *  cannot prompt; we choose a non-interactive policy up front. */
+export type CliPermissionMode = "default" | "acceptEdits" | "full";

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -75,6 +75,10 @@ const PROVIDER_ICON = {
   lmstudio: ComputerIcon,
   mlx: AppleIcon,
   ollama: ServerStack01Icon,
+  "cli-claude": ClaudeIcon,
+  "cli-codex": ChatGptIcon,
+  "cli-cursor": ComputerIcon,
+  "cli-opencode": CpuIcon,
 } as const satisfies Record<ProviderId, typeof ChatGptIcon>;
 
 export function AiOpenButton({ onOpen }: { onOpen: () => void }) {

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -13,7 +13,25 @@ export type ProviderId =
   | "openai-compatible"
   | "lmstudio"
   | "mlx"
-  | "ollama";
+  | "ollama"
+  | "cli-claude"
+  | "cli-codex"
+  | "cli-cursor"
+  | "cli-opencode";
+
+/** Providers backed by a locally-installed agent CLI (no API key, runs the
+ *  agent's own tool loop). Maps each provider to its CLI agent id. */
+export const CLI_PROVIDERS: Partial<Record<ProviderId, "claude" | "codex" | "cursor" | "opencode">> =
+  {
+    "cli-claude": "claude",
+    "cli-codex": "codex",
+    "cli-cursor": "cursor",
+    "cli-opencode": "opencode",
+  };
+
+export function isCliProvider(id: ProviderId): boolean {
+  return id in CLI_PROVIDERS;
+}
 
 export type ProviderInfo = {
   id: ProviderId;
@@ -117,6 +135,34 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     keyringAccount: "",
     keyPrefix: null,
     consoleUrl: "https://ollama.com/download",
+  },
+  {
+    id: "cli-claude",
+    label: "Claude Code (CLI)",
+    keyringAccount: "",
+    keyPrefix: null,
+    consoleUrl: "https://docs.anthropic.com/en/docs/claude-code",
+  },
+  {
+    id: "cli-codex",
+    label: "Codex (CLI)",
+    keyringAccount: "",
+    keyPrefix: null,
+    consoleUrl: "https://github.com/openai/codex",
+  },
+  {
+    id: "cli-cursor",
+    label: "Cursor Agent (CLI)",
+    keyringAccount: "",
+    keyPrefix: null,
+    consoleUrl: "https://docs.cursor.com/cli",
+  },
+  {
+    id: "cli-opencode",
+    label: "OpenCode (CLI)",
+    keyringAccount: "",
+    keyPrefix: null,
+    consoleUrl: "https://opencode.ai/docs",
   },
 ] as const;
 
@@ -522,6 +568,44 @@ export const MODELS = [
     description: "Local models via Ollama.",
     capabilities: { intelligence: 3, speed: 3, cost: 5 },
   },
+
+  // ── Local CLI agents (no API key; the installed CLI runs its own agent) ───
+  {
+    id: "cli-claude-agent",
+    provider: "cli-claude",
+    label: "Claude Code",
+    hint: "CLI",
+    description: "Your installed Claude Code CLI, no API key.",
+    capabilities: { intelligence: 5, speed: 3, cost: 5 },
+    tags: ["reasoning", "tools", "coding"],
+  },
+  {
+    id: "cli-codex-agent",
+    provider: "cli-codex",
+    label: "Codex",
+    hint: "CLI",
+    description: "Your installed Codex CLI, no API key.",
+    capabilities: { intelligence: 5, speed: 3, cost: 5 },
+    tags: ["reasoning", "tools", "coding"],
+  },
+  {
+    id: "cli-cursor-agent",
+    provider: "cli-cursor",
+    label: "Cursor Agent",
+    hint: "CLI",
+    description: "Your installed cursor-agent CLI, no API key.",
+    capabilities: { intelligence: 4, speed: 4, cost: 5 },
+    tags: ["tools", "coding"],
+  },
+  {
+    id: "cli-opencode-agent",
+    provider: "cli-opencode",
+    label: "OpenCode",
+    hint: "CLI",
+    description: "Your installed OpenCode CLI, no API key.",
+    capabilities: { intelligence: 4, speed: 4, cost: 5 },
+    tags: ["tools", "coding"],
+  },
 ] as const satisfies readonly ModelInfo[];
 
 export type ModelId = (typeof MODELS)[number]["id"];
@@ -681,6 +765,10 @@ export const KEYLESS_PROVIDERS: readonly ProviderId[] = [
   "mlx",
   "ollama",
   "openai-compatible",
+  "cli-claude",
+  "cli-codex",
+  "cli-cursor",
+  "cli-opencode",
 ] as const;
 
 export function providerNeedsKey(id: ProviderId): boolean {

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -8,10 +8,12 @@ import {
   type UIMessage,
 } from "ai";
 import {
+  CLI_PROVIDERS,
   DEFAULT_MODEL_ID,
   endpointIdFromCompatModel,
   getModelContextLimit,
   isCompatModelId,
+  isCliProvider,
   LMSTUDIO_DEFAULT_BASE_URL,
   MAX_AGENT_STEPS,
   MLX_DEFAULT_BASE_URL,
@@ -23,6 +25,7 @@ import {
   type CustomEndpoint,
   type ProviderId,
 } from "../config";
+import { runCliAgentStream } from "../cli";
 import { buildTools, type ToolContext } from "../tools/tools";
 import { compactModelMessagesDetailed } from "./compact";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
@@ -207,6 +210,13 @@ export async function buildLanguageModel(
       })(resolvedModelId);
       break;
     }
+    case "cli-claude":
+    case "cli-codex":
+    case "cli-cursor":
+    case "cli-opencode":
+      throw new Error(
+        "CLI agent providers do not build a LanguageModel; they stream via runCliAgentStream.",
+      );
     default: {
       const _exhaustive: never = provider;
       throw new Error(`Unsupported provider: ${_exhaustive as ProviderId}`);
@@ -390,6 +400,25 @@ export type RunAgentOptions = {
 
 export async function runAgentStream(opts: RunAgentOptions) {
   const modelId = opts.modelId ?? DEFAULT_MODEL_ID;
+  const endpoints = opts.customEndpoints ?? [];
+  const info = resolveModel(modelId, endpoints);
+  const provider = info.provider;
+
+  // CLI agent providers run their own end-to-end agent loop; we do not build a
+  // LanguageModel, attach Terax tools, or compact history. Hand the transcript
+  // to the CLI and relay its event stream into the chat UI.
+  if (isCliProvider(provider)) {
+    const cliId = CLI_PROVIDERS[provider];
+    if (!cliId) throw new Error(`No CLI agent mapped for provider ${provider}`);
+    return runCliAgentStream({
+      cliId,
+      uiMessages: opts.uiMessages,
+      cwd: opts.toolContext.getCwd(),
+      abortSignal: opts.abortSignal,
+      onStep: opts.onStep,
+    });
+  }
+
   const model = await buildConfiguredLanguageModel(modelId, opts.keys, {
     lmstudioBaseURL: opts.lmstudioBaseURL,
     lmstudioModelId: opts.lmstudioModelId,
@@ -403,9 +432,6 @@ export async function runAgentStream(opts: RunAgentOptions) {
     customEndpoints: opts.customEndpoints,
     customEndpointKeys: opts.customEndpointKeys,
   });
-  const endpoints = opts.customEndpoints ?? [];
-  const info = resolveModel(modelId, endpoints);
-  const provider = info.provider;
 
   const stableSystem = buildStableSystem(
     modelId,

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -25,6 +25,10 @@ export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   lmstudio: null,
   mlx: null,
   ollama: null,
+  "cli-claude": null,
+  "cli-codex": null,
+  "cli-cursor": null,
+  "cli-opencode": null,
 };
 
 export async function getKey(provider: ProviderId): Promise<string | null> {

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -11,6 +11,7 @@ import {
   type CustomEndpoint,
   type ModelId,
 } from "@/modules/ai/config";
+import type { CliPermissionMode } from "@/modules/ai/cli/types";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
@@ -75,6 +76,8 @@ export type Preferences = {
   openaiCompatibleContextLimit: number;
   customEndpoints: CustomEndpoint[];
   openrouterModelId: string;
+  /** Permission posture for wrapped CLI agents (claude/codex/cursor/opencode). */
+  cliAgentPermission: CliPermissionMode;
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
@@ -118,6 +121,7 @@ const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
 const KEY_OPENAI_COMPAT_CONTEXT_LIMIT = "openaiCompatibleContextLimit";
 const KEY_CUSTOM_ENDPOINTS = "customEndpoints";
 const KEY_OPENROUTER_MODEL_ID = "openrouterModelId";
+const KEY_CLI_AGENT_PERMISSION = "cliAgentPermission";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
@@ -176,6 +180,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   openaiCompatibleContextLimit: 128_000,
   customEndpoints: [],
   openrouterModelId: "",
+  cliAgentPermission: "acceptEdits",
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
@@ -285,6 +290,9 @@ export async function loadPreferences(): Promise<Preferences> {
     openrouterModelId:
       get<string>(KEY_OPENROUTER_MODEL_ID) ??
       DEFAULT_PREFERENCES.openrouterModelId,
+    cliAgentPermission:
+      get<CliPermissionMode>(KEY_CLI_AGENT_PERMISSION) ??
+      DEFAULT_PREFERENCES.cliAgentPermission,
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds
@@ -457,6 +465,12 @@ export async function setOpenrouterModelId(value: string): Promise<void> {
   await writePref(KEY_OPENROUTER_MODEL_ID, value);
 }
 
+export async function setCliAgentPermission(
+  value: CliPermissionMode,
+): Promise<void> {
+  await writePref(KEY_CLI_AGENT_PERMISSION, value);
+}
+
 export async function setFavoriteModelIds(value: string[]): Promise<void> {
   await writePref(KEY_FAVORITE_MODELS, value);
 }
@@ -575,6 +589,7 @@ export async function onPreferencesChange(
     [KEY_OPENAI_COMPAT_CONTEXT_LIMIT]: "openaiCompatibleContextLimit",
     [KEY_CUSTOM_ENDPOINTS]: "customEndpoints",
     [KEY_OPENROUTER_MODEL_ID]: "openrouterModelId",
+    [KEY_CLI_AGENT_PERMISSION]: "cliAgentPermission",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -30,6 +30,10 @@ const ICON_BY_PROVIDER = {
   lmstudio: ComputerIcon,
   mlx: AppleIcon,
   ollama: ServerStack01Icon,
+  "cli-claude": ClaudeIcon,
+  "cli-codex": ChatGptIcon,
+  "cli-cursor": ComputerIcon,
+  "cli-opencode": CpuIcon,
 } as const satisfies Record<ProviderId, typeof ChatGptIcon>;
 
 type Props = {

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -12,12 +12,14 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import {
   DEFAULT_MODEL_ID,
+  CLI_PROVIDERS,
   MODELS,
   PROVIDERS,
   compatModelIdForEndpoint,
   getAutocompleteEligibleModels,
   getModel,
   getProvider,
+  isCliProvider,
   providerNeedsKey,
   type CustomEndpoint,
   type ModelId,
@@ -34,6 +36,8 @@ import {
   type CustomEndpointKeys,
 } from "@/modules/ai/lib/keyring";
 import { useChatStore } from "@/modules/ai/store/chatStore";
+import { CLI_AGENTS, detectCliAgents } from "@/modules/ai/cli";
+import type { CliPermissionMode } from "@/modules/ai/cli/types";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   emitKeysChanged,
@@ -54,6 +58,7 @@ import {
   setOpenaiCompatibleModelId,
   setOpenrouterModelId,
   setRecentModelIds,
+  setCliAgentPermission,
 } from "@/modules/settings/store";
 import {
   Add01Icon,
@@ -133,6 +138,17 @@ export function ModelsSection() {
   const [keys, setKeys] = useState<KeysMap | null>(null);
   const [epKeys, setEpKeys] = useState<CustomEndpointKeys>({});
   const [adding, setAdding] = useState<Set<ProviderId>>(new Set());
+  const [cliPaths, setCliPaths] = useState<Record<string, string | null>>({});
+
+  useEffect(() => {
+    const bins = Object.values(CLI_PROVIDERS).map((id) => CLI_AGENTS[id].bin);
+    void detectCliAgents(bins).then(setCliPaths);
+  }, []);
+
+  const cliInstalled = (id: ProviderId): boolean => {
+    const cliId = CLI_PROVIDERS[id];
+    return !!cliId && !!cliPaths[CLI_AGENTS[cliId].bin];
+  };
 
   const defaultModel = usePreferencesStore((s) => s.defaultModelId);
   const lmstudioBaseURL = usePreferencesStore((s) => s.lmstudioBaseURL);
@@ -282,6 +298,7 @@ export function ModelsSection() {
   };
 
   const isConfigured = (id: ProviderId): boolean => {
+    if (isCliProvider(id)) return cliInstalled(id);
     if (id === "openrouter")
       return !!keys?.[id] && !!openrouterModelId.trim();
     if (!isLocalProvider(id)) return !!keys?.[id];
@@ -299,13 +316,20 @@ export function ModelsSection() {
   const configuredIds = new Set(
     PROVIDERS.filter((p) => isConfigured(p.id)).map((p) => p.id),
   );
-  const visibleIds = new Set<ProviderId>(configuredIds);
+  // CLI agents have their own block (detection-based, no key/URL config), so
+  // keep them out of the cloud/local add-remove flow.
+  const visibleIds = new Set<ProviderId>(
+    [...configuredIds].filter((id) => !isCliProvider(id)),
+  );
   for (const id of adding) visibleIds.add(id);
   const visibleProviders = PROVIDERS.filter(
     (p) => p.id !== "openai-compatible" && visibleIds.has(p.id),
   );
   const addableProviders = PROVIDERS.filter(
-    (p) => p.id !== "openai-compatible" && !visibleIds.has(p.id),
+    (p) =>
+      p.id !== "openai-compatible" &&
+      !visibleIds.has(p.id) &&
+      !isCliProvider(p.id),
   );
 
   const removeProvider = (id: ProviderId) => {
@@ -416,6 +440,8 @@ export function ModelsSection() {
           </div>
         )}
       </div>
+
+      <CliAgentsBlock cliPaths={cliPaths} />
     </div>
   );
 }
@@ -498,6 +524,147 @@ function ProviderMenuItem({
       <ProviderIcon provider={provider.id} size={13} />
       <span>{provider.label}</span>
     </DropdownMenuItem>
+  );
+}
+
+const CLI_PERMISSION_OPTIONS: {
+  value: CliPermissionMode;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "default",
+    label: "Plan only",
+    description: "Read-only. The agent can inspect but not edit or run commands.",
+  },
+  {
+    value: "acceptEdits",
+    label: "Auto-edit",
+    description: "Auto-accepts file edits; commands stay sandboxed.",
+  },
+  {
+    value: "full",
+    label: "Full access",
+    description: "Edits and runs commands without prompts. Use with care.",
+  },
+];
+
+function CliAgentsBlock({
+  cliPaths,
+}: {
+  cliPaths: Record<string, string | null>;
+}) {
+  const permission = usePreferencesStore((s) => s.cliAgentPermission);
+  const current =
+    CLI_PERMISSION_OPTIONS.find((o) => o.value === permission) ??
+    CLI_PERMISSION_OPTIONS[1];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <Label>Local CLI agents</Label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 justify-between gap-1.5 px-2.5 text-[11px]"
+            >
+              {current.label}
+              <HugeiconsIcon icon={ArrowDown01Icon} size={11} strokeWidth={2} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-64 p-1">
+            <DropdownMenuLabel className="px-2 text-[10px] tracking-wide text-muted-foreground uppercase">
+              Permission
+            </DropdownMenuLabel>
+            {CLI_PERMISSION_OPTIONS.map((o) => (
+              <DropdownMenuItem
+                key={o.value}
+                onSelect={() => void setCliAgentPermission(o.value)}
+                className={cn(
+                  "flex flex-col items-start gap-0.5 text-[12px]",
+                  o.value === permission && "bg-accent/50",
+                )}
+              >
+                <span>{o.label}</span>
+                <span className="text-[10px] text-muted-foreground">
+                  {o.description}
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <p className="text-[10.5px] leading-relaxed text-muted-foreground">
+        Use coding-agent CLIs you already have installed — no API key. They run
+        in the active workspace and bring their own tools. Detected on your
+        login PATH.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {(
+          Object.entries(CLI_PROVIDERS) as [
+            ProviderId,
+            "claude" | "codex" | "cursor" | "opencode",
+          ][]
+        ).map(([providerId, cliId]) => {
+          const def = CLI_AGENTS[cliId];
+          const path = cliPaths[def.bin] ?? null;
+          const installed = !!path;
+          return (
+            <div
+              key={providerId}
+              className="flex items-center gap-2 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5"
+            >
+              <ProviderIcon provider={providerId} size={15} />
+              <span className="text-[12.5px] font-medium">{def.label}</span>
+              {installed ? (
+                <Badge
+                  variant="outline"
+                  className="ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal text-muted-foreground"
+                >
+                  <HugeiconsIcon
+                    icon={CheckmarkCircle02Icon}
+                    size={9}
+                    strokeWidth={2}
+                  />
+                  Installed
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="ml-1 h-4 px-1.5 text-[10px] font-normal text-muted-foreground/70"
+                >
+                  Not installed
+                </Badge>
+              )}
+              {installed ? (
+                <code
+                  className="ml-1 truncate font-mono text-[10px] text-muted-foreground/60"
+                  title={path ?? undefined}
+                >
+                  {def.bin}
+                </code>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => void openUrl(def.docsUrl)}
+                className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {installed ? "Docs" : "Install"}
+                <HugeiconsIcon
+                  icon={ArrowUpRight01Icon}
+                  size={11}
+                  strokeWidth={1.75}
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
Adds **Claude Code, Codex, cursor-agent and OpenCode** as keyless "Local CLI agent" providers, so users can drive a coding-agent CLI they already have installed from the Terax chat — no API key. Each CLI is a full agent: `runAgentStream` branches on `isCliProvider` to `runCliAgentStream`, bypassing Terax's own tool loop and relaying the CLI's event stream into the chat UI.

## Backend (`src-tauri/src/modules/agent_cli.rs`)
A generic, injection-safe spawner:
- argv passed as separate args (no shell), binary resolved against the login PATH, cwd authorized.
- stdout/stderr streamed over a Tauri `Channel`; `which` / `spawn` / `kill` commands.

## Frontend (`src/modules/ai/cli/*`)
- Per-CLI JSON parsing in `cli/parsers/{claude,codex,cursor,opencode}.ts`, mapping each CLI's output to AI-SDK `UIMessageChunk`s via a shared `emitter`.
- `registry.ts` describes each agent (binary name, args, permission-flag mapping); `detectCliAgents` resolves which are installed.

## Permissions
A new `cliAgentPermission` preference (plan / auto-edit / full access) maps to each CLI's native permission flags at spawn time. Settings shows install detection + the permission selector ("Local CLI agents" block in the Models section).

## Notes
- `tsc` clean; `cargo check` clean.
- New providers slot into the existing provider/model registry; non-CLI providers are unaffected.
