### PR TITLE
feat(terminal): confirm before closing tab with a running process

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_close,
             pty::pty_close_all,
+            pty::pty_has_foreground_process,
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -159,6 +159,44 @@ pub fn pty_close(state: tauri::State<PtyState>, id: u32) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+pub fn pty_has_foreground_process(state: tauri::State<PtyState>, id: u32) -> Result<bool, String> {
+    let sessions = state.sessions.read().unwrap();
+    let session = sessions.get(&id).ok_or_else(|| {
+        log::warn!("pty_has_foreground_process: unknown session id={id}");
+        "no session".to_string()
+    })?;
+    let shell_pid = session.shell_pid;
+    log::debug!("pty_has_foreground_process id={id} shell_pid={shell_pid}");
+    if shell_pid == 0 {
+        return Ok(false);
+    }
+
+    #[cfg(unix)]
+    {
+        // `pgrep -P <ppid>` exits 0 when at least one child of shell_pid
+        // exists, 1 when none — reliable on macOS and Linux without needing
+        // platform-specific syscall constants.
+        let result = std::process::Command::new("pgrep")
+            .args(["-P", &shell_pid.to_string()])
+            .output();
+        match result {
+            Ok(output) => {
+                let has_children = output.status.success();
+                log::debug!("pty_has_foreground_process id={id}: pgrep exit={}, has_children={has_children}", output.status);
+                return Ok(has_children);
+            }
+            Err(e) => {
+                log::warn!("pty_has_foreground_process id={id}: pgrep failed: {e}");
+                return Ok(false);
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    Ok(false)
+}
+
 // A fresh webview load orphans the previous frontend's sessions in this still
 // running process; reap them on boot before any new tab spawns.
 #[tauri::command]

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -44,6 +44,8 @@ pub struct Session {
     //      is dead and conhost has nothing left to drain.
     #[cfg(windows)]
     _job: Option<super::job::PtyJob>,
+    /// PID of the shell process. 0 means unknown; callers must skip checks when 0.
+    pub shell_pid: u32,
     pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
     pub master: Mutex<Box<dyn MasterPty + Send>>,
@@ -130,6 +132,8 @@ pub fn spawn(
     ));
     guard.disarm();
 
+    let shell_pid = child.process_id().unwrap_or(0);
+
     #[cfg(windows)]
     let job = match child.process_id() {
         Some(pid) => match super::job::PtyJob::create_for(pid) {
@@ -145,6 +149,7 @@ pub fn spawn(
     let session = Arc::new(Session {
         #[cfg(windows)]
         _job: job,
+        shell_pid,
         killer: Mutex::new(killer),
         writer: writer.clone(),
         master: Mutex::new(pair.master),
@@ -318,6 +323,7 @@ mod tests {
             Arc::new(Mutex::new(pair.master.take_writer().expect("writer")));
 
         let session = Arc::new(Session {
+            shell_pid: child.process_id().unwrap_or(0),
             killer: Mutex::new(killer),
             writer,
             master: Mutex::new(pair.master),
@@ -365,6 +371,7 @@ mod tests {
             Arc::new(Mutex::new(pair.master.take_writer().expect("writer")));
 
         let session = Arc::new(Session {
+            shell_pid: 0,
             killer: Mutex::new(killer),
             writer,
             master: Mutex::new(pair.master),

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -84,6 +84,7 @@ import {
   disposeSession,
   findLeafCwd,
   hasLeaf,
+  leafHasForegroundProcess,
   leafIds,
   respawnSession,
   TerminalStack,
@@ -322,6 +323,7 @@ export default function App() {
 
   const [home, setHome] = useState<string | null>(null);
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
+  const [pendingTerminalCloseTab, setPendingTerminalCloseTab] = useState<number | null>(null);
   const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
   const [launchCwd, setLaunchCwd] = useState<string | null>(null);
@@ -672,11 +674,19 @@ export default function App() {
   }, [tabs]);
 
   const handleClose = useCallback(
-    (id: number) => {
+    async (id: number) => {
       const t = tabs.find((x) => x.id === id);
       if (t?.kind === "editor" && t.dirty) {
         setPendingCloseTab(id);
         return;
+      }
+      if (t?.kind === "terminal") {
+        const leaves = leafIds(t.paneTree);
+        const checks = await Promise.all(leaves.map(leafHasForegroundProcess));
+        if (checks.some(Boolean)) {
+          setPendingTerminalCloseTab(id);
+          return;
+        }
       }
       disposeTab(id);
     },
@@ -1029,7 +1039,7 @@ export default function App() {
       closeActivePane(activeId);
       return;
     }
-    handleClose(activeId);
+    void handleClose(activeId);
   }, [activeId, closeActivePane, handleClose]);
 
   const shortcutHandlers = useMemo<ShortcutHandlers>(
@@ -1614,6 +1624,36 @@ export default function App() {
                   Cancel
                 </AlertDialogCancel>
                 <AlertDialogAction onClick={confirmClose}>
+                  Close Anyway
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <AlertDialog
+            open={pendingTerminalCloseTab !== null}
+            onOpenChange={(open) => !open && setPendingTerminalCloseTab(null)}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Close Terminal?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  A process is running. Closing this tab will terminate it.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel
+                  onClick={() => setPendingTerminalCloseTab(null)}
+                >
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => {
+                    if (pendingTerminalCloseTab !== null)
+                      disposeTab(pendingTerminalCloseTab);
+                    setPendingTerminalCloseTab(null);
+                  }}
+                >
                   Close Anyway
                 </AlertDialogAction>
               </AlertDialogFooter>

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -3,6 +3,7 @@ export { TerminalStack } from "./TerminalStack";
 export {
   clearFocusedTerminal,
   disposeSession,
+  leafHasForegroundProcess,
   leafIdForPty,
   respawnSession,
   whenSessionReady,

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { ensureMonoFontsLoaded } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -359,6 +360,18 @@ export async function respawnSession(
   }
   s.pty = pty;
   if (s.cols > 0 && s.rows > 0) pty.resize(s.cols, s.rows);
+}
+
+export async function leafHasForegroundProcess(leafId: number): Promise<boolean> {
+  const s = sessions.get(leafId);
+  if (!s?.pty || s.shellExited) return false;
+  try {
+    const result = await invoke<boolean>("pty_has_foreground_process", { id: s.pty.id });
+    return result;
+  } catch (e) {
+    console.error("[terax] pty_has_foreground_process failed for leaf", leafId, e);
+    return false;
+  }
 }
 
 export function disposeSession(leafId: number): void {


### PR DESCRIPTION
## Summary

- When the user closes a terminal tab (× button, middle-click, or Cmd+W) while a child process is running in the shell, Terax now shows a confirmation dialog instead of silently killing everything — matching the behaviour of macOS Terminal and Warp.
- If the shell is idle (just a prompt), the tab closes immediately with no dialog.

## How it works

**Rust (`src-tauri/src/modules/pty/`)**
- `session.rs`: stores `shell_pid: u32` in the `Session` struct at PTY-open time using `child.process_id()`
- `mod.rs`: new `pty_has_foreground_process` Tauri command — runs `pgrep -P <shell_pid>` on Unix to check for live child processes; returns `false` on Windows (no-op)
- `lib.rs`: registers the new command in `invoke_handler`

**TypeScript (`src/`)**
- `useTerminalSession.ts`: exports `leafHasForegroundProcess(leafId)` — maps a leaf ID → PTY session ID and invokes the backend command
- `terminal/index.ts`: re-exports the new helper
- `App.tsx`: `handleClose()` is made async; terminal tabs call `leafHasForegroundProcess` across all panes before disposing; a new `AlertDialog` ("Close Terminal? / A process is running…") offers Cancel / Close Anyway

## Test plan

- [ ] Open a terminal tab, run `sleep 60`, press Cmd+W → dialog appears
- [ ] Click **Cancel** → tab stays open, `sleep` keeps running
- [ ] Click **Close Anyway** → tab closes, process is killed
- [ ] Open a terminal at idle prompt, press Cmd+W → closes immediately, no dialog
- [ ] Open a split-pane tab, run `sleep 60` in one pane, close the tab → dialog appears
- [ ] Run `exit` in shell (shell exits), then press Cmd+W → closes immediately, no dialog

🤖 Generated with [Claude Code](https://claude.ai/claude-code)