### PR TITLE
fix(explorer): open files on double click

### DIFF
--- a/src/modules/explorer/TreeRow.tsx
+++ b/src/modules/explorer/TreeRow.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { cn } from "@/lib/utils";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useState } from "react";
@@ -61,6 +62,9 @@ function EntryRowImpl(props: EntryRowProps) {
   } = props;
 
   const [isConfirming, setIsConfirming] = useState(false);
+  const doubleClickAction = usePreferencesStore(
+    (s) => s.explorerDoubleClickAction,
+  );
   const iconUrl = isDir ? folderIconUrl(name, isExpanded) : fileIconUrl(name);
   const createTarget = isDir ? path : path.slice(0, path.lastIndexOf("/")) || rootPath;
   const paddingLeft = 6 + depth * 12;
@@ -97,7 +101,11 @@ function EntryRowImpl(props: EntryRowProps) {
             type="button"
             data-fs-path={path}
             onClick={handleClick}
-            onDoubleClick={() => !isDir && tree.beginRename(path)}
+            onDoubleClick={() => {
+              if (isDir) return;
+              if (doubleClickAction === "rename") tree.beginRename(path);
+              else onOpenFile(path, true);
+            }}
             className={cn(
               "group flex h-6 w-full min-w-0 cursor-pointer items-center gap-2 rounded-sm px-1.5 text-left text-[13px] text-foreground/85 transition-colors hover:bg-accent/70",
               isSelected && "bg-accent text-foreground",
@@ -187,6 +195,13 @@ function EntryRowImpl(props: EntryRowProps) {
           onSelect={() => void copyToClipboard(relativePath(rootPath, path))}
         >
           Copy Relative Path
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          className={COMPACT_ITEM}
+          onSelect={() => tree.beginRename(path)}
+        >
+          Rename
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -20,6 +20,7 @@ export type ThemePref = "system" | "light" | "dark";
 export const DEFAULT_THEME_ID = "terax-default";
 
 export type BackgroundKind = "none" | "image";
+export type ExplorerDoubleClickAction = "open" | "rename";
 
 export const EDITOR_THEMES = [
   "atomone",
@@ -79,6 +80,7 @@ export type Preferences = {
   recentModelIds: string[];
   vimMode: boolean;
   showHidden: boolean;
+  explorerDoubleClickAction: ExplorerDoubleClickAction;
   terminalWebglEnabled: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
@@ -123,6 +125,7 @@ const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
+const KEY_EXPLORER_DOUBLE_CLICK_ACTION = "explorerDoubleClickAction";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
@@ -180,6 +183,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   recentModelIds: [],
   vimMode: false,
   showHidden: false,
+  explorerDoubleClickAction: "open",
   terminalWebglEnabled: true,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
@@ -297,6 +301,9 @@ export async function loadPreferences(): Promise<Preferences> {
       get<boolean>(KEY_SHOW_HIDDEN) ??
       get<boolean>(LEGACY_KEY_SHOW_HIDDEN_DIRS) ??
       DEFAULT_PREFERENCES.showHidden,
+    explorerDoubleClickAction: parseExplorerDoubleClickAction(
+      get<string>(KEY_EXPLORER_DOUBLE_CLICK_ACTION),
+    ),
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
@@ -473,6 +480,20 @@ export async function setShowHidden(value: boolean): Promise<void> {
   await writePref(KEY_SHOW_HIDDEN, value);
 }
 
+function parseExplorerDoubleClickAction(
+  value: string | undefined,
+): ExplorerDoubleClickAction {
+  return value === "rename"
+    ? "rename"
+    : DEFAULT_PREFERENCES.explorerDoubleClickAction;
+}
+
+export async function setExplorerDoubleClickAction(
+  value: ExplorerDoubleClickAction,
+): Promise<void> {
+  await writePref(KEY_EXPLORER_DOUBLE_CLICK_ACTION, value);
+}
+
 export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
 }
@@ -579,6 +600,7 @@ export async function onPreferencesChange(
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",
     [KEY_SHOW_HIDDEN]: "showHidden",
+    [KEY_EXPLORER_DOUBLE_CLICK_ACTION]: "explorerDoubleClickAction",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -24,6 +24,7 @@ import {
   setAutostart,
   setEditorAutoSave,
   setEditorAutoSaveDelay,
+  setExplorerDoubleClickAction,
   setRestoreWindowState,
   setShowHidden,
   setTerminalFontFamily,
@@ -73,6 +74,9 @@ export function GeneralSection() {
   const editorAutoSave = usePreferencesStore((s) => s.editorAutoSave);
   const editorAutoSaveDelay = usePreferencesStore((s) => s.editorAutoSaveDelay);
   const showHidden = usePreferencesStore((s) => s.showHidden);
+  const explorerDoubleClickAction = usePreferencesStore(
+    (s) => s.explorerDoubleClickAction,
+  );
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
   );
@@ -202,6 +206,31 @@ export function GeneralSection() {
             checked={showHidden}
             onCheckedChange={(v) => void setShowHidden(v)}
           />
+        </SettingRow>
+        <SettingRow
+          title="Double-click file"
+          description="Choose whether double-clicking a file opens it permanently or starts rename."
+        >
+          <Select
+            value={explorerDoubleClickAction}
+            onValueChange={(v) =>
+              void setExplorerDoubleClickAction(
+                v === "rename" ? "rename" : "open",
+              )
+            }
+          >
+            <SelectTrigger size="sm" className="h-8 w-32 text-[12px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="open" className="text-[12px]">
+                Open
+              </SelectItem>
+              <SelectItem value="rename" className="text-[12px]">
+                Rename
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </SettingRow>
       </div>
 
@@ -418,4 +447,3 @@ function AutoSaveDelayInput({
     </SettingRow>
   );
 }
-


### PR DESCRIPTION
## Summary
- make file-row double-click open a persistent editor tab by default
- add a General → Explorer preference to choose whether double-click opens or renames files
- add an explicit Rename context-menu action so rename remains discoverable

## Why
The explorer already uses single-click for preview tabs. Double-clicking a file currently starts rename, which conflicts with common file navigator behavior and issue #541. The setting keeps the old behavior available for users who prefer it.

## Validation
- pnpm exec tsc --noEmit
- pnpm test
- pnpm build

Closes #541