### PR TITLE
[codex] add agent worktree isolation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             fs::grep::fs_grep,
             fs::grep::fs_glob,
             git::commands::git_resolve_repo,
+            git::commands::git_create_agent_worktree,
             git::commands::git_panel_snapshot,
             git::commands::git_status,
             git::commands::git_diff,

--- a/src-tauri/src/modules/git/commands.rs
+++ b/src-tauri/src/modules/git/commands.rs
@@ -2,8 +2,8 @@ use tauri::{AppHandle, Manager};
 
 use crate::modules::git::operations;
 use crate::modules::git::types::{
-    DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult, GitDiffResult,
-    GitLogEntry, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
+    AgentWorktreeResult, DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult,
+    GitDiffResult, GitLogEntry, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
 };
 use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
 
@@ -29,6 +29,20 @@ pub async fn git_resolve_repo(
     let workspace = WorkspaceEnv::from_option(workspace);
     blocking(app, move |r| {
         operations::resolve_repo(r, &cwd, &workspace).map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn git_create_agent_worktree(
+    cwd: String,
+    task: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<AgentWorktreeResult, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::create_agent_worktree(r, &cwd, &task, &workspace).map_err(Into::into)
     })
     .await
 }

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -1,5 +1,6 @@
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::modules::git::errors::{GitError, Result};
 use crate::modules::git::parser::parse_porcelain_v2;
@@ -8,12 +9,13 @@ use crate::modules::git::process::{
     read_text_file, run_git,
 };
 use crate::modules::git::types::{
-    DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult, GitDiffResult,
-    GitLogEntry, GitOutput, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
-    TextSource, DEFAULT_TIMEOUT_SECS, NETWORK_TIMEOUT_SECS,
+    AgentWorktreeResult, DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult,
+    GitDiffResult, GitLogEntry, GitOutput, GitPanelSnapshot, GitPushResult, GitRepoInfo,
+    GitStatusSnapshot, TextSource, DEFAULT_TIMEOUT_SECS, NETWORK_TIMEOUT_SECS,
 };
 use crate::modules::git::utils::{
-    authorized_repo_root, canonical_dir, resolve_within_repo, split_upstream, ResolvedGitDirectory,
+    authorized_repo_root, canonical_dir, display_path, resolve_within_repo, split_upstream,
+    ResolvedGitDirectory,
 };
 use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
 
@@ -28,6 +30,88 @@ pub fn resolve_repo(
     }
     ensure_git_available(&cwd.workspace)?;
     resolve_repo_in_authorized(registry, &cwd)
+}
+
+pub fn create_agent_worktree(
+    registry: &WorkspaceRegistry,
+    cwd: &str,
+    task: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<AgentWorktreeResult> {
+    let cwd = canonical_dir(registry, cwd, workspace)?;
+    if !registry.is_authorized(&cwd.local_path) {
+        return Err(GitError::PathOutsideWorkspace(cwd.local_path));
+    }
+    ensure_git_available(&cwd.workspace)?;
+    let Some(root_line) = git_stdout_line_opt(
+        &cwd.workspace,
+        &cwd.git_path,
+        ["rev-parse", "--show-toplevel"],
+    )?
+    else {
+        return Err(GitError::command(
+            "agent worktree",
+            "current directory is not inside a git repository",
+        ));
+    };
+    let repo_root = canonical_dir(registry, &root_line, &cwd.workspace)?;
+    let _ = registry.authorize(&repo_root.local_path);
+
+    let base_branch = git_stdout_line_opt(
+        &repo_root.workspace,
+        &repo_root.git_path,
+        ["branch", "--show-current"],
+    )?
+    .filter(|branch| !branch.is_empty())
+    .unwrap_or_else(|| "HEAD".into());
+
+    let task = branch_component_or(task, "task");
+    let stamp = epoch_millis();
+    let branch = format!("terax/agent/claude/{task}-{stamp}");
+    let leaf_dir = format!("claude-{task}-{stamp}");
+    let (worktree_git_path, worktree_local_path) = worktree_destination(&repo_root, &leaf_dir)?;
+
+    if worktree_local_path.exists() {
+        return Err(GitError::command(
+            "agent worktree",
+            "worktree destination already exists",
+        ));
+    }
+    if let Some(parent) = worktree_local_path.parent() {
+        std::fs::create_dir_all(parent).map_err(GitError::Io)?;
+    }
+
+    let args: Vec<OsString> = vec![
+        "worktree".into(),
+        "add".into(),
+        "-b".into(),
+        branch.clone().into(),
+        worktree_git_path.clone().into(),
+        "HEAD".into(),
+    ];
+    let output = run_git(
+        &repo_root.workspace,
+        Some(&repo_root.git_path),
+        args,
+        DEFAULT_TIMEOUT_SECS,
+    )?;
+    ensure_success(&output, "git worktree add failed")?;
+
+    let canonical_worktree = registry
+        .authorize(&worktree_local_path)
+        .map_err(GitError::Io)?;
+    let path = if repo_root.workspace.is_wsl() {
+        worktree_git_path
+    } else {
+        display_path(&canonical_worktree)
+    };
+
+    Ok(AgentWorktreeResult {
+        source_repo_root: repo_root.git_path,
+        path,
+        branch,
+        base_branch,
+    })
 }
 
 fn resolve_repo_in_authorized(
@@ -77,6 +161,80 @@ fn resolve_repo_in_authorized(
         upstream,
         is_detached: head == "HEAD",
     }))
