### PR TITLE
feat(agents): add Codex CLI notification hooks

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -224,6 +224,8 @@ pub fn run() {
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,
+            agent::agent_enable_codex_hooks,
+            agent::agent_codex_hooks_status,
             secrets::secrets_get,
             secrets::secrets_set,
             secrets::secrets_delete,

--- a/src-tauri/src/modules/agent.rs
+++ b/src-tauri/src/modules/agent.rs
@@ -1,31 +1,125 @@
 use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
 
-const HOOK_EVENTS: [(&str, &str); 3] = [
-    ("UserPromptSubmit", "working"),
-    ("Notification", "attention"),
-    ("Stop", "finished"),
+#[derive(Clone, Copy)]
+struct HookEvent {
+    name: &'static str,
+    marker: &'static str,
+}
+
+#[derive(Clone, Copy)]
+struct ProviderHooks {
+    events: &'static [HookEvent],
+    marker_prefix: &'static str,
+    owned_markers: &'static [&'static str],
+    hook_group: fn(&str) -> Value,
+}
+
+impl ProviderHooks {
+    fn claude() -> Self {
+        Self {
+            events: &CLAUDE_HOOK_EVENTS,
+            marker_prefix: "notify;Terax;",
+            owned_markers: &CLAUDE_OWNED_MARKERS,
+            hook_group: claude_hook_group,
+        }
+    }
+
+    fn codex() -> Self {
+        Self {
+            events: &CODEX_HOOK_EVENTS,
+            marker_prefix: "notify;Terax;codex;",
+            owned_markers: &CODEX_OWNED_MARKERS,
+            hook_group: codex_hook_group,
+        }
+    }
+
+    fn marker_text(self, marker: &str) -> String {
+        format!("{}{marker}", self.marker_prefix)
+    }
+}
+
+const CLAUDE_HOOK_EVENTS: [HookEvent; 3] = [
+    HookEvent {
+        name: "UserPromptSubmit",
+        marker: "working",
+    },
+    HookEvent {
+        name: "Notification",
+        marker: "attention",
+    },
+    HookEvent {
+        name: "Stop",
+        marker: "finished",
+    },
+];
+
+const CODEX_HOOK_EVENTS: [HookEvent; 3] = [
+    HookEvent {
+        name: "UserPromptSubmit",
+        marker: "working",
+    },
+    HookEvent {
+        name: "PermissionRequest",
+        marker: "attention",
+    },
+    HookEvent {
+        name: "Stop",
+        marker: "finished",
+    },
 ];
 
 // Includes the pre-v2.1.139 /dev/tty variant so re-running migrates it.
-const OWNED_MARKERS: [&str; 2] = ["notify;Terax;", "terax;notify"];
+const CLAUDE_OWNED_MARKERS: [&str; 2] = ["notify;Terax;", "terax;notify"];
+const CODEX_OWNED_MARKERS: [&str; 1] = ["notify;Terax;codex;"];
 
 // Gated on TERAX_TERMINAL; no-op outside Terax. Returns the sequence via
 // `terminalSequence` because hooks lost /dev/tty access in v2.1.139.
-fn hook_cmd(event: &str) -> String {
+fn claude_hook_cmd(event: &str) -> String {
     format!(
         r#"[ -n "$TERAX_TERMINAL" ] && printf '{{"terminalSequence":"\\u001b]777;notify;Terax;{event}\\u0007"}}' || true"#
     )
 }
 
-fn is_ours(group: &Value) -> bool {
+fn codex_hook_cmd(event: &str) -> String {
+    format!(
+        r#"[ -n "$TERAX_TERMINAL" ] && {{ printf '\033]777;notify;Terax;codex;{event}\007' 2>/dev/null > /dev/tty || printf '\033]777;notify;Terax;codex;{event}\007' 2>/dev/null > "/proc/$PPID/fd/1" || true; }}"#
+    )
+}
+
+fn codex_windows_hook_cmd(event: &str) -> String {
+    format!(
+        r#"powershell -NoProfile -Command "if ($env:TERAX_TERMINAL) {{ $s = [string][char]27 + ']777;notify;Terax;codex;{event}' + [string][char]7; $bytes = [System.Text.Encoding]::UTF8.GetBytes($s); $out = [System.IO.File]::OpenWrite('\\.\CONOUT$'); try {{ $out.Write($bytes, 0, $bytes.Length) }} finally {{ $out.Dispose() }} }}""#
+    )
+}
+
+fn claude_hook_group(event: &str) -> Value {
+    json!({
+        "hooks": [ { "type": "command", "command": claude_hook_cmd(event) } ]
+    })
+}
+
+fn codex_hook_group(event: &str) -> Value {
+    json!({
+        "hooks": [ {
+            "type": "command",
+            "command": codex_hook_cmd(event),
+            "commandWindows": codex_windows_hook_cmd(event),
+        } ]
+    })
+}
+
+fn is_ours(group: &Value, spec: ProviderHooks) -> bool {
     group
         .get("hooks")
         .and_then(Value::as_array)
         .is_some_and(|hs| {
             hs.iter().any(|h| {
-                h.get("command")
-                    .and_then(Value::as_str)
-                    .is_some_and(|c| OWNED_MARKERS.iter().any(|m| c.contains(m)))
+                ["command", "commandWindows"].iter().any(|key| {
+                    h.get(key)
+                        .and_then(Value::as_str)
+                        .is_some_and(|c| spec.owned_markers.iter().any(|m| c.contains(m)))
+                })
             })
         })
 }
@@ -39,7 +133,7 @@ fn is_empty_group(group: &Value) -> bool {
         .is_none_or(|hs| hs.is_empty())
 }
 
-fn merge_hooks(mut root: Value) -> Value {
+fn merge_provider_hooks(mut root: Value, spec: ProviderHooks) -> Value {
     if !root.is_object() {
         root = json!({});
     }
@@ -50,39 +144,50 @@ fn merge_hooks(mut root: Value) -> Value {
     }
     let hooks = hooks.as_object_mut().unwrap();
 
-    for (event, marker) in HOOK_EVENTS {
-        let arr = hooks.entry(event).or_insert_with(|| json!([]));
+    for event in spec.events {
+        let arr = hooks.entry(event.name).or_insert_with(|| json!([]));
         if !arr.is_array() {
             *arr = json!([]);
         }
         let arr = arr.as_array_mut().unwrap();
-        arr.retain(|group| !is_ours(group) && !is_empty_group(group));
-        arr.push(json!({
-            "hooks": [ { "type": "command", "command": hook_cmd(marker) } ]
-        }));
+        arr.retain(|group| !is_ours(group, spec) && !is_empty_group(group));
+        arr.push((spec.hook_group)(event.marker));
     }
     root
 }
 
-fn existing_config(contents: Option<&str>, path: &std::path::Path) -> Result<Value, String> {
+#[cfg(test)]
+fn merge_hooks(root: Value) -> Value {
+    merge_provider_hooks(root, ProviderHooks::claude())
+}
+
+fn existing_config(contents: Option<&str>, path: &Path) -> Result<Value, String> {
     match contents {
         Some(s) if !s.trim().is_empty() => serde_json::from_str::<Value>(s).map_err(|e| {
-            format!("{} is not valid JSON ({e}); refusing to overwrite", path.display())
+            format!(
+                "{} is not valid JSON ({e}); refusing to overwrite",
+                path.display()
+            )
         }),
         _ => Ok(json!({})),
     }
 }
 
-fn settings_path() -> Result<std::path::PathBuf, String> {
+fn claude_settings_path() -> Result<PathBuf, String> {
     Ok(dirs::home_dir()
         .ok_or_else(|| "could not resolve home dir".to_string())?
         .join(".claude")
         .join("settings.json"))
 }
 
-#[tauri::command]
-pub fn agent_enable_claude_hooks() -> Result<(), String> {
-    let path = settings_path()?;
+fn codex_hooks_path() -> Result<PathBuf, String> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| "could not resolve home dir".to_string())?
+        .join(".codex")
+        .join("hooks.json"))
+}
+
+fn enable_hooks_at(path: PathBuf, spec: ProviderHooks) -> Result<(), String> {
     let dir = path.parent().unwrap();
     std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
 
@@ -92,11 +197,11 @@ pub fn agent_enable_claude_hooks() -> Result<(), String> {
         Err(e) => return Err(format!("read {}: {e}", path.display())),
     };
 
-    let merged = merge_hooks(existing);
+    let merged = merge_provider_hooks(existing, spec);
     let out = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())?;
 
     // Write to a sibling temp file then rename so a crash mid-write can't leave
-    // a truncated settings.json.
+    // a truncated config file.
     let tmp = path.with_extension("json.terax-tmp");
     std::fs::write(&tmp, out).map_err(|e| format!("write {}: {e}", tmp.display()))?;
     std::fs::rename(&tmp, &path).map_err(|e| {
@@ -106,17 +211,60 @@ pub fn agent_enable_claude_hooks() -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command]
-pub fn agent_claude_hooks_status() -> bool {
-    let Some(content) = settings_path()
-        .ok()
-        .and_then(|p| std::fs::read_to_string(p).ok())
-    else {
+fn hooks_status_at(path: PathBuf, spec: ProviderHooks) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
         return false;
     };
-    HOOK_EVENTS
-        .iter()
-        .all(|(_, m)| content.contains(&format!("notify;Terax;{m}")))
+    let Ok(root) = serde_json::from_str::<Value>(&content) else {
+        return false;
+    };
+
+    spec.events.iter().all(|event| {
+        let marker = spec.marker_text(event.marker);
+        root.get("hooks")
+            .and_then(|hooks| hooks.get(event.name))
+            .and_then(Value::as_array)
+            .is_some_and(|groups| {
+                groups.iter().any(|group| {
+                    group
+                        .get("hooks")
+                        .and_then(Value::as_array)
+                        .is_some_and(|hooks| {
+                            hooks.iter().any(|hook| {
+                                ["command", "commandWindows"].iter().any(|key| {
+                                    hook.get(key)
+                                        .and_then(Value::as_str)
+                                        .is_some_and(|command| command.contains(&marker))
+                                })
+                            })
+                        })
+                })
+            })
+    })
+}
+
+#[tauri::command]
+pub fn agent_enable_claude_hooks() -> Result<(), String> {
+    enable_hooks_at(claude_settings_path()?, ProviderHooks::claude())
+}
+
+#[tauri::command]
+pub fn agent_claude_hooks_status() -> bool {
+    claude_settings_path()
+        .map(|path| hooks_status_at(path, ProviderHooks::claude()))
+        .unwrap_or(false)
+}
+
+#[tauri::command]
+pub fn agent_enable_codex_hooks() -> Result<(), String> {
+    enable_hooks_at(codex_hooks_path()?, ProviderHooks::codex())
+}
+
+#[tauri::command]
+pub fn agent_codex_hooks_status() -> bool {
+    codex_hooks_path()
+        .map(|path| hooks_status_at(path, ProviderHooks::codex()))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -201,13 +349,48 @@ mod tests {
             "hooks": {
                 "Notification": [
                     { "hooks": [] },
-                    { "hooks": [ { "type": "command", "command": hook_cmd("attention") } ] }
+                    { "hooks": [ { "type": "command", "command": claude_hook_cmd("attention") } ] }
                 ]
             }
         });
         let out = merge_hooks(input);
         assert_eq!(hook_count(&out, "Notification"), 1);
         assert!(command(&out, "Notification", 0).contains("notify;Terax;attention"));
+    }
+
+    #[test]
+    fn adds_codex_hooks_to_empty_config() {
+        let out = merge_provider_hooks(json!({}), ProviderHooks::codex());
+        assert_eq!(hook_count(&out, "UserPromptSubmit"), 1);
+        assert_eq!(hook_count(&out, "PermissionRequest"), 1);
+        assert_eq!(hook_count(&out, "Stop"), 1);
+        assert!(command(&out, "UserPromptSubmit", 0).contains("notify;Terax;codex;working"));
+        assert!(command(&out, "PermissionRequest", 0).contains("notify;Terax;codex;attention"));
+        assert!(command(&out, "Stop", 0).contains("notify;Terax;codex;finished"));
+        assert!(command(&out, "PermissionRequest", 0).contains("/proc/$PPID/fd/1"));
+    }
+
+    #[test]
+    fn codex_hooks_are_idempotent_and_preserve_foreign_hooks() {
+        let input = json!({
+            "hooks": {
+                "Stop": [
+                    { "hooks": [ { "type": "command", "command": "echo foreign" } ] }
+                ]
+            }
+        });
+        let once = merge_provider_hooks(input, ProviderHooks::codex());
+        let twice = merge_provider_hooks(once.clone(), ProviderHooks::codex());
+        assert_eq!(once, twice);
+        assert_eq!(hook_count(&twice, "Stop"), 2);
+        assert_eq!(command(&twice, "Stop", 0), "echo foreign");
+    }
+
+    #[test]
+    fn claude_hooks_still_use_terminal_sequence() {
+        let out = merge_provider_hooks(json!({}), ProviderHooks::claude());
+        assert!(command(&out, "Stop", 0).contains("terminalSequence"));
+        assert!(command(&out, "Stop", 0).contains("notify;Terax;finished"));
     }
 
     #[test]

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -24,6 +24,18 @@ enum Status {
     Waiting,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum MarkerEvent {
+    Working,
+    Attention,
+    Finished,
+}
+
+struct ParsedMarker<'a> {
+    agent: Option<&'a str>,
+    event: MarkerEvent,
+}
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Transition {
     Started { agent: String },
@@ -43,13 +55,31 @@ pub struct AgentSignal {
 impl Transition {
     pub fn into_signal(self, id: u32) -> AgentSignal {
         match self {
-            Transition::Started { agent } => {
-                AgentSignal { id, kind: "started", agent: Some(agent) }
-            }
-            Transition::Working => AgentSignal { id, kind: "working", agent: None },
-            Transition::Attention => AgentSignal { id, kind: "attention", agent: None },
-            Transition::Finished => AgentSignal { id, kind: "finished", agent: None },
-            Transition::Exited => AgentSignal { id, kind: "exited", agent: None },
+            Transition::Started { agent } => AgentSignal {
+                id,
+                kind: "started",
+                agent: Some(agent),
+            },
+            Transition::Working => AgentSignal {
+                id,
+                kind: "working",
+                agent: None,
+            },
+            Transition::Attention => AgentSignal {
+                id,
+                kind: "attention",
+                agent: None,
+            },
+            Transition::Finished => AgentSignal {
+                id,
+                kind: "finished",
+                agent: None,
+            },
+            Transition::Exited => AgentSignal {
+                id,
+                kind: "exited",
+                agent: None,
+            },
         }
     }
 }
@@ -160,25 +190,30 @@ impl AgentDetector {
     }
 
     fn handle_osc777<F: FnMut(Transition)>(&mut self, pt: &[u8], emit: &mut F) {
-        if let Some(event) = pt.strip_prefix(TERAX_MARKER) {
+        if pt.starts_with(TERAX_MARKER) {
             // Self-arms so notifications work even when no shell preexec fired
             // (bash, Windows, tmux, wrappers).
-            match event {
-                b"working" => {
-                    self.ensure_armed(emit);
-                    self.set_working(emit);
+            if let Some(marker) = parse_terax_marker(pt) {
+                let agent = marker.agent.unwrap_or("claude");
+                if marker.agent.is_some() && !self.agents.iter().any(|a| a == agent) {
+                    return;
                 }
-                b"attention" => {
-                    self.ensure_armed(emit);
-                    self.status = Status::Waiting;
-                    emit(Transition::Attention);
+                match marker.event {
+                    MarkerEvent::Working => {
+                        self.ensure_armed(agent, emit);
+                        self.set_working(emit);
+                    }
+                    MarkerEvent::Attention => {
+                        self.ensure_armed(agent, emit);
+                        self.status = Status::Waiting;
+                        emit(Transition::Attention);
+                    }
+                    MarkerEvent::Finished => {
+                        self.ensure_armed(agent, emit);
+                        self.status = Status::Waiting;
+                        emit(Transition::Finished);
+                    }
                 }
-                b"finished" => {
-                    self.ensure_armed(emit);
-                    self.status = Status::Waiting;
-                    emit(Transition::Finished);
-                }
-                _ => {}
             }
             return;
         }
@@ -206,11 +241,13 @@ impl AgentDetector {
         }
     }
 
-    fn ensure_armed<F: FnMut(Transition)>(&mut self, emit: &mut F) {
+    fn ensure_armed<F: FnMut(Transition)>(&mut self, agent: &str, emit: &mut F) {
         if !self.armed {
             self.armed = true;
             self.status = Status::Working;
-            emit(Transition::Started { agent: "claude".into() });
+            emit(Transition::Started {
+                agent: agent.into(),
+            });
         }
     }
 
@@ -246,6 +283,49 @@ impl AgentDetector {
     }
 }
 
+fn parse_terax_marker(pt: &[u8]) -> Option<ParsedMarker<'_>> {
+    let rest = pt.strip_prefix(TERAX_MARKER)?;
+    match rest {
+        b"working" => Some(ParsedMarker {
+            agent: None,
+            event: MarkerEvent::Working,
+        }),
+        b"attention" => Some(ParsedMarker {
+            agent: None,
+            event: MarkerEvent::Attention,
+        }),
+        b"finished" => Some(ParsedMarker {
+            agent: None,
+            event: MarkerEvent::Finished,
+        }),
+        _ => {
+            let i = rest.iter().position(|b| *b == b';')?;
+            let (agent, event) = (&rest[..i], &rest[i + 1..]);
+            if !is_valid_marker_agent(agent) {
+                return None;
+            }
+            let agent = std::str::from_utf8(agent).ok()?;
+            let event = match event {
+                b"working" => MarkerEvent::Working,
+                b"attention" => MarkerEvent::Attention,
+                b"finished" => MarkerEvent::Finished,
+                _ => return None,
+            };
+            Some(ParsedMarker {
+                agent: Some(agent),
+                event,
+            })
+        }
+    }
+}
+
+fn is_valid_marker_agent(agent: &[u8]) -> bool {
+    !agent.is_empty()
+        && agent
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,13 +344,18 @@ mod tests {
     }
 
     fn started(agent: &str) -> Transition {
-        Transition::Started { agent: agent.into() }
+        Transition::Started {
+            agent: agent.into(),
+        }
     }
 
     #[test]
     fn arms_on_agent_command() {
         let mut d = AgentDetector::new();
-        assert_eq!(run(&mut d, &osc("133;C;claude -p hello")), vec![started("claude")]);
+        assert_eq!(
+            run(&mut d, &osc("133;C;claude -p hello")),
+            vec![started("claude")]
+        );
     }
 
     #[test]
@@ -281,13 +366,19 @@ mod tests {
             vec![started("codex")]
         );
         let mut d2 = AgentDetector::new();
-        assert_eq!(run(&mut d2, &osc("133;C;npx claude")), vec![started("claude")]);
+        assert_eq!(
+            run(&mut d2, &osc("133;C;npx claude")),
+            vec![started("claude")]
+        );
     }
 
     #[test]
     fn arms_on_dash_suffixed_alias() {
         let mut d = AgentDetector::new();
-        assert_eq!(run(&mut d, &osc("133;C;claude-enigma")), vec![started("claude")]);
+        assert_eq!(
+            run(&mut d, &osc("133;C;claude-enigma")),
+            vec![started("claude")]
+        );
     }
 
     #[test]
@@ -310,10 +401,19 @@ mod tests {
     fn terax_marker_drives_status() {
         let mut d = AgentDetector::new();
         run(&mut d, &osc("133;C;claude"));
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;attention")), vec![Transition::Attention]);
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;working")), vec![Transition::Working]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;attention")),
+            vec![Transition::Attention]
+        );
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;working")),
+            vec![Transition::Working]
+        );
         assert!(run(&mut d, &osc("777;notify;Terax;working")).is_empty());
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;finished")), vec![Transition::Finished]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;finished")),
+            vec![Transition::Finished]
+        );
     }
 
     #[test]
@@ -326,12 +426,64 @@ mod tests {
     }
 
     #[test]
+    fn qualified_terax_marker_auto_arms_provider() {
+        let mut d = AgentDetector::new();
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;codex;attention")),
+            vec![started("codex"), Transition::Attention]
+        );
+    }
+
+    #[test]
+    fn qualified_terax_marker_uses_provider_when_already_armed() {
+        let mut d = AgentDetector::new();
+        run(&mut d, &osc("133;C;codex"));
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;codex;finished")),
+            vec![Transition::Finished]
+        );
+    }
+
+    #[test]
+    fn unqualified_terax_marker_keeps_legacy_claude_auto_arm() {
+        let mut d = AgentDetector::new();
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;attention")),
+            vec![started("claude"), Transition::Attention]
+        );
+    }
+
+    #[test]
+    fn terax_marker_rejects_empty_provider() {
+        let mut d = AgentDetector::new();
+        assert!(run(&mut d, &osc("777;notify;Terax;;attention")).is_empty());
+    }
+
+    #[test]
+    fn terax_marker_rejects_provider_with_spaces() {
+        let mut d = AgentDetector::new();
+        assert!(run(&mut d, &osc("777;notify;Terax;bad provider;attention")).is_empty());
+    }
+
+    #[test]
+    fn terax_marker_rejects_unknown_provider() {
+        let mut d = AgentDetector::new();
+        assert!(run(&mut d, &osc("777;notify;Terax;other;attention")).is_empty());
+    }
+
+    #[test]
     fn generic_osc777_and_osc9_attention_only_when_armed() {
         let mut d = AgentDetector::new();
         assert!(run(&mut d, &osc("777;notify;Other;ready")).is_empty());
         run(&mut d, &osc("133;C;codex"));
-        assert_eq!(run(&mut d, &osc("777;notify;Codex;ready")), vec![Transition::Attention]);
-        assert_eq!(run(&mut d, &osc("9;needs you")), vec![Transition::Attention]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Codex;ready")),
+            vec![Transition::Attention]
+        );
+        assert_eq!(
+            run(&mut d, &osc("9;needs you")),
+            vec![Transition::Attention]
+        );
         assert!(run(&mut d, &osc("9;4;1;50")).is_empty());
     }
 
@@ -383,6 +535,9 @@ mod tests {
         seq.extend(std::iter::repeat_n(b'x', OSC_MAX + 100));
         seq.extend_from_slice(&[ESC, ST_FINAL]);
         assert!(run(&mut d, &seq).is_empty());
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;attention")), vec![Transition::Attention]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;attention")),
+            vec![Transition::Attention]
+        );
     }
 }

