### PR TITLE
Add terminal file drops and restore dev PTY colors

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,22 @@ fn parse_launch_dir() -> Option<String> {
     None
 }
 
+fn app_display_name() -> &'static str {
+    if cfg!(debug_assertions) {
+        "Terax-Dev"
+    } else {
+        "Terax"
+    }
+}
+
+fn settings_window_title() -> &'static str {
+    if cfg!(debug_assertions) {
+        "Terax-Dev Settings"
+    } else {
+        "Settings"
+    }
+}
+
 #[tauri::command]
 async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Result<(), String> {
     let url_path = match tab.as_deref() {
@@ -52,7 +68,7 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     }
 
     let builder = WebviewWindowBuilder::new(&app, "settings", WebviewUrl::App(url_path.into()))
-        .title("Settings")
+        .title(settings_window_title())
         .inner_size(900.0, 700.0)
         .min_inner_size(820.0, 620.0)
         .resizable(true)
@@ -137,6 +153,10 @@ pub fn run() {
         )
         .plugin(tauri_plugin_opener::init())
         .setup(|_app| {
+            if let Some(main) = _app.get_webview_window("main") {
+                let _ = main.set_title(app_display_name());
+            }
+
             // macOS skips parent() for the settings window, so tie its lifecycle
             // to the main window here instead. Other platforms keep parent().
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -82,10 +82,16 @@ fn ensure_utf8_locale(cmd: &mut CommandBuilder) {
     cmd.env("LANG", fallback);
 }
 
-fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
+fn apply_color_env(cmd: &mut CommandBuilder) {
+    cmd.env_remove("NO_COLOR");
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
+    cmd.env("CLICOLOR", "1");
     cmd.env("TERAX_TERMINAL", "1");
+}
+
+fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
+    apply_color_env(cmd);
     ensure_utf8_locale(cmd);
 
     let resolved_cwd = cwd
@@ -100,6 +106,34 @@ fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
         cmd.cwd(cwd);
     } else {
         log::warn!("pty cwd: no usable directory, inheriting from process");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn color_env_enables_color_for_interactive_pty() {
+        let mut cmd = CommandBuilder::new("sh");
+        cmd.env("NO_COLOR", "1");
+
+        apply_color_env(&mut cmd);
+
+        assert_eq!(
+            cmd.get_env("TERM").and_then(|v| v.to_str()),
+            Some("xterm-256color")
+        );
+        assert_eq!(
+            cmd.get_env("COLORTERM").and_then(|v| v.to_str()),
+            Some("truecolor")
+        );
+        assert_eq!(cmd.get_env("CLICOLOR").and_then(|v| v.to_str()), Some("1"));
+        assert_eq!(
+            cmd.get_env("TERAX_TERMINAL").and_then(|v| v.to_str()),
+            Some("1")
+        );
+        assert!(cmd.get_env("NO_COLOR").is_none());
     }
 }
 
@@ -300,7 +334,9 @@ mod windows {
             zdotdir: String,
             user_zdotdir: Option<String>,
         },
-        Bash { rcfile: String },
+        Bash {
+            rcfile: String,
+        },
         Fish,
         None,
     }
@@ -405,9 +441,7 @@ mod windows {
         for arg in &spec.args {
             cmd.arg(arg);
         }
-        cmd.env("TERM", "xterm-256color");
-        cmd.env("COLORTERM", "truecolor");
-        cmd.env("TERAX_TERMINAL", "1");
+        super::apply_color_env(&mut cmd);
         super::ensure_utf8_locale(&mut cmd);
         log::info!("spawning WSL shell: {distro} ({shell_path})");
         Ok(cmd)

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -185,6 +185,15 @@ export function Header({
 
       {IS_MAC && <span className="mr-1 h-full w-px shrink-0 bg-border" />}
 
+      {import.meta.env.DEV ? (
+        <span
+          data-tauri-drag-region
+          className="shrink-0 rounded-sm border border-amber-400/40 bg-amber-400/10 px-1.5 py-0.5 text-[10px] leading-4 font-semibold text-amber-300"
+        >
+          Terax-Dev
+        </span>
+      ) : null}
+
       <div
         className="flex min-w-0 flex-1 items-center gap-2"
         data-tauri-drag-region

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -19,6 +19,7 @@ type Props = {
   node: PaneNode;
   tabVisible: boolean;
   activeLeafId: number;
+  dropTargetLeafId: number | null;
   onFocusLeaf: (leafId: number) => void;
   getBundle: (leafId: number) => LeafBundle;
 };
@@ -27,11 +28,13 @@ export function PaneTreeView({
   node,
   tabVisible,
   activeLeafId,
+  dropTargetLeafId,
   onFocusLeaf,
   getBundle,
 }: Props) {
   if (node.kind === "leaf") {
     const focused = node.id === activeLeafId;
+    const dropTarget = node.id === dropTargetLeafId;
     const b = getBundle(node.id);
     return (
       <div
@@ -56,6 +59,9 @@ export function PaneTreeView({
           onCwd={(_id, cwd) => b.onCwd(cwd)}
           onExit={(_id, code) => b.onExit(code)}
         />
+        {dropTarget ? (
+          <div className="pointer-events-none absolute inset-0 z-10 rounded-md border border-primary/70 bg-primary/10" />
+        ) : null}
       </div>
     );
   }
@@ -72,6 +78,7 @@ export function PaneTreeView({
               node={child}
               tabVisible={tabVisible}
               activeLeafId={activeLeafId}
+              dropTargetLeafId={dropTargetLeafId}
               onFocusLeaf={onFocusLeaf}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -1,9 +1,12 @@
 import type { Tab } from "@/modules/tabs";
 import type { SearchAddon } from "@xterm/addon-search";
-import { useEffect, useMemo, useRef } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PaneTreeView } from "./PaneTreeView";
 import type { TerminalPaneHandle } from "./TerminalPane";
+import { formatDroppedPaths, parsePaneLeafId } from "./lib/fileDrop";
 import { leafIds } from "./lib/panes";
+import { writeToSession } from "./lib/useTerminalSession";
 
 type Props = {
   tabs: Tab[];
@@ -23,6 +26,16 @@ type Bundle = {
   onExit: (code: number) => void;
 };
 
+function leafIdAtPosition(position: { x: number; y: number }): number | null {
+  const x = Number(position.x);
+  const y = Number(position.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+
+  const el = document.elementFromPoint(x, y);
+  const leaf = el?.closest("[data-pane-leaf]") as HTMLElement | null;
+  return parsePaneLeafId(leaf?.dataset.paneLeaf);
+}
+
 export function TerminalStack({
   tabs,
   activeId,
@@ -36,11 +49,13 @@ export function TerminalStack({
     () => tabs.filter((t) => t.kind === "terminal"),
     [tabs],
   );
+  const [dropTargetLeafId, setDropTargetLeafId] = useState<number | null>(null);
 
   const registerRef = useRef(registerHandle);
   const searchReadyRef = useRef(onSearchReady);
   const cwdRef = useRef(onCwd);
   const exitRef = useRef(onExit);
+  const leafToTabRef = useRef(new Map<number, number>());
   useEffect(() => {
     registerRef.current = registerHandle;
   }, [registerHandle]);
@@ -71,11 +86,63 @@ export function TerminalStack({
 
   useEffect(() => {
     const live = new Set<number>();
-    for (const t of terminals) for (const id of leafIds(t.paneTree)) live.add(id);
+    const leafToTab = new Map<number, number>();
+    for (const t of terminals) {
+      for (const id of leafIds(t.paneTree)) {
+        live.add(id);
+        leafToTab.set(id, t.id);
+      }
+    }
+    leafToTabRef.current = leafToTab;
     for (const id of bundles.current.keys()) {
       if (!live.has(id)) bundles.current.delete(id);
     }
   }, [terminals]);
+
+  useEffect(() => {
+    let mounted = true;
+    let unlisten: (() => void) | undefined;
+
+    void getCurrentWebview()
+      .onDragDropEvent((event) => {
+        const payload = event.payload;
+        if (payload.type === "leave") {
+          setDropTargetLeafId(null);
+          return;
+        }
+
+        const leafId = leafIdAtPosition(payload.position);
+        if (payload.type === "enter" || payload.type === "over") {
+          setDropTargetLeafId(leafId);
+          return;
+        }
+
+        setDropTargetLeafId(null);
+        if (leafId === null) return;
+
+        const text = formatDroppedPaths(payload.paths);
+        if (!text) return;
+
+        const tabId = leafToTabRef.current.get(leafId);
+        if (tabId !== undefined) onFocusLeaf(tabId, leafId);
+        writeToSession(leafId, text);
+      })
+      .then((cleanup) => {
+        if (mounted) {
+          unlisten = cleanup;
+        } else {
+          cleanup();
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn("[terax] failed to register terminal file drop", error);
+      });
+
+    return () => {
+      mounted = false;
+      unlisten?.();
+    };
+  }, [onFocusLeaf]);
 
   return (
     <div className="relative h-full w-full">
@@ -95,6 +162,7 @@ export function TerminalStack({
               node={t.paneTree}
               tabVisible={tabVisible}
               activeLeafId={t.activeLeafId}
+              dropTargetLeafId={tabVisible ? dropTargetLeafId : null}
               onFocusLeaf={(leafId) => onFocusLeaf(t.id, leafId)}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/lib/fileDrop.test.ts
+++ b/src/modules/terminal/lib/fileDrop.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { formatDroppedPaths, parsePaneLeafId } from "./fileDrop";
+
+describe("formatDroppedPaths", () => {
+  it("quotes a dropped POSIX path and leaves a space for the next token", () => {
+    expect(formatDroppedPaths(["/tmp/screen shot.png"], false)).toBe(
+      "'/tmp/screen shot.png' ",
+    );
+  });
+
+  it("quotes multiple POSIX paths without dropping embedded quotes", () => {
+    expect(
+      formatDroppedPaths(["/tmp/first.png", "/tmp/it's here.txt"], false),
+    ).toBe("'/tmp/first.png' '/tmp/it'\\''s here.txt' ");
+  });
+
+  it("uses PowerShell-compatible quoting on Windows", () => {
+    expect(formatDroppedPaths(["C:\\Users\\Arya\\it's here.png"], true)).toBe(
+      "'C:\\Users\\Arya\\it''s here.png' ",
+    );
+  });
+
+  it("ignores empty paths", () => {
+    expect(formatDroppedPaths(["", "/tmp/file.png"], false)).toBe(
+      "'/tmp/file.png' ",
+    );
+    expect(formatDroppedPaths([], false)).toBe("");
+  });
+});
+
+describe("parsePaneLeafId", () => {
+  it("accepts positive integer leaf ids", () => {
+    expect(parsePaneLeafId("1")).toBe(1);
+    expect(parsePaneLeafId("42")).toBe(42);
+  });
+
+  it("rejects missing, zero, negative, and partial ids", () => {
+    expect(parsePaneLeafId(undefined)).toBeNull();
+    expect(parsePaneLeafId("0")).toBeNull();
+    expect(parsePaneLeafId("-1")).toBeNull();
+    expect(parsePaneLeafId("1x")).toBeNull();
+  });
+});

--- a/src/modules/terminal/lib/fileDrop.ts
+++ b/src/modules/terminal/lib/fileDrop.ts
@@ -1,0 +1,18 @@
+import { quoteShellArg } from "@/lib/shellQuote";
+
+export function formatDroppedPaths(
+  paths: readonly string[],
+  windows?: boolean,
+): string {
+  const quoted = paths
+    .filter((path) => path.length > 0)
+    .map((path) => quoteShellArg(path, windows));
+
+  return quoted.length > 0 ? `${quoted.join(" ")} ` : "";
+}
+
+export function parsePaneLeafId(raw: string | undefined): number | null {
+  if (!raw || !/^[1-9]\d*$/.test(raw)) return null;
+  const value = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(value) ? value : null;
+}


### PR DESCRIPTION
## Summary
- Add terminal drag and drop support that inserts dropped file/image paths into the targeted pane, using existing shell quoting for safe POSIX and Windows paths.
- Restore color-aware CLI output in Terax PTYs by removing inherited `NO_COLOR` and forcing `TERM=xterm-256color`, `COLORTERM=truecolor`, and `CLICOLOR=1`, including the WSL launch path.
- Make debug builds identifiable as `Terax-Dev` via the native window/settings titles and a visible dev badge in the app chrome.

## Findings
- The missing colors were not caused by xterm theme tokens. The dev launcher environment had `NO_COLOR=1` and `TERM=dumb`; Terax overrode `TERM`/`COLORTERM` but allowed `NO_COLOR` to leak into PTY shells, so CLIs suppressed ANSI output before xterm could render it.
- `http://localhost:1420/` is the Vite dev server feed used by the Tauri webview. It serves HTML, but the useful test surface is the native Tauri window because the app expects Tauri IPC.

## Code review
### Critical
- None.

### Major
- None.

### Minor
- None.

### Looks good
- Path insertion is pane-targeted through `data-pane-leaf` and reuses `quoteShellArg` rather than ad hoc escaping.
- The color fix is centralized in the PTY shell initializer and reused by the WSL path.
- New logic has focused Vitest and Rust unit coverage.

## Verification
- `pnpm test` - 8 files, 97 tests passed.
- `pnpm exec tsc --noEmit` - passed.
- `pnpm build` - passed.
- `cargo test --locked shell_init` - passed.
- `cargo test --locked` - 123 lib tests, 23 fs_search tests, 25 git_operations tests, 7 shell_background tests passed.
- `git diff --check` - passed.
- Live dev window check: `Terax-Dev` badge is visible, and a dev PTY reports `NO_COLOR=` with `TERM=xterm-256color`, `COLORTERM=truecolor`, and `CLICOLOR=1`.

## Not in this slice
- Clipboard image paste to a temporary file is not implemented yet. This PR covers drag/drop file and image path insertion plus the PTY color restoration.