### PR TITLE
fix(shortcuts): let Ctrl+B reach the terminal/Claude; sidebar toggle on Ctrl+Shift+B

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1117,6 +1117,19 @@ export default function App() {
           (e.target as HTMLElement | null) ?? document.activeElement;
         return !(target as HTMLElement | null)?.closest?.(".xterm");
       }
+      if (id === "sidebar.toggle") {
+        // Ctrl+B is also Claude Code's "run in background" key. While a terminal
+        // is focused, let Ctrl+B reach the shell/Claude instead of toggling the
+        // sidebar. Ctrl+Shift+B (second binding) still toggles it from anywhere.
+        const target =
+          (e.target as HTMLElement | null) ?? document.activeElement;
+        const inTerminal = !!(target as HTMLElement | null)?.closest?.(
+          ".xterm",
+        );
+        // Only defer the plain (no-shift) Ctrl/⌘+B binding; the Shift variant
+        // is the always-on toggle and is never claimed by the terminal.
+        return inTerminal && !e.shiftKey;
+      }
       return false;
     },
     [activeTab],

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -187,7 +187,13 @@ export const SHORTCUTS: Shortcut[] = [
     id: "sidebar.toggle",
     label: "Toggle file explorer",
     group: "View",
-    defaultBindings: [{ [MOD_PROP]: true, key: "b" }],
+    // Plain Mod+B toggles the sidebar everywhere EXCEPT a focused terminal,
+    // where it's handed to the shell / Claude Code (its "run in background"
+    // key). Mod+Shift+B always toggles, including from inside a terminal.
+    defaultBindings: [
+      { [MOD_PROP]: true, key: "b" },
+      { [MOD_PROP]: true, shift: true, key: "b" },
+    ],
   },
   {
     id: "explorer.focus",


### PR DESCRIPTION
## Summary
Plain **Ctrl/⌘+B** toggled the file explorer even inside a focused terminal — stealing Claude Code's "run in background" key (Ctrl+B). This defers Ctrl+B to the shell/agent while a terminal is focused, and adds **Ctrl/⌘+Shift+B** as an always-on sidebar toggle that still works from inside a terminal.

## Changes
- `shortcuts.ts`: `sidebar.toggle` gains a second binding — `{ mod, shift, key: "b" }` alongside the existing `{ mod, key: "b" }`.
- `App.tsx`: the shortcut-deferral callback returns `true` for `sidebar.toggle` when the event target is inside `.xterm` **and** Shift is not held — so plain Ctrl+B reaches the terminal/Claude, while the Shift variant always toggles the sidebar.

## Notes
- `tsc` clean. TypeScript-only.
- Outside a terminal, plain Ctrl+B behaves exactly as before.
