### PR TITLE
feat(claude-chat): chat-GUI view for a running Claude Code session in a terminal tab

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5335,6 +5335,7 @@ dependencies = [
 name = "terax"
 version = "0.7.3"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "dirs 5.0.1",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"
 notify = "8.2.0"
+base64 = "0.22"
 
 [dev-dependencies]
 proptest = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, claude, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -159,6 +159,7 @@ pub fn run() {
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())
         .manage(fs::watch::FsWatchState::default())
+        .manage(claude::ClaudeState::default())
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
             workspace::bootstrap_registry(&registry);
@@ -224,6 +225,9 @@ pub fn run() {
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,
+            claude::claude_find_transcript,
+            claude::claude_transcript_subscribe,
+            claude::claude_transcript_unsubscribe,
             secrets::secrets_get,
             secrets::secrets_set,
             secrets::secrets_delete,

--- a/src-tauri/src/modules/agent.rs
+++ b/src-tauri/src/modules/agent.rs
@@ -11,9 +11,15 @@ const OWNED_MARKERS: [&str; 2] = ["notify;Terax;", "terax;notify"];
 
 // Gated on TERAX_TERMINAL; no-op outside Terax. Returns the sequence via
 // `terminalSequence` because hooks lost /dev/tty access in v2.1.139.
+//
+// Two OSC 777 markers are emitted in one terminalSequence: the status word
+// (working/attention/finished) and `transcript;<base64-path>`. The path comes
+// from the hook's stdin JSON (`transcript_path`), extracted with sed so we don't
+// depend on jq. This lets the chat GUI mirror the exact running session instead
+// of guessing the newest file among the project's many sibling sessions.
 fn hook_cmd(event: &str) -> String {
     format!(
-        r#"[ -n "$TERAX_TERMINAL" ] && printf '{{"terminalSequence":"\\u001b]777;notify;Terax;{event}\\u0007"}}' || true"#
+        r#"[ -n "$TERAX_TERMINAL" ] && {{ __tp=$(sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'); __b=$(printf '%s' "$__tp" | base64 2>/dev/null | tr -d '\n'); printf '{{"terminalSequence":"\\u001b]777;notify;Terax;{event}\\u0007\\u001b]777;notify;Terax;transcript;%s\\u0007"}}' "$__b"; }} || true"#
     )
 }
 
@@ -114,9 +120,12 @@ pub fn agent_claude_hooks_status() -> bool {
     else {
         return false;
     };
+    // Require the transcript marker too, so installs predating it are reported
+    // as not-enabled and get upgraded on the next enable.
     HOOK_EVENTS
         .iter()
         .all(|(_, m)| content.contains(&format!("notify;Terax;{m}")))
+        && content.contains("notify;Terax;transcript;")
 }
 
 #[cfg(test)]
@@ -145,6 +154,9 @@ mod tests {
         assert!(command(&out, "UserPromptSubmit", 0).contains("notify;Terax;working"));
         assert!(command(&out, "Stop", 0).contains("terminalSequence"));
         assert!(!command(&out, "Stop", 0).contains("/dev/tty"));
+        // Each hook also reports the session transcript path for the chat mirror.
+        assert!(command(&out, "UserPromptSubmit", 0).contains("notify;Terax;transcript;"));
+        assert!(command(&out, "UserPromptSubmit", 0).contains("transcript_path"));
     }
 
     #[test]

--- a/src-tauri/src/modules/claude/mod.rs
+++ b/src-tauri/src/modules/claude/mod.rs
@@ -1,0 +1,282 @@
+//! Claude Code session bridge: locate a running `claude` session's transcript
+//! JSONL and tail it so the chat GUI can mirror the interactive PTY session
+//! without spawning a second `claude` process.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::ipc::Channel;
+
+// Coalesce a burst of writes so we read the file at most once per quiet gap.
+const DEBOUNCE: Duration = Duration::from_millis(60);
+
+fn projects_root() -> Result<PathBuf, String> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| "could not resolve home dir".to_string())?
+        .join(".claude")
+        .join("projects"))
+}
+
+/// Claude derives the per-project directory name by replacing every byte that
+/// is not ASCII-alphanumeric with `-` (so `/home/u/git/x` -> `-home-u-git-x`,
+/// `.claude` -> `-claude`). Forward-encoding only; we never reverse it.
+fn encode_project_dir(cwd: &str) -> String {
+    cwd.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// Newest `.jsonl` (by mtime) in the project dir for `cwd`, if any. This is the
+/// session the user is most likely interacting with right now.
+#[tauri::command]
+pub fn claude_find_transcript(cwd: String) -> Result<Option<String>, String> {
+    let dir = projects_root()?.join(encode_project_dir(&cwd));
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("read {}: {e}", dir.display())),
+    };
+
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        if best.as_ref().is_none_or(|(t, _)| mtime > *t) {
+            best = Some((mtime, path));
+        }
+    }
+    Ok(best.map(|(_, p)| p.to_string_lossy().into_owned()))
+}
+
+fn validate_transcript_path(path: &str) -> Result<PathBuf, String> {
+    let root = projects_root()?;
+    let canon = std::fs::canonicalize(path).map_err(|e| format!("canonicalize: {e}"))?;
+    let root_canon = std::fs::canonicalize(&root).unwrap_or(root);
+    if !canon.starts_with(&root_canon) {
+        return Err("path is outside ~/.claude/projects".to_string());
+    }
+    if canon.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+        return Err("not a .jsonl transcript".to_string());
+    }
+    Ok(canon)
+}
+
+struct TailHandle {
+    stop: Arc<AtomicBool>,
+    // Dropping the watcher unregisters the OS watch; kept alive for the tail's
+    // lifetime.
+    _watcher: RecommendedWatcher,
+}
+
+#[derive(Default)]
+pub struct ClaudeState {
+    tails: Mutex<HashMap<String, TailHandle>>,
+}
+
+fn stop_tail(state: &ClaudeState, key: &str) {
+    if let Some(handle) = state.tails.lock().unwrap().remove(key) {
+        handle.stop.store(true, Ordering::Release);
+    }
+}
+
+/// Read appended complete lines starting at `*offset`, advancing `*offset` past
+/// the last newline consumed. Returns the appended text (one or more whole
+/// lines) or an empty string when there's nothing new. Handles truncation
+/// (file replaced / rotated) by resetting to the start.
+fn read_appended(path: &Path, offset: &mut u64) -> std::io::Result<String> {
+    let mut file = File::open(path)?;
+    let len = file.metadata()?.len();
+    if len < *offset {
+        *offset = 0;
+    }
+    if len == *offset {
+        return Ok(String::new());
+    }
+    file.seek(SeekFrom::Start(*offset))?;
+    let mut buf = Vec::with_capacity((len - *offset) as usize);
+    file.read_to_end(&mut buf)?;
+    let last_nl = match buf.iter().rposition(|&b| b == b'\n') {
+        Some(i) => i,
+        None => return Ok(String::new()), // no complete line yet
+    };
+    *offset += (last_nl + 1) as u64;
+    Ok(String::from_utf8_lossy(&buf[..=last_nl]).into_owned())
+}
+
+/// Subscribe to a transcript file. Emits the full existing content first (so the
+/// GUI shows history), then streams appended lines as the live `claude` writes
+/// them. Idempotent per path: re-subscribing replaces the previous tail.
+#[tauri::command]
+pub fn claude_transcript_subscribe(
+    state: tauri::State<'_, ClaudeState>,
+    path: String,
+    on_chunk: Channel<String>,
+) -> Result<(), String> {
+    let canon = validate_transcript_path(&path)?;
+    let key = canon.to_string_lossy().into_owned();
+
+    // Replace any existing tail for this path.
+    stop_tail(&state, &key);
+
+    let mut offset: u64 = 0;
+    // Initial backfill: everything already written.
+    match read_appended(&canon, &mut offset) {
+        Ok(initial) if !initial.is_empty() => {
+            let _ = on_chunk.send(initial);
+        }
+        Ok(_) => {}
+        Err(e) => return Err(format!("read transcript: {e}")),
+    }
+
+    let (tx, rx) = mpsc::channel::<()>();
+    let mut watcher = RecommendedWatcher::new(
+        move |res: notify::Result<Event>| {
+            if let Ok(ev) = res {
+                if matches!(ev.kind, EventKind::Access(_)) {
+                    return;
+                }
+                let _ = tx.send(());
+            }
+        },
+        Config::default(),
+    )
+    .map_err(|e| e.to_string())?;
+    // Watch the parent dir: editors/rotations replace the inode, which a
+    // file-level watch would miss.
+    let parent = canon.parent().ok_or("transcript has no parent dir")?;
+    watcher
+        .watch(parent, RecursiveMode::NonRecursive)
+        .map_err(|e| format!("watch {}: {e}", parent.display()))?;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_thread = stop.clone();
+    let path_thread = canon.clone();
+    std::thread::Builder::new()
+        .name("terax-claude-tail".into())
+        .spawn(move || {
+            let mut offset = offset;
+            loop {
+                match rx.recv_timeout(DEBOUNCE) {
+                    Ok(()) => {
+                        // Drain the debounce window so a burst is one read.
+                        let deadline = Instant::now() + DEBOUNCE;
+                        while rx.recv_timeout(DEBOUNCE.min(
+                            deadline.saturating_duration_since(Instant::now()),
+                        )).is_ok()
+                        {
+                            if Instant::now() >= deadline {
+                                break;
+                            }
+                        }
+                    }
+                    Err(RecvTimeoutError::Timeout) => {
+                        if stop_thread.load(Ordering::Acquire) {
+                            return;
+                        }
+                        continue;
+                    }
+                    Err(RecvTimeoutError::Disconnected) => return,
+                }
+                if stop_thread.load(Ordering::Acquire) {
+                    return;
+                }
+                match read_appended(&path_thread, &mut offset) {
+                    Ok(chunk) if !chunk.is_empty() => {
+                        if on_chunk.send(chunk).is_err() {
+                            return; // channel closed (frontend gone)
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => log::debug!("claude tail read failed: {e}"),
+                }
+            }
+        })
+        .map_err(|e| e.to_string())?;
+
+    state
+        .tails
+        .lock()
+        .unwrap()
+        .insert(key, TailHandle { stop, _watcher: watcher });
+    Ok(())
+}
+
+#[tauri::command]
+pub fn claude_transcript_unsubscribe(
+    state: tauri::State<'_, ClaudeState>,
+    path: String,
+) -> Result<(), String> {
+    // Accept either the raw or canonical form.
+    let key = std::fs::canonicalize(&path)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or(path);
+    stop_tail(&state, &key);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn encodes_project_dir_like_claude() {
+        assert_eq!(encode_project_dir("/home/user/git/terax-ai"), "-home-user-git-terax-ai");
+        assert_eq!(
+            encode_project_dir("/home/user/.claude/mem/observer/sessions"),
+            "-home-user--claude-mem-observer-sessions"
+        );
+        assert_eq!(encode_project_dir("/a_b/c.d"), "-a-b-c-d");
+    }
+
+    #[test]
+    fn read_appended_emits_only_complete_lines() {
+        let dir = std::env::temp_dir().join(format!("terax-claude-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("t.jsonl");
+        let mut f = File::create(&path).unwrap();
+        write!(f, "{{\"a\":1}}\n{{\"b\":2}}\n{{\"part").unwrap();
+        f.flush().unwrap();
+
+        let mut offset = 0u64;
+        let out = read_appended(&path, &mut offset).unwrap();
+        assert_eq!(out, "{\"a\":1}\n{\"b\":2}\n");
+
+        // Partial trailing line is not consumed; completing it emits it next.
+        let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(f, "ial\":3}}").unwrap();
+        f.flush().unwrap();
+        let out2 = read_appended(&path, &mut offset).unwrap();
+        assert_eq!(out2, "{\"partial\":3}\n");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_appended_resets_on_truncation() {
+        let dir = std::env::temp_dir().join(format!("terax-claude-trunc-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("t.jsonl");
+        std::fs::write(&path, "{\"a\":1}\n{\"b\":2}\n").unwrap();
+        let mut offset = 0u64;
+        let _ = read_appended(&path, &mut offset).unwrap();
+        assert!(offset > 0);
+
+        std::fs::write(&path, "{\"c\":3}\n").unwrap();
+        let out = read_appended(&path, &mut offset).unwrap();
+        assert_eq!(out, "{\"c\":3}\n");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod claude;
 pub mod fs;
 pub mod git;
 pub mod net;

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+
 const ESC: u8 = 0x1b;
 const BEL: u8 = 0x07;
 const OSC_INTRO: u8 = b']';
@@ -31,6 +33,10 @@ pub enum Transition {
     Attention,
     Finished,
     Exited,
+    // The session's transcript JSONL path, reported by our Claude Code hooks so
+    // the chat GUI mirrors the exact running session (never a newest-mtime guess
+    // among the project's many sibling sessions).
+    Transcript { path: String },
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -38,18 +44,30 @@ pub struct AgentSignal {
     pub id: u32,
     pub kind: &'static str,
     pub agent: Option<String>,
+    pub path: Option<String>,
 }
 
 impl Transition {
     pub fn into_signal(self, id: u32) -> AgentSignal {
         match self {
             Transition::Started { agent } => {
-                AgentSignal { id, kind: "started", agent: Some(agent) }
+                AgentSignal { id, kind: "started", agent: Some(agent), path: None }
             }
-            Transition::Working => AgentSignal { id, kind: "working", agent: None },
-            Transition::Attention => AgentSignal { id, kind: "attention", agent: None },
-            Transition::Finished => AgentSignal { id, kind: "finished", agent: None },
-            Transition::Exited => AgentSignal { id, kind: "exited", agent: None },
+            Transition::Working => {
+                AgentSignal { id, kind: "working", agent: None, path: None }
+            }
+            Transition::Attention => {
+                AgentSignal { id, kind: "attention", agent: None, path: None }
+            }
+            Transition::Finished => {
+                AgentSignal { id, kind: "finished", agent: None, path: None }
+            }
+            Transition::Exited => {
+                AgentSignal { id, kind: "exited", agent: None, path: None }
+            }
+            Transition::Transcript { path } => {
+                AgentSignal { id, kind: "transcript", agent: None, path: Some(path) }
+            }
         }
     }
 }
@@ -161,6 +179,19 @@ impl AgentDetector {
 
     fn handle_osc777<F: FnMut(Transition)>(&mut self, pt: &[u8], emit: &mut F) {
         if let Some(event) = pt.strip_prefix(TERAX_MARKER) {
+            // `transcript;<base64-path>`: identifies the exact session JSONL for
+            // the chat mirror. Carried by the same hooks as the status markers.
+            if let Some(b64) = event.strip_prefix(b"transcript;") {
+                if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64) {
+                    if let Ok(path) = String::from_utf8(decoded) {
+                        if !path.is_empty() {
+                            self.ensure_armed(emit);
+                            emit(Transition::Transcript { path });
+                        }
+                    }
+                }
+                return;
+            }
             // Self-arms so notifications work even when no shell preexec fired
             // (bash, Windows, tmux, wrappers).
             match event {
@@ -314,6 +345,31 @@ mod tests {
         assert_eq!(run(&mut d, &osc("777;notify;Terax;working")), vec![Transition::Working]);
         assert!(run(&mut d, &osc("777;notify;Terax;working")).is_empty());
         assert_eq!(run(&mut d, &osc("777;notify;Terax;finished")), vec![Transition::Finished]);
+    }
+
+    #[test]
+    fn transcript_marker_decodes_and_arms() {
+        let mut d = AgentDetector::new();
+        let path = "/home/u/.claude/projects/-x/abc.jsonl";
+        let b64 = base64::engine::general_purpose::STANDARD.encode(path);
+        let out = run(&mut d, &osc(&format!("777;notify;Terax;transcript;{b64}")));
+        assert_eq!(
+            out,
+            vec![
+                started("claude"),
+                Transition::Transcript { path: path.into() }
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_transcript_marker_is_ignored() {
+        let mut d = AgentDetector::new();
+        run(&mut d, &osc("133;C;claude"));
+        // Not valid base64 -> no Transcript, no panic.
+        assert!(run(&mut d, &osc("777;notify;Terax;transcript;!!!!")).is_empty());
+        // Empty payload -> ignored.
+        assert!(run(&mut d, &osc("777;notify;Terax;transcript;")).is_empty());
     }
 
     #[test]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,115 +1,3 @@
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/components/ui/resizable";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { cn } from "@/lib/utils";
-import { AgentNotificationsBridge } from "@/modules/agents";
-import { firePendingReviewForSession } from "@/modules/agents/lib/review";
-import { useManagedAgentsStore } from "@/modules/agents/store/managedAgentsStore";
-import { Toaster } from "@/components/ui/sonner";
-import {
-  AgentRunBridge,
-  AiInputBar,
-  AiInputBarConnect,
-  AiMiniWindow,
-  getAllKeys,
-  getAllCustomEndpointKeys,
-  hasAnyKey,
-  LocalAgentNotificationsBridge,
-  SelectionAskAi,
-  useChatStore,
-} from "@/modules/ai";
-import { AiComposerProvider } from "@/modules/ai/lib/composer";
-import { redactSensitive } from "@/modules/ai/lib/redact";
-import { native } from "@/modules/ai/lib/native";
-import { useAgentsStore } from "@/modules/ai/store/agentsStore";
-import { useSnippetsStore } from "@/modules/ai/store/snippetsStore";
-import {
-  AiDiffStack,
-  EditorStack,
-  GitDiffStack,
-  NewEditorDialog,
-  type EditorPaneHandle,
-} from "@/modules/editor";
-import {
-  GitHistoryStack,
-  type GitHistorySearchHandle,
-} from "@/modules/git-history";
-import { getLaunchDir } from "@/lib/launchDir";
-import { quoteShellArg } from "@/lib/shellQuote";
-import { useZoom } from "@/lib/useZoom";
-import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
-import {
-  listenFsChanged,
-  parentDir,
-  watchAdd,
-  watchRemove,
-} from "@/modules/explorer/lib/watch";
-import {
-  Header,
-  type SearchInlineHandle,
-  type SearchTarget,
-} from "@/modules/header";
-import { MarkdownStack } from "@/modules/markdown";
-import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
-import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
-import { usePreferencesStore } from "@/modules/settings/preferences";
-import { onKeysChanged, setThemeId as persistThemeId } from "@/modules/settings/store";
-import {
-  ShortcutsDialog,
-  useGlobalShortcuts,
-  type ShortcutHandlers,
-  type ShortcutId,
-} from "@/modules/shortcuts";
-import { SidebarRail, type SidebarViewId } from "@/modules/sidebar";
-import {
-  SourceControlPanel,
-  useSourceControl,
-} from "@/modules/source-control";
-import { StatusBar } from "@/modules/statusbar";
-import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
-import {
-  clearFocusedTerminal,
-  disposeSession,
-  findLeafCwd,
-  hasLeaf,
-  leafIds,
-  respawnSession,
-  TerminalStack,
-  whenSessionReady,
-  writeToSession,
-  type TerminalPaneHandle,
-} from "@/modules/terminal";
-import { ThemeProvider } from "@/modules/theme";
-import { listCustomThemes, saveCustomTheme } from "@/modules/theme/customThemes";
-import {
-  isThemeFilePath,
-  onThemeEdit,
-  parseThemeFile,
-  starterTheme,
-  themeFilePath,
-  writeThemeFile,
-} from "@/modules/theme/themeFiles";
-import { UpdaterDialog } from "@/modules/updater";
-import {
-  currentWorkspaceEnv,
-  getWslHome,
-  LOCAL_WORKSPACE,
-  useWorkspaceEnvStore,
-  type WorkspaceEnv,
-} from "@/modules/workspace";
 import { invoke } from "@tauri-apps/api/core";
 import { homeDir } from "@tauri-apps/api/path";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
@@ -117,29 +5,144 @@ import type { SearchAddon } from "@xterm/addon-search";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PanelImperativeHandle } from "react-resizable-panels";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+	ResizableHandle,
+	ResizablePanel,
+	ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { getLaunchDir } from "@/lib/launchDir";
+import { quoteShellArg } from "@/lib/shellQuote";
+import { useZoom } from "@/lib/useZoom";
+import { cn } from "@/lib/utils";
+import { AgentNotificationsBridge } from "@/modules/agents";
+import { firePendingReviewForSession } from "@/modules/agents/lib/review";
+import { useManagedAgentsStore } from "@/modules/agents/store/managedAgentsStore";
+import {
+	AgentRunBridge,
+	AiInputBar,
+	AiInputBarConnect,
+	AiMiniWindow,
+	getAllCustomEndpointKeys,
+	getAllKeys,
+	hasAnyKey,
+	LocalAgentNotificationsBridge,
+	SelectionAskAi,
+	useChatStore,
+} from "@/modules/ai";
+import { AiComposerProvider } from "@/modules/ai/lib/composer";
+import { native } from "@/modules/ai/lib/native";
+import { redactSensitive } from "@/modules/ai/lib/redact";
+import { useAgentsStore } from "@/modules/ai/store/agentsStore";
+import { useSnippetsStore } from "@/modules/ai/store/snippetsStore";
+import {
+	AiDiffStack,
+	type EditorPaneHandle,
+	EditorStack,
+	GitDiffStack,
+	NewEditorDialog,
+} from "@/modules/editor";
+import { FileExplorer, type FileExplorerHandle } from "@/modules/explorer";
+import {
+	listenFsChanged,
+	parentDir,
+	watchAdd,
+	watchRemove,
+} from "@/modules/explorer/lib/watch";
+import {
+	type GitHistorySearchHandle,
+	GitHistoryStack,
+} from "@/modules/git-history";
+import {
+	Header,
+	type SearchInlineHandle,
+	type SearchTarget,
+} from "@/modules/header";
+import { MarkdownStack } from "@/modules/markdown";
+import { type PreviewPaneHandle, PreviewStack } from "@/modules/preview";
+import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+	onKeysChanged,
+	setThemeId as persistThemeId,
+} from "@/modules/settings/store";
+import {
+	type ShortcutHandlers,
+	type ShortcutId,
+	ShortcutsDialog,
+	useGlobalShortcuts,
+} from "@/modules/shortcuts";
+import { SidebarRail, type SidebarViewId } from "@/modules/sidebar";
+import { SourceControlPanel, useSourceControl } from "@/modules/source-control";
+import { StatusBar } from "@/modules/statusbar";
+import { MAX_PANES_PER_TAB, useTabs, useWorkspaceCwd } from "@/modules/tabs";
+import {
+	clearFocusedTerminal,
+	disposeSession,
+	findLeafCwd,
+	hasLeaf,
+	leafIds,
+	respawnSession,
+	type TerminalPaneHandle,
+	TerminalStack,
+	whenSessionReady,
+	writeToSession,
+} from "@/modules/terminal";
+import { ThemeProvider } from "@/modules/theme";
+import {
+	listCustomThemes,
+	saveCustomTheme,
+} from "@/modules/theme/customThemes";
+import {
+	isThemeFilePath,
+	onThemeEdit,
+	parseThemeFile,
+	starterTheme,
+	themeFilePath,
+	writeThemeFile,
+} from "@/modules/theme/themeFiles";
+import { UpdaterDialog } from "@/modules/updater";
+import {
+	currentWorkspaceEnv,
+	getWslHome,
+	LOCAL_WORKSPACE,
+	useWorkspaceEnvStore,
+	type WorkspaceEnv,
+} from "@/modules/workspace";
 
 type TuiWaitResult = "ready" | "gone" | "timeout";
 
 async function waitForClaudeTuiReady(
-  readBuf: () => string | null,
-  timeoutMs = 8000,
+	readBuf: () => string | null,
+	timeoutMs = 8000,
 ): Promise<TuiWaitResult> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const buf = readBuf();
-    if (buf === null) return "gone";
-    if (buf.includes("shortcuts") || buf.includes("? for")) return "ready";
-    await new Promise((r) => setTimeout(r, 120));
-  }
-  return "timeout";
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		const buf = readBuf();
+		if (buf === null) return "gone";
+		if (buf.includes("shortcuts") || buf.includes("? for")) return "ready";
+		await new Promise((r) => setTimeout(r, 120));
+	}
+	return "timeout";
 }
 
 function dirname(path: string | null): string | null {
-  if (!path) return null;
-  const normalized = path.replace(/\\/g, "/");
-  const idx = normalized.lastIndexOf("/");
-  if (idx <= 0) return normalized;
-  return normalized.slice(0, idx);
+	if (!path) return null;
+	const normalized = path.replace(/\\/g, "/");
+	const idx = normalized.lastIndexOf("/");
+	if (idx <= 0) return normalized;
+	return normalized.slice(0, idx);
 }
 
 const SIDEBAR_DEFAULT_WIDTH = 260;
@@ -149,1522 +152,1544 @@ const SIDEBAR_WIDTH_STORAGE_KEY = "terax.sidebar.width";
 const SIDEBAR_VIEW_STORAGE_KEY = "terax.sidebar.view";
 
 function clampSidebarWidth(width: number): number {
-  return Math.min(
-    SIDEBAR_MAX_WIDTH,
-    Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)),
-  );
+	return Math.min(
+		SIDEBAR_MAX_WIDTH,
+		Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)),
+	);
 }
 
 function readSidebarWidth(): number {
-  try {
-    const stored = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
-    const parsed = stored ? Number.parseInt(stored, 10) : NaN;
-    return Number.isFinite(parsed)
-      ? clampSidebarWidth(parsed)
-      : SIDEBAR_DEFAULT_WIDTH;
-  } catch {
-    return SIDEBAR_DEFAULT_WIDTH;
-  }
+	try {
+		const stored = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+		const parsed = stored ? Number.parseInt(stored, 10) : NaN;
+		return Number.isFinite(parsed)
+			? clampSidebarWidth(parsed)
+			: SIDEBAR_DEFAULT_WIDTH;
+	} catch {
+		return SIDEBAR_DEFAULT_WIDTH;
+	}
 }
 
 function readSidebarView(): SidebarViewId {
-  try {
-    const stored = window.localStorage.getItem(SIDEBAR_VIEW_STORAGE_KEY);
-    if (stored === "explorer" || stored === "source-control") return stored;
-  } catch {
-    // ignore
-  }
-  return "explorer";
+	try {
+		const stored = window.localStorage.getItem(SIDEBAR_VIEW_STORAGE_KEY);
+		if (stored === "explorer" || stored === "source-control") return stored;
+	} catch {
+		// ignore
+	}
+	return "explorer";
 }
 
 export default function App() {
-  const {
-    tabs,
-    activeId,
-    setActiveId,
-    newTab,
-    newAgentTab,
-    newPrivateTab,
-    openFileTab,
-    pinTab,
-    newPreviewTab,
-    newMarkdownTab,
-    openAiDiffTab,
-    closeAiDiffTab,
-    openGitDiffTab,
-    openCommitHistoryTab,
-    openCommitFileDiffTab,
-    closeTab,
-    updateTab,
-    selectByIndex,
-    setLeafCwd,
-    focusPane,
-    focusNextPaneInTab,
-    splitActivePane,
-    closeActivePane,
-    closePaneByLeaf,
-    resetWorkspace,
-  } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
-
-  // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
-  // (e.g. cdInNewTab) read the latest pane state instead of a stale closure.
-  const tabsRef = useRef(tabs);
-  tabsRef.current = tabs;
-
-  const activeTerminalTab = useMemo(() => {
-    const t = tabs.find((x) => x.id === activeId);
-    return t && t.kind === "terminal" ? t : null;
-  }, [tabs, activeId]);
-  const activeLeafId = activeTerminalTab?.activeLeafId ?? null;
-
-  const searchAddons = useRef<Map<number, SearchAddon>>(new Map());
-  const [activeSearchAddon, setActiveSearchAddon] =
-    useState<SearchAddon | null>(null);
-  const searchInlineRef = useRef<SearchInlineHandle | null>(null);
-  const terminalRefs = useRef<Map<number, TerminalPaneHandle>>(new Map());
-  const editorRefs = useRef<Map<number, EditorPaneHandle>>(new Map());
-  const previewRefs = useRef<Map<number, PreviewPaneHandle>>(new Map());
-  const [activeEditorHandle, setActiveEditorHandle] =
-    useState<EditorPaneHandle | null>(null);
-  const [gitHistoryHandle, setGitHistoryHandle] =
-    useState<GitHistorySearchHandle | null>(null);
-  const { zoomIn, zoomOut, zoomReset } = useZoom();
-  const explorerRef = useRef<FileExplorerHandle>(null);
-  const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
-
-  const sidebarRef = useRef<PanelImperativeHandle | null>(null);
-  const sidebarWidthRef = useRef(readSidebarWidth());
-  const sidebarWidthWriteTimerRef = useRef(0);
-  const [sidebarView, setSidebarViewState] = useState<SidebarViewId>(readSidebarView);
-  const persistSidebarView = useCallback((view: SidebarViewId) => {
-    setSidebarViewState(view);
-    try {
-      window.localStorage.setItem(SIDEBAR_VIEW_STORAGE_KEY, view);
-    } catch {
-      // storage may fail in private mode
-    }
-  }, []);
-  const toggleSidebar = useCallback(() => {
-    const p = sidebarRef.current;
-    if (!p) return;
-    if (p.getSize().asPercentage <= 0) p.expand();
-    else p.collapse();
-  }, []);
-  const cycleSidebarView = useCallback(
-    (view: SidebarViewId) => {
-      const panel = sidebarRef.current;
-      const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
-      if (collapsed) {
-        if (panel) panel.resize(`${sidebarWidthRef.current}px`);
-        if (view !== sidebarView) persistSidebarView(view);
-        return;
-      }
-      if (view === sidebarView) {
-        panel?.collapse();
-        return;
-      }
-      persistSidebarView(view);
-    },
-    [persistSidebarView, sidebarView],
-  );
-  const persistSidebarWidth = useCallback((next: number) => {
-    sidebarWidthRef.current = next;
-    if (sidebarWidthWriteTimerRef.current) {
-      window.clearTimeout(sidebarWidthWriteTimerRef.current);
-    }
-    sidebarWidthWriteTimerRef.current = window.setTimeout(() => {
-      sidebarWidthWriteTimerRef.current = 0;
-      try {
-        window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(next));
-      } catch {
-        // ignore
-      }
-    }, 200);
-  }, []);
-  useEffect(() => {
-    return () => {
-      if (sidebarWidthWriteTimerRef.current) {
-        window.clearTimeout(sidebarWidthWriteTimerRef.current);
-      }
-    };
-  }, []);
-
-  const toggleExplorerFocus = useCallback(() => {
-    const explorer = explorerRef.current;
-    const panel = sidebarRef.current;
-    const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
-    if (sidebarView !== "explorer" || collapsed) {
-      if (panel && collapsed) panel.resize(`${sidebarWidthRef.current}px`);
-      if (sidebarView !== "explorer") persistSidebarView("explorer");
-      const active = document.activeElement;
-      explorerReturnFocusRef.current =
-        active instanceof HTMLElement && active !== document.body
-          ? active
-          : null;
-      requestAnimationFrame(() => explorerRef.current?.focus());
-      return;
-    }
-    if (!explorer) return;
-    if (explorer.isFocused()) {
-      const target = explorerReturnFocusRef.current;
-      explorerReturnFocusRef.current = null;
-      if (target && document.body.contains(target)) {
-        target.focus();
-      } else {
-        (document.activeElement as HTMLElement | null)?.blur?.();
-      }
-      return;
-    }
-    const active = document.activeElement;
-    explorerReturnFocusRef.current =
-      active instanceof HTMLElement && active !== document.body ? active : null;
-    explorer.focus();
-  }, [persistSidebarView, sidebarView]);
-
-  const [home, setHome] = useState<string | null>(null);
-  const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
-  const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
-  const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
-  const [launchCwd, setLaunchCwd] = useState<string | null>(null);
-  const [launchCwdResolved, setLaunchCwdResolved] = useState(false);
-  const [pendingDeleteTabs, setPendingDeleteTabs] = useState<number[] | null>(
-    null,
-  );
-  useEffect(() => {
-    homeDir()
-      .then(async (p) => {
-        const normalized = p.replace(/\\/g, "/");
-        setHome(normalized);
-        try {
-          await native.workspaceAuthorize(normalized);
-        } catch {
-          // Bootstrap already authorizes home from Rust; ignore.
-        }
-      })
-      .catch(() => setHome(null));
-  }, []);
-
-  const switchWorkspace = useCallback(
-    async (env: WorkspaceEnv) => {
-      if (
-        env.kind === workspaceEnv.kind &&
-        (env.kind === "local" ||
-          (workspaceEnv.kind === "wsl" && env.distro === workspaceEnv.distro))
-      ) {
-        return;
-      }
-      const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
-      if (dirty) {
-        window.alert("Save or close unsaved editor tabs before switching workspace.");
-        return;
-      }
-
-      let nextHome: string | null = null;
-      try {
-        if (env.kind === "wsl") {
-          nextHome = await getWslHome(env.distro);
-        } else {
-          nextHome = (await homeDir()).replace(/\\/g, "/");
-        }
-      } catch (e) {
-        window.alert(String(e));
-        return;
-      }
-
-      for (const id of liveLeavesRef.current) disposeSession(id);
-      searchAddons.current.clear();
-      terminalRefs.current.clear();
-      editorRefs.current.clear();
-      previewRefs.current.clear();
-      setActiveSearchAddon(null);
-      setActiveEditorHandle(null);
-      setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
-      setHome(nextHome);
-      setLaunchCwd(nextHome);
-      if (nextHome) {
-        try {
-          await native.workspaceAuthorize(nextHome);
-        } catch {
-          // Non-fatal — git panel will surface "not authorized" if needed.
-        }
-      }
-      resetWorkspace(nextHome ?? undefined);
-    },
-    [workspaceEnv, setWorkspaceEnv, resetWorkspace],
-  );
-  useEffect(() => {
-    native
-      .workspaceCurrentDir()
-      .then(setLaunchCwd)
-      .catch(() => setLaunchCwd(null))
-      .finally(() => setLaunchCwdResolved(true));
-  }, []);
-
-  const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const [newEditorOpen, setNewEditorOpen] = useState(false);
-  const miniOpen = useChatStore((s) => s.mini.open);
-  const activeSessionId = useChatStore((s) => s.activeSessionId);
-  const openMini = useChatStore((s) => s.openMini);
-  const focusInput = useChatStore((s) => s.focusInput);
-  const openPanel = useChatStore((s) => s.openPanel);
-  const panelOpen = useChatStore((s) => s.panelOpen);
-  const apiKeys = useChatStore((s) => s.apiKeys);
-  const setApiKeys = useChatStore((s) => s.setApiKeys);
-  const setCustomEndpointKeys = useChatStore((s) => s.setCustomEndpointKeys);
-  const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
-  const setLive = useChatStore((s) => s.setLive);
-  const respondToApproval = useChatStore((s) => s.respondToApproval);
-
-  useEffect(() => {
-    if (activeSessionId) firePendingReviewForSession(activeSessionId);
-  }, [activeSessionId]);
-  const lmstudioModelId = usePreferencesStore((s) => s.lmstudioModelId);
-  const lmstudioBaseURL = usePreferencesStore((s) => s.lmstudioBaseURL);
-  const mlxModelId = usePreferencesStore((s) => s.mlxModelId);
-  const mlxBaseURL = usePreferencesStore((s) => s.mlxBaseURL);
-  const ollamaModelId = usePreferencesStore((s) => s.ollamaModelId);
-  const ollamaBaseURL = usePreferencesStore((s) => s.ollamaBaseURL);
-  const openaiCompatibleModelId = usePreferencesStore(
-    (s) => s.openaiCompatibleModelId,
-  );
-  const openaiCompatibleBaseURL = usePreferencesStore(
-    (s) => s.openaiCompatibleBaseURL,
-  );
-  const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
-  const hasLocalModel =
-    (lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0) ||
-    (mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0) ||
-    (ollamaBaseURL.trim().length > 0 && ollamaModelId.trim().length > 0) ||
-    (openaiCompatibleBaseURL.trim().length > 0 &&
-      openaiCompatibleModelId.trim().length > 0) ||
-    customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0);
-  const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
-
-  const prefsHydrated = usePreferencesStore((s) => s.hydrated);
-  const [keysLoaded, setKeysLoaded] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    const reload = () => {
-      void getAllKeys().then((keys) => {
-        if (!alive) return;
-        setApiKeys(keys);
-        setKeysLoaded(true);
-      });
-      if (!prefsHydrated) return;
-      void getAllCustomEndpointKeys(
-        usePreferencesStore.getState().customEndpoints,
-      ).then((epKeys) => {
-        if (!alive) return;
-        setCustomEndpointKeys(epKeys);
-      });
-    };
-    reload();
-    const unlistenP = onKeysChanged(reload);
-    return () => {
-      alive = false;
-      void unlistenP.then((fn) => fn());
-    };
-  }, [setApiKeys, setCustomEndpointKeys, prefsHydrated]);
-
-  // Hydrate the cross-window preference store and mirror the default model
-  // into chatStore so the dropdown reflects what the user picked in Settings.
-  const initPrefs = usePreferencesStore((s) => s.init);
-  const prefDefaultModel = usePreferencesStore((s) => s.defaultModelId);
-  useEffect(() => {
-    void initPrefs();
-  }, [initPrefs]);
-  useEffect(() => {
-    if (!prefsHydrated) return;
-    setSelectedModelId(prefDefaultModel);
-  }, [prefsHydrated, prefDefaultModel, setSelectedModelId]);
-
-  const hydrateSessions = useChatStore((s) => s.hydrateSessions);
-  useEffect(() => {
-    void hydrateSessions();
-    void useAgentsStore.getState().hydrate();
-    void useSnippetsStore.getState().hydrate();
-  }, [hydrateSessions]);
-
-  const activeTab = tabs.find((t) => t.id === activeId);
-  const isTerminalTab = activeTab?.kind === "terminal";
-  const isEditorTab = activeTab?.kind === "editor";
-  const isPreviewTab = activeTab?.kind === "preview";
-  const isMarkdownTab = activeTab?.kind === "markdown";
-  const isAiDiffTab = activeTab?.kind === "ai-diff";
-  const isGitDiffTab =
-    activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
-  const isGitHistoryTab = activeTab?.kind === "git-history";
-
-  // When an AI diff is approved (write_file applied to disk), reload any
-  // open editor tabs for that path so the user sees the new content. We
-  // track which approvalIds we've already handled to fire the reload only
-  // once per applied diff.
-  const appliedDiffsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    for (const t of tabs) {
-      if (t.kind !== "ai-diff") continue;
-      if (t.status !== "approved") continue;
-      if (appliedDiffsRef.current.has(t.approvalId)) continue;
-      appliedDiffsRef.current.add(t.approvalId);
-      for (const e of tabs) {
-        if (e.kind !== "editor") continue;
-        if (e.path !== t.path) continue;
-        editorRefs.current.get(e.id)?.reload();
-      }
-    }
-  }, [tabs]);
-
-  useEffect(() => {
-    type FileWrittenPayload = { path: string; source?: string };
-    const unlistenPromise = getCurrentWebviewWindow().listen<FileWrittenPayload>(
-      "fs:file-written",
-      (event) => {
-        if (event.payload.source === "editor") return;
-        const normalizedPath = event.payload.path.replace(/\\/g, "/");
-        const currentTabs = tabsRef.current;
-        for (const t of currentTabs) {
-          if (t.kind !== "editor") continue;
-          if (t.path.replace(/\\/g, "/") === normalizedPath) {
-            editorRefs.current.get(t.id)?.reload();
-          }
-        }
-      },
-    );
-    return () => {
-      void unlistenPromise.then((un) => un());
-    };
-  }, []);
-
-  const editorWatchRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    const want = new Set<string>();
-    for (const t of tabs) if (t.kind === "editor") want.add(parentDir(t.path));
-    const prev = editorWatchRef.current;
-    const toAdd = [...want].filter((d) => !prev.has(d));
-    const toRemove = [...prev].filter((d) => !want.has(d));
-    watchAdd(toAdd);
-    watchRemove(toRemove);
-    editorWatchRef.current = want;
-  }, [tabs]);
-
-  useEffect(() => {
-    let alive = true;
-    let unlisten: (() => void) | undefined;
-    void listenFsChanged((paths) => {
-      const changed = new Set(paths.map((p) => p.replace(/\\/g, "/")));
-      for (const t of tabsRef.current) {
-        if (t.kind !== "editor") continue;
-        if (changed.has(t.path.replace(/\\/g, "/"))) {
-          editorRefs.current.get(t.id)?.reload();
-        }
-      }
-    }).then((un) => {
-      if (alive) unlisten = un;
-      else un();
-    });
-    return () => {
-      alive = false;
-      unlisten?.();
-    };
-  }, []);
-
-  // Theme editing: a custom theme is materialized to a real file and edited in
-  // the code editor. Saving it re-ingests into the runtime store + applies live.
-  useEffect(() => {
-    type FileWrittenPayload = { path: string; source?: string };
-    const unlistenPromise = getCurrentWebviewWindow().listen<FileWrittenPayload>(
-      "fs:file-written",
-      (event) => {
-        if (event.payload.source !== "editor") return;
-        if (!isThemeFilePath(event.payload.path)) return;
-        void (async () => {
-          try {
-            const res = await invoke<{ kind: string; content?: string }>(
-              "fs_read_file",
-              { path: event.payload.path, workspace: currentWorkspaceEnv() },
-            );
-            if (res.kind !== "text" || typeof res.content !== "string") return;
-            const parsed = parseThemeFile(res.content);
-            if (!parsed.ok) {
-              console.warn("[terax] theme not applied:", parsed.error);
-              return;
-            }
-            await saveCustomTheme(parsed.theme);
-          } catch (e) {
-            console.warn("[terax] theme ingest failed:", e);
-          }
-        })();
-      },
-    );
-    return () => {
-      void unlistenPromise.then((un) => un());
-    };
-  }, []);
-
-  useEffect(() => {
-    let alive = true;
-    let unsub: (() => void) | undefined;
-    void onThemeEdit(async (req) => {
-      const theme =
-        req.action === "create"
-          ? starterTheme()
-          : (await listCustomThemes()).find((t) => t.id === req.id);
-      if (!theme) return;
-      if (req.action === "create") await saveCustomTheme(theme);
-      const path = await themeFilePath(theme.id);
-      const open = tabsRef.current.some(
-        (t) => t.kind === "editor" && t.path === path,
-      );
-      if (!open) await writeThemeFile(theme);
-      void persistThemeId(theme.id);
-      openFileTab(path);
-      void getCurrentWebviewWindow().setFocus();
-    }).then((fn) => {
-      if (alive) unsub = fn;
-      else fn();
-    });
-    return () => {
-      alive = false;
-      unsub?.();
-    };
-  }, [openFileTab]);
-
-  const { explorerRoot, inheritedCwdForNewTab } = useWorkspaceCwd(
-    activeTab,
-    tabs,
-    launchCwd ?? home,
-  );
-
-  useEffect(() => {
-    setActiveSearchAddon(
-      activeLeafId !== null ? (searchAddons.current.get(activeLeafId) ?? null) : null,
-    );
-    setActiveEditorHandle(editorRefs.current.get(activeId) ?? null);
-  }, [activeId, activeLeafId]);
-
-  const handleSearchReady = useCallback(
-    (leafId: number, addon: SearchAddon) => {
-      searchAddons.current.set(leafId, addon);
-      if (leafId === activeLeafId) setActiveSearchAddon(addon);
-    },
-    [activeLeafId],
-  );
-
-  const disposeTab = useCallback(
-    (id: number) => {
-      // Terminal-leaf-keyed maps (terminalRefs/searchAddons) are pruned by
-      // the effect below as the pane tree changes; only the tab-id-keyed
-      // handles need explicit cleanup here.
-      editorRefs.current.delete(id);
-      previewRefs.current.delete(id);
-      closeTab(id);
-    },
-    [closeTab],
-  );
-
-  // Drives session disposal off the pane tree, not React lifecycles —
-  // split/unsplit re-mount components but the leaf is still live.
-  const liveLeavesRef = useRef<Set<number>>(new Set());
-  useEffect(() => {
-    const live = new Set<number>();
-    for (const t of tabs) {
-      if (t.kind === "terminal") {
-        for (const id of leafIds(t.paneTree)) live.add(id);
-      }
-    }
-    for (const id of liveLeavesRef.current) {
-      if (!live.has(id)) disposeSession(id);
-    }
-    liveLeavesRef.current = live;
-    for (const k of [...terminalRefs.current.keys()])
-      if (!live.has(k)) terminalRefs.current.delete(k);
-    for (const k of [...searchAddons.current.keys()])
-      if (!live.has(k)) searchAddons.current.delete(k);
-  }, [tabs]);
-
-  const handleClose = useCallback(
-    (id: number) => {
-      const t = tabs.find((x) => x.id === id);
-      if (t?.kind === "editor" && t.dirty) {
-        setPendingCloseTab(id);
-        return;
-      }
-      disposeTab(id);
-    },
-    [tabs, disposeTab],
-  );
-
-  const confirmClose = useCallback(() => {
-    if (pendingCloseTab !== null) {
-      disposeTab(pendingCloseTab);
-      setPendingCloseTab(null);
-    }
-  }, [pendingCloseTab, disposeTab]);
-
-  const cancelClose = useCallback(() => {
-    setPendingCloseTab(null);
-  }, []);
-
-  const cycleTab = useCallback(
-    (delta: 1 | -1) => {
-      if (tabs.length < 2) return;
-      const idx = tabs.findIndex((t) => t.id === activeId);
-      const nextIdx = (idx + delta + tabs.length) % tabs.length;
-      setActiveId(tabs[nextIdx].id);
-    },
-    [tabs, activeId, setActiveId],
-  );
-
-  const captureActiveSelection = useCallback((): string | null => {
-    const t = tabs.find((x) => x.id === activeId);
-    if (!t) return null;
-    if (t.kind === "terminal") {
-      const lid = t.activeLeafId;
-      return terminalRefs.current.get(lid)?.getSelection() ?? null;
-    }
-    if (t.kind === "editor") {
-      return editorRefs.current.get(activeId)?.getSelection() ?? null;
-    }
-    return null;
-  }, [tabs, activeId]);
-
-  const togglePanelAndFocus = useCallback(() => {
-    if (!hasComposer) {
-      void openSettingsWindow("models");
-      return;
-    }
-    if (panelOpen) {
-      useChatStore.getState().closePanel();
-    } else {
-      openPanel();
-      focusInput(null);
-    }
-  }, [hasComposer, panelOpen, openPanel, focusInput]);
-
-  const attachSelection = useChatStore((s) => s.attachSelection);
-
-  const handleAttachFileToAgent = useCallback(
-    (path: string) => {
-      if (!hasComposer) {
-        void openSettingsWindow("models");
-        return;
-      }
-      // Dispatch a window event the composer listens for. Same pattern as
-      // selections — keeps file-explorer decoupled from the AI module.
-      window.dispatchEvent(
-        new CustomEvent<string>("terax:ai-attach-file", { detail: path }),
-      );
-      openPanel();
-      focusInput(null);
-    },
-    [hasComposer, openPanel, focusInput],
-  );
-
-  const askFromSelection = useCallback(() => {
-    if (!hasComposer) {
-      void openSettingsWindow("models");
-      return;
-    }
-    const selection = captureActiveSelection();
-    if (!selection || !selection.trim()) {
-      focusInput(null);
-      return;
-    }
-    const source: "terminal" | "editor" =
-      activeTab?.kind === "editor" ? "editor" : "terminal";
-    attachSelection(selection, source);
-  }, [
-    hasComposer,
-    captureActiveSelection,
-    focusInput,
-    attachSelection,
-    activeTab,
-  ]);
-
-  const [askPopup, setAskPopup] = useState<{ x: number; y: number } | null>(
-    null,
-  );
-
-  useEffect(() => {
-    const isInsideAi = (t: EventTarget | null) => {
-      const el = t as HTMLElement | null;
-      if (!el) return false;
-      return !!(
-        el.closest("[data-selection-ask-ai]") ||
-        el.closest("[data-ai-input-bar]") ||
-        el.closest("[data-ai-mini-window]")
-      );
-    };
-
-    const onDown = (e: MouseEvent) => {
-      if (isInsideAi(e.target)) return;
-      setAskPopup(null);
-    };
-    const onUp = (e: MouseEvent) => {
-      if (isInsideAi(e.target)) return;
-      const el = e.target as HTMLElement | null;
-      const inContentArea = el?.closest?.(".xterm, .cm-editor");
-      if (!inContentArea) return;
-      // Defer one tick so xterm/CodeMirror finalize the selection.
-      setTimeout(() => {
-        const text = captureActiveSelection();
-        if (text && text.trim().length > 0) {
-          setAskPopup({ x: e.clientX, y: e.clientY });
-        } else {
-          setAskPopup(null);
-        }
-      }, 0);
-    };
-
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("mouseup", onUp);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("mouseup", onUp);
-    };
-  }, [captureActiveSelection]);
-
-  const onAskFromSelection = useCallback(() => {
-    askFromSelection();
-    setAskPopup(null);
-  }, [askFromSelection]);
-
-  const openNewTab = useCallback(() => {
-    newTab(inheritedCwdForNewTab());
-  }, [newTab, inheritedCwdForNewTab]);
-
-  const openNewPrivateTab = useCallback(() => {
-    newPrivateTab(inheritedCwdForNewTab());
-  }, [newPrivateTab, inheritedCwdForNewTab]);
-
-  const sendCd = useCallback(
-    (path: string) => {
-      if (activeLeafId === null) return;
-      const term = terminalRefs.current.get(activeLeafId);
-      if (!term) return;
-      term.write(`cd ${quoteShellArg(path)}\r`);
-      term.focus();
-    },
-    [activeLeafId],
-  );
-
-  const cdInNewTab = useCallback(
-    (path: string) => {
-      const tabId = newTab(path);
-      setTimeout(() => {
-        const tab = tabsRef.current.find((x) => x.id === tabId);
-        if (!tab || tab.kind !== "terminal") return;
-        const t = terminalRefs.current.get(tab.activeLeafId);
-        if (!t) return;
-        t.write(`cd ${quoteShellArg(path)}\r`);
-        t.focus();
-      }, 80);
-    },
-    [newTab],
-  );
-
-  const handleOpenFile = useCallback(
-    (path: string, pin?: boolean) => {
-      // Explorer defaults to preview (pin=false); explicit actions like
-      // context-menu "Open" pass pin=true for a persistent tab.
-      openFileTab(path, pin ?? false);
-    },
-    [openFileTab],
-  );
-
-  const handlePathRenamed = useCallback(
-    (from: string, to: string) => {
-      for (const t of tabs) {
-        if (t.kind !== "editor") continue;
-        if (t.path === from) {
-          const i = to.lastIndexOf("/");
-          updateTab(t.id, { path: to, title: i === -1 ? to : to.slice(i + 1) });
-        } else if (t.path.startsWith(`${from}/`)) {
-          const suffix = t.path.slice(from.length);
-          const newPath = `${to}${suffix}`;
-          const i = newPath.lastIndexOf("/");
-          updateTab(t.id, {
-            path: newPath,
-            title: i === -1 ? newPath : newPath.slice(i + 1),
-          });
-        }
-      }
-    },
-    [tabs, updateTab],
-  );
-
-  const confirmDeleteClose = useCallback(() => {
-    if (pendingDeleteTabs !== null) {
-      for (const id of pendingDeleteTabs) disposeTab(id);
-      setPendingDeleteTabs(null);
-    }
-  }, [pendingDeleteTabs, disposeTab]);
-
-  const cancelDeleteClose = useCallback(() => {
-    setPendingDeleteTabs(null);
-  }, []);
-
-  const handlePathDeleted = useCallback(
-    (path: string) => {
-      const dirty: number[] = [];
-      for (const t of tabs) {
-        if (t.kind !== "editor") continue;
-        if (t.path !== path && !t.path.startsWith(`${path}/`)) continue;
-        if (t.dirty) {
-          dirty.push(t.id);
-        } else {
-          disposeTab(t.id);
-        }
-      }
-      if (dirty.length > 0) setPendingDeleteTabs(dirty);
-    },
-    [tabs, disposeTab],
-  );
-
-  const activeTerminalLeafCwd =
-    activeTab?.kind === "terminal"
-      ? (findLeafCwd(activeTab.paneTree, activeTab.activeLeafId) ??
-        activeTab.cwd ??
-        null)
-      : null;
-
-  const activeFilePath = (() => {
-    if (activeTab?.kind === "editor") return activeTab.path;
-    if (activeTab?.kind === "git-diff") {
-      if (/^([A-Za-z]:|\/|\\)/.test(activeTab.path)) return activeTab.path;
-      const root = activeTab.repoRoot.replace(/[\\/]+$/, "");
-      const rel = activeTab.path.replace(/^[\\/]+/, "");
-      return `${root}/${rel}`;
-    }
-    if (activeTab?.kind === "git-commit-file") {
-      const root = activeTab.repoRoot.replace(/[\\/]+$/, "");
-      const rel = activeTab.path.replace(/^[\\/]+/, "");
-      return `${root}/${rel}`;
-    }
-    return null;
-  })();
-  const workspaceFallbackPath = launchCwdResolved
-    ? (launchCwd ?? home ?? null)
-    : null;
-  const sourceControlContextPath = (() => {
-    if (activeTab?.kind === "terminal") {
-      return activeTerminalLeafCwd ?? explorerRoot ?? workspaceFallbackPath;
-    }
-    if (activeTab?.kind === "editor") return dirname(activeTab.path);
-    if (activeTab?.kind === "git-diff") return activeTab.repoRoot;
-    if (activeTab?.kind === "git-commit-file") return activeTab.repoRoot;
-    if (activeTab?.kind === "git-history") return activeTab.repoRoot;
-    return explorerRoot ?? workspaceFallbackPath;
-  })();
-  const hasOpenGitTab = useMemo(
-    () =>
-      tabs.some(
-        (t) =>
-          t.kind === "git-diff" ||
-          t.kind === "git-history" ||
-          t.kind === "git-commit-file",
-      ),
-    [tabs],
-  );
-  const sourceControlActive =
-    hasOpenGitTab || sidebarView === "source-control";
-  // Stable per-session path so switching tabs / cd-ing in a shell does NOT
-  // re-fire git IPC for the badge. The active panel resolves the current
-  // context path on its own when the user actually opens git.
-  const badgeContextPath = workspaceFallbackPath;
-  const sourceControlPath = sourceControlActive
-    ? sourceControlContextPath
-    : badgeContextPath;
-  const sourceControl = useSourceControl(sourceControlPath, true);
-
-  const toggleSourceControl = useCallback(() => {
-    cycleSidebarView("source-control");
-  }, [cycleSidebarView]);
-
-  const openGitGraphFromContext = useCallback(async () => {
-    const known = sourceControl.hasRepo ? sourceControl.repo : null;
-    if (known) {
-      openCommitHistoryTab({
-        repoRoot: known.repoRoot,
-        branch: sourceControl.status?.branch ?? null,
-      });
-      return;
-    }
-    if (!sourceControlContextPath) return;
-    try {
-      const repo = await native.gitResolveRepo(sourceControlContextPath);
-      if (!repo) return;
-      openCommitHistoryTab({ repoRoot: repo.repoRoot, branch: repo.branch });
-    } catch {
-      /* noop */
-    }
-  }, [
-    openCommitHistoryTab,
-    sourceControl.hasRepo,
-    sourceControl.repo,
-    sourceControl.status?.branch,
-    sourceControlContextPath,
-  ]);
-
-  const openPreviewTab = useCallback(
-    (url: string) => {
-      const id = newPreviewTab(url);
-      // Focus the address bar if the URL is empty so the user can type.
-      if (!url) {
-        setTimeout(() => previewRefs.current.get(id)?.focusAddressBar(), 0);
-      }
-      return id;
-    },
-    [newPreviewTab],
-  );
-
-  const openMarkdownPreview = useCallback(
-    (path: string) => {
-      newMarkdownTab(path);
-    },
-    [newMarkdownTab],
-  );
-
-  const splitActivePaneInActiveTab = useCallback(
-    (dir: "row" | "col") => {
-      const t = tabsRef.current.find((x) => x.id === activeId);
-      if (!t || t.kind !== "terminal") return;
-      splitActivePane(activeId, dir);
-    },
-    [activeId, splitActivePane],
-  );
-
-  const handleCloseTabOrPane = useCallback(() => {
-    const t = tabsRef.current.find((x) => x.id === activeId);
-    if (t?.kind === "terminal" && leafIds(t.paneTree).length > 1) {
-      closeActivePane(activeId);
-      return;
-    }
-    handleClose(activeId);
-  }, [activeId, closeActivePane, handleClose]);
-
-  const shortcutHandlers = useMemo<ShortcutHandlers>(
-    () => ({
-      "tab.new": openNewTab,
-      "tab.newPrivate": openNewPrivateTab,
-      "tab.newPreview": () => openPreviewTab(""),
-      "tab.newEditor": () => setNewEditorOpen(true),
-      "tab.close": handleCloseTabOrPane,
-      "tab.next": () => cycleTab(1),
-      "tab.prev": () => cycleTab(-1),
-      "tab.selectByIndex": (e) => selectByIndex(parseInt(e.key, 10) - 1),
-      "pane.splitRight": () => splitActivePaneInActiveTab("row"),
-      "pane.splitDown": () => splitActivePaneInActiveTab("col"),
-      "pane.focusNext": () => focusNextPaneInTab(activeId, 1),
-      "pane.focusPrev": () => focusNextPaneInTab(activeId, -1),
-      "pane.source": toggleSourceControl,
-      "terminal.clear": () => {
-        clearFocusedTerminal();
-      },
-      "search.focus": () => searchInlineRef.current?.focus(),
-      "ai.toggle": togglePanelAndFocus,
-      "ai.askSelection": askFromSelection,
-      "shortcuts.open": () => setShortcutsOpen((v) => !v),
-      "settings.open": () => void openSettingsWindow(),
-      "sidebar.toggle": toggleSidebar,
-      "explorer.focus": toggleExplorerFocus,
-      "view.zoomIn": zoomIn,
-      "view.zoomOut": zoomOut,
-      "view.zoomReset": zoomReset,
-      "editor.undo": () => editorRefs.current.get(activeId)?.undo(),
-      "editor.redo": () => editorRefs.current.get(activeId)?.redo(),
-    }),
-    [
-      activeId,
-      cycleTab,
-      handleCloseTabOrPane,
-      openNewTab,
-      openNewPrivateTab,
-      openPreviewTab,
-      selectByIndex,
-      splitActivePaneInActiveTab,
-      focusNextPaneInTab,
-      toggleSourceControl,
-      togglePanelAndFocus,
-      askFromSelection,
-      toggleSidebar,
-      toggleExplorerFocus,
-      zoomIn,
-      zoomOut,
-      zoomReset,
-    ],
-  );
-
-  const shortcutsDisabled = useCallback(
-    (id: ShortcutId, e: KeyboardEvent) => {
-      if (id === "editor.undo" || id === "editor.redo") {
-        return activeTab?.kind !== "editor";
-      }
-      if (id === "ai.askSelection") {
-        const target =
-          (e.target as HTMLElement | null) ?? document.activeElement;
-        const inTerminal = !!(target as HTMLElement | null)?.closest?.(
-          ".xterm",
-        );
-        if (!inTerminal) return false;
-        const sel = captureActiveSelection();
-        return !sel || !sel.trim();
-      }
-      if (id === "terminal.clear") {
-        // Only intercept ⌘K while a terminal is focused; elsewhere let the key
-        // fall through (we never preventDefault when disabled).
-        const target =
-          (e.target as HTMLElement | null) ?? document.activeElement;
-        return !(target as HTMLElement | null)?.closest?.(".xterm");
-      }
-      return false;
-    },
-    [activeTab],
-  );
-
-  useGlobalShortcuts(shortcutHandlers, { isDisabled: shortcutsDisabled });
-
-  const registerTerminalHandle = useCallback(
-    (leafId: number, h: TerminalPaneHandle | null) => {
-      if (h) terminalRefs.current.set(leafId, h);
-      else terminalRefs.current.delete(leafId);
-    },
-    [],
-  );
-
-  const registerEditorHandle = useCallback(
-    (id: number, h: EditorPaneHandle | null) => {
-      if (h) editorRefs.current.set(id, h);
-      else editorRefs.current.delete(id);
-      if (id === activeId) setActiveEditorHandle(h);
-    },
-    [activeId],
-  );
-
-  const registerPreviewHandle = useCallback(
-    (id: number, h: PreviewPaneHandle | null) => {
-      if (h) previewRefs.current.set(id, h);
-      else previewRefs.current.delete(id);
-    },
-    [],
-  );
-
-  const handlePreviewUrl = useCallback(
-    (id: number, url: string) => updateTab(id, { url }),
-    [updateTab],
-  );
-
-  const authorizedCwds = useRef(new Set<string>());
-  const handleTerminalCwd = useCallback(
-    (leafId: number, cwd: string) => {
-      setLeafCwd(leafId, cwd);
-      if (cwd && !authorizedCwds.current.has(cwd)) {
-        authorizedCwds.current.add(cwd);
-        native.workspaceAuthorize(cwd).catch(() => {
-          authorizedCwds.current.delete(cwd);
-        });
-      }
-    },
-    [setLeafCwd],
-  );
-
-  const handleFocusLeaf = useCallback(
-    (tabId: number, leafId: number) => focusPane(tabId, leafId),
-    [focusPane],
-  );
-
-  const onActivateAgent = useCallback(
-    (tabId: number, leafId: number) => {
-      setActiveId(tabId);
-      focusPane(tabId, leafId);
-    },
-    [setActiveId, focusPane],
-  );
-
-  const onActivateLocalAgent = useCallback(() => {
-    openPanel();
-    focusInput(null);
-  }, [openPanel, focusInput]);
-
-  const handleLeafExit = useCallback(
-    (leafId: number, _code: number) => {
-      const all = tabsRef.current;
-      const tab = all.find(
-        (t) => t.kind === "terminal" && hasLeaf(t.paneTree, leafId),
-      );
-      if (!tab || tab.kind !== "terminal") return;
-      const isLast =
-        leafIds(tab.paneTree).length === 1 &&
-        all.filter((t) => t.kind === "terminal").length === 1;
-      if (isLast) {
-        void respawnSession(leafId, tab.cwd);
-      } else {
-        closePaneByLeaf(leafId);
-      }
-    },
-    [closePaneByLeaf],
-  );
-
-  const handleEditorDirty = useCallback(
-    (id: number, dirty: boolean) => updateTab(id, { dirty }),
-    [updateTab],
-  );
-
-  const searchTarget = useMemo<SearchTarget>(() => {
-    if (isTerminalTab && activeLeafId !== null && activeSearchAddon)
-      return {
-        kind: "terminal",
-        addon: activeSearchAddon,
-        focus: () => terminalRefs.current.get(activeLeafId)?.focus(),
-      };
-    if (isEditorTab && activeEditorHandle)
-      return {
-        kind: "editor",
-        handle: activeEditorHandle,
-        focus: () => activeEditorHandle.focus(),
-      };
-    if (isGitHistoryTab && gitHistoryHandle)
-      return {
-        kind: "git-history",
-        handle: gitHistoryHandle,
-        focus: () => {},
-      };
-    return null;
-  }, [
-    isTerminalTab,
-    isEditorTab,
-    isGitHistoryTab,
-    activeLeafId,
-    activeSearchAddon,
-    activeEditorHandle,
-    gitHistoryHandle,
-  ]);
-
-  const activeCwd = activeTerminalLeafCwd;
-
-  useEffect(() => {
-    const findCwd = () => {
-      const active = tabs.find((x) => x.id === activeId);
-      if (active?.kind === "terminal") {
-        return findLeafCwd(active.paneTree, active.activeLeafId) ?? active.cwd ?? null;
-      }
-      for (let i = tabs.length - 1; i >= 0; i--) {
-        const t = tabs[i];
-        if (t.kind !== "terminal") continue;
-        const cwd = findLeafCwd(t.paneTree, t.activeLeafId) ?? t.cwd;
-        if (cwd) return cwd;
-      }
-      return explorerRoot ?? launchCwd ?? home ?? null;
-    };
-
-    setLive({
-      getCwd: findCwd,
-      getTerminalContext: () => {
-        const t = tabs.find((x) => x.id === activeId);
-        if (t?.kind !== "terminal") return null;
-        if (t.private) return null;
-        const buf = terminalRefs.current.get(t.activeLeafId)?.getBuffer(300);
-        return buf ? redactSensitive(buf) : null;
-      },
-      isActiveTerminalPrivate: () => {
-        const t = tabs.find((x) => x.id === activeId);
-        return t?.kind === "terminal" && t.private === true;
-      },
-      injectIntoActivePty: (text) => {
-        const t = tabs.find((x) => x.id === activeId);
-        if (t?.kind !== "terminal") return false;
-        const term = terminalRefs.current.get(t.activeLeafId);
-        if (!term) return false;
-        term.write(text);
-        term.focus();
-        return true;
-      },
-      getWorkspaceRoot: () => explorerRoot ?? launchCwd ?? home ?? null,
-      getActiveFile: () => {
-        const t = tabs.find((x) => x.id === activeId);
-        return t?.kind === "editor" ? t.path : null;
-      },
-      openPreview: (url: string) => {
-        openPreviewTab(url);
-        return true;
-      },
-      spawnManagedAgent: (prompt: string, sessionId: string) => {
-        const trimmed = prompt.trim();
-        if (!trimmed) return null;
-        const oneLine = trimmed.replace(/\s*\r?\n\s*/g, " ");
-        const cwd = findCwd();
-        const short = oneLine.length > 32 ? `${oneLine.slice(0, 32)}…` : oneLine;
-        const { tabId, leafId } = newAgentTab(cwd ?? undefined, `claude · ${short}`);
-        useManagedAgentsStore
-          .getState()
-          .register({ leafId, tabId, sessionId, task: oneLine, cwd });
-        const hooksReady = invoke("agent_enable_claude_hooks").catch(() => {});
-        void (async () => {
-          await Promise.all([whenSessionReady(leafId), hooksReady]);
-          if (!writeToSession(leafId, "claude\r")) {
-            useManagedAgentsStore.getState().remove(leafId);
-            return;
-          }
-          const readBuf = () => {
-            const term = terminalRefs.current.get(leafId);
-            return term ? term.getBuffer(120) : null;
-          };
-          const result = await waitForClaudeTuiReady(readBuf);
-          if (result !== "ready") {
-            if (result === "timeout") {
-              console.warn(
-                "[terax] Claude TUI did not appear in time; aborting prompt send",
-              );
-            }
-            useManagedAgentsStore.getState().remove(leafId);
-            return;
-          }
-          if (!writeToSession(leafId, `\x1b[200~${trimmed}\x1b[201~`)) {
-            useManagedAgentsStore.getState().remove(leafId);
-            return;
-          }
-          setTimeout(() => writeToSession(leafId, "\r"), 120);
-          useManagedAgentsStore.getState().setPhase(leafId, "working");
-        })();
-        return { tabId, leafId };
-      },
-      readLeafBuffer: (leafId: number) => {
-        const buf = terminalRefs.current.get(leafId)?.getBuffer(300);
-        return buf ? redactSensitive(buf) : null;
-      },
-    });
-  }, [
-    setLive,
-    activeId,
-    tabs,
-    explorerRoot,
-    launchCwd,
-    home,
-    openPreviewTab,
-    newAgentTab,
-  ]);
-
-  const workspaceSurface = (
-    <div className="relative h-full min-h-0">
-      <div
-        className={cn(
-          "absolute inset-0 px-3 pt-2 pb-2",
-          !isTerminalTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isTerminalTab}
-      >
-        <TerminalStack
-          tabs={tabs}
-          activeId={activeId}
-          registerHandle={registerTerminalHandle}
-          onSearchReady={handleSearchReady}
-          onCwd={handleTerminalCwd}
-          onExit={handleLeafExit}
-          onFocusLeaf={handleFocusLeaf}
-        />
-      </div>
-      <div
-        className={cn(
-          "absolute inset-0 px-3 pt-2 pb-2",
-          !isEditorTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isEditorTab}
-      >
-        <EditorStack
-          tabs={tabs}
-          activeId={activeId}
-          registerHandle={registerEditorHandle}
-          onDirtyChange={handleEditorDirty}
-          onCloseTab={disposeTab}
-        />
-      </div>
-      <div
-        className={cn(
-          "absolute inset-0 px-3 pt-2 pb-2",
-          !isPreviewTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isPreviewTab}
-      >
-        <PreviewStack
-          tabs={tabs}
-          activeId={activeId}
-          registerHandle={registerPreviewHandle}
-          onUrlChange={handlePreviewUrl}
-        />
-      </div>
-      <div
-        className={cn(
-          "absolute inset-0 px-3 pt-2 pb-2",
-          !isMarkdownTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isMarkdownTab}
-      >
-        <MarkdownStack tabs={tabs} activeId={activeId} />
-      </div>
-      <div
-        className={cn(
-          "absolute inset-0 px-3 pt-2 pb-2",
-          !isAiDiffTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isAiDiffTab}
-      >
-        <AiDiffStack
-          tabs={tabs}
-          activeId={activeId}
-          onAccept={(id) => respondToApproval(id, true)}
-          onReject={(id) => respondToApproval(id, false)}
-        />
-      </div>
-      <div
-        className={cn(
-          "absolute inset-0 px-3 pt-2 pb-2",
-          !isGitDiffTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isGitDiffTab}
-      >
-        <GitDiffStack tabs={tabs} activeId={activeId} />
-      </div>
-      <div
-        className={cn(
-          "absolute inset-0",
-          !isGitHistoryTab && "invisible pointer-events-none",
-        )}
-        aria-hidden={!isGitHistoryTab}
-      >
-        <GitHistoryStack
-          tabs={tabs}
-          activeId={activeId}
-          onOpenCommitFile={openCommitFileDiffTab}
-          onSearchHandle={setGitHistoryHandle}
-        />
-      </div>
-    </div>
-  );
-
-  const shell = (
-    <ThemeProvider>
-      <TooltipProvider>
-        <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
-          <Header
-            tabs={tabs}
-            activeId={activeId}
-            onSelect={setActiveId}
-            onNew={openNewTab}
-            onNewPrivate={openNewPrivateTab}
-            onNewPreview={() => openPreviewTab("")}
-            onNewEditor={() => setNewEditorOpen(true)}
-            onNewGitGraph={openGitGraphFromContext}
-            onClose={handleClose}
-            onPin={pinTab}
-            onToggleSidebar={toggleSidebar}
-            onSplit={splitActivePaneInActiveTab}
-            canSplit={
-              activeTerminalTab !== null &&
-              leafIds(activeTerminalTab.paneTree).length < MAX_PANES_PER_TAB
-            }
-            onActivateAgent={onActivateAgent}
-            onActivateLocalAgent={onActivateLocalAgent}
-            onOpenSettings={() => void openSettingsWindow()}
-            searchTarget={searchTarget}
-            searchRef={searchInlineRef}
-          />
-
-          <main className="zoom-content flex min-h-0 flex-1 flex-col">
-            <ResizablePanelGroup
-              orientation="horizontal"
-              className="min-h-0 flex-1"
-            >
-              <ResizablePanel
-                id="sidebar"
-                panelRef={sidebarRef}
-                defaultSize={`${sidebarWidthRef.current}px`}
-                minSize={`${SIDEBAR_MIN_WIDTH}px`}
-                maxSize={`${SIDEBAR_MAX_WIDTH}px`}
-                collapsible
-                collapsedSize={0}
-                onResize={(size) => {
-                  if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
-                }}
-              >
-                <div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">
-                  <div className="min-h-0 flex-1">
-                    {sidebarView === "explorer" ? (
-                      <FileExplorer
-                        ref={explorerRef}
-                        rootPath={explorerRoot}
-                        onOpenFile={handleOpenFile}
-                        onPathRenamed={handlePathRenamed}
-                        onPathDeleted={handlePathDeleted}
-                        onRevealInTerminal={cdInNewTab}
-                        onAttachToAgent={handleAttachFileToAgent}
-                        onOpenMarkdownPreview={openMarkdownPreview}
-                      />
-                    ) : (
-                      <SourceControlPanel
-                        open
-                        sourceControl={sourceControl}
-                        onOpenDiff={openGitDiffTab}
-                        onOpenGitGraph={openGitGraphFromContext}
-                      />
-                    )}
-                  </div>
-                  <SidebarRail
-                    activeView={sidebarView}
-                    onSelectView={persistSidebarView}
-                    changedCount={sourceControl.changedCount}
-                  />
-                </div>
-              </ResizablePanel>
-              <ResizableHandle withHandle />
-              <ResizablePanel id="workspace" defaultSize="78%" minSize="30%">
-                <div className="flex h-full min-h-0 flex-col">
-                  <div className="relative min-h-0 flex-1">
-                    {workspaceSurface}
-                  </div>
-
-                  {keysLoaded ? (
-                    <motion.div
-                      data-ai-input-bar
-                      initial={false}
-                      animate={{
-                        height: panelOpen ? "auto" : 0,
-                        opacity: panelOpen ? 1 : 0,
-                      }}
-                      transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
-                      className="overflow-hidden"
-                      aria-hidden={!panelOpen}
-                    >
-                      {hasComposer ? (
-                        <AiInputBar />
-                      ) : (
-                        <AiInputBarConnect
-                          onAdd={() => void openSettingsWindow("models")}
-                        />
-                      )}
-                    </motion.div>
-                  ) : null}
-                </div>
-              </ResizablePanel>
-            </ResizablePanelGroup>
-          </main>
-
-          <StatusBar
-            cwd={activeCwd}
-            filePath={activeFilePath}
-            home={home}
-            onCd={sendCd}
-            onWorkspaceChange={switchWorkspace}
-            onOpenMini={openMini}
-            hasComposer={hasComposer}
-            privateActive={
-              activeTab?.kind === "terminal" && activeTab.private === true
-            }
-          />
-
-          <AgentNotificationsBridge
-            tabs={tabs}
-            activeId={activeId}
-            onActivate={onActivateAgent}
-          />
-          <Toaster position="bottom-right" />
-
-          {hasComposer ? (
-            <>
-              <AgentRunBridge
-                openAiDiffTab={openAiDiffTab}
-                closeAiDiffTab={closeAiDiffTab}
-              />
-              <LocalAgentNotificationsBridge />
-            </>
-          ) : null}
-
-          <AnimatePresence>
-            {miniOpen && hasComposer ? <AiMiniWindow key="ai-mini" /> : null}
-            {askPopup ? (
-              <SelectionAskAi
-                key="ask-ai-popup"
-                x={askPopup.x}
-                y={askPopup.y}
-                onAsk={onAskFromSelection}
-                onDismiss={() => setAskPopup(null)}
-              />
-            ) : null}
-          </AnimatePresence>
-
-          <ShortcutsDialog
-            open={shortcutsOpen}
-            onOpenChange={setShortcutsOpen}
-          />
-
-          <NewEditorDialog
-            open={newEditorOpen}
-            onOpenChange={setNewEditorOpen}
-            rootPath={explorerRoot ?? home}
-            onCreated={(path) => openFileTab(path)}
-          />
-
-          <UpdaterDialog />
-
-          <AlertDialog
-            open={pendingCloseTab !== null}
-            onOpenChange={(open) => !open && cancelClose()}
-          >
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
-                <AlertDialogDescription>
-                  {tabs.find((t) => t.id === pendingCloseTab)?.title
-                    ? `"${
-                        tabs.find((t) => t.id === pendingCloseTab)?.title
-                      }" has unsaved changes. Close anyway?`
-                    : "This file has unsaved changes. Close anyway?"}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel onClick={cancelClose}>
-                  Cancel
-                </AlertDialogCancel>
-                <AlertDialogAction onClick={confirmClose}>
-                  Close Anyway
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-
-          <AlertDialog
-            open={pendingDeleteTabs !== null}
-            onOpenChange={(open) => !open && cancelDeleteClose()}
-          >
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
-                <AlertDialogDescription>
-                  {pendingDeleteTabs?.length === 1
-                    ? (() => {
-                        const title = tabs.find(
-                          (t) => t.id === pendingDeleteTabs[0],
-                        )?.title;
-                        return title
-                          ? `"${title}" has unsaved changes. The file has been deleted. Close anyway?`
-                          : "This file has unsaved changes. The file has been deleted. Close anyway?";
-                      })()
-                    : `${pendingDeleteTabs?.length ?? 0} files have unsaved changes. They have been deleted. Close all anyway?`}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel onClick={cancelDeleteClose}>
-                  Cancel
-                </AlertDialogCancel>
-                <AlertDialogAction onClick={confirmDeleteClose}>
-                  Close Anyway
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
-      </TooltipProvider>
-    </ThemeProvider>
-  );
-
-  return <AiComposerProvider>{shell}</AiComposerProvider>;
+	const {
+		tabs,
+		activeId,
+		setActiveId,
+		newTab,
+		newAgentTab,
+		newPrivateTab,
+		openFileTab,
+		pinTab,
+		newPreviewTab,
+		newMarkdownTab,
+		openAiDiffTab,
+		closeAiDiffTab,
+		openGitDiffTab,
+		openCommitHistoryTab,
+		openCommitFileDiffTab,
+		closeTab,
+		updateTab,
+		selectByIndex,
+		setLeafCwd,
+		focusPane,
+		focusNextPaneInTab,
+		splitActivePane,
+		closeActivePane,
+		closePaneByLeaf,
+		resetWorkspace,
+	} = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
+
+	// Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
+	// (e.g. cdInNewTab) read the latest pane state instead of a stale closure.
+	const tabsRef = useRef(tabs);
+	tabsRef.current = tabs;
+
+	const activeTerminalTab = useMemo(() => {
+		const t = tabs.find((x) => x.id === activeId);
+		return t && t.kind === "terminal" ? t : null;
+	}, [tabs, activeId]);
+	const activeLeafId = activeTerminalTab?.activeLeafId ?? null;
+
+	const searchAddons = useRef<Map<number, SearchAddon>>(new Map());
+	const [activeSearchAddon, setActiveSearchAddon] =
+		useState<SearchAddon | null>(null);
+	const searchInlineRef = useRef<SearchInlineHandle | null>(null);
+	const terminalRefs = useRef<Map<number, TerminalPaneHandle>>(new Map());
+	const editorRefs = useRef<Map<number, EditorPaneHandle>>(new Map());
+	const previewRefs = useRef<Map<number, PreviewPaneHandle>>(new Map());
+	const [activeEditorHandle, setActiveEditorHandle] =
+		useState<EditorPaneHandle | null>(null);
+	const [gitHistoryHandle, setGitHistoryHandle] =
+		useState<GitHistorySearchHandle | null>(null);
+	const { zoomIn, zoomOut, zoomReset } = useZoom();
+	const explorerRef = useRef<FileExplorerHandle>(null);
+	const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
+
+	const sidebarRef = useRef<PanelImperativeHandle | null>(null);
+	const sidebarWidthRef = useRef(readSidebarWidth());
+	const sidebarWidthWriteTimerRef = useRef(0);
+	const [sidebarView, setSidebarViewState] =
+		useState<SidebarViewId>(readSidebarView);
+	const persistSidebarView = useCallback((view: SidebarViewId) => {
+		setSidebarViewState(view);
+		try {
+			window.localStorage.setItem(SIDEBAR_VIEW_STORAGE_KEY, view);
+		} catch {
+			// storage may fail in private mode
+		}
+	}, []);
+	const toggleSidebar = useCallback(() => {
+		const p = sidebarRef.current;
+		if (!p) return;
+		if (p.getSize().asPercentage <= 0) p.expand();
+		else p.collapse();
+	}, []);
+	const cycleSidebarView = useCallback(
+		(view: SidebarViewId) => {
+			const panel = sidebarRef.current;
+			const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
+			if (collapsed) {
+				if (panel) panel.resize(`${sidebarWidthRef.current}px`);
+				if (view !== sidebarView) persistSidebarView(view);
+				return;
+			}
+			if (view === sidebarView) {
+				panel?.collapse();
+				return;
+			}
+			persistSidebarView(view);
+		},
+		[persistSidebarView, sidebarView],
+	);
+	const persistSidebarWidth = useCallback((next: number) => {
+		sidebarWidthRef.current = next;
+		if (sidebarWidthWriteTimerRef.current) {
+			window.clearTimeout(sidebarWidthWriteTimerRef.current);
+		}
+		sidebarWidthWriteTimerRef.current = window.setTimeout(() => {
+			sidebarWidthWriteTimerRef.current = 0;
+			try {
+				window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(next));
+			} catch {
+				// ignore
+			}
+		}, 200);
+	}, []);
+	useEffect(() => {
+		return () => {
+			if (sidebarWidthWriteTimerRef.current) {
+				window.clearTimeout(sidebarWidthWriteTimerRef.current);
+			}
+		};
+	}, []);
+
+	const toggleExplorerFocus = useCallback(() => {
+		const explorer = explorerRef.current;
+		const panel = sidebarRef.current;
+		const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
+		if (sidebarView !== "explorer" || collapsed) {
+			if (panel && collapsed) panel.resize(`${sidebarWidthRef.current}px`);
+			if (sidebarView !== "explorer") persistSidebarView("explorer");
+			const active = document.activeElement;
+			explorerReturnFocusRef.current =
+				active instanceof HTMLElement && active !== document.body
+					? active
+					: null;
+			requestAnimationFrame(() => explorerRef.current?.focus());
+			return;
+		}
+		if (!explorer) return;
+		if (explorer.isFocused()) {
+			const target = explorerReturnFocusRef.current;
+			explorerReturnFocusRef.current = null;
+			if (target && document.body.contains(target)) {
+				target.focus();
+			} else {
+				(document.activeElement as HTMLElement | null)?.blur?.();
+			}
+			return;
+		}
+		const active = document.activeElement;
+		explorerReturnFocusRef.current =
+			active instanceof HTMLElement && active !== document.body ? active : null;
+		explorer.focus();
+	}, [persistSidebarView, sidebarView]);
+
+	const [home, setHome] = useState<string | null>(null);
+	const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
+	const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
+	const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
+	const [launchCwd, setLaunchCwd] = useState<string | null>(null);
+	const [launchCwdResolved, setLaunchCwdResolved] = useState(false);
+	const [pendingDeleteTabs, setPendingDeleteTabs] = useState<number[] | null>(
+		null,
+	);
+	useEffect(() => {
+		homeDir()
+			.then(async (p) => {
+				const normalized = p.replace(/\\/g, "/");
+				setHome(normalized);
+				try {
+					await native.workspaceAuthorize(normalized);
+				} catch {
+					// Bootstrap already authorizes home from Rust; ignore.
+				}
+			})
+			.catch(() => setHome(null));
+	}, []);
+
+	const switchWorkspace = useCallback(
+		async (env: WorkspaceEnv) => {
+			if (
+				env.kind === workspaceEnv.kind &&
+				(env.kind === "local" ||
+					(workspaceEnv.kind === "wsl" && env.distro === workspaceEnv.distro))
+			) {
+				return;
+			}
+			const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
+			if (dirty) {
+				window.alert(
+					"Save or close unsaved editor tabs before switching workspace.",
+				);
+				return;
+			}
+
+			let nextHome: string | null = null;
+			try {
+				if (env.kind === "wsl") {
+					nextHome = await getWslHome(env.distro);
+				} else {
+					nextHome = (await homeDir()).replace(/\\/g, "/");
+				}
+			} catch (e) {
+				window.alert(String(e));
+				return;
+			}
+
+			for (const id of liveLeavesRef.current) disposeSession(id);
+			searchAddons.current.clear();
+			terminalRefs.current.clear();
+			editorRefs.current.clear();
+			previewRefs.current.clear();
+			setActiveSearchAddon(null);
+			setActiveEditorHandle(null);
+			setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
+			setHome(nextHome);
+			setLaunchCwd(nextHome);
+			if (nextHome) {
+				try {
+					await native.workspaceAuthorize(nextHome);
+				} catch {
+					// Non-fatal — git panel will surface "not authorized" if needed.
+				}
+			}
+			resetWorkspace(nextHome ?? undefined);
+		},
+		[workspaceEnv, setWorkspaceEnv, resetWorkspace],
+	);
+	useEffect(() => {
+		native
+			.workspaceCurrentDir()
+			.then(setLaunchCwd)
+			.catch(() => setLaunchCwd(null))
+			.finally(() => setLaunchCwdResolved(true));
+	}, []);
+
+	const [shortcutsOpen, setShortcutsOpen] = useState(false);
+	const [newEditorOpen, setNewEditorOpen] = useState(false);
+	const miniOpen = useChatStore((s) => s.mini.open);
+	const activeSessionId = useChatStore((s) => s.activeSessionId);
+	const openMini = useChatStore((s) => s.openMini);
+	const focusInput = useChatStore((s) => s.focusInput);
+	const openPanel = useChatStore((s) => s.openPanel);
+	const panelOpen = useChatStore((s) => s.panelOpen);
+	const apiKeys = useChatStore((s) => s.apiKeys);
+	const setApiKeys = useChatStore((s) => s.setApiKeys);
+	const setCustomEndpointKeys = useChatStore((s) => s.setCustomEndpointKeys);
+	const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
+	const setLive = useChatStore((s) => s.setLive);
+	const respondToApproval = useChatStore((s) => s.respondToApproval);
+
+	useEffect(() => {
+		if (activeSessionId) firePendingReviewForSession(activeSessionId);
+	}, [activeSessionId]);
+	const lmstudioModelId = usePreferencesStore((s) => s.lmstudioModelId);
+	const lmstudioBaseURL = usePreferencesStore((s) => s.lmstudioBaseURL);
+	const mlxModelId = usePreferencesStore((s) => s.mlxModelId);
+	const mlxBaseURL = usePreferencesStore((s) => s.mlxBaseURL);
+	const ollamaModelId = usePreferencesStore((s) => s.ollamaModelId);
+	const ollamaBaseURL = usePreferencesStore((s) => s.ollamaBaseURL);
+	const openaiCompatibleModelId = usePreferencesStore(
+		(s) => s.openaiCompatibleModelId,
+	);
+	const openaiCompatibleBaseURL = usePreferencesStore(
+		(s) => s.openaiCompatibleBaseURL,
+	);
+	const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+	const hasLocalModel =
+		(lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0) ||
+		(mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0) ||
+		(ollamaBaseURL.trim().length > 0 && ollamaModelId.trim().length > 0) ||
+		(openaiCompatibleBaseURL.trim().length > 0 &&
+			openaiCompatibleModelId.trim().length > 0) ||
+		customEndpoints.some(
+			(e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0,
+		);
+	const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
+
+	const prefsHydrated = usePreferencesStore((s) => s.hydrated);
+	const [keysLoaded, setKeysLoaded] = useState(false);
+	useEffect(() => {
+		let alive = true;
+		const reload = () => {
+			void getAllKeys().then((keys) => {
+				if (!alive) return;
+				setApiKeys(keys);
+				setKeysLoaded(true);
+			});
+			if (!prefsHydrated) return;
+			void getAllCustomEndpointKeys(
+				usePreferencesStore.getState().customEndpoints,
+			).then((epKeys) => {
+				if (!alive) return;
+				setCustomEndpointKeys(epKeys);
+			});
+		};
+		reload();
+		const unlistenP = onKeysChanged(reload);
+		return () => {
+			alive = false;
+			void unlistenP.then((fn) => fn());
+		};
+	}, [setApiKeys, setCustomEndpointKeys, prefsHydrated]);
+
+	// Hydrate the cross-window preference store and mirror the default model
+	// into chatStore so the dropdown reflects what the user picked in Settings.
+	const initPrefs = usePreferencesStore((s) => s.init);
+	const prefDefaultModel = usePreferencesStore((s) => s.defaultModelId);
+	useEffect(() => {
+		void initPrefs();
+	}, [initPrefs]);
+	useEffect(() => {
+		if (!prefsHydrated) return;
+		setSelectedModelId(prefDefaultModel);
+	}, [prefsHydrated, prefDefaultModel, setSelectedModelId]);
+
+	const hydrateSessions = useChatStore((s) => s.hydrateSessions);
+	useEffect(() => {
+		void hydrateSessions();
+		void useAgentsStore.getState().hydrate();
+		void useSnippetsStore.getState().hydrate();
+		// Install the Claude Code hooks on launch so agent detection, notifications,
+		// and the chat-view session binding work without the user enabling them by
+		// hand. Idempotent and self-migrating: re-running upgrades a stale install
+		// (e.g. one predating the transcript marker). Fire-and-forget.
+		void invoke("agent_enable_claude_hooks").catch(() => {});
+	}, [hydrateSessions]);
+
+	const activeTab = tabs.find((t) => t.id === activeId);
+	const isTerminalTab = activeTab?.kind === "terminal";
+	const isEditorTab = activeTab?.kind === "editor";
+	const isPreviewTab = activeTab?.kind === "preview";
+	const isMarkdownTab = activeTab?.kind === "markdown";
+	const isAiDiffTab = activeTab?.kind === "ai-diff";
+	const isGitDiffTab =
+		activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
+	const isGitHistoryTab = activeTab?.kind === "git-history";
+
+	// When an AI diff is approved (write_file applied to disk), reload any
+	// open editor tabs for that path so the user sees the new content. We
+	// track which approvalIds we've already handled to fire the reload only
+	// once per applied diff.
+	const appliedDiffsRef = useRef<Set<string>>(new Set());
+	useEffect(() => {
+		for (const t of tabs) {
+			if (t.kind !== "ai-diff") continue;
+			if (t.status !== "approved") continue;
+			if (appliedDiffsRef.current.has(t.approvalId)) continue;
+			appliedDiffsRef.current.add(t.approvalId);
+			for (const e of tabs) {
+				if (e.kind !== "editor") continue;
+				if (e.path !== t.path) continue;
+				editorRefs.current.get(e.id)?.reload();
+			}
+		}
+	}, [tabs]);
+
+	useEffect(() => {
+		type FileWrittenPayload = { path: string; source?: string };
+		const unlistenPromise =
+			getCurrentWebviewWindow().listen<FileWrittenPayload>(
+				"fs:file-written",
+				(event) => {
+					if (event.payload.source === "editor") return;
+					const normalizedPath = event.payload.path.replace(/\\/g, "/");
+					const currentTabs = tabsRef.current;
+					for (const t of currentTabs) {
+						if (t.kind !== "editor") continue;
+						if (t.path.replace(/\\/g, "/") === normalizedPath) {
+							editorRefs.current.get(t.id)?.reload();
+						}
+					}
+				},
+			);
+		return () => {
+			void unlistenPromise.then((un) => un());
+		};
+	}, []);
+
+	const editorWatchRef = useRef<Set<string>>(new Set());
+	useEffect(() => {
+		const want = new Set<string>();
+		for (const t of tabs) if (t.kind === "editor") want.add(parentDir(t.path));
+		const prev = editorWatchRef.current;
+		const toAdd = [...want].filter((d) => !prev.has(d));
+		const toRemove = [...prev].filter((d) => !want.has(d));
+		watchAdd(toAdd);
+		watchRemove(toRemove);
+		editorWatchRef.current = want;
+	}, [tabs]);
+
+	useEffect(() => {
+		let alive = true;
+		let unlisten: (() => void) | undefined;
+		void listenFsChanged((paths) => {
+			const changed = new Set(paths.map((p) => p.replace(/\\/g, "/")));
+			for (const t of tabsRef.current) {
+				if (t.kind !== "editor") continue;
+				if (changed.has(t.path.replace(/\\/g, "/"))) {
+					editorRefs.current.get(t.id)?.reload();
+				}
+			}
+		}).then((un) => {
+			if (alive) unlisten = un;
+			else un();
+		});
+		return () => {
+			alive = false;
+			unlisten?.();
+		};
+	}, []);
+
+	// Theme editing: a custom theme is materialized to a real file and edited in
+	// the code editor. Saving it re-ingests into the runtime store + applies live.
+	useEffect(() => {
+		type FileWrittenPayload = { path: string; source?: string };
+		const unlistenPromise =
+			getCurrentWebviewWindow().listen<FileWrittenPayload>(
+				"fs:file-written",
+				(event) => {
+					if (event.payload.source !== "editor") return;
+					if (!isThemeFilePath(event.payload.path)) return;
+					void (async () => {
+						try {
+							const res = await invoke<{ kind: string; content?: string }>(
+								"fs_read_file",
+								{ path: event.payload.path, workspace: currentWorkspaceEnv() },
+							);
+							if (res.kind !== "text" || typeof res.content !== "string")
+								return;
+							const parsed = parseThemeFile(res.content);
+							if (!parsed.ok) {
+								console.warn("[terax] theme not applied:", parsed.error);
+								return;
+							}
+							await saveCustomTheme(parsed.theme);
+						} catch (e) {
+							console.warn("[terax] theme ingest failed:", e);
+						}
+					})();
+				},
+			);
+		return () => {
+			void unlistenPromise.then((un) => un());
+		};
+	}, []);
+
+	useEffect(() => {
+		let alive = true;
+		let unsub: (() => void) | undefined;
+		void onThemeEdit(async (req) => {
+			const theme =
+				req.action === "create"
+					? starterTheme()
+					: (await listCustomThemes()).find((t) => t.id === req.id);
+			if (!theme) return;
+			if (req.action === "create") await saveCustomTheme(theme);
+			const path = await themeFilePath(theme.id);
+			const open = tabsRef.current.some(
+				(t) => t.kind === "editor" && t.path === path,
+			);
+			if (!open) await writeThemeFile(theme);
+			void persistThemeId(theme.id);
+			openFileTab(path);
+			void getCurrentWebviewWindow().setFocus();
+		}).then((fn) => {
+			if (alive) unsub = fn;
+			else fn();
+		});
+		return () => {
+			alive = false;
+			unsub?.();
+		};
+	}, [openFileTab]);
+
+	const { explorerRoot, inheritedCwdForNewTab } = useWorkspaceCwd(
+		activeTab,
+		tabs,
+		launchCwd ?? home,
+	);
+
+	useEffect(() => {
+		setActiveSearchAddon(
+			activeLeafId !== null
+				? (searchAddons.current.get(activeLeafId) ?? null)
+				: null,
+		);
+		setActiveEditorHandle(editorRefs.current.get(activeId) ?? null);
+	}, [activeId, activeLeafId]);
+
+	const handleSearchReady = useCallback(
+		(leafId: number, addon: SearchAddon) => {
+			searchAddons.current.set(leafId, addon);
+			if (leafId === activeLeafId) setActiveSearchAddon(addon);
+		},
+		[activeLeafId],
+	);
+
+	const disposeTab = useCallback(
+		(id: number) => {
+			// Terminal-leaf-keyed maps (terminalRefs/searchAddons) are pruned by
+			// the effect below as the pane tree changes; only the tab-id-keyed
+			// handles need explicit cleanup here.
+			editorRefs.current.delete(id);
+			previewRefs.current.delete(id);
+			closeTab(id);
+		},
+		[closeTab],
+	);
+
+	// Drives session disposal off the pane tree, not React lifecycles —
+	// split/unsplit re-mount components but the leaf is still live.
+	const liveLeavesRef = useRef<Set<number>>(new Set());
+	useEffect(() => {
+		const live = new Set<number>();
+		for (const t of tabs) {
+			if (t.kind === "terminal") {
+				for (const id of leafIds(t.paneTree)) live.add(id);
+			}
+		}
+		for (const id of liveLeavesRef.current) {
+			if (!live.has(id)) disposeSession(id);
+		}
+		liveLeavesRef.current = live;
+		for (const k of [...terminalRefs.current.keys()])
+			if (!live.has(k)) terminalRefs.current.delete(k);
+		for (const k of [...searchAddons.current.keys()])
+			if (!live.has(k)) searchAddons.current.delete(k);
+	}, [tabs]);
+
+	const handleClose = useCallback(
+		(id: number) => {
+			const t = tabs.find((x) => x.id === id);
+			if (t?.kind === "editor" && t.dirty) {
+				setPendingCloseTab(id);
+				return;
+			}
+			disposeTab(id);
+		},
+		[tabs, disposeTab],
+	);
+
+	const confirmClose = useCallback(() => {
+		if (pendingCloseTab !== null) {
+			disposeTab(pendingCloseTab);
+			setPendingCloseTab(null);
+		}
+	}, [pendingCloseTab, disposeTab]);
+
+	const cancelClose = useCallback(() => {
+		setPendingCloseTab(null);
+	}, []);
+
+	const cycleTab = useCallback(
+		(delta: 1 | -1) => {
+			if (tabs.length < 2) return;
+			const idx = tabs.findIndex((t) => t.id === activeId);
+			const nextIdx = (idx + delta + tabs.length) % tabs.length;
+			setActiveId(tabs[nextIdx].id);
+		},
+		[tabs, activeId, setActiveId],
+	);
+
+	const captureActiveSelection = useCallback((): string | null => {
+		const t = tabs.find((x) => x.id === activeId);
+		if (!t) return null;
+		if (t.kind === "terminal") {
+			const lid = t.activeLeafId;
+			return terminalRefs.current.get(lid)?.getSelection() ?? null;
+		}
+		if (t.kind === "editor") {
+			return editorRefs.current.get(activeId)?.getSelection() ?? null;
+		}
+		return null;
+	}, [tabs, activeId]);
+
+	const togglePanelAndFocus = useCallback(() => {
+		if (!hasComposer) {
+			void openSettingsWindow("models");
+			return;
+		}
+		if (panelOpen) {
+			useChatStore.getState().closePanel();
+		} else {
+			openPanel();
+			focusInput(null);
+		}
+	}, [hasComposer, panelOpen, openPanel, focusInput]);
+
+	const attachSelection = useChatStore((s) => s.attachSelection);
+
+	const handleAttachFileToAgent = useCallback(
+		(path: string) => {
+			if (!hasComposer) {
+				void openSettingsWindow("models");
+				return;
+			}
+			// Dispatch a window event the composer listens for. Same pattern as
+			// selections — keeps file-explorer decoupled from the AI module.
+			window.dispatchEvent(
+				new CustomEvent<string>("terax:ai-attach-file", { detail: path }),
+			);
+			openPanel();
+			focusInput(null);
+		},
+		[hasComposer, openPanel, focusInput],
+	);
+
+	const askFromSelection = useCallback(() => {
+		if (!hasComposer) {
+			void openSettingsWindow("models");
+			return;
+		}
+		const selection = captureActiveSelection();
+		if (!selection || !selection.trim()) {
+			focusInput(null);
+			return;
+		}
+		const source: "terminal" | "editor" =
+			activeTab?.kind === "editor" ? "editor" : "terminal";
+		attachSelection(selection, source);
+	}, [
+		hasComposer,
+		captureActiveSelection,
+		focusInput,
+		attachSelection,
+		activeTab,
+	]);
+
+	const [askPopup, setAskPopup] = useState<{ x: number; y: number } | null>(
+		null,
+	);
+
+	useEffect(() => {
+		const isInsideAi = (t: EventTarget | null) => {
+			const el = t as HTMLElement | null;
+			if (!el) return false;
+			return !!(
+				el.closest("[data-selection-ask-ai]") ||
+				el.closest("[data-ai-input-bar]") ||
+				el.closest("[data-ai-mini-window]")
+			);
+		};
+
+		const onDown = (e: MouseEvent) => {
+			if (isInsideAi(e.target)) return;
+			setAskPopup(null);
+		};
+		const onUp = (e: MouseEvent) => {
+			if (isInsideAi(e.target)) return;
+			const el = e.target as HTMLElement | null;
+			const inContentArea = el?.closest?.(".xterm, .cm-editor");
+			if (!inContentArea) return;
+			// Defer one tick so xterm/CodeMirror finalize the selection.
+			setTimeout(() => {
+				const text = captureActiveSelection();
+				if (text && text.trim().length > 0) {
+					setAskPopup({ x: e.clientX, y: e.clientY });
+				} else {
+					setAskPopup(null);
+				}
+			}, 0);
+		};
+
+		document.addEventListener("mousedown", onDown);
+		document.addEventListener("mouseup", onUp);
+		return () => {
+			document.removeEventListener("mousedown", onDown);
+			document.removeEventListener("mouseup", onUp);
+		};
+	}, [captureActiveSelection]);
+
+	const onAskFromSelection = useCallback(() => {
+		askFromSelection();
+		setAskPopup(null);
+	}, [askFromSelection]);
+
+	const openNewTab = useCallback(() => {
+		newTab(inheritedCwdForNewTab());
+	}, [newTab, inheritedCwdForNewTab]);
+
+	const openNewPrivateTab = useCallback(() => {
+		newPrivateTab(inheritedCwdForNewTab());
+	}, [newPrivateTab, inheritedCwdForNewTab]);
+
+	const sendCd = useCallback(
+		(path: string) => {
+			if (activeLeafId === null) return;
+			const term = terminalRefs.current.get(activeLeafId);
+			if (!term) return;
+			term.write(`cd ${quoteShellArg(path)}\r`);
+			term.focus();
+		},
+		[activeLeafId],
+	);
+
+	const cdInNewTab = useCallback(
+		(path: string) => {
+			const tabId = newTab(path);
+			setTimeout(() => {
+				const tab = tabsRef.current.find((x) => x.id === tabId);
+				if (!tab || tab.kind !== "terminal") return;
+				const t = terminalRefs.current.get(tab.activeLeafId);
+				if (!t) return;
+				t.write(`cd ${quoteShellArg(path)}\r`);
+				t.focus();
+			}, 80);
+		},
+		[newTab],
+	);
+
+	const handleOpenFile = useCallback(
+		(path: string, pin?: boolean) => {
+			// Explorer defaults to preview (pin=false); explicit actions like
+			// context-menu "Open" pass pin=true for a persistent tab.
+			openFileTab(path, pin ?? false);
+		},
+		[openFileTab],
+	);
+
+	const handlePathRenamed = useCallback(
+		(from: string, to: string) => {
+			for (const t of tabs) {
+				if (t.kind !== "editor") continue;
+				if (t.path === from) {
+					const i = to.lastIndexOf("/");
+					updateTab(t.id, { path: to, title: i === -1 ? to : to.slice(i + 1) });
+				} else if (t.path.startsWith(`${from}/`)) {
+					const suffix = t.path.slice(from.length);
+					const newPath = `${to}${suffix}`;
+					const i = newPath.lastIndexOf("/");
+					updateTab(t.id, {
+						path: newPath,
+						title: i === -1 ? newPath : newPath.slice(i + 1),
+					});
+				}
+			}
+		},
+		[tabs, updateTab],
+	);
+
+	const confirmDeleteClose = useCallback(() => {
+		if (pendingDeleteTabs !== null) {
+			for (const id of pendingDeleteTabs) disposeTab(id);
+			setPendingDeleteTabs(null);
+		}
+	}, [pendingDeleteTabs, disposeTab]);
+
+	const cancelDeleteClose = useCallback(() => {
+		setPendingDeleteTabs(null);
+	}, []);
+
+	const handlePathDeleted = useCallback(
+		(path: string) => {
+			const dirty: number[] = [];
+			for (const t of tabs) {
+				if (t.kind !== "editor") continue;
+				if (t.path !== path && !t.path.startsWith(`${path}/`)) continue;
+				if (t.dirty) {
+					dirty.push(t.id);
+				} else {
+					disposeTab(t.id);
+				}
+			}
+			if (dirty.length > 0) setPendingDeleteTabs(dirty);
+		},
+		[tabs, disposeTab],
+	);
+
+	const activeTerminalLeafCwd =
+		activeTab?.kind === "terminal"
+			? (findLeafCwd(activeTab.paneTree, activeTab.activeLeafId) ??
+				activeTab.cwd ??
+				null)
+			: null;
+
+	const activeFilePath = (() => {
+		if (activeTab?.kind === "editor") return activeTab.path;
+		if (activeTab?.kind === "git-diff") {
+			if (/^([A-Za-z]:|\/|\\)/.test(activeTab.path)) return activeTab.path;
+			const root = activeTab.repoRoot.replace(/[\\/]+$/, "");
+			const rel = activeTab.path.replace(/^[\\/]+/, "");
+			return `${root}/${rel}`;
+		}
+		if (activeTab?.kind === "git-commit-file") {
+			const root = activeTab.repoRoot.replace(/[\\/]+$/, "");
+			const rel = activeTab.path.replace(/^[\\/]+/, "");
+			return `${root}/${rel}`;
+		}
+		return null;
+	})();
+	const workspaceFallbackPath = launchCwdResolved
+		? (launchCwd ?? home ?? null)
+		: null;
+	const sourceControlContextPath = (() => {
+		if (activeTab?.kind === "terminal") {
+			return activeTerminalLeafCwd ?? explorerRoot ?? workspaceFallbackPath;
+		}
+		if (activeTab?.kind === "editor") return dirname(activeTab.path);
+		if (activeTab?.kind === "git-diff") return activeTab.repoRoot;
+		if (activeTab?.kind === "git-commit-file") return activeTab.repoRoot;
+		if (activeTab?.kind === "git-history") return activeTab.repoRoot;
+		return explorerRoot ?? workspaceFallbackPath;
+	})();
+	const hasOpenGitTab = useMemo(
+		() =>
+			tabs.some(
+				(t) =>
+					t.kind === "git-diff" ||
+					t.kind === "git-history" ||
+					t.kind === "git-commit-file",
+			),
+		[tabs],
+	);
+	const sourceControlActive = hasOpenGitTab || sidebarView === "source-control";
+	// Stable per-session path so switching tabs / cd-ing in a shell does NOT
+	// re-fire git IPC for the badge. The active panel resolves the current
+	// context path on its own when the user actually opens git.
+	const badgeContextPath = workspaceFallbackPath;
+	const sourceControlPath = sourceControlActive
+		? sourceControlContextPath
+		: badgeContextPath;
+	const sourceControl = useSourceControl(sourceControlPath, true);
+
+	const toggleSourceControl = useCallback(() => {
+		cycleSidebarView("source-control");
+	}, [cycleSidebarView]);
+
+	const openGitGraphFromContext = useCallback(async () => {
+		const known = sourceControl.hasRepo ? sourceControl.repo : null;
+		if (known) {
+			openCommitHistoryTab({
+				repoRoot: known.repoRoot,
+				branch: sourceControl.status?.branch ?? null,
+			});
+			return;
+		}
+		if (!sourceControlContextPath) return;
+		try {
+			const repo = await native.gitResolveRepo(sourceControlContextPath);
+			if (!repo) return;
+			openCommitHistoryTab({ repoRoot: repo.repoRoot, branch: repo.branch });
+		} catch {
+			/* noop */
+		}
+	}, [
+		openCommitHistoryTab,
+		sourceControl.hasRepo,
+		sourceControl.repo,
+		sourceControl.status?.branch,
+		sourceControlContextPath,
+	]);
+
+	const openPreviewTab = useCallback(
+		(url: string) => {
+			const id = newPreviewTab(url);
+			// Focus the address bar if the URL is empty so the user can type.
+			if (!url) {
+				setTimeout(() => previewRefs.current.get(id)?.focusAddressBar(), 0);
+			}
+			return id;
+		},
+		[newPreviewTab],
+	);
+
+	const openMarkdownPreview = useCallback(
+		(path: string) => {
+			newMarkdownTab(path);
+		},
+		[newMarkdownTab],
+	);
+
+	const splitActivePaneInActiveTab = useCallback(
+		(dir: "row" | "col") => {
+			const t = tabsRef.current.find((x) => x.id === activeId);
+			if (!t || t.kind !== "terminal") return;
+			splitActivePane(activeId, dir);
+		},
+		[activeId, splitActivePane],
+	);
+
+	const handleCloseTabOrPane = useCallback(() => {
+		const t = tabsRef.current.find((x) => x.id === activeId);
+		if (t?.kind === "terminal" && leafIds(t.paneTree).length > 1) {
+			closeActivePane(activeId);
+			return;
+		}
+		handleClose(activeId);
+	}, [activeId, closeActivePane, handleClose]);
+
+	const shortcutHandlers = useMemo<ShortcutHandlers>(
+		() => ({
+			"tab.new": openNewTab,
+			"tab.newPrivate": openNewPrivateTab,
+			"tab.newPreview": () => openPreviewTab(""),
+			"tab.newEditor": () => setNewEditorOpen(true),
+			"tab.close": handleCloseTabOrPane,
+			"tab.next": () => cycleTab(1),
+			"tab.prev": () => cycleTab(-1),
+			"tab.selectByIndex": (e) => selectByIndex(parseInt(e.key, 10) - 1),
+			"pane.splitRight": () => splitActivePaneInActiveTab("row"),
+			"pane.splitDown": () => splitActivePaneInActiveTab("col"),
+			"pane.focusNext": () => focusNextPaneInTab(activeId, 1),
+			"pane.focusPrev": () => focusNextPaneInTab(activeId, -1),
+			"pane.source": toggleSourceControl,
+			"terminal.clear": () => {
+				clearFocusedTerminal();
+			},
+			"search.focus": () => searchInlineRef.current?.focus(),
+			"ai.toggle": togglePanelAndFocus,
+			"ai.askSelection": askFromSelection,
+			"shortcuts.open": () => setShortcutsOpen((v) => !v),
+			"settings.open": () => void openSettingsWindow(),
+			"sidebar.toggle": toggleSidebar,
+			"explorer.focus": toggleExplorerFocus,
+			"view.zoomIn": zoomIn,
+			"view.zoomOut": zoomOut,
+			"view.zoomReset": zoomReset,
+			"editor.undo": () => editorRefs.current.get(activeId)?.undo(),
+			"editor.redo": () => editorRefs.current.get(activeId)?.redo(),
+		}),
+		[
+			activeId,
+			cycleTab,
+			handleCloseTabOrPane,
+			openNewTab,
+			openNewPrivateTab,
+			openPreviewTab,
+			selectByIndex,
+			splitActivePaneInActiveTab,
+			focusNextPaneInTab,
+			toggleSourceControl,
+			togglePanelAndFocus,
+			askFromSelection,
+			toggleSidebar,
+			toggleExplorerFocus,
+			zoomIn,
+			zoomOut,
+			zoomReset,
+		],
+	);
+
+	const shortcutsDisabled = useCallback(
+		(id: ShortcutId, e: KeyboardEvent) => {
+			if (id === "editor.undo" || id === "editor.redo") {
+				return activeTab?.kind !== "editor";
+			}
+			if (id === "ai.askSelection") {
+				const target =
+					(e.target as HTMLElement | null) ?? document.activeElement;
+				const inTerminal = !!(target as HTMLElement | null)?.closest?.(
+					".xterm",
+				);
+				if (!inTerminal) return false;
+				const sel = captureActiveSelection();
+				return !sel || !sel.trim();
+			}
+			if (id === "terminal.clear") {
+				// Only intercept ⌘K while a terminal is focused; elsewhere let the key
+				// fall through (we never preventDefault when disabled).
+				const target =
+					(e.target as HTMLElement | null) ?? document.activeElement;
+				return !(target as HTMLElement | null)?.closest?.(".xterm");
+			}
+			return false;
+		},
+		[activeTab],
+	);
+
+	useGlobalShortcuts(shortcutHandlers, { isDisabled: shortcutsDisabled });
+
+	const registerTerminalHandle = useCallback(
+		(leafId: number, h: TerminalPaneHandle | null) => {
+			if (h) terminalRefs.current.set(leafId, h);
+			else terminalRefs.current.delete(leafId);
+		},
+		[],
+	);
+
+	const registerEditorHandle = useCallback(
+		(id: number, h: EditorPaneHandle | null) => {
+			if (h) editorRefs.current.set(id, h);
+			else editorRefs.current.delete(id);
+			if (id === activeId) setActiveEditorHandle(h);
+		},
+		[activeId],
+	);
+
+	const registerPreviewHandle = useCallback(
+		(id: number, h: PreviewPaneHandle | null) => {
+			if (h) previewRefs.current.set(id, h);
+			else previewRefs.current.delete(id);
+		},
+		[],
+	);
+
+	const handlePreviewUrl = useCallback(
+		(id: number, url: string) => updateTab(id, { url }),
+		[updateTab],
+	);
+
+	const authorizedCwds = useRef(new Set<string>());
+	const handleTerminalCwd = useCallback(
+		(leafId: number, cwd: string) => {
+			setLeafCwd(leafId, cwd);
+			if (cwd && !authorizedCwds.current.has(cwd)) {
+				authorizedCwds.current.add(cwd);
+				native.workspaceAuthorize(cwd).catch(() => {
+					authorizedCwds.current.delete(cwd);
+				});
+			}
+		},
+		[setLeafCwd],
+	);
+
+	const handleFocusLeaf = useCallback(
+		(tabId: number, leafId: number) => focusPane(tabId, leafId),
+		[focusPane],
+	);
+
+	const onActivateAgent = useCallback(
+		(tabId: number, leafId: number) => {
+			setActiveId(tabId);
+			focusPane(tabId, leafId);
+		},
+		[setActiveId, focusPane],
+	);
+
+	const onActivateLocalAgent = useCallback(() => {
+		openPanel();
+		focusInput(null);
+	}, [openPanel, focusInput]);
+
+	const handleLeafExit = useCallback(
+		(leafId: number, _code: number) => {
+			const all = tabsRef.current;
+			const tab = all.find(
+				(t) => t.kind === "terminal" && hasLeaf(t.paneTree, leafId),
+			);
+			if (!tab || tab.kind !== "terminal") return;
+			const isLast =
+				leafIds(tab.paneTree).length === 1 &&
+				all.filter((t) => t.kind === "terminal").length === 1;
+			if (isLast) {
+				void respawnSession(leafId, tab.cwd);
+			} else {
+				closePaneByLeaf(leafId);
+			}
+		},
+		[closePaneByLeaf],
+	);
+
+	const handleEditorDirty = useCallback(
+		(id: number, dirty: boolean) => updateTab(id, { dirty }),
+		[updateTab],
+	);
+
+	const searchTarget = useMemo<SearchTarget>(() => {
+		if (isTerminalTab && activeLeafId !== null && activeSearchAddon)
+			return {
+				kind: "terminal",
+				addon: activeSearchAddon,
+				focus: () => terminalRefs.current.get(activeLeafId)?.focus(),
+			};
+		if (isEditorTab && activeEditorHandle)
+			return {
+				kind: "editor",
+				handle: activeEditorHandle,
+				focus: () => activeEditorHandle.focus(),
+			};
+		if (isGitHistoryTab && gitHistoryHandle)
+			return {
+				kind: "git-history",
+				handle: gitHistoryHandle,
+				focus: () => {},
+			};
+		return null;
+	}, [
+		isTerminalTab,
+		isEditorTab,
+		isGitHistoryTab,
+		activeLeafId,
+		activeSearchAddon,
+		activeEditorHandle,
+		gitHistoryHandle,
+	]);
+
+	const activeCwd = activeTerminalLeafCwd;
+
+	useEffect(() => {
+		const findCwd = () => {
+			const active = tabs.find((x) => x.id === activeId);
+			if (active?.kind === "terminal") {
+				return (
+					findLeafCwd(active.paneTree, active.activeLeafId) ??
+					active.cwd ??
+					null
+				);
+			}
+			for (let i = tabs.length - 1; i >= 0; i--) {
+				const t = tabs[i];
+				if (t.kind !== "terminal") continue;
+				const cwd = findLeafCwd(t.paneTree, t.activeLeafId) ?? t.cwd;
+				if (cwd) return cwd;
+			}
+			return explorerRoot ?? launchCwd ?? home ?? null;
+		};
+
+		setLive({
+			getCwd: findCwd,
+			getTerminalContext: () => {
+				const t = tabs.find((x) => x.id === activeId);
+				if (t?.kind !== "terminal") return null;
+				if (t.private) return null;
+				const buf = terminalRefs.current.get(t.activeLeafId)?.getBuffer(300);
+				return buf ? redactSensitive(buf) : null;
+			},
+			isActiveTerminalPrivate: () => {
+				const t = tabs.find((x) => x.id === activeId);
+				return t?.kind === "terminal" && t.private === true;
+			},
+			injectIntoActivePty: (text) => {
+				const t = tabs.find((x) => x.id === activeId);
+				if (t?.kind !== "terminal") return false;
+				const term = terminalRefs.current.get(t.activeLeafId);
+				if (!term) return false;
+				term.write(text);
+				term.focus();
+				return true;
+			},
+			getWorkspaceRoot: () => explorerRoot ?? launchCwd ?? home ?? null,
+			getActiveFile: () => {
+				const t = tabs.find((x) => x.id === activeId);
+				return t?.kind === "editor" ? t.path : null;
+			},
+			openPreview: (url: string) => {
+				openPreviewTab(url);
+				return true;
+			},
+			spawnManagedAgent: (prompt: string, sessionId: string) => {
+				const trimmed = prompt.trim();
+				if (!trimmed) return null;
+				const oneLine = trimmed.replace(/\s*\r?\n\s*/g, " ");
+				const cwd = findCwd();
+				const short =
+					oneLine.length > 32 ? `${oneLine.slice(0, 32)}…` : oneLine;
+				const { tabId, leafId } = newAgentTab(
+					cwd ?? undefined,
+					`claude · ${short}`,
+				);
+				useManagedAgentsStore
+					.getState()
+					.register({ leafId, tabId, sessionId, task: oneLine, cwd });
+				const hooksReady = invoke("agent_enable_claude_hooks").catch(() => {});
+				void (async () => {
+					await Promise.all([whenSessionReady(leafId), hooksReady]);
+					if (!writeToSession(leafId, "claude\r")) {
+						useManagedAgentsStore.getState().remove(leafId);
+						return;
+					}
+					const readBuf = () => {
+						const term = terminalRefs.current.get(leafId);
+						return term ? term.getBuffer(120) : null;
+					};
+					const result = await waitForClaudeTuiReady(readBuf);
+					if (result !== "ready") {
+						if (result === "timeout") {
+							console.warn(
+								"[terax] Claude TUI did not appear in time; aborting prompt send",
+							);
+						}
+						useManagedAgentsStore.getState().remove(leafId);
+						return;
+					}
+					if (!writeToSession(leafId, `\x1b[200~${trimmed}\x1b[201~`)) {
+						useManagedAgentsStore.getState().remove(leafId);
+						return;
+					}
+					setTimeout(() => writeToSession(leafId, "\r"), 120);
+					useManagedAgentsStore.getState().setPhase(leafId, "working");
+				})();
+				return { tabId, leafId };
+			},
+			readLeafBuffer: (leafId: number) => {
+				const buf = terminalRefs.current.get(leafId)?.getBuffer(300);
+				return buf ? redactSensitive(buf) : null;
+			},
+		});
+	}, [
+		setLive,
+		activeId,
+		tabs,
+		explorerRoot,
+		launchCwd,
+		home,
+		openPreviewTab,
+		newAgentTab,
+	]);
+
+	const workspaceSurface = (
+		<div className="relative h-full min-h-0">
+			<div
+				className={cn(
+					"absolute inset-0 px-3 pt-2 pb-2",
+					!isTerminalTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isTerminalTab}
+			>
+				<TerminalStack
+					tabs={tabs}
+					activeId={activeId}
+					registerHandle={registerTerminalHandle}
+					onSearchReady={handleSearchReady}
+					onCwd={handleTerminalCwd}
+					onExit={handleLeafExit}
+					onFocusLeaf={handleFocusLeaf}
+				/>
+			</div>
+			<div
+				className={cn(
+					"absolute inset-0 px-3 pt-2 pb-2",
+					!isEditorTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isEditorTab}
+			>
+				<EditorStack
+					tabs={tabs}
+					activeId={activeId}
+					registerHandle={registerEditorHandle}
+					onDirtyChange={handleEditorDirty}
+					onCloseTab={disposeTab}
+				/>
+			</div>
+			<div
+				className={cn(
+					"absolute inset-0 px-3 pt-2 pb-2",
+					!isPreviewTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isPreviewTab}
+			>
+				<PreviewStack
+					tabs={tabs}
+					activeId={activeId}
+					registerHandle={registerPreviewHandle}
+					onUrlChange={handlePreviewUrl}
+				/>
+			</div>
+			<div
+				className={cn(
+					"absolute inset-0 px-3 pt-2 pb-2",
+					!isMarkdownTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isMarkdownTab}
+			>
+				<MarkdownStack tabs={tabs} activeId={activeId} />
+			</div>
+			<div
+				className={cn(
+					"absolute inset-0 px-3 pt-2 pb-2",
+					!isAiDiffTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isAiDiffTab}
+			>
+				<AiDiffStack
+					tabs={tabs}
+					activeId={activeId}
+					onAccept={(id) => respondToApproval(id, true)}
+					onReject={(id) => respondToApproval(id, false)}
+				/>
+			</div>
+			<div
+				className={cn(
+					"absolute inset-0 px-3 pt-2 pb-2",
+					!isGitDiffTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isGitDiffTab}
+			>
+				<GitDiffStack tabs={tabs} activeId={activeId} />
+			</div>
+			<div
+				className={cn(
+					"absolute inset-0",
+					!isGitHistoryTab && "invisible pointer-events-none",
+				)}
+				aria-hidden={!isGitHistoryTab}
+			>
+				<GitHistoryStack
+					tabs={tabs}
+					activeId={activeId}
+					onOpenCommitFile={openCommitFileDiffTab}
+					onSearchHandle={setGitHistoryHandle}
+				/>
+			</div>
+		</div>
+	);
+
+	const shell = (
+		<ThemeProvider>
+			<TooltipProvider>
+				<div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
+					<Header
+						tabs={tabs}
+						activeId={activeId}
+						onSelect={setActiveId}
+						onNew={openNewTab}
+						onNewPrivate={openNewPrivateTab}
+						onNewPreview={() => openPreviewTab("")}
+						onNewEditor={() => setNewEditorOpen(true)}
+						onNewGitGraph={openGitGraphFromContext}
+						onClose={handleClose}
+						onPin={pinTab}
+						onToggleSidebar={toggleSidebar}
+						onSplit={splitActivePaneInActiveTab}
+						canSplit={
+							activeTerminalTab !== null &&
+							leafIds(activeTerminalTab.paneTree).length < MAX_PANES_PER_TAB
+						}
+						onActivateAgent={onActivateAgent}
+						onActivateLocalAgent={onActivateLocalAgent}
+						onOpenSettings={() => void openSettingsWindow()}
+						searchTarget={searchTarget}
+						searchRef={searchInlineRef}
+					/>
+
+					<main className="zoom-content flex min-h-0 flex-1 flex-col">
+						<ResizablePanelGroup
+							orientation="horizontal"
+							className="min-h-0 flex-1"
+						>
+							<ResizablePanel
+								id="sidebar"
+								panelRef={sidebarRef}
+								defaultSize={`${sidebarWidthRef.current}px`}
+								minSize={`${SIDEBAR_MIN_WIDTH}px`}
+								maxSize={`${SIDEBAR_MAX_WIDTH}px`}
+								collapsible
+								collapsedSize={0}
+								onResize={(size) => {
+									if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
+								}}
+							>
+								<div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">
+									<div className="min-h-0 flex-1">
+										{sidebarView === "explorer" ? (
+											<FileExplorer
+												ref={explorerRef}
+												rootPath={explorerRoot}
+												onOpenFile={handleOpenFile}
+												onPathRenamed={handlePathRenamed}
+												onPathDeleted={handlePathDeleted}
+												onRevealInTerminal={cdInNewTab}
+												onAttachToAgent={handleAttachFileToAgent}
+												onOpenMarkdownPreview={openMarkdownPreview}
+											/>
+										) : (
+											<SourceControlPanel
+												open
+												sourceControl={sourceControl}
+												onOpenDiff={openGitDiffTab}
+												onOpenGitGraph={openGitGraphFromContext}
+											/>
+										)}
+									</div>
+									<SidebarRail
+										activeView={sidebarView}
+										onSelectView={persistSidebarView}
+										changedCount={sourceControl.changedCount}
+									/>
+								</div>
+							</ResizablePanel>
+							<ResizableHandle withHandle />
+							<ResizablePanel id="workspace" defaultSize="78%" minSize="30%">
+								<div className="flex h-full min-h-0 flex-col">
+									<div className="relative min-h-0 flex-1">
+										{workspaceSurface}
+									</div>
+
+									{keysLoaded ? (
+										<motion.div
+											data-ai-input-bar
+											initial={false}
+											animate={{
+												height: panelOpen ? "auto" : 0,
+												opacity: panelOpen ? 1 : 0,
+											}}
+											transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+											className="overflow-hidden"
+											aria-hidden={!panelOpen}
+										>
+											{hasComposer ? (
+												<AiInputBar />
+											) : (
+												<AiInputBarConnect
+													onAdd={() => void openSettingsWindow("models")}
+												/>
+											)}
+										</motion.div>
+									) : null}
+								</div>
+							</ResizablePanel>
+						</ResizablePanelGroup>
+					</main>
+
+					<StatusBar
+						cwd={activeCwd}
+						filePath={activeFilePath}
+						home={home}
+						onCd={sendCd}
+						onWorkspaceChange={switchWorkspace}
+						onOpenMini={openMini}
+						hasComposer={hasComposer}
+						privateActive={
+							activeTab?.kind === "terminal" && activeTab.private === true
+						}
+					/>
+
+					<AgentNotificationsBridge
+						tabs={tabs}
+						activeId={activeId}
+						onActivate={onActivateAgent}
+					/>
+					<Toaster position="bottom-right" />
+
+					{hasComposer ? (
+						<>
+							<AgentRunBridge
+								openAiDiffTab={openAiDiffTab}
+								closeAiDiffTab={closeAiDiffTab}
+							/>
+							<LocalAgentNotificationsBridge />
+						</>
+					) : null}
+
+					<AnimatePresence>
+						{miniOpen && hasComposer ? <AiMiniWindow key="ai-mini" /> : null}
+						{askPopup ? (
+							<SelectionAskAi
+								key="ask-ai-popup"
+								x={askPopup.x}
+								y={askPopup.y}
+								onAsk={onAskFromSelection}
+								onDismiss={() => setAskPopup(null)}
+							/>
+						) : null}
+					</AnimatePresence>
+
+					<ShortcutsDialog
+						open={shortcutsOpen}
+						onOpenChange={setShortcutsOpen}
+					/>
+
+					<NewEditorDialog
+						open={newEditorOpen}
+						onOpenChange={setNewEditorOpen}
+						rootPath={explorerRoot ?? home}
+						onCreated={(path) => openFileTab(path)}
+					/>
+
+					<UpdaterDialog />
+
+					<AlertDialog
+						open={pendingCloseTab !== null}
+						onOpenChange={(open) => !open && cancelClose()}
+					>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
+								<AlertDialogDescription>
+									{tabs.find((t) => t.id === pendingCloseTab)?.title
+										? `"${
+												tabs.find((t) => t.id === pendingCloseTab)?.title
+											}" has unsaved changes. Close anyway?`
+										: "This file has unsaved changes. Close anyway?"}
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel onClick={cancelClose}>
+									Cancel
+								</AlertDialogCancel>
+								<AlertDialogAction onClick={confirmClose}>
+									Close Anyway
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+
+					<AlertDialog
+						open={pendingDeleteTabs !== null}
+						onOpenChange={(open) => !open && cancelDeleteClose()}
+					>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
+								<AlertDialogDescription>
+									{pendingDeleteTabs?.length === 1
+										? (() => {
+												const title = tabs.find(
+													(t) => t.id === pendingDeleteTabs[0],
+												)?.title;
+												return title
+													? `"${title}" has unsaved changes. The file has been deleted. Close anyway?`
+													: "This file has unsaved changes. The file has been deleted. Close anyway?";
+											})()
+										: `${pendingDeleteTabs?.length ?? 0} files have unsaved changes. They have been deleted. Close all anyway?`}
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel onClick={cancelDeleteClose}>
+									Cancel
+								</AlertDialogCancel>
+								<AlertDialogAction onClick={confirmDeleteClose}>
+									Close Anyway
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+				</div>
+			</TooltipProvider>
+		</ThemeProvider>
+	);
+
+	return <AiComposerProvider>{shell}</AiComposerProvider>;
 }

--- a/src/modules/agents/components/AgentNotificationsBridge.tsx
+++ b/src/modules/agents/components/AgentNotificationsBridge.tsx
@@ -1,7 +1,7 @@
-import type { Tab } from "@/modules/tabs";
-import { hasLeaf, leafIdForPty } from "@/modules/terminal";
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
+import type { Tab } from "@/modules/tabs";
+import { hasLeaf, leafIdForPty } from "@/modules/terminal";
 import { maybeTriggerManagedReview } from "../lib/review";
 import { routeAgentNotification } from "../lib/route";
 import type { AgentSession, AgentSignal } from "../lib/types";
@@ -11,115 +11,118 @@ import { useManagedAgentsStore } from "../store/managedAgentsStore";
 
 type Activate = (tabId: number, leafId: number) => void;
 type Ctx = {
-  tabs: Tab[];
-  activeId: number;
-  focused: boolean;
-  onActivate: Activate;
+	tabs: Tab[];
+	activeId: number;
+	focused: boolean;
+	onActivate: Activate;
 };
 
 function tabInfo(
-  tabs: Tab[],
-  leafId: number,
+	tabs: Tab[],
+	leafId: number,
 ): { tabId: number; title: string } | null {
-  for (const t of tabs) {
-    if (t.kind === "terminal" && hasLeaf(t.paneTree, leafId)) {
-      return { tabId: t.id, title: t.title };
-    }
-  }
-  return null;
+	for (const t of tabs) {
+		if (t.kind === "terminal" && hasLeaf(t.paneTree, leafId)) {
+			return { tabId: t.id, title: t.title };
+		}
+	}
+	return null;
 }
 
 function route(
-  session: AgentSession,
-  kind: "attention" | "finished",
-  ctx: Ctx,
+	session: AgentSession,
+	kind: "attention" | "finished",
+	ctx: Ctx,
 ): void {
-  const info = tabInfo(ctx.tabs, session.leafId);
-  const heading =
-    kind === "attention"
-      ? `${session.agent} needs your input`
-      : `${session.agent} finished`;
+	const info = tabInfo(ctx.tabs, session.leafId);
+	const heading =
+		kind === "attention"
+			? `${session.agent} needs your input`
+			: `${session.agent} finished`;
 
-  routeAgentNotification({
-    source: "terminal",
-    agent: session.agent,
-    kind,
-    title: heading,
-    body: info?.title,
-    focused: ctx.focused,
-    visible: ctx.activeId === session.tabId,
-    // Stop fires every turn, so finished only updates the bell; attention toasts.
-    allowToast: kind === "attention",
-    tabId: session.tabId,
-    leafId: session.leafId,
-    onActivate: () => ctx.onActivate(session.tabId, session.leafId),
-  });
+	routeAgentNotification({
+		source: "terminal",
+		agent: session.agent,
+		kind,
+		title: heading,
+		body: info?.title,
+		focused: ctx.focused,
+		visible: ctx.activeId === session.tabId,
+		// Stop fires every turn, so finished only updates the bell; attention toasts.
+		allowToast: kind === "attention",
+		tabId: session.tabId,
+		leafId: session.leafId,
+		onActivate: () => ctx.onActivate(session.tabId, session.leafId),
+	});
 }
 
 function handleSignal(sig: AgentSignal, ctx: Ctx): void {
-  const leafId = leafIdForPty(sig.id);
-  if (leafId === null) return;
-  const store = useAgentStore.getState();
+	const leafId = leafIdForPty(sig.id);
+	if (leafId === null) return;
+	const store = useAgentStore.getState();
 
-  switch (sig.kind) {
-    case "started": {
-      const info = tabInfo(ctx.tabs, leafId);
-      if (!info) return;
-      store.start(leafId, info.tabId, sig.agent ?? "agent");
-      return;
-    }
-    case "working":
-      store.setStatus(leafId, "working");
-      return;
-    case "attention": {
-      store.setStatus(leafId, "waiting");
-      const session = store.sessions[leafId];
-      if (session) route(session, "attention", ctx);
-      return;
-    }
-    case "finished": {
-      store.setStatus(leafId, "waiting");
-      const session = store.sessions[leafId];
-      if (session) route(session, "finished", ctx);
-      maybeTriggerManagedReview(leafId);
-      return;
-    }
-    case "exited":
-      store.finish(leafId);
-      useManagedAgentsStore.getState().remove(leafId);
-      return;
-  }
+	switch (sig.kind) {
+		case "started": {
+			const info = tabInfo(ctx.tabs, leafId);
+			if (!info) return;
+			store.start(leafId, info.tabId, sig.agent ?? "agent");
+			return;
+		}
+		case "working":
+			store.setStatus(leafId, "working");
+			return;
+		case "transcript":
+			if (sig.path) store.setTranscript(leafId, sig.path);
+			return;
+		case "attention": {
+			store.setStatus(leafId, "waiting");
+			const session = store.sessions[leafId];
+			if (session) route(session, "attention", ctx);
+			return;
+		}
+		case "finished": {
+			store.setStatus(leafId, "waiting");
+			const session = store.sessions[leafId];
+			if (session) route(session, "finished", ctx);
+			maybeTriggerManagedReview(leafId);
+			return;
+		}
+		case "exited":
+			store.finish(leafId);
+			useManagedAgentsStore.getState().remove(leafId);
+			return;
+	}
 }
 
 export function AgentNotificationsBridge({
-  tabs,
-  activeId,
-  onActivate,
+	tabs,
+	activeId,
+	onActivate,
 }: {
-  tabs: Tab[];
-  activeId: number;
-  onActivate: Activate;
+	tabs: Tab[];
+	activeId: number;
+	onActivate: Activate;
 }) {
-  const focused = useWindowFocus();
-  const ctxRef = useRef<Ctx>({ tabs, activeId, focused, onActivate });
-  ctxRef.current = { tabs, activeId, focused, onActivate };
+	const focused = useWindowFocus();
+	const ctxRef = useRef<Ctx>({ tabs, activeId, focused, onActivate });
+	ctxRef.current = { tabs, activeId, focused, onActivate };
 
-  useEffect(() => {
-    let alive = true;
-    let unlisten: (() => void) | undefined;
-    listen<AgentSignal>("terax:agent-signal", (e) =>
-      handleSignal(e.payload, ctxRef.current),
-    )
-      .then((u) => {
-        if (alive) unlisten = u;
-        else u();
-      })
-      .catch(() => {});
-    return () => {
-      alive = false;
-      unlisten?.();
-    };
-  }, []);
+	useEffect(() => {
+		let alive = true;
+		let unlisten: (() => void) | undefined;
+		listen<AgentSignal>("terax:agent-signal", (e) =>
+			handleSignal(e.payload, ctxRef.current),
+		)
+			.then((u) => {
+				if (alive) unlisten = u;
+				else u();
+			})
+			.catch(() => {});
+		return () => {
+			alive = false;
+			unlisten?.();
+		};
+	}, []);
 
-  return null;
+	return null;
 }

--- a/src/modules/agents/lib/types.ts
+++ b/src/modules/agents/lib/types.ts
@@ -3,42 +3,47 @@ export type AgentStatus = "working" | "waiting";
 export type AgentSource = "terminal" | "local";
 
 export type AgentSignalKind =
-  | "started"
-  | "working"
-  | "attention"
-  | "finished"
-  | "exited";
+	| "started"
+	| "working"
+	| "attention"
+	| "finished"
+	| "exited"
+	| "transcript";
 
 export type AgentSignal = {
-  id: number;
-  kind: AgentSignalKind;
-  agent: string | null;
+	id: number;
+	kind: AgentSignalKind;
+	agent: string | null;
+	path: string | null;
 };
 
 export type AgentSession = {
-  leafId: number;
-  tabId: number;
-  agent: string;
-  status: AgentStatus;
-  startedAt: number;
-  lastActivityAt: number;
-  attentionSince: number | null;
+	leafId: number;
+	tabId: number;
+	agent: string;
+	status: AgentStatus;
+	startedAt: number;
+	lastActivityAt: number;
+	attentionSince: number | null;
+	// The exact transcript JSONL path for this session, learned from the Claude
+	// Code hooks. Null until the first hook fires (e.g. the first prompt).
+	transcriptPath: string | null;
 };
 
 export type AgentNotification = {
-  id: string;
-  source: AgentSource;
-  leafId: number;
-  tabId: number;
-  agent: string;
-  kind: NotificationKind;
-  at: number;
-  read: boolean;
+	id: string;
+	source: AgentSource;
+	leafId: number;
+	tabId: number;
+	agent: string;
+	kind: NotificationKind;
+	at: number;
+	read: boolean;
 };
 
 export type NotificationKind = "attention" | "finished" | "error";
 
 export type LocalAgentState = {
-  agent: string;
-  status: AgentStatus;
+	agent: string;
+	status: AgentStatus;
 } | null;

--- a/src/modules/agents/store/agentStore.ts
+++ b/src/modules/agents/store/agentStore.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
 import type {
-  AgentNotification,
-  AgentSession,
-  AgentStatus,
-  LocalAgentState,
+	AgentNotification,
+	AgentSession,
+	AgentStatus,
+	LocalAgentState,
 } from "../lib/types";
 
 const MAX_NOTIFICATIONS = 50;
@@ -11,93 +11,107 @@ const MAX_NOTIFICATIONS = 50;
 let notifSeq = 0;
 
 type AgentStoreState = {
-  sessions: Record<number, AgentSession>;
-  localAgent: LocalAgentState;
-  notifications: AgentNotification[];
-  start: (leafId: number, tabId: number, agent: string) => void;
-  setStatus: (leafId: number, status: AgentStatus) => void;
-  finish: (leafId: number) => void;
-  setLocalAgent: (state: LocalAgentState) => void;
-  pushNotification: (
-    n: Omit<AgentNotification, "id" | "at" | "read">,
-  ) => void;
-  markAllRead: () => void;
-  clearNotifications: () => void;
+	sessions: Record<number, AgentSession>;
+	localAgent: LocalAgentState;
+	notifications: AgentNotification[];
+	start: (leafId: number, tabId: number, agent: string) => void;
+	setStatus: (leafId: number, status: AgentStatus) => void;
+	setTranscript: (leafId: number, path: string) => void;
+	finish: (leafId: number) => void;
+	setLocalAgent: (state: LocalAgentState) => void;
+	pushNotification: (n: Omit<AgentNotification, "id" | "at" | "read">) => void;
+	markAllRead: () => void;
+	clearNotifications: () => void;
 };
 
 export const useAgentStore = create<AgentStoreState>((set) => ({
-  sessions: {},
-  localAgent: null,
-  notifications: [],
+	sessions: {},
+	localAgent: null,
+	notifications: [],
 
-  start: (leafId, tabId, agent) =>
-    set((s) => {
-      const now = Date.now();
-      return {
-        sessions: {
-          ...s.sessions,
-          [leafId]: {
-            leafId,
-            tabId,
-            agent,
-            status: "working",
-            startedAt: now,
-            lastActivityAt: now,
-            attentionSince: null,
-          },
-        },
-      };
-    }),
+	start: (leafId, tabId, agent) =>
+		set((s) => {
+			const now = Date.now();
+			return {
+				sessions: {
+					...s.sessions,
+					[leafId]: {
+						leafId,
+						tabId,
+						agent,
+						status: "working",
+						startedAt: now,
+						lastActivityAt: now,
+						attentionSince: null,
+						transcriptPath: s.sessions[leafId]?.transcriptPath ?? null,
+					},
+				},
+			};
+		}),
 
-  setStatus: (leafId, status) =>
-    set((s) => {
-      const prev = s.sessions[leafId];
-      if (!prev || prev.status === status) return s;
-      const now = Date.now();
-      return {
-        sessions: {
-          ...s.sessions,
-          [leafId]: {
-            ...prev,
-            status,
-            lastActivityAt: now,
-            attentionSince: status === "waiting" ? now : null,
-          },
-        },
-      };
-    }),
+	setStatus: (leafId, status) =>
+		set((s) => {
+			const prev = s.sessions[leafId];
+			if (!prev || prev.status === status) return s;
+			const now = Date.now();
+			return {
+				sessions: {
+					...s.sessions,
+					[leafId]: {
+						...prev,
+						status,
+						lastActivityAt: now,
+						attentionSince: status === "waiting" ? now : null,
+					},
+				},
+			};
+		}),
 
-  finish: (leafId) =>
-    set((s) => {
-      if (!s.sessions[leafId]) return s;
-      const next = { ...s.sessions };
-      delete next[leafId];
-      return { sessions: next };
-    }),
+	setTranscript: (leafId, path) =>
+		set((s) => {
+			const prev = s.sessions[leafId];
+			if (!prev || prev.transcriptPath === path) return s;
+			return {
+				sessions: {
+					...s.sessions,
+					[leafId]: { ...prev, transcriptPath: path },
+				},
+			};
+		}),
 
-  setLocalAgent: (state) =>
-    set((s) => {
-      const a = s.localAgent;
-      if (a === state) return s;
-      if (a && state && a.status === state.status && a.agent === state.agent) {
-        return s;
-      }
-      return { localAgent: state };
-    }),
+	finish: (leafId) =>
+		set((s) => {
+			if (!s.sessions[leafId]) return s;
+			const next = { ...s.sessions };
+			delete next[leafId];
+			return { sessions: next };
+		}),
 
-  pushNotification: (n) =>
-    set((s) => ({
-      notifications: [
-        { ...n, id: `n${++notifSeq}`, at: Date.now(), read: false },
-        ...s.notifications,
-      ].slice(0, MAX_NOTIFICATIONS),
-    })),
+	setLocalAgent: (state) =>
+		set((s) => {
+			const a = s.localAgent;
+			if (a === state) return s;
+			if (a && state && a.status === state.status && a.agent === state.agent) {
+				return s;
+			}
+			return { localAgent: state };
+		}),
 
-  markAllRead: () =>
-    set((s) => {
-      if (!s.notifications.some((n) => !n.read)) return s;
-      return { notifications: s.notifications.map((n) => ({ ...n, read: true })) };
-    }),
+	pushNotification: (n) =>
+		set((s) => ({
+			notifications: [
+				{ ...n, id: `n${++notifSeq}`, at: Date.now(), read: false },
+				...s.notifications,
+			].slice(0, MAX_NOTIFICATIONS),
+		})),
 
-  clearNotifications: () => set({ notifications: [] }),
+	markAllRead: () =>
+		set((s) => {
+			if (!s.notifications.some((n) => !n.read)) return s;
+			return {
+				notifications: s.notifications.map((n) => ({ ...n, read: true })),
+			};
+		}),
+
+	clearNotifications: () => set({ notifications: [] }),
 }));

--- a/src/modules/claude-chat/ClaudeChatView.tsx
+++ b/src/modules/claude-chat/ClaudeChatView.tsx
@@ -1,232 +1,350 @@
 import {
-  Conversation,
-  ConversationContent,
-  ConversationEmptyState,
-  ConversationScrollButton,
+	ArrowDown01Icon,
+	ArrowRight01Icon,
+	ArrowUpIcon,
+	Cancel01Icon,
+	SquareIcon,
+	Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import {
+	Conversation,
+	ConversationContent,
+	ConversationEmptyState,
+	ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
 import {
-  Message,
-  MessageContent,
-  MessageResponse,
+	Message,
+	MessageContent,
+	MessageResponse,
 } from "@/components/ai-elements/message";
 import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
+	Reasoning,
+	ReasoningContent,
+	ReasoningTrigger,
 } from "@/components/ai-elements/reasoning";
 import { Tool } from "@/components/ai-elements/tool";
 import { Button } from "@/components/ui/button";
+import { useAgentStore } from "@/modules/agents/store/agentStore";
 import { AiDiffPane } from "@/modules/editor/AiDiffPane";
 import { writeToSession } from "@/modules/terminal";
-import { ArrowUpIcon, SquareIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { memo, useCallback, useRef, useState } from "react";
-import { useTranscriptTail } from "./lib/useTranscriptTail";
 import { diffsFromTool, teraxToolName } from "./lib/toolMap";
 import type { ChatMessage, ChatPart } from "./lib/transcript";
+import { useTranscriptTail } from "./lib/useTranscriptTail";
 
 type Props = {
-  leafId: number;
-  cwd: string | undefined;
-  active: boolean;
+	leafId: number;
+	/** Exact transcript path for this session (from hooks), or undefined if unknown yet. */
+	transcriptPath: string | undefined;
+	active: boolean;
 };
 
-export function ClaudeChatView({ leafId, cwd, active }: Props) {
-  const { messages, status } = useTranscriptTail(cwd, active);
+// The claude TUI permission dialog defaults to the "Yes" option, so Enter
+// approves the highlighted choice and Esc cancels (denies).
+const KEY_APPROVE = "\r";
+const KEY_DENY = "\x1b";
 
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="min-h-0 flex-1">
-        <ChatBody messages={messages} status={status} />
-      </div>
-      <Composer leafId={leafId} />
-    </div>
-  );
+// A permission block leaves the last assistant message ending in a tool call
+// that has no result yet. A tool that is merely still running looks the same in
+// the transcript, so the caller additionally gates on the agent `waiting`
+// status to tell the two apart.
+function pendingToolName(messages: ChatMessage[]): string | null {
+	const last = messages[messages.length - 1];
+	if (!last || last.role !== "assistant") return null;
+	for (let i = last.parts.length - 1; i >= 0; i -= 1) {
+		const p = last.parts[i];
+		if (p.kind === "tool") {
+			return p.state === "input-available" ? p.name : null;
+		}
+	}
+	return null;
 }
 
-const ChatBody = memo(function ChatBody({
-  messages,
-  status,
-}: {
-  messages: ChatMessage[];
-  status: ReturnType<typeof useTranscriptTail>["status"];
-}) {
-  if (messages.length === 0) {
-    return (
-      <Conversation>
-        <ConversationContent>
-          <ConversationEmptyState
-            title={
-              status === "not-found"
-                ? "No Claude session found"
-                : "Waiting for Claude"
-            }
-            description={
-              status === "not-found"
-                ? "Start `claude` in this terminal, then switch back to Chat."
-                : "Messages from the running Claude session will appear here."
-            }
-          />
-        </ConversationContent>
-      </Conversation>
-    );
-  }
+export function ClaudeChatView({ leafId, transcriptPath, active }: Props) {
+	const { messages, status } = useTranscriptTail(transcriptPath, active);
+	// A pending trailing tool call only means "awaiting permission" when the
+	// agent is also parked in `waiting`; a running tool is still `working`.
+	const agentStatus = useAgentStore((s) => s.sessions[leafId]?.status);
+	const awaitingTool =
+		agentStatus === "waiting" ? pendingToolName(messages) : null;
 
-  return (
-    <Conversation>
-      <ConversationContent className="gap-5 p-3">
-        {messages.map((m) => (
-          <RenderedMessage key={m.id} message={m} />
-        ))}
-      </ConversationContent>
-      <ConversationScrollButton />
-    </Conversation>
-  );
+	return (
+		<div className="flex h-full min-h-0 flex-col">
+			<div className="min-h-0 flex-1">
+				<ChatBody messages={messages} status={status} />
+			</div>
+			{awaitingTool ? (
+				<PermissionBar leafId={leafId} toolName={awaitingTool} />
+			) : null}
+			<Composer leafId={leafId} active={active} />
+		</div>
+	);
+}
+
+const PermissionBar = memo(function PermissionBar({
+	leafId,
+	toolName,
+}: {
+	leafId: number;
+	toolName: string;
+}) {
+	const approve = useCallback(
+		() => writeToSession(leafId, KEY_APPROVE),
+		[leafId],
+	);
+	const deny = useCallback(() => writeToSession(leafId, KEY_DENY), [leafId]);
+
+	return (
+		<div className="flex shrink-0 items-center gap-2 border-t border-amber-500/40 bg-amber-500/10 px-3 py-2">
+			<span className="size-1.5 shrink-0 rounded-full bg-amber-500" />
+			<span className="min-w-0 flex-1 truncate text-[12px] text-foreground">
+				Claude needs permission to run{" "}
+				<span className="font-medium">{toolName}</span>
+			</span>
+			<Button size="sm" className="h-7 gap-1.5" onClick={approve}>
+				<HugeiconsIcon icon={Tick02Icon} size={13} strokeWidth={2} />
+				Approve
+			</Button>
+			<Button size="sm" variant="ghost" className="h-7 gap-1.5" onClick={deny}>
+				<HugeiconsIcon icon={Cancel01Icon} size={13} strokeWidth={2} />
+				Deny
+			</Button>
+		</div>
+	);
+});
+
+const ChatBody = memo(function ChatBody({
+	messages,
+	status,
+}: {
+	messages: ChatMessage[];
+	status: ReturnType<typeof useTranscriptTail>["status"];
+}) {
+	if (messages.length === 0) {
+		return (
+			<Conversation>
+				<ConversationContent>
+					<ConversationEmptyState
+						title={
+							status === "live"
+								? "Waiting for Claude"
+								: "Type a message to begin"
+						}
+						description={
+							status === "live"
+								? "Messages from the running Claude session will appear here."
+								: "Send a message below and Claude's reply will show up here."
+						}
+					/>
+				</ConversationContent>
+			</Conversation>
+		);
+	}
+
+	return (
+		<Conversation>
+			<ConversationContent className="gap-5 p-3">
+				{messages.map((m) => (
+					<RenderedMessage key={m.id} message={m} />
+				))}
+			</ConversationContent>
+			<ConversationScrollButton />
+		</Conversation>
+	);
 });
 
 const RenderedMessage = memo(function RenderedMessage({
-  message,
+	message,
 }: {
-  message: ChatMessage;
+	message: ChatMessage;
 }) {
-  if (message.role === "user") {
-    const text = message.parts
-      .filter((p): p is Extract<ChatPart, { kind: "text" }> => p.kind === "text")
-      .map((p) => p.text)
-      .join("\n");
-    if (!text.trim()) return null;
-    return (
-      <Message from="user">
-        <MessageContent>
-          <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
-        </MessageContent>
-      </Message>
-    );
-  }
+	if (message.role === "user") {
+		const text = message.parts
+			.filter(
+				(p): p is Extract<ChatPart, { kind: "text" }> => p.kind === "text",
+			)
+			.map((p) => p.text)
+			.join("\n");
+		if (!text.trim()) return null;
+		return (
+			<Message from="user">
+				<MessageContent>
+					<p className="whitespace-pre-wrap wrap-break-word">{text}</p>
+				</MessageContent>
+			</Message>
+		);
+	}
 
-  return (
-    <Message from="assistant">
-      <MessageContent>
-        <div className="flex flex-col gap-3">
-          {message.parts.map((part, i) => (
-            <RenderedPart key={`${message.id}-${i}`} part={part} />
-          ))}
-        </div>
-      </MessageContent>
-    </Message>
-  );
+	return (
+		<Message from="assistant">
+			<MessageContent>
+				<div className="flex flex-col gap-3">
+					{message.parts.map((part, i) => (
+						<RenderedPart key={`${message.id}-${i}`} part={part} />
+					))}
+				</div>
+			</MessageContent>
+		</Message>
+	);
 });
 
 const RenderedPart = memo(function RenderedPart({ part }: { part: ChatPart }) {
-  if (part.kind === "text") {
-    if (!part.text.trim()) return null;
-    return <MessageResponse>{part.text}</MessageResponse>;
-  }
+	if (part.kind === "text") {
+		if (!part.text.trim()) return null;
+		return <MessageResponse>{part.text}</MessageResponse>;
+	}
 
-  if (part.kind === "thinking") {
-    if (!part.text.trim()) return null;
-    return (
-      <Reasoning>
-        <ReasoningTrigger />
-        <ReasoningContent>{part.text}</ReasoningContent>
-      </Reasoning>
-    );
-  }
+	if (part.kind === "thinking") {
+		if (!part.text.trim()) return null;
+		return (
+			<Reasoning>
+				<ReasoningTrigger />
+				<ReasoningContent>{part.text}</ReasoningContent>
+			</Reasoning>
+		);
+	}
 
-  // Tool call: render file mutations through the shared diff renderer, the rest
-  // through the shared Tool card.
-  const diffs = diffsFromTool(part.name, part.input);
-  if (diffs.length > 0) {
-    return (
-      <div className="flex flex-col gap-2">
-        {diffs.map((d, i) => (
-          <div
-            key={`${part.id}-${i}`}
-            className="h-[min(420px,60vh)] overflow-hidden"
-          >
-            <AiDiffPane
-              path={d.path}
-              originalContent={d.originalContent}
-              proposedContent={d.proposedContent}
-              status="approved"
-              isNewFile={d.isNewFile}
-              onAccept={noop}
-              onReject={noop}
-            />
-          </div>
-        ))}
-      </div>
-    );
-  }
+	// Tool call: render file mutations through the shared diff renderer, the rest
+	// through the shared Tool card.
+	const diffs = diffsFromTool(part.name, part.input);
+	if (diffs.length > 0) {
+		return (
+			<div className="flex flex-col gap-2">
+				{diffs.map((d, i) => (
+					<LazyDiff key={`${part.id}-${i}`} diff={d} />
+				))}
+			</div>
+		);
+	}
 
-  return (
-    <Tool
-      toolName={teraxToolName(part.name)}
-      state={part.state}
-      input={part.input}
-      output={part.output}
-      errorText={part.state === "output-error" ? part.output : undefined}
-    />
-  );
+	return (
+		<Tool
+			toolName={teraxToolName(part.name)}
+			state={part.state}
+			input={part.input}
+			output={part.output}
+			errorText={part.state === "output-error" ? part.output : undefined}
+		/>
+	);
 });
 
 function noop() {}
 
-const Composer = memo(function Composer({ leafId }: { leafId: number }) {
-  const [value, setValue] = useState("");
-  const taRef = useRef<HTMLTextAreaElement>(null);
+type DiffSpec = ReturnType<typeof diffsFromTool>[number];
 
-  const send = useCallback(() => {
-    const text = value.trim();
-    if (!text) return;
-    // Drive the same interactive PTY claude the terminal view talks to. The CR
-    // submits the prompt exactly as if typed in the TUI.
-    if (writeToSession(leafId, text + "\r")) {
-      setValue("");
-    }
-  }, [leafId, value]);
+// Collapsed by default: a session can hold hundreds of file edits, and eagerly
+// mounting a CodeMirror diff editor for each one froze the whole app. The heavy
+// AiDiffPane only mounts when the user expands a specific change.
+const LazyDiff = memo(function LazyDiff({ diff }: { diff: DiffSpec }) {
+	const [open, setOpen] = useState(false);
+	const name = diff.path.split("/").pop() || diff.path;
 
-  const interrupt = useCallback(() => {
-    // ESC cancels the current turn in the claude TUI.
-    writeToSession(leafId, "\x1b");
-  }, [leafId]);
+	return (
+		<div className="overflow-hidden rounded-md border border-border/60">
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] hover:bg-muted/50"
+			>
+				<HugeiconsIcon
+					icon={open ? ArrowDown01Icon : ArrowRight01Icon}
+					size={13}
+					strokeWidth={2}
+					className="shrink-0 text-muted-foreground"
+				/>
+				<span className="truncate font-medium">{name}</span>
+				<span className="ml-auto shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+					{diff.isNewFile ? "new file" : "edit"}
+				</span>
+			</button>
+			{open ? (
+				<div className="h-[min(420px,60vh)] overflow-hidden border-t border-border/60">
+					<AiDiffPane
+						path={diff.path}
+						originalContent={diff.originalContent}
+						proposedContent={diff.proposedContent}
+						status="approved"
+						isNewFile={diff.isNewFile}
+						onAccept={noop}
+						onReject={noop}
+					/>
+				</div>
+			) : null}
+		</div>
+	);
+});
 
-  return (
-    <div className="shrink-0 border-t border-border/60 p-2">
-      <div className="flex items-end gap-2 rounded-lg border border-border/60 bg-background px-2 py-1.5">
-        <textarea
-          ref={taRef}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              send();
-            }
-          }}
-          rows={1}
-          placeholder="Message Claude…"
-          className="max-h-40 min-h-[1.75rem] flex-1 resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
-        />
-        <Button
-          size="icon"
-          variant="ghost"
-          className="size-7 shrink-0"
-          title="Interrupt (Esc)"
-          onClick={interrupt}
-        >
-          <HugeiconsIcon icon={SquareIcon} size={15} strokeWidth={2} />
-        </Button>
-        <Button
-          size="icon"
-          className="size-7 shrink-0"
-          title="Send (Enter)"
-          onClick={send}
-          disabled={!value.trim()}
-        >
-          <HugeiconsIcon icon={ArrowUpIcon} size={15} strokeWidth={2} />
-        </Button>
-      </div>
-    </div>
-  );
+const Composer = memo(function Composer({
+	leafId,
+	active,
+}: {
+	leafId: number;
+	active: boolean;
+}) {
+	const [value, setValue] = useState("");
+	const taRef = useRef<HTMLTextAreaElement>(null);
+
+	// Grab focus when the chat face comes up so the user can type immediately.
+	// The terminal pane yields focus while chat is active (see LeafPane), so this
+	// doesn't fight xterm for the cursor.
+	useEffect(() => {
+		if (!active) return;
+		const id = requestAnimationFrame(() => taRef.current?.focus());
+		return () => cancelAnimationFrame(id);
+	}, [active]);
+
+	const send = useCallback(() => {
+		const text = value.trim();
+		if (!text) return;
+		// Drive the same interactive PTY claude the terminal view talks to. The CR
+		// submits the prompt exactly as if typed in the TUI.
+		if (writeToSession(leafId, text + "\r")) {
+			setValue("");
+		}
+	}, [leafId, value]);
+
+	const interrupt = useCallback(() => {
+		// ESC cancels the current turn in the claude TUI.
+		writeToSession(leafId, "\x1b");
+	}, [leafId]);
+
+	return (
+		<div className="shrink-0 border-t border-border/60 p-2">
+			<div className="flex items-end gap-2 rounded-lg border border-border/60 bg-background px-2 py-1.5">
+				<textarea
+					ref={taRef}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && !e.shiftKey) {
+							e.preventDefault();
+							send();
+						}
+					}}
+					rows={1}
+					placeholder="Message Claude…"
+					className="max-h-40 min-h-[1.75rem] flex-1 resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+				/>
+				<Button
+					size="icon"
+					variant="ghost"
+					className="size-7 shrink-0"
+					title="Interrupt (Esc)"
+					onClick={interrupt}
+				>
+					<HugeiconsIcon icon={SquareIcon} size={15} strokeWidth={2} />
+				</Button>
+				<Button
+					size="icon"
+					className="size-7 shrink-0"
+					title="Send (Enter)"
+					onClick={send}
+					disabled={!value.trim()}
+				>
+					<HugeiconsIcon icon={ArrowUpIcon} size={15} strokeWidth={2} />
+				</Button>
+			</div>
+		</div>
+	);
 });

--- a/src/modules/claude-chat/ClaudeChatView.tsx
+++ b/src/modules/claude-chat/ClaudeChatView.tsx
@@ -1,0 +1,232 @@
+import {
+  Conversation,
+  ConversationContent,
+  ConversationEmptyState,
+  ConversationScrollButton,
+} from "@/components/ai-elements/conversation";
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "@/components/ai-elements/reasoning";
+import { Tool } from "@/components/ai-elements/tool";
+import { Button } from "@/components/ui/button";
+import { AiDiffPane } from "@/modules/editor/AiDiffPane";
+import { writeToSession } from "@/modules/terminal";
+import { ArrowUpIcon, SquareIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { memo, useCallback, useRef, useState } from "react";
+import { useTranscriptTail } from "./lib/useTranscriptTail";
+import { diffsFromTool, teraxToolName } from "./lib/toolMap";
+import type { ChatMessage, ChatPart } from "./lib/transcript";
+
+type Props = {
+  leafId: number;
+  cwd: string | undefined;
+  active: boolean;
+};
+
+export function ClaudeChatView({ leafId, cwd, active }: Props) {
+  const { messages, status } = useTranscriptTail(cwd, active);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="min-h-0 flex-1">
+        <ChatBody messages={messages} status={status} />
+      </div>
+      <Composer leafId={leafId} />
+    </div>
+  );
+}
+
+const ChatBody = memo(function ChatBody({
+  messages,
+  status,
+}: {
+  messages: ChatMessage[];
+  status: ReturnType<typeof useTranscriptTail>["status"];
+}) {
+  if (messages.length === 0) {
+    return (
+      <Conversation>
+        <ConversationContent>
+          <ConversationEmptyState
+            title={
+              status === "not-found"
+                ? "No Claude session found"
+                : "Waiting for Claude"
+            }
+            description={
+              status === "not-found"
+                ? "Start `claude` in this terminal, then switch back to Chat."
+                : "Messages from the running Claude session will appear here."
+            }
+          />
+        </ConversationContent>
+      </Conversation>
+    );
+  }
+
+  return (
+    <Conversation>
+      <ConversationContent className="gap-5 p-3">
+        {messages.map((m) => (
+          <RenderedMessage key={m.id} message={m} />
+        ))}
+      </ConversationContent>
+      <ConversationScrollButton />
+    </Conversation>
+  );
+});
+
+const RenderedMessage = memo(function RenderedMessage({
+  message,
+}: {
+  message: ChatMessage;
+}) {
+  if (message.role === "user") {
+    const text = message.parts
+      .filter((p): p is Extract<ChatPart, { kind: "text" }> => p.kind === "text")
+      .map((p) => p.text)
+      .join("\n");
+    if (!text.trim()) return null;
+    return (
+      <Message from="user">
+        <MessageContent>
+          <p className="whitespace-pre-wrap wrap-break-word">{text}</p>
+        </MessageContent>
+      </Message>
+    );
+  }
+
+  return (
+    <Message from="assistant">
+      <MessageContent>
+        <div className="flex flex-col gap-3">
+          {message.parts.map((part, i) => (
+            <RenderedPart key={`${message.id}-${i}`} part={part} />
+          ))}
+        </div>
+      </MessageContent>
+    </Message>
+  );
+});
+
+const RenderedPart = memo(function RenderedPart({ part }: { part: ChatPart }) {
+  if (part.kind === "text") {
+    if (!part.text.trim()) return null;
+    return <MessageResponse>{part.text}</MessageResponse>;
+  }
+
+  if (part.kind === "thinking") {
+    if (!part.text.trim()) return null;
+    return (
+      <Reasoning>
+        <ReasoningTrigger />
+        <ReasoningContent>{part.text}</ReasoningContent>
+      </Reasoning>
+    );
+  }
+
+  // Tool call: render file mutations through the shared diff renderer, the rest
+  // through the shared Tool card.
+  const diffs = diffsFromTool(part.name, part.input);
+  if (diffs.length > 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        {diffs.map((d, i) => (
+          <div
+            key={`${part.id}-${i}`}
+            className="h-[min(420px,60vh)] overflow-hidden"
+          >
+            <AiDiffPane
+              path={d.path}
+              originalContent={d.originalContent}
+              proposedContent={d.proposedContent}
+              status="approved"
+              isNewFile={d.isNewFile}
+              onAccept={noop}
+              onReject={noop}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <Tool
+      toolName={teraxToolName(part.name)}
+      state={part.state}
+      input={part.input}
+      output={part.output}
+      errorText={part.state === "output-error" ? part.output : undefined}
+    />
+  );
+});
+
+function noop() {}
+
+const Composer = memo(function Composer({ leafId }: { leafId: number }) {
+  const [value, setValue] = useState("");
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  const send = useCallback(() => {
+    const text = value.trim();
+    if (!text) return;
+    // Drive the same interactive PTY claude the terminal view talks to. The CR
+    // submits the prompt exactly as if typed in the TUI.
+    if (writeToSession(leafId, text + "\r")) {
+      setValue("");
+    }
+  }, [leafId, value]);
+
+  const interrupt = useCallback(() => {
+    // ESC cancels the current turn in the claude TUI.
+    writeToSession(leafId, "\x1b");
+  }, [leafId]);
+
+  return (
+    <div className="shrink-0 border-t border-border/60 p-2">
+      <div className="flex items-end gap-2 rounded-lg border border-border/60 bg-background px-2 py-1.5">
+        <textarea
+          ref={taRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
+          rows={1}
+          placeholder="Message Claude…"
+          className="max-h-40 min-h-[1.75rem] flex-1 resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        />
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-7 shrink-0"
+          title="Interrupt (Esc)"
+          onClick={interrupt}
+        >
+          <HugeiconsIcon icon={SquareIcon} size={15} strokeWidth={2} />
+        </Button>
+        <Button
+          size="icon"
+          className="size-7 shrink-0"
+          title="Send (Enter)"
+          onClick={send}
+          disabled={!value.trim()}
+        >
+          <HugeiconsIcon icon={ArrowUpIcon} size={15} strokeWidth={2} />
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/src/modules/claude-chat/index.ts
+++ b/src/modules/claude-chat/index.ts
@@ -1,0 +1,2 @@
+export { ClaudeChatView } from "./ClaudeChatView";
+export { useChatViewStore } from "./store/chatViewStore";

--- a/src/modules/claude-chat/lib/bridge.ts
+++ b/src/modules/claude-chat/lib/bridge.ts
@@ -1,0 +1,32 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+
+/** Newest transcript JSONL for `claude` running in `cwd`, or null if none. */
+export function findTranscript(cwd: string): Promise<string | null> {
+  return invoke<string | null>("claude_find_transcript", { cwd });
+}
+
+export type TranscriptSubscription = {
+  close: () => void;
+};
+
+/**
+ * Tail a transcript file. `onChunk` receives the existing content first, then
+ * appended whole lines as the live `claude` writes them. Caller must `close()`
+ * to stop the backend tail when leaving chat mode.
+ */
+export async function subscribeTranscript(
+  path: string,
+  onChunk: (text: string) => void,
+): Promise<TranscriptSubscription> {
+  const channel = new Channel<string>();
+  channel.onmessage = onChunk;
+  await invoke("claude_transcript_subscribe", { path, onChunk: channel });
+  let closed = false;
+  return {
+    close: () => {
+      if (closed) return;
+      closed = true;
+      void invoke("claude_transcript_unsubscribe", { path }).catch(() => {});
+    },
+  };
+}

--- a/src/modules/claude-chat/lib/toolMap.ts
+++ b/src/modules/claude-chat/lib/toolMap.ts
@@ -1,0 +1,79 @@
+// Map Claude Code's tool names to Terax's internal tool ids so the shared
+// `Tool` component resolves the same icons, labels, and input summaries it uses
+// for the built-in agent. Unknown tools fall through to the generic rendering.
+export const CLAUDE_TOOL_TO_TERAX: Record<string, string> = {
+  Bash: "bash_run",
+  BashOutput: "bash_logs",
+  KillShell: "bash_kill",
+  Read: "read_file",
+  Write: "write_file",
+  Edit: "edit",
+  MultiEdit: "multi_edit",
+  NotebookEdit: "edit",
+  Glob: "glob",
+  Grep: "grep",
+  LS: "list_directory",
+  TodoWrite: "todo_write",
+  Task: "run_subagent",
+};
+
+export function teraxToolName(claudeName: string): string {
+  return CLAUDE_TOOL_TO_TERAX[claudeName] ?? claudeName;
+}
+
+export type DiffInput = {
+  path: string;
+  originalContent: string;
+  proposedContent: string;
+  isNewFile: boolean;
+};
+
+/**
+ * Extract before/after diffs from a file-mutating tool's input so they can be
+ * shown in the shared diff renderer. Edit -> one diff (old/new snippet); Write
+ * -> whole new file; MultiEdit -> one diff per edit.
+ */
+export function diffsFromTool(name: string, input: unknown): DiffInput[] {
+  if (!input || typeof input !== "object") return [];
+  const i = input as Record<string, unknown>;
+  const path = typeof i.file_path === "string" ? i.file_path : "";
+  if (!path) return [];
+
+  if (name === "Edit" || name === "NotebookEdit") {
+    const oldStr =
+      typeof i.old_string === "string"
+        ? i.old_string
+        : typeof i.old_source === "string"
+          ? i.old_source
+          : "";
+    const newStr =
+      typeof i.new_string === "string"
+        ? i.new_string
+        : typeof i.new_source === "string"
+          ? i.new_source
+          : "";
+    return [{ path, originalContent: oldStr, proposedContent: newStr, isNewFile: false }];
+  }
+
+  if (name === "Write") {
+    const content = typeof i.content === "string" ? i.content : "";
+    return [{ path, originalContent: "", proposedContent: content, isNewFile: true }];
+  }
+
+  if (name === "MultiEdit" && Array.isArray(i.edits)) {
+    const out: DiffInput[] = [];
+    for (const e of i.edits) {
+      if (!e || typeof e !== "object") continue;
+      const ed = e as Record<string, unknown>;
+      out.push({
+        path,
+        originalContent: typeof ed.old_string === "string" ? ed.old_string : "",
+        proposedContent: typeof ed.new_string === "string" ? ed.new_string : "",
+        isNewFile: false,
+      });
+    }
+    return out;
+  }
+
+  return [];
+}

--- a/src/modules/claude-chat/lib/transcript.test.ts
+++ b/src/modules/claude-chat/lib/transcript.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { parseTranscript, type ChatMessage } from "./transcript";
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+describe("parseTranscript", () => {
+  it("ignores meta line types", () => {
+    const raw = [
+      line({ type: "mode", mode: "x", sessionId: "s" }),
+      line({ type: "permission-mode", permissionMode: "default" }),
+      line({ type: "file-history-snapshot", messageId: "m" }),
+      line({ type: "ai-title", aiTitle: "t" }),
+    ].join("\n");
+    expect(parseTranscript(raw)).toEqual([]);
+  });
+
+  it("renders a user string prompt as a bubble", () => {
+    const raw = line({
+      type: "user",
+      uuid: "u1",
+      message: { role: "user", content: "hello there" },
+    });
+    expect(parseTranscript(raw)).toEqual<ChatMessage[]>([
+      { id: "u1", role: "user", parts: [{ kind: "text", text: "hello there" }] },
+    ]);
+  });
+
+  it("merges assistant lines sharing message.id in order", () => {
+    const raw = [
+      line({
+        type: "assistant",
+        uuid: "a1",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "hmm", signature: "x" }],
+        },
+      }),
+      line({
+        type: "assistant",
+        uuid: "a2",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "text", text: "answer" }],
+        },
+      }),
+    ].join("\n");
+    const out = parseTranscript(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("msg_1");
+    expect(out[0].parts).toEqual([
+      { kind: "thinking", text: "hmm" },
+      { kind: "text", text: "answer" },
+    ]);
+  });
+
+  it("attaches tool_result to the tool_use, no user bubble", () => {
+    const raw = [
+      line({
+        type: "assistant",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tu_1",
+              name: "Bash",
+              input: { command: "ls", description: "list" },
+            },
+          ],
+        },
+      }),
+      line({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tu_1", content: "a\nb" },
+          ],
+        },
+      }),
+    ].join("\n");
+    const out = parseTranscript(raw);
+    expect(out).toHaveLength(1);
+    const tool = out[0].parts[0];
+    expect(tool).toMatchObject({
+      kind: "tool",
+      name: "Bash",
+      state: "output-available",
+      output: "a\nb",
+    });
+  });
+
+  it("marks errored tool results", () => {
+    const raw = [
+      line({
+        type: "assistant",
+        message: {
+          id: "m",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t", name: "Edit", input: {} }],
+        },
+      }),
+      line({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t",
+              content: "boom",
+              is_error: true,
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+    const tool = parseTranscript(raw)[0].parts[0];
+    expect(tool).toMatchObject({ state: "output-error", output: "boom" });
+  });
+
+  it("flattens array tool_result content into text", () => {
+    const raw = [
+      line({
+        type: "assistant",
+        message: {
+          id: "m",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "t", name: "Read", input: {} }],
+        },
+      }),
+      line({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t",
+              content: [{ type: "text", text: "file body" }],
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+    const tool = parseTranscript(raw)[0].parts[0] as Extract<
+      ChatMessage["parts"][number],
+      { kind: "tool" }
+    >;
+    expect(tool.output).toBe("file body");
+  });
+
+  it("tolerates a partial trailing line", () => {
+    const raw =
+      line({
+        type: "user",
+        uuid: "u1",
+        message: { role: "user", content: "hi" },
+      }) + '\n{"type":"assist';
+    const out = parseTranscript(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
+  });
+
+  it("leaves a pending tool call as input-available until its result", () => {
+    const raw = line({
+      type: "assistant",
+      message: {
+        id: "m",
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t", name: "Bash", input: {} }],
+      },
+    });
+    const tool = parseTranscript(raw)[0].parts[0];
+    expect(tool).toMatchObject({ kind: "tool", state: "input-available" });
+  });
+});

--- a/src/modules/claude-chat/lib/transcript.ts
+++ b/src/modules/claude-chat/lib/transcript.ts
@@ -1,0 +1,155 @@
+// Pure parser for Claude Code session transcripts (~/.claude/projects/<enc>/<id>.jsonl).
+// Each line is one JSON object with a `type`. We render `user` and `assistant`
+// lines and ignore the many meta types (mode, permission-mode, attachment,
+// system, file-history-snapshot, ai-title, queue-operation, bridge-session,
+// last-prompt, ...). Allowlist, never blocklist: unknown shapes are skipped.
+//
+// Assistant turns are split across many lines that share `message.id`; their
+// content blocks must be merged in order. Tool results arrive as `user` lines
+// carrying `tool_result` blocks keyed by `tool_use_id`, and attach to the tool
+// call rather than rendering as a user bubble.
+
+export type ToolState = "input-available" | "output-available" | "output-error";
+
+export type ChatPart =
+  | { kind: "text"; text: string }
+  | { kind: "thinking"; text: string }
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      input: unknown;
+      state: ToolState;
+      output?: string;
+    };
+
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  parts: ChatPart[];
+};
+
+type RawBlock = {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+};
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/** Tool results carry a string or an array of `{type:"text",text}` blocks. */
+function stringifyToolContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter(isObject)
+      .map((b) => (typeof b.text === "string" ? b.text : ""))
+      .filter(Boolean);
+    if (texts.length > 0) return texts.join("\n");
+  }
+  if (content == null) return "";
+  try {
+    return JSON.stringify(content, null, 2);
+  } catch {
+    return String(content);
+  }
+}
+
+export function parseTranscript(raw: string): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  // message.id -> index in `messages`, for merging split assistant turns.
+  const assistantIndex = new Map<string, number>();
+  // tool_use id -> the tool part awaiting its result.
+  const toolParts = new Map<string, Extract<ChatPart, { kind: "tool" }>>();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      continue; // partial trailing line or non-JSON; skip
+    }
+    if (!isObject(obj)) continue;
+    const type = obj.type;
+    const message = obj.message;
+
+    if (type === "assistant" && isObject(message)) {
+      const content = message.content;
+      if (!Array.isArray(content)) continue;
+      const mid =
+        (typeof message.id === "string" && message.id) ||
+        (typeof obj.uuid === "string" && obj.uuid) ||
+        `a-${messages.length}`;
+
+      let idx = assistantIndex.get(mid);
+      if (idx === undefined) {
+        idx = messages.length;
+        messages.push({ id: mid, role: "assistant", parts: [] });
+        assistantIndex.set(mid, idx);
+      }
+      const parts = messages[idx].parts;
+
+      for (const block of content as RawBlock[]) {
+        if (!isObject(block)) continue;
+        if (block.type === "thinking" && typeof block.thinking === "string") {
+          parts.push({ kind: "thinking", text: block.thinking });
+        } else if (block.type === "text" && typeof block.text === "string") {
+          parts.push({ kind: "text", text: block.text });
+        } else if (block.type === "tool_use" && typeof block.id === "string") {
+          const part: Extract<ChatPart, { kind: "tool" }> = {
+            kind: "tool",
+            id: block.id,
+            name: typeof block.name === "string" ? block.name : "tool",
+            input: block.input,
+            state: "input-available",
+          };
+          parts.push(part);
+          toolParts.set(block.id, part);
+        }
+      }
+      continue;
+    }
+
+    if (type === "user" && isObject(message)) {
+      const content = message.content;
+      if (typeof content === "string") {
+        const text = content.trim();
+        if (text) {
+          messages.push({
+            id: typeof obj.uuid === "string" ? obj.uuid : `u-${messages.length}`,
+            role: "user",
+            parts: [{ kind: "text", text }],
+          });
+        }
+        continue;
+      }
+      if (Array.isArray(content)) {
+        for (const block of content as RawBlock[]) {
+          if (!isObject(block)) continue;
+          if (
+            block.type === "tool_result" &&
+            typeof block.tool_use_id === "string"
+          ) {
+            const part = toolParts.get(block.tool_use_id);
+            if (part) {
+              part.output = stringifyToolContent(block.content);
+              part.state = block.is_error ? "output-error" : "output-available";
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return messages;
+}

--- a/src/modules/claude-chat/lib/useTranscriptTail.ts
+++ b/src/modules/claude-chat/lib/useTranscriptTail.ts
@@ -1,52 +1,57 @@
 import { useEffect, useState } from "react";
-import { findTranscript, subscribeTranscript } from "./bridge";
-import { parseTranscript, type ChatMessage } from "./transcript";
+import { subscribeTranscript } from "./bridge";
+import { type ChatMessage, parseTranscript } from "./transcript";
 
 export type TailState = {
-  messages: ChatMessage[];
-  status: "idle" | "searching" | "live" | "not-found";
+	messages: ChatMessage[];
+	status: "idle" | "live";
 };
 
 /**
- * While `active`, locate the transcript for the claude session running in `cwd`
- * and stream it into parsed chat messages. Re-parses the full accumulated text
- * on each chunk (transcripts are small enough; merging split assistant turns
- * needs the whole stream). Tears down the backend tail when inactive.
+ * While `active` and given the exact transcript `path` (learned from the Claude
+ * Code hooks, never guessed), stream that session's JSONL into parsed chat
+ * messages. Re-parses the full accumulated text on each chunk: transcripts are
+ * small, and merging split assistant turns needs the whole stream. Tears down
+ * the backend tail when inactive or when the path changes.
+ *
+ * No path means we don't yet know which of the project's many sibling sessions
+ * is this one (e.g. a fresh session before its first prompt). We stay idle and
+ * show nothing rather than mirror the wrong session.
  */
-export function useTranscriptTail(cwd: string | undefined, active: boolean): TailState {
-  const [state, setState] = useState<TailState>({ messages: [], status: "idle" });
+export function useTranscriptTail(
+	path: string | undefined,
+	active: boolean,
+): TailState {
+	const [state, setState] = useState<TailState>({
+		messages: [],
+		status: "idle",
+	});
 
-  useEffect(() => {
-    if (!active || !cwd) {
-      setState({ messages: [], status: "idle" });
-      return;
-    }
+	useEffect(() => {
+		if (!active || !path) {
+			setState({ messages: [], status: "idle" });
+			return;
+		}
 
-    let cancelled = false;
-    let raw = "";
-    let sub: { close: () => void } | null = null;
-    setState({ messages: [], status: "searching" });
+		let cancelled = false;
+		let raw = "";
+		let sub: { close: () => void } | null = null;
+		setState({ messages: [], status: "live" });
 
-    (async () => {
-      const path = await findTranscript(cwd).catch(() => null);
-      if (cancelled) return;
-      if (!path) {
-        setState({ messages: [], status: "not-found" });
-        return;
-      }
-      sub = await subscribeTranscript(path, (chunk) => {
-        if (cancelled) return;
-        raw += chunk;
-        setState({ messages: parseTranscript(raw), status: "live" });
-      }).catch(() => null);
-      if (cancelled) sub?.close();
-    })();
+		(async () => {
+			sub = await subscribeTranscript(path, (chunk) => {
+				if (cancelled) return;
+				raw += chunk;
+				setState({ messages: parseTranscript(raw), status: "live" });
+			}).catch(() => null);
+			if (cancelled) sub?.close();
+		})();
 
-    return () => {
-      cancelled = true;
-      sub?.close();
-    };
-  }, [cwd, active]);
+		return () => {
+			cancelled = true;
+			sub?.close();
+		};
+	}, [path, active]);
 
-  return state;
+	return state;
 }

--- a/src/modules/claude-chat/lib/useTranscriptTail.ts
+++ b/src/modules/claude-chat/lib/useTranscriptTail.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { findTranscript, subscribeTranscript } from "./bridge";
+import { parseTranscript, type ChatMessage } from "./transcript";
+
+export type TailState = {
+  messages: ChatMessage[];
+  status: "idle" | "searching" | "live" | "not-found";
+};
+
+/**
+ * While `active`, locate the transcript for the claude session running in `cwd`
+ * and stream it into parsed chat messages. Re-parses the full accumulated text
+ * on each chunk (transcripts are small enough; merging split assistant turns
+ * needs the whole stream). Tears down the backend tail when inactive.
+ */
+export function useTranscriptTail(cwd: string | undefined, active: boolean): TailState {
+  const [state, setState] = useState<TailState>({ messages: [], status: "idle" });
+
+  useEffect(() => {
+    if (!active || !cwd) {
+      setState({ messages: [], status: "idle" });
+      return;
+    }
+
+    let cancelled = false;
+    let raw = "";
+    let sub: { close: () => void } | null = null;
+    setState({ messages: [], status: "searching" });
+
+    (async () => {
+      const path = await findTranscript(cwd).catch(() => null);
+      if (cancelled) return;
+      if (!path) {
+        setState({ messages: [], status: "not-found" });
+        return;
+      }
+      sub = await subscribeTranscript(path, (chunk) => {
+        if (cancelled) return;
+        raw += chunk;
+        setState({ messages: parseTranscript(raw), status: "live" });
+      }).catch(() => null);
+      if (cancelled) sub?.close();
+    })();
+
+    return () => {
+      cancelled = true;
+      sub?.close();
+    };
+  }, [cwd, active]);
+
+  return state;
+}

--- a/src/modules/claude-chat/store/chatViewStore.ts
+++ b/src/modules/claude-chat/store/chatViewStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+export type ViewMode = "terminal" | "chat";
+
+// Per-leaf transient UI state: which face (raw terminal vs chat GUI) a terminal
+// pane currently shows. Not persisted — defaults to terminal on restore so a
+// reopened window never hides a live PTY behind a stale chat view.
+type ChatViewState = {
+  modes: Record<number, ViewMode>;
+  setMode: (leafId: number, mode: ViewMode) => void;
+  toggle: (leafId: number) => void;
+  clear: (leafId: number) => void;
+};
+
+export const useChatViewStore = create<ChatViewState>((set) => ({
+  modes: {},
+  setMode: (leafId, mode) =>
+    set((s) => ({ modes: { ...s.modes, [leafId]: mode } })),
+  toggle: (leafId) =>
+    set((s) => ({
+      modes: {
+        ...s.modes,
+        [leafId]: s.modes[leafId] === "chat" ? "terminal" : "chat",
+      },
+    })),
+  clear: (leafId) =>
+    set((s) => {
+      if (!(leafId in s.modes)) return s;
+      const rest = { ...s.modes };
+      delete rest[leafId];
+      return { modes: rest };
+    }),
+}));

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -1,83 +1,224 @@
-import { Fragment } from "react";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/components/ui/resizable";
+import { BubbleChatIcon, TerminalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
-import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
+import { Fragment } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	ResizableHandle,
+	ResizablePanel,
+	ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { cn } from "@/lib/utils";
+import { useAgentStore } from "@/modules/agents/store/agentStore";
+import { ClaudeChatView } from "@/modules/claude-chat/ClaudeChatView";
+import { useChatViewStore } from "@/modules/claude-chat/store/chatViewStore";
 import type { PaneNode } from "./lib/panes";
+import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 
 type LeafBundle = {
-  setRef: (h: TerminalPaneHandle | null) => void;
-  onSearch: (addon: SearchAddon) => void;
-  onCwd: (cwd: string) => void;
-  onExit: (code: number) => void;
+	setRef: (h: TerminalPaneHandle | null) => void;
+	onSearch: (addon: SearchAddon) => void;
+	onCwd: (cwd: string) => void;
+	onExit: (code: number) => void;
 };
 
 type Props = {
-  node: PaneNode;
-  tabVisible: boolean;
-  activeLeafId: number;
-  onFocusLeaf: (leafId: number) => void;
-  getBundle: (leafId: number) => LeafBundle;
+	node: PaneNode;
+	tabVisible: boolean;
+	activeLeafId: number;
+	onFocusLeaf: (leafId: number) => void;
+	getBundle: (leafId: number) => LeafBundle;
 };
 
 export function PaneTreeView({
-  node,
-  tabVisible,
-  activeLeafId,
-  onFocusLeaf,
-  getBundle,
+	node,
+	tabVisible,
+	activeLeafId,
+	onFocusLeaf,
+	getBundle,
 }: Props) {
-  if (node.kind === "leaf") {
-    const focused = node.id === activeLeafId;
-    const b = getBundle(node.id);
-    return (
-      <div
-        onMouseDownCapture={() => {
-          if (!focused) onFocusLeaf(node.id);
-        }}
-        // Catches focus from Tab, programmatic focus, or any path that
-        // skips mousedown — keeps activeLeafId in sync with DOM focus.
-        onFocus={() => {
-          if (!focused) onFocusLeaf(node.id);
-        }}
-        data-pane-leaf={node.id}
-        className="relative h-full w-full"
-      >
-        <TerminalPane
-          leafId={node.id}
-          visible={tabVisible}
-          focused={focused}
-          initialCwd={node.cwd}
-          ref={b.setRef}
-          onSearchReady={(_id, addon) => b.onSearch(addon)}
-          onCwd={(_id, cwd) => b.onCwd(cwd)}
-          onExit={(_id, code) => b.onExit(code)}
-        />
-      </div>
-    );
-  }
+	if (node.kind === "leaf") {
+		const focused = node.id === activeLeafId;
+		return (
+			<LeafPane
+				node={node}
+				focused={focused}
+				tabVisible={tabVisible}
+				onFocusLeaf={onFocusLeaf}
+				getBundle={getBundle}
+			/>
+		);
+	}
 
-  return (
-    <ResizablePanelGroup
-      orientation={node.dir === "row" ? "horizontal" : "vertical"}
-    >
-      {node.children.map((child, i) => (
-        <Fragment key={child.id}>
-          {i > 0 && <ResizableHandle />}
-          <ResizablePanel id={`pane-${child.id}`} minSize="10%">
-            <PaneTreeView
-              node={child}
-              tabVisible={tabVisible}
-              activeLeafId={activeLeafId}
-              onFocusLeaf={onFocusLeaf}
-              getBundle={getBundle}
-            />
-          </ResizablePanel>
-        </Fragment>
-      ))}
-    </ResizablePanelGroup>
-  );
+	return (
+		<ResizablePanelGroup
+			orientation={node.dir === "row" ? "horizontal" : "vertical"}
+		>
+			{node.children.map((child, i) => (
+				<Fragment key={child.id}>
+					{i > 0 && <ResizableHandle />}
+					<ResizablePanel id={`pane-${child.id}`} minSize="10%">
+						<PaneTreeView
+							node={child}
+							tabVisible={tabVisible}
+							activeLeafId={activeLeafId}
+							onFocusLeaf={onFocusLeaf}
+							getBundle={getBundle}
+						/>
+					</ResizablePanel>
+				</Fragment>
+			))}
+		</ResizablePanelGroup>
+	);
+}
+
+// One leaf: the live PTY pane plus, when a claude agent is detected for it, an
+// optional chat mirror overlaid on top. The chat lives per-leaf (not per-tab)
+// so a split shows the chat only over the pane running claude; the sibling pane
+// stays a normal terminal. The PTY is never unmounted — switching is a CSS flip
+// — so the running agent survives the toggle.
+function LeafPane({
+	node,
+	focused,
+	tabVisible,
+	onFocusLeaf,
+	getBundle,
+}: {
+	node: Extract<PaneNode, { kind: "leaf" }>;
+	focused: boolean;
+	tabVisible: boolean;
+	onFocusLeaf: (leafId: number) => void;
+	getBundle: (leafId: number) => LeafBundle;
+}) {
+	const leafId = node.id;
+	const b = getBundle(leafId);
+	const session = useAgentStore((s) => s.sessions[leafId]);
+	const hasAgent = !!session;
+	const mode = useChatViewStore((s) => s.modes[leafId] ?? "terminal");
+	const setMode = useChatViewStore((s) => s.setMode);
+	const chatActive = mode === "chat" && hasAgent;
+	// When the chat face is up, the terminal must NOT keep grabbing DOM focus —
+	// otherwise xterm's hidden textarea steals it back and the composer can't be
+	// typed into. So the PTY pane is told it is unfocused while chat is showing.
+	const terminalFocused = focused && !chatActive;
+
+	return (
+		<div
+			onMouseDownCapture={() => {
+				if (!focused) onFocusLeaf(leafId);
+			}}
+			// Catches focus from Tab, programmatic focus, or any path that
+			// skips mousedown — keeps activeLeafId in sync with DOM focus.
+			onFocus={() => {
+				if (!focused) onFocusLeaf(leafId);
+			}}
+			data-pane-leaf={leafId}
+			className="relative flex h-full w-full flex-col"
+		>
+			{hasAgent ? (
+				<ChatModeBar
+					leafId={leafId}
+					focused={focused}
+					mode={mode}
+					onSetMode={(m) => setMode(leafId, m)}
+				/>
+			) : null}
+			<div className="relative min-h-0 w-full flex-1">
+				<TerminalPane
+					leafId={leafId}
+					visible={tabVisible}
+					focused={terminalFocused}
+					initialCwd={node.cwd}
+					ref={b.setRef}
+					onSearchReady={(_id, addon) => b.onSearch(addon)}
+					onCwd={(_id, cwd) => b.onCwd(cwd)}
+					onExit={(_id, code) => b.onExit(code)}
+				/>
+				{hasAgent ? (
+					<div
+						className={cn(
+							"absolute inset-0 bg-background",
+							chatActive ? "" : "invisible pointer-events-none",
+						)}
+						aria-hidden={!chatActive}
+					>
+						<ClaudeChatView
+							leafId={leafId}
+							transcriptPath={session?.transcriptPath ?? undefined}
+							active={chatActive && tabVisible}
+						/>
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+// Header strip for a pane running a coding agent: a Terminal/Chat segmented
+// toggle plus a live status pill (working/waiting) so the chat face mirrors the
+// TUI's "crunching..." state. Sits ABOVE the content, never floating over the
+// first chat message.
+function ChatModeBar({
+	leafId,
+	focused,
+	mode,
+	onSetMode,
+}: {
+	leafId: number;
+	focused: boolean;
+	mode: "terminal" | "chat";
+	onSetMode: (mode: "terminal" | "chat") => void;
+}) {
+	const status = useAgentStore((s) => s.sessions[leafId]?.status);
+
+	return (
+		<div
+			className={cn(
+				"flex h-[26px] shrink-0 select-none items-center gap-2 border-b px-2",
+				focused ? "border-border bg-muted" : "border-border/60 bg-background",
+			)}
+		>
+			{status ? (
+				<span className="flex shrink-0 items-center gap-1.5">
+					<span
+						className={cn(
+							"size-1.5 rounded-full",
+							status === "working"
+								? "animate-pulse bg-amber-500"
+								: "bg-sky-500",
+						)}
+					/>
+					<span
+						className={cn(
+							"text-[10px] font-medium tracking-tight",
+							status === "working" ? "text-amber-500" : "text-sky-500",
+						)}
+					>
+						{status === "working" ? "Working" : "Waiting"}
+					</span>
+				</span>
+			) : null}
+			<span className="flex-1" />
+			<div className="flex shrink-0 items-center gap-0.5 rounded-md border border-border/60 bg-background/90 p-0.5">
+				<Button
+					size="icon"
+					variant={mode === "terminal" ? "secondary" : "ghost"}
+					className="size-5"
+					title="Terminal view"
+					onClick={() => onSetMode("terminal")}
+				>
+					<HugeiconsIcon icon={TerminalIcon} size={12} strokeWidth={2} />
+				</Button>
+				<Button
+					size="icon"
+					variant={mode === "chat" ? "secondary" : "ghost"}
+					className="size-5"
+					title="Chat view"
+					onClick={() => onSetMode("chat")}
+				>
+					<HugeiconsIcon icon={BubbleChatIcon} size={12} strokeWidth={2} />
+				</Button>
+			</div>
+		</div>
+	);
 }

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -1,9 +1,16 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useAgentStore } from "@/modules/agents/store/agentStore";
+import { ClaudeChatView } from "@/modules/claude-chat/ClaudeChatView";
+import { useChatViewStore } from "@/modules/claude-chat/store/chatViewStore";
 import type { Tab } from "@/modules/tabs";
+import { BubbleChatIcon, TerminalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useEffect, useMemo, useRef } from "react";
 import { PaneTreeView } from "./PaneTreeView";
 import type { TerminalPaneHandle } from "./TerminalPane";
-import { leafIds } from "./lib/panes";
+import { findLeafCwd, leafIds } from "./lib/panes";
 
 type Props = {
   tabs: Tab[];
@@ -91,16 +98,86 @@ export function TerminalStack({
             }}
             aria-hidden={!tabVisible}
           >
-            <PaneTreeView
-              node={t.paneTree}
+            <TerminalTabBody
+              tab={t}
               tabVisible={tabVisible}
-              activeLeafId={t.activeLeafId}
-              onFocusLeaf={(leafId) => onFocusLeaf(t.id, leafId)}
+              onFocusLeaf={onFocusLeaf}
               getBundle={getBundle}
             />
           </div>
         );
       })}
+    </div>
+  );
+}
+
+// One terminal tab: the live PTY pane tree, plus a Claude chat mirror overlaid
+// on top when chat mode is on for the tab's active leaf. The PTY tree stays
+// mounted underneath (hidden, not unmounted) so the running agent is never
+// killed by a view switch.
+function TerminalTabBody({
+  tab,
+  tabVisible,
+  onFocusLeaf,
+  getBundle,
+}: {
+  tab: Extract<Tab, { kind: "terminal" }>;
+  tabVisible: boolean;
+  onFocusLeaf: (tabId: number, leafId: number) => void;
+  getBundle: (leafId: number) => Bundle;
+}) {
+  const leafId = tab.activeLeafId;
+  const mode = useChatViewStore((s) => s.modes[leafId] ?? "terminal");
+  const toggle = useChatViewStore((s) => s.toggle);
+  // Only offer chat mode once a coding agent (claude) is detected in this tab.
+  const hasAgent = useAgentStore((s) =>
+    Object.values(s.sessions).some((sess) => sess.tabId === tab.id),
+  );
+  const chatActive = mode === "chat" && hasAgent;
+  const cwd = findLeafCwd(tab.paneTree, leafId) ?? tab.cwd;
+
+  return (
+    <div className="relative h-full w-full">
+      <PaneTreeView
+        node={tab.paneTree}
+        tabVisible={tabVisible}
+        activeLeafId={tab.activeLeafId}
+        onFocusLeaf={(lid) => onFocusLeaf(tab.id, lid)}
+        getBundle={getBundle}
+      />
+
+      <div
+        className={cn(
+          "absolute inset-0 bg-background",
+          chatActive ? "" : "invisible pointer-events-none",
+        )}
+        aria-hidden={!chatActive}
+      >
+        <ClaudeChatView leafId={leafId} cwd={cwd} active={chatActive && tabVisible} />
+      </div>
+
+      {hasAgent ? (
+        <div className="absolute right-3 top-2 z-10 flex items-center gap-0.5 rounded-md border border-border/60 bg-background/90 p-0.5 shadow-sm backdrop-blur">
+          <Button
+            size="icon"
+            variant={mode === "terminal" ? "secondary" : "ghost"}
+            className="size-6"
+            title="Terminal view"
+            onClick={() => mode !== "terminal" && toggle(leafId)}
+          >
+            <HugeiconsIcon icon={TerminalIcon} size={13} strokeWidth={2} />
+          </Button>
+          <Button
+            size="icon"
+            variant={mode === "chat" ? "secondary" : "ghost"}
+            className="size-6"
+            title="Chat view"
+            onClick={() => mode !== "chat" && toggle(leafId)}
+          >
+            <HugeiconsIcon icon={BubbleChatIcon} size={13} strokeWidth={2} />
+          </Button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -1,183 +1,133 @@
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { useAgentStore } from "@/modules/agents/store/agentStore";
-import { ClaudeChatView } from "@/modules/claude-chat/ClaudeChatView";
-import { useChatViewStore } from "@/modules/claude-chat/store/chatViewStore";
-import type { Tab } from "@/modules/tabs";
-import { BubbleChatIcon, TerminalIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useEffect, useMemo, useRef } from "react";
+import type { Tab } from "@/modules/tabs";
+import { leafIds } from "./lib/panes";
 import { PaneTreeView } from "./PaneTreeView";
 import type { TerminalPaneHandle } from "./TerminalPane";
-import { findLeafCwd, leafIds } from "./lib/panes";
 
 type Props = {
-  tabs: Tab[];
-  activeId: number;
-  /** Register/unregister handle by leaf id (not tab id). */
-  registerHandle: (leafId: number, handle: TerminalPaneHandle | null) => void;
-  onSearchReady: (leafId: number, addon: SearchAddon) => void;
-  onCwd: (leafId: number, cwd: string) => void;
-  onExit: (leafId: number, code: number) => void;
-  onFocusLeaf: (tabId: number, leafId: number) => void;
+	tabs: Tab[];
+	activeId: number;
+	/** Register/unregister handle by leaf id (not tab id). */
+	registerHandle: (leafId: number, handle: TerminalPaneHandle | null) => void;
+	onSearchReady: (leafId: number, addon: SearchAddon) => void;
+	onCwd: (leafId: number, cwd: string) => void;
+	onExit: (leafId: number, code: number) => void;
+	onFocusLeaf: (tabId: number, leafId: number) => void;
 };
 
 type Bundle = {
-  setRef: (h: TerminalPaneHandle | null) => void;
-  onSearch: (addon: SearchAddon) => void;
-  onCwd: (cwd: string) => void;
-  onExit: (code: number) => void;
+	setRef: (h: TerminalPaneHandle | null) => void;
+	onSearch: (addon: SearchAddon) => void;
+	onCwd: (cwd: string) => void;
+	onExit: (code: number) => void;
 };
 
 export function TerminalStack({
-  tabs,
-  activeId,
-  registerHandle,
-  onSearchReady,
-  onCwd,
-  onExit,
-  onFocusLeaf,
+	tabs,
+	activeId,
+	registerHandle,
+	onSearchReady,
+	onCwd,
+	onExit,
+	onFocusLeaf,
 }: Props) {
-  const terminals = useMemo(
-    () => tabs.filter((t) => t.kind === "terminal"),
-    [tabs],
-  );
+	const terminals = useMemo(
+		() => tabs.filter((t) => t.kind === "terminal"),
+		[tabs],
+	);
 
-  const registerRef = useRef(registerHandle);
-  const searchReadyRef = useRef(onSearchReady);
-  const cwdRef = useRef(onCwd);
-  const exitRef = useRef(onExit);
-  useEffect(() => {
-    registerRef.current = registerHandle;
-  }, [registerHandle]);
-  useEffect(() => {
-    searchReadyRef.current = onSearchReady;
-  }, [onSearchReady]);
-  useEffect(() => {
-    cwdRef.current = onCwd;
-  }, [onCwd]);
-  useEffect(() => {
-    exitRef.current = onExit;
-  }, [onExit]);
+	const registerRef = useRef(registerHandle);
+	const searchReadyRef = useRef(onSearchReady);
+	const cwdRef = useRef(onCwd);
+	const exitRef = useRef(onExit);
+	useEffect(() => {
+		registerRef.current = registerHandle;
+	}, [registerHandle]);
+	useEffect(() => {
+		searchReadyRef.current = onSearchReady;
+	}, [onSearchReady]);
+	useEffect(() => {
+		cwdRef.current = onCwd;
+	}, [onCwd]);
+	useEffect(() => {
+		exitRef.current = onExit;
+	}, [onExit]);
 
-  const bundles = useRef(new Map<number, Bundle>());
-  const getBundle = (leafId: number): Bundle => {
-    let b = bundles.current.get(leafId);
-    if (!b) {
-      b = {
-        setRef: (h) => registerRef.current(leafId, h),
-        onSearch: (addon) => searchReadyRef.current(leafId, addon),
-        onCwd: (cwd) => cwdRef.current(leafId, cwd),
-        onExit: (code) => exitRef.current(leafId, code),
-      };
-      bundles.current.set(leafId, b);
-    }
-    return b;
-  };
+	const bundles = useRef(new Map<number, Bundle>());
+	const getBundle = (leafId: number): Bundle => {
+		let b = bundles.current.get(leafId);
+		if (!b) {
+			b = {
+				setRef: (h) => registerRef.current(leafId, h),
+				onSearch: (addon) => searchReadyRef.current(leafId, addon),
+				onCwd: (cwd) => cwdRef.current(leafId, cwd),
+				onExit: (code) => exitRef.current(leafId, code),
+			};
+			bundles.current.set(leafId, b);
+		}
+		return b;
+	};
 
-  useEffect(() => {
-    const live = new Set<number>();
-    for (const t of terminals) for (const id of leafIds(t.paneTree)) live.add(id);
-    for (const id of bundles.current.keys()) {
-      if (!live.has(id)) bundles.current.delete(id);
-    }
-  }, [terminals]);
+	useEffect(() => {
+		const live = new Set<number>();
+		for (const t of terminals)
+			for (const id of leafIds(t.paneTree)) live.add(id);
+		for (const id of bundles.current.keys()) {
+			if (!live.has(id)) bundles.current.delete(id);
+		}
+	}, [terminals]);
 
-  return (
-    <div className="relative h-full w-full">
-      {terminals.map((t) => {
-        const tabVisible = t.id === activeId;
-        return (
-          <div
-            key={t.id}
-            className="absolute inset-0"
-            style={{
-              visibility: tabVisible ? "visible" : "hidden",
-              pointerEvents: tabVisible ? "auto" : "none",
-            }}
-            aria-hidden={!tabVisible}
-          >
-            <TerminalTabBody
-              tab={t}
-              tabVisible={tabVisible}
-              onFocusLeaf={onFocusLeaf}
-              getBundle={getBundle}
-            />
-          </div>
-        );
-      })}
-    </div>
-  );
+	return (
+		<div className="relative h-full w-full">
+			{terminals.map((t) => {
+				const tabVisible = t.id === activeId;
+				return (
+					<div
+						key={t.id}
+						className="absolute inset-0"
+						style={{
+							visibility: tabVisible ? "visible" : "hidden",
+							pointerEvents: tabVisible ? "auto" : "none",
+						}}
+						aria-hidden={!tabVisible}
+					>
+						<TerminalTabBody
+							tab={t}
+							tabVisible={tabVisible}
+							onFocusLeaf={onFocusLeaf}
+							getBundle={getBundle}
+						/>
+					</div>
+				);
+			})}
+		</div>
+	);
 }
 
-// One terminal tab: the live PTY pane tree, plus a Claude chat mirror overlaid
-// on top when chat mode is on for the tab's active leaf. The PTY tree stays
-// mounted underneath (hidden, not unmounted) so the running agent is never
-// killed by a view switch.
+// One terminal tab: the live PTY pane tree. Each leaf decides on its own
+// whether to show its Claude chat mirror (per-pane, so a split shows chat only
+// over the pane running claude). See PaneTreeView's LeafPane.
 function TerminalTabBody({
-  tab,
-  tabVisible,
-  onFocusLeaf,
-  getBundle,
+	tab,
+	tabVisible,
+	onFocusLeaf,
+	getBundle,
 }: {
-  tab: Extract<Tab, { kind: "terminal" }>;
-  tabVisible: boolean;
-  onFocusLeaf: (tabId: number, leafId: number) => void;
-  getBundle: (leafId: number) => Bundle;
+	tab: Extract<Tab, { kind: "terminal" }>;
+	tabVisible: boolean;
+	onFocusLeaf: (tabId: number, leafId: number) => void;
+	getBundle: (leafId: number) => Bundle;
 }) {
-  const leafId = tab.activeLeafId;
-  const mode = useChatViewStore((s) => s.modes[leafId] ?? "terminal");
-  const toggle = useChatViewStore((s) => s.toggle);
-  // Only offer chat mode once a coding agent (claude) is detected in this tab.
-  const hasAgent = useAgentStore((s) =>
-    Object.values(s.sessions).some((sess) => sess.tabId === tab.id),
-  );
-  const chatActive = mode === "chat" && hasAgent;
-  const cwd = findLeafCwd(tab.paneTree, leafId) ?? tab.cwd;
-
-  return (
-    <div className="relative h-full w-full">
-      <PaneTreeView
-        node={tab.paneTree}
-        tabVisible={tabVisible}
-        activeLeafId={tab.activeLeafId}
-        onFocusLeaf={(lid) => onFocusLeaf(tab.id, lid)}
-        getBundle={getBundle}
-      />
-
-      <div
-        className={cn(
-          "absolute inset-0 bg-background",
-          chatActive ? "" : "invisible pointer-events-none",
-        )}
-        aria-hidden={!chatActive}
-      >
-        <ClaudeChatView leafId={leafId} cwd={cwd} active={chatActive && tabVisible} />
-      </div>
-
-      {hasAgent ? (
-        <div className="absolute right-3 top-2 z-10 flex items-center gap-0.5 rounded-md border border-border/60 bg-background/90 p-0.5 shadow-sm backdrop-blur">
-          <Button
-            size="icon"
-            variant={mode === "terminal" ? "secondary" : "ghost"}
-            className="size-6"
-            title="Terminal view"
-            onClick={() => mode !== "terminal" && toggle(leafId)}
-          >
-            <HugeiconsIcon icon={TerminalIcon} size={13} strokeWidth={2} />
-          </Button>
-          <Button
-            size="icon"
-            variant={mode === "chat" ? "secondary" : "ghost"}
-            className="size-6"
-            title="Chat view"
-            onClick={() => mode !== "chat" && toggle(leafId)}
-          >
-            <HugeiconsIcon icon={BubbleChatIcon} size={13} strokeWidth={2} />
-          </Button>
-        </div>
-      ) : null}
-    </div>
-  );
+	return (
+		<div className="relative h-full w-full">
+			<PaneTreeView
+				node={tab.paneTree}
+				tabVisible={tabVisible}
+				activeLeafId={tab.activeLeafId}
+				onFocusLeaf={(lid) => onFocusLeaf(tab.id, lid)}
+				getBundle={getBundle}
+			/>
+		</div>
+	);
 }


### PR DESCRIPTION
## Summary
Adds an optional **chat-GUI view** for a running Claude Code session inside a terminal tab. A per-leaf toggle flips the tab between the live PTY and a chat transcript; the PTY stays mounted underneath, so the agent is never killed by a view switch.

## How it works
- **Backend** (`src-tauri/src/modules/claude/mod.rs`): locates the active Claude Code session transcript and tails it, streaming updates to the frontend over a Tauri `Channel` (`claude_find_transcript` / `claude_transcript_subscribe` / `claude_transcript_unsubscribe`).
- **Frontend** (`src/modules/claude-chat/*`): parses the transcript (`lib/transcript.ts`, covered by `transcript.test.ts`), maps tool calls to friendly labels (`lib/toolMap.ts`), tails via `useTranscriptTail`, and renders `ClaudeChatView`. View mode is held per-leaf in `chatViewStore`.
- **Integration** (`TerminalStack.tsx`): overlays the chat view on the tab and shows a Terminal/Chat toggle once a coding agent is detected in that tab.

## Notes
- `tsc` clean; `cargo check` clean.
- The chat toggle only appears when an agent is detected, so non-agent terminals are unaffected.
- Decoupled from the fork's separate split-resize work (the `onResizeSplit` prop threading is not part of this PR), so it applies cleanly on its own.
