### PR TITLE
fix(terminal): add missing context menu items to file search results

### DIFF
--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -25,7 +25,7 @@ import {
 } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { fileIconUrl } from "./lib/iconResolver";
-import { copyToClipboard, revealInFinder } from "./lib/contextActions";
+import { copyToClipboard, relativePath, revealInFinder } from "./lib/contextActions";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { cn } from "@/lib/utils";
 
@@ -41,6 +41,10 @@ type SearchResult = {
   truncated: boolean;
 };
 
+function isMarkdownPath(path: string): boolean {
+  return /\.(md|markdown|mdx)$/i.test(path);
+}
+
 const MIN_QUERY_LEN = 2;
 const DEBOUNCE_MS = 300;
 
@@ -52,6 +56,7 @@ type Props = {
   onActiveChange?: (active: boolean) => void;
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
+  onOpenMarkdownPreview?: (path: string) => void;
 };
 
 export type ExplorerSearchHandle = {
@@ -67,6 +72,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   onActiveChange,
   onRevealInTerminal,
   onAttachToAgent,
+  onOpenMarkdownPreview,
 }: Props,
   ref,
 ) {
@@ -283,6 +289,14 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                           Open
                         </ContextMenuItem>
                       )}
+                      {!hit.is_dir && isMarkdownPath(hit.path) && onOpenMarkdownPreview && (
+                        <ContextMenuItem
+                          className={COMPACT_ITEM}
+                          onSelect={() => onOpenMarkdownPreview(hit.path)}
+                        >
+                          Open Preview
+                        </ContextMenuItem>
+                      )}
                       {hit.is_dir && onRevealInTerminal && (
                         <ContextMenuItem
                           className={COMPACT_ITEM}
@@ -303,6 +317,12 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                         onSelect={() => void copyToClipboard(hit.path)}
                       >
                         Copy Path
+                      </ContextMenuItem>
+                      <ContextMenuItem
+                        className={COMPACT_ITEM}
+                        onSelect={() => void copyToClipboard(relativePath(rootPath, hit.path))}
+                      >
+                        Copy Relative Path
                       </ContextMenuItem>
                       <ContextMenuSeparator />
                       <ContextMenuItem

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -433,6 +433,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
           onActiveChange={setIsSearchActive}
           onRevealInTerminal={onRevealInTerminal}
           onAttachToAgent={onAttachToAgent}
+          onOpenMarkdownPreview={onOpenMarkdownPreview}
         />
 
         {!isSearchActive ? (


### PR DESCRIPTION
The right-click context menu on file search results was missing two items that are available in the file tree:
  1. Open Preview — not available for .md / .markdown / .mdx files
  2. Copy Relative Path — not available for any file

before fix:
<img width="1818" height="722" alt="0ea6382364c84af577717aba6792e3e5" src="https://github.com/user-attachments/assets/475dae1f-9cf7-4063-b561-9c917d930be4" />

after fix:
<img width="1590" height="710" alt="4f6614ba374c82592ff9ba3d6da789d6" src="https://github.com/user-attachments/assets/9b9de0be-2b9d-49b4-9b1a-1beace240f35" />