### PR TITLE
fix(terminal): reconstruct Hangul/CJK IME input on macOS WKWebView

### DIFF
--- a/src/modules/terminal/lib/ime.test.ts
+++ b/src/modules/terminal/lib/ime.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { imeReconstruct } from "./ime";
+
+// Apply a PTY byte stream (text + DEL erases) to a line buffer the way a line
+// editor would, so a sequence of steps can be asserted against the final line.
+function applyToLine(line: string, send: string): string {
+  const buf = [...line];
+  for (const ch of send) {
+    if (ch === "\x7f") buf.pop();
+    else buf.push(ch);
+  }
+  return buf.join("");
+}
+
+describe("imeReconstruct", () => {
+  it("appends a new unit on insertText", () => {
+    expect(imeReconstruct("", "insertText", "ㅇ")).toEqual({
+      send: "ㅇ",
+      unit: "ㅇ",
+    });
+  });
+
+  it("erases the previous unit and resends on insertReplacementText", () => {
+    expect(imeReconstruct("ㅇ", "insertReplacementText", "아")).toEqual({
+      send: "\x7f아",
+      unit: "아",
+    });
+  });
+
+  it("treats insertCompositionText like insertText", () => {
+    expect(imeReconstruct("", "insertCompositionText", "x")).toEqual({
+      send: "x",
+      unit: "x",
+    });
+  });
+
+  it("erases the previous unit on delete, leaving an empty unit", () => {
+    expect(imeReconstruct("녕", "deleteContentBackward", "")).toEqual({
+      send: "\x7f",
+      unit: "",
+    });
+  });
+
+  it("always erases at least one code point on delete", () => {
+    expect(imeReconstruct("", "deleteContentBackward", "")).toEqual({
+      send: "\x7f",
+      unit: "",
+    });
+  });
+
+  it("ignores empty insert data and unknown input types", () => {
+    expect(imeReconstruct("a", "insertText", "")).toBeNull();
+    expect(imeReconstruct("a", "insertFromPaste", "p")).toBeNull();
+    expect(imeReconstruct("a", "historyUndo", "")).toBeNull();
+  });
+
+  // The end-to-end invariant: replaying the WKWebView event trace for a word
+  // must reconstruct exactly that word on the PTY line, with no leaked jamo.
+  it("reconstructs '안녕' from the WKWebView event trace", () => {
+    const trace: Array<[string, string]> = [
+      ["insertText", "ㅇ"],
+      ["insertReplacementText", "아"],
+      ["insertReplacementText", "안"],
+      ["insertReplacementText", "안"],
+      ["insertText", "ㄴ"],
+      ["insertReplacementText", "녀"],
+      ["insertReplacementText", "녕"],
+      ["insertReplacementText", "녕"],
+    ];
+    let unit = "";
+    let line = "";
+    for (const [type, data] of trace) {
+      const step = imeReconstruct(unit, type, data);
+      if (!step) continue;
+      line = applyToLine(line, step.send);
+      unit = step.unit;
+    }
+    expect(line).toBe("안녕");
+  });
+});

--- a/src/modules/terminal/lib/ime.ts
+++ b/src/modules/terminal/lib/ime.ts
@@ -1,0 +1,28 @@
+// Pure core for the macOS WKWebView IME reconstruction (see attachImeInput in
+// rendererPool). Given the last committed input unit and a DOM InputEvent
+// (inputType + data), it returns the bytes to write to the PTY and the new
+// unit. A new unit is appended; a replacement erases the previous unit (one
+// DEL per code point) and resends; a delete erases the previous unit.
+export type ImeStep = { send: string; unit: string };
+
+const DEL = "\x7f";
+const cpLen = (s: string): number => [...s].length;
+
+export function imeReconstruct(
+  unit: string,
+  inputType: string,
+  data: string,
+): ImeStep | null {
+  if (inputType === "insertReplacementText") {
+    if (!data) return null;
+    return { send: DEL.repeat(cpLen(unit)) + data, unit: data };
+  }
+  if (inputType === "insertText" || inputType === "insertCompositionText") {
+    if (!data) return null;
+    return { send: data, unit: data };
+  }
+  if (inputType.startsWith("delete")) {
+    return { send: DEL.repeat(Math.max(1, cpLen(unit))), unit: "" };
+  }
+  return null;
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -8,6 +8,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { imeReconstruct } from "./ime";
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
@@ -55,6 +56,10 @@ export type Slot = {
   lastW: number;
   lastH: number;
   lastUsedAt: number;
+  // IME reconstruction state (see attachImeInput).
+  imeNative: boolean;
+  imeInputActive: boolean;
+  imeUnit: string;
 };
 
 const slots: Slot[] = [];
@@ -117,6 +122,51 @@ export function applyBackgroundActive(active: boolean): void {
   }
 }
 