--- a/src/modules/agents/components/NotificationBell.tsx
+++ b/src/modules/agents/components/NotificationBell.tsx
@@ -23,6 +23,36 @@ type Props = {
   onActivateLocal: () => void;
 };
 
+type HookTargetId = "claude" | "codex";
+
+type HookTarget = {
+  id: HookTargetId;
+  statusCommand: string;
+  enableCommand: string;
+  enableLabel: string;
+  enabledLabel: string;
+  errorLabel: string;
+};
+
+const HOOK_TARGETS: HookTarget[] = [
+  {
+    id: "claude",
+    statusCommand: "agent_claude_hooks_status",
+    enableCommand: "agent_enable_claude_hooks",
+    enableLabel: "Enable Claude Code alerts",
+    enabledLabel: "Claude Code alerts enabled",
+    errorLabel: "Could not update Claude Code config.",
+  },
+  {
+    id: "codex",
+    statusCommand: "agent_codex_hooks_status",
+    enableCommand: "agent_enable_codex_hooks",
+    enableLabel: "Enable Codex alerts",
+    enabledLabel: "Codex alerts enabled",
+    errorLabel: "Could not update Codex config.",
+  },
+];
+
 function relativeTime(ts: number): string {
   const s = Math.floor((Date.now() - ts) / 1000);
   if (s < 60) return "just now";
@@ -117,8 +147,13 @@ function NotificationRow({
 
 export function NotificationBell({ onActivate, onActivateLocal }: Props) {
   const [open, setOpen] = useState(false);
-  const [hooksReady, setHooksReady] = useState<boolean | null>(null);
-  const [installing, setInstalling] = useState(false);
+  const [hooksReady, setHooksReady] = useState<
+    Record<HookTargetId, boolean | null>
+  >({
+    claude: null,
+    codex: null,
+  });
+  const [installing, setInstalling] = useState<HookTargetId | null>(null);
   const sessions = useAgentStore((s) => s.sessions);
   const localAgent = useAgentStore((s) => s.localAgent);
   const notifications = useAgentStore((s) => s.notifications);
@@ -137,9 +172,15 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
   const badge = waitingCount + unreadDone;
 
   const refreshHooks = () => {
-    invoke<boolean>("agent_claude_hooks_status")
-      .then(setHooksReady)
-      .catch(() => setHooksReady(null));
+    for (const target of HOOK_TARGETS) {
+      invoke<boolean>(target.statusCommand)
+        .then((ready) =>
+          setHooksReady((state) => ({ ...state, [target.id]: ready })),
+        )
+        .catch(() =>
+          setHooksReady((state) => ({ ...state, [target.id]: null })),
+        );
+    }
   };
 
   const onOpenChange = (next: boolean) => {
@@ -150,15 +191,15 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
     }
   };
 
-  const enableClaudeHooks = async () => {
-    setInstalling(true);
+  const enableHooks = async (target: HookTarget) => {
+    setInstalling(target.id);
     try {
-      await invoke("agent_enable_claude_hooks");
-      setHooksReady(true);
+      await invoke(target.enableCommand);
+      setHooksReady((state) => ({ ...state, [target.id]: true }));
     } catch {
-      setHooksReady(false);
+      setHooksReady((state) => ({ ...state, [target.id]: false }));
     } finally {
-      setInstalling(false);
+      setInstalling(null);
     }
   };
 
@@ -220,7 +261,7 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
           <div className="border-t border-border/60 px-3 py-5 text-center text-xs leading-relaxed text-muted-foreground">
             No agent activity yet.
             <br />
-            Run the Terax agent or Claude Code to track it here.
+            Run the Terax agent, Claude Code, or Codex to track it here.
           </div>
         ) : (
           <div className="max-h-80 overflow-y-auto border-t border-border/60 p-1">
@@ -252,38 +293,49 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
           </div>
         )}
 
-        <div className="border-t flex justify-center border-border/60 p-1">
-          {hooksReady ? (
-            <div className="flex items-center gap-2 px-2 py-1.5 text-[11px] text-muted-foreground">
-              <HugeiconsIcon
-                icon={CheckmarkCircle02Icon}
-                size={13}
-                strokeWidth={1.75}
-                className="text-primary"
-              />
-              Claude Code alerts enabled
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={enableClaudeHooks}
-              disabled={installing}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60"
-            >
-              <HugeiconsIcon
-                icon={installing ? Loading03Icon : Notification03Icon}
-                size={14}
-                strokeWidth={1.75}
-                className={cn(installing && "animate-spin")}
-              />
-              {installing ? "Enabling..." : "Enable Claude Code alerts"}
-            </button>
+        <div className="border-t flex flex-col gap-0.5 border-border/60 p-1">
+          {HOOK_TARGETS.map((target) =>
+            hooksReady[target.id] ? (
+              <div
+                key={target.id}
+                className="flex items-center gap-2 px-2 py-1.5 text-[11px] text-muted-foreground"
+              >
+                <HugeiconsIcon
+                  icon={CheckmarkCircle02Icon}
+                  size={13}
+                  strokeWidth={1.75}
+                  className="text-primary"
+                />
+                {target.enabledLabel}
+              </div>
+            ) : (
+              <div key={target.id}>
+                <button
+                  type="button"
+                  onClick={() => void enableHooks(target)}
+                  disabled={installing !== null}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-60"
+                >
+                  <HugeiconsIcon
+                    icon={
+                      installing === target.id
+                        ? Loading03Icon
+                        : Notification03Icon
+                    }
+                    size={14}
+                    strokeWidth={1.75}
+                    className={cn(installing === target.id && "animate-spin")}
+                  />
+                  {installing === target.id ? "Enabling..." : target.enableLabel}
+                </button>
+                {hooksReady[target.id] === false && installing !== target.id ? (
+                  <p className="px-2 pt-1 text-[11px] text-destructive">
+                    {target.errorLabel}
+                  </p>
+                ) : null}
+              </div>
+            ),
           )}
-          {hooksReady === false && !installing ? (
-            <p className="px-2 pt-1 text-[11px] text-destructive">
-              Could not update Claude Code config.
-            </p>
-          ) : null}
         </div>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
 Adds Codex CLI notification hook support alongside the existing Claude Code alerts.


## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->
Terax already tracks Claude Code from terminal hooks. Codex CLI should emit the same agent signals for working, permission request, and finished states.

## How
<!-- Brief notes on the approach, only if non-obvious. -->
Adds Codex hook install/status commands, writes provider-qualified OSC markers, and updates the PTY detector to accept known provider markers while preserving legacy Claude markers.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature in `pnpm tauri dev`
- [x] `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] New Tauri commands called out: `agent_enable_codex_hooks`, `agent_codex_hooks_status`
- [x] Platforms tested: Linux
- [x] Shells tested: bash


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->
<img width="475" height="343" alt="2026-05-31_11-36" src="https://github.com/user-attachments/assets/9a50737e-a235-4d44-9365-fb827cb2fb3e" />

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
The implementation includes Unix and Windows hook commands, but only Linux/bash was manually tested.