+}
+
+fn worktree_destination(
+    repo_root: &ResolvedGitDirectory,
+    leaf_dir: &str,
+) -> Result<(String, PathBuf)> {
+    let repo_name = repo_root
+        .local_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(sanitize_branch_component)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "repo".into());
+    let local_parent = repo_root.local_path.parent().ok_or_else(|| {
+        GitError::command("agent worktree", "repository root has no parent directory")
+    })?;
+    let local_path = local_parent
+        .join(format!("{repo_name}.terax-worktrees"))
+        .join(leaf_dir);
+
+    let git_parent = git_path_parent(&repo_root.git_path).ok_or_else(|| {
+        GitError::command("agent worktree", "repository root has no parent directory")
+    })?;
+    let git_path = format!(
+        "{}/{repo_name}.terax-worktrees/{}",
+        git_parent.trim_end_matches('/'),
+        leaf_dir
+    );
+    Ok((git_path, local_path))
+}
+
+fn git_path_parent(path: &str) -> Option<&str> {
+    let trimmed = path.trim_end_matches('/');
+    trimmed.rsplit_once('/').map(|(parent, _)| parent)
+}
+
+fn sanitize_branch_component(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len().min(48));
+    let mut last_dash = false;
+    for ch in raw.chars().flat_map(char::to_lowercase) {
+        let keep = ch.is_ascii_alphanumeric();
+        if keep {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+        if out.len() >= 48 {
+            break;
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "task".into()
+    } else {
+        trimmed
+    }
+}
+
+fn branch_component_or(raw: &str, fallback: &str) -> String {
+    let cleaned = sanitize_branch_component(raw);
+    if cleaned == "task" && raw.trim().is_empty() {
+        fallback.into()
+    } else {
+        cleaned
+    }
+}
+
+fn epoch_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
 }
 
 pub fn panel_snapshot(
@@ -313,12 +471,7 @@ pub fn unstage(
     if !looks_like_no_head(&output) {
         return ensure_success(&output, "git reset failed");
     }
-    let mut rm_args: Vec<OsString> = vec![
-        "rm".into(),
-        "--cached".into(),
-        "-r".into(),
-        "--".into(),
-    ];
+    let mut rm_args: Vec<OsString> = vec!["rm".into(), "--cached".into(), "-r".into(), "--".into()];
     for p in &resolved {
         rm_args.push(p.clone().into());
     }
@@ -1021,6 +1174,23 @@ mod tests {
     #[test]
     fn parse_shortstat_returns_zeros_when_absent() {
         assert_eq!(parse_shortstat("no stat here"), (0, 0, 0));
+    }
+
+    #[test]
+    fn sanitize_branch_component_produces_safe_slug() {
+        assert_eq!(
+            sanitize_branch_component("Fix PR comments: fetch threads!"),
+            "fix-pr-comments-fetch-threads"
+        );
+        assert_eq!(sanitize_branch_component("../weird.lock"), "weird-lock");
+        assert_eq!(sanitize_branch_component(""), "task");
+    }
+
+    #[test]
+    fn git_path_parent_uses_forward_slash_paths() {
+        assert_eq!(git_path_parent("/home/me/repo"), Some("/home/me"));
+        assert_eq!(git_path_parent("C:/Users/me/repo"), Some("C:/Users/me"));
+        assert_eq!(git_path_parent("/"), None);
     }
 
     #[test]

--- a/src-tauri/src/modules/git/types.rs
+++ b/src-tauri/src/modules/git/types.rs
@@ -18,6 +18,15 @@ pub struct GitRepoInfo {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AgentWorktreeResult {
+    pub source_repo_root: String,
+    pub path: String,
+    pub branch: String,
+    pub base_branch: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GitChangedFile {
     pub path: String,
     pub original_path: Option<String>,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -120,6 +120,11 @@ import type { PanelImperativeHandle } from "react-resizable-panels";
 
 type TuiWaitResult = "ready" | "gone" | "timeout";
 
+function shortBranchName(branch: string): string {
+  const parts = branch.split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? branch;
+}
+
 async function waitForClaudeTuiReady(
   readBuf: () => string | null,
   timeoutMs = 8000,
@@ -1288,16 +1293,41 @@ export default function App() {
         openPreviewTab(url);
         return true;
       },
-      spawnManagedAgent: (prompt: string, sessionId: string) => {
+      spawnManagedAgent: async (prompt: string, sessionId: string) => {
         const trimmed = prompt.trim();
         if (!trimmed) return null;
         const oneLine = trimmed.replace(/\s*\r?\n\s*/g, " ");
         const cwd = findCwd();
-        const short = oneLine.length > 32 ? `${oneLine.slice(0, 32)}…` : oneLine;
-        const { tabId, leafId } = newAgentTab(cwd ?? undefined, `claude · ${short}`);
+        let launchCwd = cwd;
+        let worktreeBranch: string | null = null;
+        if (usePreferencesStore.getState().agentWorktreeIsolation) {
+          if (!cwd) {
+            console.warn(
+              "[terax] agent worktree isolation needs an active workspace cwd",
+            );
+            return null;
+          }
+          try {
+            const worktree = await native.gitCreateAgentWorktree({
+              cwd,
+              task: oneLine,
+            });
+            launchCwd = worktree.path;
+            worktreeBranch = worktree.branch;
+          } catch (e) {
+            console.warn("[terax] agent worktree creation failed", e);
+            return null;
+          }
+        }
+        const short =
+          oneLine.length > 32 ? `${oneLine.slice(0, 29)}...` : oneLine;
+        const title = worktreeBranch
+          ? `claude - ${shortBranchName(worktreeBranch)}`
+          : `claude - ${short}`;
+        const { tabId, leafId } = newAgentTab(launchCwd ?? undefined, title);
         useManagedAgentsStore
           .getState()
-          .register({ leafId, tabId, sessionId, task: oneLine, cwd });
+          .register({ leafId, tabId, sessionId, task: oneLine, cwd: launchCwd });
         const hooksReady = invoke("agent_enable_claude_hooks").catch(() => {});
         void (async () => {
           await Promise.all([whenSessionReady(leafId), hooksReady]);

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -44,6 +44,13 @@ export type GitRepoInfo = {
   isDetached: boolean;
 };
 
+export type AgentWorktreeResult = {
+  sourceRepoRoot: string;
+  path: string;
+  branch: string;
+  baseBranch: string;
+};
+
 export type GitChangedFile = {
   path: string;
   originalPath: string | null;
@@ -248,6 +255,12 @@ export const native = {
   gitResolveRepo: (cwd: string) =>
     invoke<GitRepoInfo | null>("git_resolve_repo", {
       cwd,
+      workspace: currentWorkspaceEnv(),
+    }),
+  gitCreateAgentWorktree: (params: { cwd: string; task: string }) =>
+    invoke<AgentWorktreeResult>("git_create_agent_worktree", {
+      cwd: params.cwd,
+      task: params.task,
       workspace: currentWorkspaceEnv(),
     }),
   gitPanelSnapshot: (cwd: string) =>

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -46,7 +46,7 @@ type Live = {
   spawnManagedAgent: (
     prompt: string,
     sessionId: string,
-  ) => { tabId: number; leafId: number } | null;
+  ) => Promise<{ tabId: number; leafId: number } | null>;
   readLeafBuffer: (leafId: number) => string | null;
 };
 
@@ -169,7 +169,7 @@ const NOOP_LIVE: Live = {
   getWorkspaceRoot: () => null,
   getActiveFile: () => null,
   openPreview: () => false,
-  spawnManagedAgent: () => null,
+  spawnManagedAgent: async () => null,
   readLeafBuffer: () => null,
 };
 

--- a/src/modules/ai/tools/agent.ts
+++ b/src/modules/ai/tools/agent.ts
@@ -46,7 +46,7 @@ export function buildManagedAgentTools(ctx: ToolContext) {
               "a Claude Code agent is already active in this session; use send_to_agent to give it more work",
           };
         }
-        const spawned = ctx.spawnAgent(prompt);
+        const spawned = await ctx.spawnAgent(prompt);
         if (!spawned) return { error: "could not spawn the agent" };
         return {
           ok: true,

--- a/src/modules/ai/tools/context.ts
+++ b/src/modules/ai/tools/context.ts
@@ -14,7 +14,9 @@ export type ToolContext = {
   /** Open a new preview tab (in-app iframe) at the given URL. */
   openPreview: (url: string) => boolean;
   /** Spawn a Claude Code agent in a new terminal tab, bound to this session. */
-  spawnAgent: (prompt: string) => { tabId: number; leafId: number } | null;
+  spawnAgent: (
+    prompt: string,
+  ) => Promise<{ tabId: number; leafId: number } | null>;
   /** Read the terminal scrollback tail of a managed agent's leaf. */
   readAgentOutput: (leafId: number) => string | null;
   readCache: Map<string, { size: number; hash: number }>;

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -87,6 +87,7 @@ export type Preferences = {
   lastWslDistro: string | null;
   zoomLevel: number;
   agentNotifications: boolean;
+  agentWorktreeIsolation: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
   editorAutoSave: boolean;
   editorAutoSaveDelay: number;
@@ -131,6 +132,7 @@ const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
+const KEY_AGENT_WORKTREE_ISOLATION = "agentWorktreeIsolation";
 const KEY_SHORTCUTS = "shortcuts";
 const KEY_EDITOR_AUTO_SAVE = "editorAutoSave";
 const KEY_EDITOR_AUTO_SAVE_DELAY = "editorAutoSaveDelay";
@@ -188,6 +190,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   lastWslDistro: null,
   zoomLevel: 1.0,
   agentNotifications: true,
+  agentWorktreeIsolation: false,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
   editorAutoSave: false,
   editorAutoSaveDelay: 1000,
@@ -320,6 +323,9 @@ export async function loadPreferences(): Promise<Preferences> {
     agentNotifications:
       get<boolean>(KEY_AGENT_NOTIFICATIONS) ??
       DEFAULT_PREFERENCES.agentNotifications,
+    agentWorktreeIsolation:
+      get<boolean>(KEY_AGENT_WORKTREE_ISOLATION) ??
+      DEFAULT_PREFERENCES.agentWorktreeIsolation,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -533,6 +539,12 @@ export async function setAgentNotifications(value: boolean): Promise<void> {
   await writePref(KEY_AGENT_NOTIFICATIONS, value);
 }
 
+export async function setAgentWorktreeIsolation(
+  value: boolean,
+): Promise<void> {
+  await writePref(KEY_AGENT_WORKTREE_ISOLATION, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {},
 ): Promise<void> {
@@ -587,6 +599,7 @@ export async function onPreferencesChange(
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
+    [KEY_AGENT_WORKTREE_ISOLATION]: "agentWorktreeIsolation",
     [KEY_SHORTCUTS]: "shortcuts",
     [KEY_EDITOR_AUTO_SAVE]: "editorAutoSave",
     [KEY_EDITOR_AUTO_SAVE_DELAY]: "editorAutoSaveDelay",

--- a/src/settings/sections/AgentsSection.tsx
+++ b/src/settings/sections/AgentsSection.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { AGENT_ICONS } from "@/modules/ai/components/AgentSwitcher";
@@ -26,7 +27,10 @@ import {
   useSnippetsStore,
 } from "@/modules/ai/store/snippetsStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import { setCustomInstructions } from "@/modules/settings/store";
+import {
+  setAgentWorktreeIsolation,
+  setCustomInstructions,
+} from "@/modules/settings/store";
 import {
   Add01Icon,
   CheckmarkCircle02Icon,
@@ -37,6 +41,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useRef, useState } from "react";
 import { SectionHeader } from "../components/SectionHeader";
+import { SettingRow } from "../components/SettingRow";
 
 const ICON_OPTIONS: AgentIconId[] = [
   "coder",
@@ -49,6 +54,9 @@ const ICON_OPTIONS: AgentIconId[] = [
 
 export function AgentsSection() {
   const customInstructions = usePreferencesStore((s) => s.customInstructions);
+  const agentWorktreeIsolation = usePreferencesStore(
+    (s) => s.agentWorktreeIsolation,
+  );
   const customAgents = useAgentsStore((s) => s.customAgents);
   const activeAgentId = useAgentsStore((s) => s.activeId);
   const setActiveAgentId = useAgentsStore((s) => s.setActiveId);
@@ -77,6 +85,19 @@ export function AgentsSection() {
       />
 
       <CustomInstructionsBlock value={customInstructions} />
+
+      <section className="flex flex-col gap-2">
+        <Label>Runtime</Label>
+        <SettingRow
+          title="Isolated worktrees"
+          description="Start each Claude Code run in a fresh git worktree and branch so the main checkout stays untouched."
+        >
+          <Switch
+            checked={agentWorktreeIsolation}
+            onCheckedChange={(v) => void setAgentWorktreeIsolation(v)}
+          />
+        </SettingRow>
+      </section>
 
       <section className="flex flex-col gap-2">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- add a Settings -> Agents toggle for isolated Claude Code worktrees
- create a backend git command that provisions a fresh branch and git worktree under a sibling .terax-worktrees directory
- launch managed Claude Code terminals directly inside the isolated worktree when enabled

## Validation
- pnpm exec tsc --noEmit
- pnpm test
- cargo test --locked
- git diff --check

## Note
- cargo fmt --check currently reports formatting drift in unrelated Rust files already present on the base tree.