+// macOS WKWebView fires no composition events for Hangul/CJK IME and delivers
+// it only as input events with isComposing always false: a syllable opens with
+// insertText, then composes through insertReplacementText. xterm forwards the
+// insertText (leaking the leading jamo) and ignores insertReplacementText
+// (dropping the composed syllable), so Hangul reaches the PTY broken. Rebuild
+// the stream from the inputType: append a new unit, or erase the previous unit
+// and resend on a replacement. Chromium webviews (Windows) fire real
+// composition events that xterm already handles, so defer to it once a
+// compositionstart is seen. Paste and drop keep xterm's own (bracketed) path.
+function attachImeInput(slot: Slot): void {
+  const ta = slot.host.querySelector(
+    ".xterm-helper-textarea",
+  ) as HTMLTextAreaElement | null;
+  if (!ta) return;
+  const write = (data: string) => {
+    const leafId = slot.currentLeafId;
+    if (leafId === null) return;
+    adapter?.resolveLeaf(leafId)?.writeToPty(data);
+  };
+  const intercepts = (type: string) =>
+    type === "insertText" ||
+    type === "insertReplacementText" ||
+    type === "insertCompositionText" ||
+    type.startsWith("delete");
+  ta.addEventListener("compositionstart", () => {
+    slot.imeNative = true;
+  });
+  ta.addEventListener(
+    "beforeinput",
+    (e) => {
+      if (intercepts((e as InputEvent).inputType)) slot.imeInputActive = true;
+    },
+    true,
+  );
+  ta.addEventListener("input", (e) => {
+    slot.imeInputActive = false;
+    if (slot.imeNative) return;
+    const ev = e as InputEvent;
+    const step = imeReconstruct(slot.imeUnit, ev.inputType, ev.data ?? "");
+    if (!step) return;
+    if (step.send) write(step.send);
+    slot.imeUnit = step.unit;
+  });
+}
+
 function createSlot(): Slot {
   const term = new Terminal(termOptions());
   const fitAddon = new FitAddon();
@@ -155,19 +205,25 @@ function createSlot(): Slot {
     lastW: 0,
     lastH: 0,
     lastUsedAt: 0,
+    imeNative: false,
+    imeInputActive: false,
+    imeUnit: "",
   };
 
   attachWebgl(slot);
+  attachImeInput(slot);
 
   term.attachCustomKeyEventHandler((event) => {
     // During IME composition the browser is assembling a multi-keystroke
-    // character (Chinese pinyin → hanzi, Korean jamo → syllable, etc.).
-    // Raw keydown events — including the Enter that commits a candidate —
-    // must NOT be forwarded to the PTY; xterm will receive the final
-    // composed string through its own compositionend handler instead.
-    // keyCode 229 ("Process") is what Chromium reports for every key
-    // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // character (Chinese pinyin to hanzi, Korean jamo to syllable, etc.).
+    // Returning false makes xterm's _keyDown bail out before it reaches
+    // CompositionHelper.keydown(), which corrupts the composition state
+    // machine and leaks half-formed jamo straight to the PTY. Return true
+    // so the CompositionHelper owns the composition and emits only the
+    // final committed string through onData. keyCode 229 ("Process") is
+    // what Chromium reports for keys pressed inside an active IME session
+    // before isComposing flips to true.
+    if (event.isComposing || event.keyCode === 229) return true;
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;
@@ -222,6 +278,12 @@ function createSlot(): Slot {
   });
 
   term.onData((data) => {
+    // On the macOS WKWebView IME path (attachImeInput) the input event
+    // reconstructs the data itself, so xterm's own onData for that same
+    // event would double-send and leak partial jamo. Drop it while an
+    // input event is in flight, but never on the native-composition path.
+    if (slot.imeInputActive && !slot.imeNative) return;
+    if (data === "\r" || data === "\n") slot.imeUnit = "";
     const leafId = slot.currentLeafId;
     if (leafId === null) return;
     adapter?.resolveLeaf(leafId)?.writeToPty(data);


### PR DESCRIPTION
## Problem

On macOS, typing Hangul into the terminal breaks: each syllable loses its body and only stray jamo reach the shell. For example "안녕" arrives as "ㅇㄴ", and a TUI like Claude Code shows "ㅇ녀".

## Root cause

macOS WKWebView fires **no composition events** for the Hangul IME. Input arrives only as `input` events with `isComposing` always `false`:

```
input insertText            data="ㅇ"   -> xterm onData "ㅇ"  (leaked jamo)
input insertReplacementText data="아"   -> xterm ignores
input insertReplacementText data="안"   -> xterm ignores
input insertText            data="ㄴ"   -> xterm onData "ㄴ"  (leaked jamo)
input insertReplacementText data="녕"   -> xterm ignores
```

xterm's `_inputEvent` forwards `insertText` (the leading jamo) and drops `insertReplacementText` (the composed syllable), so the PTY receives only the jamo and never the finished characters. Chromium-based webviews (Windows WebView2) are unaffected because they fire real composition events that xterm already handles.

## Fix

- Reconstruct the PTY stream from the `inputType` semantics in a pure helper (`ime.ts`): a new unit is appended; a replacement erases the previous unit (one DEL per code point) and resends. So "안녕" is sent as `ㅇ \x7f아 \x7f안 ㄴ \x7f녀 \x7f녕`, which a line editor renders as exactly "안녕".
- Suppress xterm's duplicate `onData` while an input event is in flight (`imeInputActive`).
- Defer to xterm's native composition handling once a `compositionstart` is seen, so Chromium webviews keep their existing behavior.
- Leave paste/drop on xterm's bracketed-paste path.
- Also return `true` (not `false`) from `attachCustomKeyEventHandler` during composition, so xterm's `_keyDown` reaches `CompositionHelper.keydown()` instead of bailing out early.

## Tests

`ime.test.ts` covers each `inputType` and locks the end-to-end invariant: replaying the WKWebView event trace for a word reconstructs exactly that word with no leaked jamo.

Verified manually on macOS (WKWebView): Hangul now composes correctly in the shell and in TUIs (Claude Code), while ASCII, Enter, control keys, and paste are unchanged.

`pnpm exec tsc --noEmit` and `pnpm test` pass (98 tests).