### PR TITLE
fix(explorer): open files in default app

### DIFF
--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -7,6 +7,8 @@ import {
 } from "@codemirror/search";
 import { keymap } from "@codemirror/view";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { Button } from "@/components/ui/button";
+import { openPath } from "@tauri-apps/plugin-opener";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { EDITOR_THEME_EXT } from "./lib/themes";
 import {
@@ -283,11 +285,19 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     }
     if (doc.status === "binary") {
       return (
-        <div className="flex h-full flex-col items-center justify-center gap-1 px-6 text-center">
+        <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
           <div className="text-sm text-foreground">Binary file</div>
           <div className="text-xs text-muted-foreground">
             {formatBytes(doc.size)} · preview not supported
           </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void openPath(path)}
+            className="h-8 px-3 text-[11px]"
+          >
+            Open in Default App
+          </Button>
         </div>
       );
     }

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -25,7 +25,11 @@ import {
 } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { fileIconUrl } from "./lib/iconResolver";
-import { copyToClipboard, revealInFinder } from "./lib/contextActions";
+import {
+  copyToClipboard,
+  openInDefaultApp,
+  revealInFinder,
+} from "./lib/contextActions";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { cn } from "@/lib/utils";
 
@@ -281,6 +285,14 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                           onSelect={() => onOpenFile(hit.path)}
                         >
                           Open
+                        </ContextMenuItem>
+                      )}
+                      {!hit.is_dir && (
+                        <ContextMenuItem
+                          className={COMPACT_ITEM}
+                          onSelect={() => void openInDefaultApp(hit.path)}
+                        >
+                          Open in Default App
                         </ContextMenuItem>
                       )}
                       {hit.is_dir && onRevealInTerminal && (

--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -12,6 +12,7 @@ import { memo, useState } from "react";
 import { InlineInput } from "./InlineInput";
 import {
   copyToClipboard,
+  openInDefaultApp,
   relativePath,
   revealInFinder,
 } from "./lib/contextActions";
@@ -148,6 +149,14 @@ function EntryRowImpl(props: EntryRowProps) {
             Open Preview
           </ContextMenuItem>
         )}
+        {!isDir && (
+          <ContextMenuItem
+            className={COMPACT_ITEM}
+            onSelect={() => void openInDefaultApp(path)}
+          >
+            Open in Default App
+          </ContextMenuItem>
+        )}
         {isDir && onRevealInTerminal && (
           <ContextMenuItem
             className={COMPACT_ITEM}
@@ -187,6 +196,13 @@ function EntryRowImpl(props: EntryRowProps) {
           onSelect={() => void copyToClipboard(relativePath(rootPath, path))}
         >
           Copy Relative Path
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          className={COMPACT_ITEM}
+          onSelect={() => tree.beginRename(path)}
+        >
+          Rename
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem

--- a/src/modules/explorer/lib/contextActions.ts
+++ b/src/modules/explorer/lib/contextActions.ts
@@ -1,4 +1,4 @@
-import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
 
 export async function copyToClipboard(text: string): Promise<void> {
   try {
@@ -19,5 +19,13 @@ export async function revealInFinder(path: string): Promise<void> {
     await revealItemInDir(path);
   } catch (e) {
     console.error("revealItemInDir failed:", e);
+  }
+}
+
+export async function openInDefaultApp(path: string): Promise<void> {
+  try {
+    await openPath(path);
+  } catch (e) {
+    console.error("openPath failed:", e);
   }
 }


### PR DESCRIPTION
## Summary
- add Open in Default App actions for file tree and search result context menus
- add an Open in Default App button when the editor hits an unsupported binary file
- expose Rename in the file tree context menu using the existing inline rename flow

## Why
Binary files currently stop at a preview-not-supported state, and users have to leave Terax to open them with the OS default app. Issue #588 also notes that Rename is hard to discover from the context menu.

## Validation
- pnpm exec tsc --noEmit
- pnpm test
- pnpm build

Closes #588