### PR TITLE
fix(explorer): highlight active file

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -943,6 +943,10 @@ export default function App() {
     }
     return null;
   })();
+  const explorerActiveFilePath =
+    activeTab?.kind === "editor" || activeTab?.kind === "markdown"
+      ? activeTab.path
+      : null;
   const workspaceFallbackPath = launchCwdResolved
     ? (launchCwd ?? home ?? null)
     : null;
@@ -1492,6 +1496,7 @@ export default function App() {
                       <FileExplorer
                         ref={explorerRef}
                         rootPath={explorerRoot}
+                        activeFilePath={explorerActiveFilePath}
                         onOpenFile={handleOpenFile}
                         onPathRenamed={handlePathRenamed}
                         onPathDeleted={handlePathDeleted}

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -40,6 +40,7 @@ export type FileExplorerHandle = {
 
 type Props = {
   rootPath: string | null;
+  activeFilePath?: string | null;
   onOpenFile: (path: string, pin?: boolean) => void;
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
@@ -147,6 +148,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
   function FileExplorer(
     {
       rootPath,
+      activeFilePath,
       onOpenFile,
       onPathRenamed,
       onPathDeleted,
@@ -197,6 +199,12 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       },
       [entryIndexByPath, virtualizer],
     );
+
+    useEffect(() => {
+      if (!activeFilePath || !entryIndexByPath.has(activeFilePath)) return;
+      setSelectedPath(activeFilePath);
+      requestAnimationFrame(() => scrollEntryIntoView(activeFilePath));
+    }, [activeFilePath, entryIndexByPath, scrollEntryIntoView]);
 
     useImperativeHandle(
       ref,

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -200,8 +200,13 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
       [entryIndexByPath, virtualizer],
     );
 
+    const lastSyncedActivePathRef = useRef<string | null>(null);
     useEffect(() => {
-      if (!activeFilePath || !entryIndexByPath.has(activeFilePath)) return;
+      if (!activeFilePath || activeFilePath === lastSyncedActivePathRef.current) {
+        return;
+      }
+      if (!entryIndexByPath.has(activeFilePath)) return;
+      lastSyncedActivePathRef.current = activeFilePath;
       setSelectedPath(activeFilePath);
       requestAnimationFrame(() => scrollEntryIntoView(activeFilePath));
     }, [activeFilePath, entryIndexByPath, scrollEntryIntoView]);


### PR DESCRIPTION
## Summary
- pass the active editor/markdown path into the file explorer
- select and scroll the matching visible tree row when that active file is present

## Why
When working in an editor tab, the explorer did not reflect which file was currently active unless it had been selected directly in the tree. This makes it harder to orient in larger projects.

## Validation
- pnpm exec tsc --noEmit
- pnpm test
- pnpm build

Closes #562