### PR TITLE
Add local Pi coding-agent provider support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, fs, git, net, pi, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -157,6 +157,7 @@ pub fn run() {
         })
         .manage(pty::PtyState::default())
         .manage(shell::ShellState::default())
+        .manage(pi::PiState::default())
         .manage(secrets::SecretsState::default())
         .manage(fs::watch::FsWatchState::default())
         .manage({
@@ -231,6 +232,10 @@ pub fn run() {
             net::lm_ping,
             net::ai_http_request,
             net::ai_http_stream,
+            pi::pi_detect,
+            pi::pi_list_models,
+            pi::pi_run,
+            pi::pi_cancel,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod fs;
 pub mod git;
 pub mod net;
+pub mod pi;
 pub mod proc;
 pub mod pty;
 pub mod secrets;

--- a/src-tauri/src/modules/pi.rs
+++ b/src-tauri/src/modules/pi.rs
@@ -1,0 +1,504 @@
+use std::collections::HashMap;
+use std::env;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use serde::Serialize;
+use shared_child::SharedChild;
+use tauri::ipc::Channel;
+
+use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
+
+const DETECT_TIMEOUT_SECS: u64 = 5;
+const LIST_TIMEOUT_SECS: u64 = 15;
+const MAX_CAPTURE_BYTES: usize = 512 * 1024;
+
+#[derive(Default)]
+pub struct PiState {
+    runs: Arc<Mutex<HashMap<String, Arc<SharedChild>>>>,
+    next_run_id: AtomicU32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PiDetectResult {
+    installed: bool,
+    path: Option<String>,
+    version: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PiModelRecord {
+    provider: String,
+    model: String,
+    context_tokens: Option<u64>,
+    max_output_tokens: Option<u64>,
+    thinking: bool,
+    images: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum PiRunEvent {
+    Line { line: String },
+    Stderr { line: String },
+    End {
+        #[serde(rename = "exitCode")]
+        exit_code: Option<i32>,
+        success: bool,
+    },
+    Error { message: String },
+}
+
+#[tauri::command]
+pub async fn pi_detect(executable_path: Option<String>) -> Result<PiDetectResult, String> {
+    let Some(path) = resolve_pi_executable(executable_path.as_deref()) else {
+        return Ok(PiDetectResult {
+            installed: false,
+            path: None,
+            version: None,
+            error: Some("pi executable not found".to_string()),
+        });
+    };
+    let cwd = stable_pi_cwd();
+    let output = run_capture(
+        &path,
+        ["--version"],
+        cwd.as_deref(),
+        Duration::from_secs(DETECT_TIMEOUT_SECS),
+    );
+    match output {
+        Ok(out) if out.exit_code == Some(0) => Ok(PiDetectResult {
+            installed: true,
+            path: Some(path_to_string(&path)),
+            version: Some(out.stdout.trim().to_string()),
+            error: None,
+        }),
+        Ok(out) => Ok(PiDetectResult {
+            installed: false,
+            path: Some(path_to_string(&path)),
+            version: None,
+            error: Some(
+                first_non_empty(&out.stderr, &out.stdout)
+                    .unwrap_or("pi failed")
+                    .to_string(),
+            ),
+        }),
+        Err(e) => Ok(PiDetectResult {
+            installed: false,
+            path: Some(path_to_string(&path)),
+            version: None,
+            error: Some(e),
+        }),
+    }
+}
+
+#[tauri::command]
+pub async fn pi_list_models(executable_path: Option<String>) -> Result<Vec<PiModelRecord>, String> {
+    let path = resolve_pi_executable(executable_path.as_deref())
+        .ok_or_else(|| "pi executable not found".to_string())?;
+    let cwd = stable_pi_cwd();
+    let out = run_capture(
+        &path,
+        ["--offline", "--list-models"],
+        cwd.as_deref(),
+        Duration::from_secs(LIST_TIMEOUT_SECS),
+    )?;
+    if out.exit_code != Some(0) {
+        return Err(first_non_empty(&out.stderr, &out.stdout)
+            .unwrap_or("pi --list-models failed")
+            .to_string());
+    }
+    let mut models = parse_model_table(&out.stdout);
+    if models.is_empty() {
+        models = parse_model_table(&out.stderr);
+    }
+    log::info!("pi_list_models returned {} models", models.len());
+    Ok(models)
+}
+
+#[tauri::command]
+pub fn pi_run(
+    state: tauri::State<PiState>,
+    registry: tauri::State<WorkspaceRegistry>,
+    executable_path: Option<String>,
+    cwd: Option<String>,
+    session_id: String,
+    model: String,
+    prompt: String,
+    workspace: Option<WorkspaceEnv>,
+    on_event: Channel<PiRunEvent>,
+) -> Result<String, String> {
+    if prompt.trim().is_empty() {
+        return Err("empty prompt".to_string());
+    }
+    validate_session_id(&session_id)?;
+    let path = resolve_pi_executable(executable_path.as_deref())
+        .ok_or_else(|| "pi executable not found".to_string())?;
+    let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_wsl() {
+        return Err("Pi provider is currently available for local workspaces only.".to_string());
+    }
+    let cwd_path = authorize_spawn_cwd(&registry, cwd.as_deref(), &workspace)?;
+    let fallback_cwd = if cwd_path.is_none() {
+        stable_pi_cwd()
+    } else {
+        None
+    };
+
+    let mut cmd = Command::new(path);
+    cmd.arg("--mode")
+        .arg("json")
+        .arg("--print")
+        .arg("--session-id")
+        .arg(&session_id)
+        .arg("--model")
+        .arg(&model)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let (WorkspaceEnv::Local, Some(dir)) =
+        (&workspace, cwd_path.as_ref().or(fallback_cwd.as_ref()))
+    {
+        cmd.current_dir(dir);
+    }
+    crate::modules::proc::hide_console(&mut cmd);
+
+    let child = Arc::new(SharedChild::spawn(&mut cmd).map_err(|e| e.to_string())?);
+    let mut stdin = child.take_stdin().ok_or_else(|| {
+        let _ = child.kill();
+        "no stdin pipe".to_string()
+    })?;
+    let stdout = child.take_stdout().ok_or_else(|| {
+        let _ = child.kill();
+        "no stdout pipe".to_string()
+    })?;
+    let stderr = child.take_stderr().ok_or_else(|| {
+        let _ = child.kill();
+        "no stderr pipe".to_string()
+    })?;
+
+    let id = format!("pi-{}", state.next_run_id.fetch_add(1, Ordering::Relaxed));
+    state
+        .runs
+        .lock()
+        .unwrap()
+        .insert(id.clone(), Arc::clone(&child));
+    let runs = Arc::clone(&state.runs);
+    let run_id = id.clone();
+
+    thread::spawn(move || {
+        let writer_child = Arc::clone(&child);
+        let prompt_for_writer = prompt;
+        thread::spawn(move || {
+            if stdin.write_all(prompt_for_writer.as_bytes()).is_err() {
+                let _ = writer_child.kill();
+                return;
+            }
+            let _ = stdin.write_all(b"\n");
+        });
+
+        let stderr_channel = on_event.clone();
+        thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                if stderr_channel.send(PiRunEvent::Stderr { line }).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if on_event.send(PiRunEvent::Line { line }).is_err() {
+                        let _ = child.kill();
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let _ = on_event.send(PiRunEvent::Error {
+                        message: e.to_string(),
+                    });
+                    let _ = child.kill();
+                    break;
+                }
+            }
+        }
+        let status = child.wait().ok();
+        let code = status.as_ref().and_then(|s| s.code());
+        let success = status.as_ref().is_some_and(|s| s.success());
+        runs.lock().unwrap().remove(&run_id);
+        let _ = on_event.send(PiRunEvent::End {
+            exit_code: code,
+            success,
+        });
+    });
+
+    Ok(id)
+}
+
+#[tauri::command]
+pub fn pi_cancel(state: tauri::State<PiState>, run_id: String) -> Result<(), String> {
+    if let Some(child) = state.runs.lock().unwrap().remove(&run_id) {
+        let _ = child.kill();
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Captured {
+    stdout: String,
+    stderr: String,
+    exit_code: Option<i32>,
+}
+
+fn run_capture<I, S>(
+    executable: &Path,
+    args: I,
+    cwd: Option<&Path>,
+    timeout: Duration,
+) -> Result<Captured, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut cmd = Command::new(executable);
+    for arg in args {
+        cmd.arg(arg.as_ref());
+    }
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    crate::modules::proc::hide_console(&mut cmd);
+
+    let child = Arc::new(SharedChild::spawn(&mut cmd).map_err(|e| e.to_string())?);
+    let mut stdout = child
+        .take_stdout()
+        .ok_or_else(|| "no stdout pipe".to_string())?;
+    let mut stderr = child
+        .take_stderr()
+        .ok_or_else(|| "no stderr pipe".to_string())?;
+    let stdout_handle = thread::spawn(move || drain_limited(&mut stdout));
+    let stderr_handle = thread::spawn(move || drain_limited(&mut stderr));
+    let (tx, rx) = mpsc::channel();
+    let waiter = Arc::clone(&child);
+    thread::spawn(move || {
+        let _ = tx.send(waiter.wait());
+    });
+
+    let status = match rx.recv_timeout(timeout) {
+        Ok(Ok(status)) => status,
+        Ok(Err(e)) => return Err(e.to_string()),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("pi command timed out".to_string());
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            return Err("pi wait thread disconnected".to_string());
+        }
+    };
+    let stdout = stdout_handle.join().unwrap_or_default();
+    let stderr = stderr_handle.join().unwrap_or_default();
+    Ok(Captured {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        exit_code: status.code(),
+    })
+}
+
+fn drain_limited<R: std::io::Read>(reader: &mut R) -> Vec<u8> {
+    let mut out = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if out.len() < MAX_CAPTURE_BYTES {
+                    let take = (MAX_CAPTURE_BYTES - out.len()).min(n);
+                    out.extend_from_slice(&buf[..take]);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+fn resolve_pi_executable(configured: Option<&str>) -> Option<PathBuf> {
+    let configured = configured.map(str::trim).filter(|s| !s.is_empty());
+    if let Some(path) = configured {
+        let p = PathBuf::from(path);
+        if p.is_file() {
+            return Some(p);
+        }
+        return None;
+    }
+    find_on_path("pi")
+}
+
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    let paths = env::var_os("PATH")?;
+    for dir in env::split_paths(&paths) {
+        for candidate in executable_candidates(&dir, name) {
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn executable_candidates(dir: &Path, name: &str) -> Vec<PathBuf> {
+    #[cfg(windows)]
+    {
+        vec![
+            dir.join(format!("{name}.exe")),
+            dir.join(format!("{name}.cmd")),
+            dir.join(format!("{name}.bat")),
+            dir.join(name),
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        vec![dir.join(name)]
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn stable_pi_cwd() -> Option<PathBuf> {
+    dirs::home_dir().filter(|path| path.is_dir())
+}
+
+fn first_non_empty<'a>(a: &'a str, b: &'a str) -> Option<&'a str> {
+    let a = a.trim();
+    if !a.is_empty() {
+        return Some(a);
+    }
+    let b = b.trim();
+    if !b.is_empty() {
+        return Some(b);
+    }
+    None
+}
+
+fn validate_session_id(id: &str) -> Result<(), String> {
+    let mut chars = id.chars();
+    let Some(first) = chars.next() else {
+        return Err("session id is empty".to_string());
+    };
+    if !first.is_ascii_alphanumeric() {
+        return Err("session id must start with an alphanumeric character".to_string());
+    }
+    let mut last = first;
+    for ch in chars {
+        if !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.') {
+            return Err("session id contains invalid characters".to_string());
+        }
+        last = ch;
+    }
+    if !last.is_ascii_alphanumeric() {
+        return Err("session id must end with an alphanumeric character".to_string());
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_model_table(output: &str) -> Vec<PiModelRecord> {
+    output
+        .lines()
+        .skip_while(|line| !line.trim_start().starts_with("provider"))
+        .skip(1)
+        .filter_map(parse_model_row)
+        .collect()
+}
+
+fn parse_model_row(line: &str) -> Option<PiModelRecord> {
+    let mut parts = line.split_whitespace();
+    let provider = parts.next()?.to_string();
+    let model = parts.next()?.to_string();
+    let context_tokens = parse_token_count(parts.next()?);
+    let max_output_tokens = parse_token_count(parts.next()?);
+    let thinking = parse_yes_no(parts.next()?);
+    let images = parse_yes_no(parts.next()?);
+    Some(PiModelRecord {
+        provider,
+        model,
+        context_tokens,
+        max_output_tokens,
+        thinking,
+        images,
+    })
+}
+
+fn parse_yes_no(value: &str) -> bool {
+    value.eq_ignore_ascii_case("yes")
+}
+
+fn parse_token_count(value: &str) -> Option<u64> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let (number, mult) = match trimmed.chars().last()? {
+        'K' | 'k' => (&trimmed[..trimmed.len() - 1], 1_000.0),
+        'M' | 'm' => (&trimmed[..trimmed.len() - 1], 1_000_000.0),
+        _ => (trimmed, 1.0),
+    };
+    let parsed = number.parse::<f64>().ok()?;
+    Some((parsed * mult).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pi_model_table() {
+        let rows = parse_model_table(
+            "provider        model                   context  max-out  thinking  images\n\
+             github-copilot  claude-sonnet-4.6       1M       32K      yes       yes\n\
+             opencode        gpt-5.4-mini            400K     128K     yes       yes\n\
+             openai          gpt-4o                  128K     4.1K     no        yes\n",
+        );
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].provider, "github-copilot");
+        assert_eq!(rows[0].model, "claude-sonnet-4.6");
+        assert_eq!(rows[0].context_tokens, Some(1_000_000));
+        assert_eq!(rows[2].max_output_tokens, Some(4_100));
+        assert!(!rows[2].thinking);
+    }
+
+    #[test]
+    fn parses_model_table_from_pi_stderr_shape() {
+        let stderr = "provider        model                   context  max-out  thinking  images\n\
+                      github-copilot  claude-opus-4.8       200K     64K      yes       yes\n";
+        let rows = parse_model_table(stderr);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].provider, "github-copilot");
+        assert_eq!(rows[0].model, "claude-opus-4.8");
+        assert_eq!(rows[0].context_tokens, Some(200_000));
+    }
+
+    #[test]
+    fn validates_pi_session_ids() {
+        assert!(validate_session_id("terax-s-abc_123").is_ok());
+        assert!(validate_session_id("-bad").is_err());
+        assert!(validate_session_id("bad!").is_err());
+        assert!(validate_session_id("bad-").is_err());
+    }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -431,13 +431,15 @@ export default function App() {
     (s) => s.openaiCompatibleBaseURL,
   );
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+  const piModelId = usePreferencesStore((s) => s.piModelId);
   const hasLocalModel =
     (lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0) ||
     (mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0) ||
     (ollamaBaseURL.trim().length > 0 && ollamaModelId.trim().length > 0) ||
     (openaiCompatibleBaseURL.trim().length > 0 &&
       openaiCompatibleModelId.trim().length > 0) ||
-    customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0);
+    customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0) ||
+    piModelId.trim().length > 0;
   const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
 
   const prefsHydrated = usePreferencesStore((s) => s.hydrated);

--- a/src/modules/ai/components/AiMiniWindow.tsx
+++ b/src/modules/ai/components/AiMiniWindow.tsx
@@ -29,7 +29,14 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
 import { useEffect, useMemo } from "react";
-import { estimateCost, getModel, getModelContextLimit, type ModelId } from "../config";
+import {
+  estimateCost,
+  getModel,
+  getModelContextLimit,
+  getPiModelInfo,
+  isPiModelId,
+  type ModelId,
+} from "../config";
 import type { ResizeDir } from "../lib/miniWindowGeometry";
 import type { SessionMeta } from "../lib/sessions";
 import { useMiniWindowGeometry } from "../lib/useMiniWindowGeometry";
@@ -338,6 +345,7 @@ function formatTokens(n: number): string {
 
 function ContextIndicator({ messages }: { messages: UIMessage[] }) {
   const modelId = useChatStore((s) => s.selectedModelId);
+  const piModels = usePreferencesStore((s) => s.piModels);
   const tokens = useChatStore((s) => s.agentMeta.tokens);
   const lastInput = useChatStore((s) => s.agentMeta.lastInputTokens);
   const lastCached = useChatStore((s) => s.agentMeta.lastCachedTokens);
@@ -350,11 +358,14 @@ function ContextIndicator({ messages }: { messages: UIMessage[] }) {
   const max = getModelContextLimit(modelId, openaiCompatibleContextLimit);
   const modelLabel = useMemo(() => {
     try {
+      if (isPiModelId(modelId)) {
+        return getPiModelInfo(modelId, piModels).label;
+      }
       return getModel(modelId as ModelId).label;
     } catch {
       return modelId;
     }
-  }, [modelId]);
+  }, [modelId, piModels]);
   const cost = estimateCost(modelId, tokens);
   const cacheRate =
     tokens.inputTokens > 0

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -38,6 +38,7 @@ import {
   Settings01Icon,
   StarIcon,
   StopCircleIcon,
+  TerminalIcon,
   Tick01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -46,9 +47,12 @@ import { useMemo, useRef, useState } from "react";
 import {
   compatModelIdForEndpoint,
   getCompatModelInfo,
+  getPiModelInfo,
   getModel,
   isCompatModelId,
+  isPiModelId,
   MODELS,
+  piModelId,
   providerNeedsKey,
   PROVIDERS,
   type ModelCapabilities,
@@ -75,6 +79,7 @@ const PROVIDER_ICON = {
   lmstudio: ComputerIcon,
   mlx: AppleIcon,
   ollama: ServerStack01Icon,
+  pi: TerminalIcon,
 } as const satisfies Record<ProviderId, typeof ChatGptIcon>;
 
 export function AiOpenButton({ onOpen }: { onOpen: () => void }) {
@@ -216,9 +221,12 @@ function ModelDropdown() {
   const favoriteIds = usePreferencesStore((s) => s.favoriteModelIds);
   const recentIds = usePreferencesStore((s) => s.recentModelIds);
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+  const piModels = usePreferencesStore((s) => s.piModels);
   const current = isCompatModelId(selected)
     ? getCompatModelInfo(selected, customEndpoints)
-    : getModel(selected as ModelId);
+    : isPiModelId(selected)
+      ? getPiModelInfo(selected, piModels)
+      : getModel(selected as ModelId);
   const [search, setSearch] = useState("");
   const [activeProvider, setActiveProvider] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("all");
@@ -238,20 +246,29 @@ function ModelDropdown() {
     );
   }, [customEndpoints]);
 
+  const piModelInfos = useMemo(
+    () => piModels.map((m) => getPiModelInfo(piModelId(m.provider, m.model), piModels)),
+    [piModels],
+  );
+
   const sortedProviders = useMemo(() => {
     const configured: (typeof PROVIDERS)[number][] = [];
     const unconfigured: (typeof PROVIDERS)[number][] = [];
     for (const p of PROVIDERS) {
       if (p.id === "openai-compatible") continue;
-      (hasKeyFor(p.id) ? configured : unconfigured).push(p);
+      if (p.id === "pi") {
+        (piModelInfos.length > 0 ? configured : unconfigured).push(p);
+      } else {
+        (hasKeyFor(p.id) ? configured : unconfigured).push(p);
+      }
     }
     return { configured, unconfigured };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKeys]);
+  }, [apiKeys, piModelInfos.length]);
 
   const allModels = useMemo(
-    () => [...MODELS, ...epModelInfos],
-    [epModelInfos],
+    () => [...MODELS, ...epModelInfos, ...piModelInfos],
+    [epModelInfos, piModelInfos],
   );
 
   const COMPAT_PROVIDER_ID = "__compat__";
@@ -413,6 +430,7 @@ function ModelDropdown() {
             ) : null}
             {activeProvider !== null &&
             activeProvider !== COMPAT_PROVIDER_ID &&
+            activeProvider !== "pi" &&
             !hasKeyFor(activeProvider as ProviderId) ? (
               <ProviderConfigureCTA providerId={activeProvider as ProviderId} />
             ) : null}
@@ -432,12 +450,13 @@ function ModelDropdown() {
                   selected={m.id === selected}
                   hasKey={
                     isCompatModelId(m.id) ||
+                    isPiModelId(m.id) ||
                     hasKeyFor(m.provider)
                   }
                   favorite={favoriteIds.includes(m.id)}
                   showProviderIcon={activeProvider === null}
                   onPick={() => {
-                    if (!isCompatModelId(m.id) && !hasKeyFor(m.provider)) {
+                    if (!isCompatModelId(m.id) && !isPiModelId(m.id) && !hasKeyFor(m.provider)) {
                       void openSettingsWindow("models");
                       return;
                     }

--- a/src/modules/ai/config.test.ts
+++ b/src/modules/ai/config.test.ts
@@ -3,9 +3,12 @@ import {
   compatModelIdForEndpoint,
   endpointIdFromCompatModel,
   getModelContextLimit,
+  isPiModelId,
   isCompatModelId,
+  parsePiModelId,
   migrateLegacyCompatEndpoint,
   modelKeepsReasoning,
+  piModelId,
   resolveModel,
   type CustomEndpoint,
 } from "./config";
@@ -31,6 +34,22 @@ describe("compat model id helpers", () => {
   });
 });
 
+describe("pi model id helpers", () => {
+  it("round-trips provider and model ids", () => {
+    const id = piModelId("github-copilot", "claude-sonnet-4.6");
+    expect(isPiModelId(id)).toBe(true);
+    expect(parsePiModelId(id)).toEqual({
+      provider: "github-copilot",
+      model: "claude-sonnet-4.6",
+    });
+  });
+
+  it("rejects malformed pi model ids", () => {
+    expect(parsePiModelId("pi:missing-slash")).toBeNull();
+    expect(parsePiModelId("gpt-5.4-mini")).toBeNull();
+  });
+});
+
 describe("resolveModel", () => {
   it("resolves a compat model id against its endpoint", () => {
     const mid = compatModelIdForEndpoint(endpoint.id);
@@ -47,6 +66,23 @@ describe("resolveModel", () => {
 
   it("resolves a static model id from the registry", () => {
     expect(resolveModel("gpt-5.4-mini").provider).toBe("openai");
+  });
+
+  it("resolves a pi model id from dynamic records", () => {
+    const id = piModelId("github-copilot", "gpt-5.4-mini");
+    const info = resolveModel(id, [], [
+      {
+        provider: "github-copilot",
+        model: "gpt-5.4-mini",
+        contextTokens: 400_000,
+        maxOutputTokens: 128_000,
+        thinking: true,
+        images: true,
+      },
+    ]);
+    expect(info.provider).toBe("pi");
+    expect(info.label).toBe("gpt-5.4-mini");
+    expect(info.hint).toBe("github-copilot");
   });
 
   it("throws on an unknown static model id", () => {

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -13,7 +13,8 @@ export type ProviderId =
   | "openai-compatible"
   | "lmstudio"
   | "mlx"
-  | "ollama";
+  | "ollama"
+  | "pi";
 
 export type ProviderInfo = {
   id: ProviderId;
@@ -118,6 +119,13 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     keyPrefix: null,
     consoleUrl: "https://ollama.com/download",
   },
+  {
+    id: "pi",
+    label: "Pi",
+    keyringAccount: "",
+    keyPrefix: null,
+    consoleUrl: "https://github.com/earendil-works/pi",
+  },
 ] as const;
 
 export type CustomEndpoint = {
@@ -129,6 +137,7 @@ export type CustomEndpoint = {
 };
 
 const COMPAT_MODEL_PREFIX = "compat-";
+const PI_MODEL_PREFIX = "pi:";
 
 export function compatModelIdForEndpoint(endpointId: string): string {
   return `${COMPAT_MODEL_PREFIX}${endpointId}`;
@@ -142,6 +151,36 @@ export function endpointIdFromCompatModel(modelId: string): string {
   return isCompatModelId(modelId)
     ? modelId.slice(COMPAT_MODEL_PREFIX.length)
     : "";
+}
+
+export type PiModelRecord = {
+  provider: string;
+  model: string;
+  contextTokens: number | null;
+  maxOutputTokens: number | null;
+  thinking: boolean;
+  images: boolean;
+};
+
+export function piModelId(provider: string, model: string): string {
+  return `${PI_MODEL_PREFIX}${provider}/${model}`;
+}
+
+export function isPiModelId(modelId: string): boolean {
+  return modelId.startsWith(PI_MODEL_PREFIX);
+}
+
+export function parsePiModelId(
+  modelId: string,
+): { provider: string; model: string } | null {
+  if (!isPiModelId(modelId)) return null;
+  const raw = modelId.slice(PI_MODEL_PREFIX.length);
+  const slash = raw.indexOf("/");
+  if (slash <= 0 || slash === raw.length - 1) return null;
+  return {
+    provider: raw.slice(0, slash),
+    model: raw.slice(slash + 1),
+  };
 }
 
 /** One-shot migration of the legacy single OpenAI-compatible config into the
@@ -543,11 +582,38 @@ export function getCompatModelInfo(
   };
 }
 
+export function getPiModelInfo(
+  modelId: string,
+  models: readonly PiModelRecord[] = [],
+): ModelInfo {
+  const parsed = parsePiModelId(modelId);
+  const found = parsed
+    ? models.find((m) => m.provider === parsed.provider && m.model === parsed.model)
+    : null;
+  const provider = found?.provider ?? parsed?.provider ?? "pi";
+  const model = found?.model ?? parsed?.model ?? modelId.replace(PI_MODEL_PREFIX, "");
+  return {
+    id: modelId,
+    provider: "pi",
+    label: model,
+    hint: provider,
+    description: `Pi ${provider}/${model}`,
+    capabilities: {
+      intelligence: found?.thinking ? 4 : 3,
+      speed: 3,
+      cost: 3,
+    },
+    tags: found?.thinking ? ["tools", "coding", "reasoning"] : ["tools", "coding"],
+  };
+}
+
 export function resolveModel(
   modelId: string,
   endpoints: readonly CustomEndpoint[] = [],
+  piModels: readonly PiModelRecord[] = [],
 ): ModelInfo {
   if (isCompatModelId(modelId)) return getCompatModelInfo(modelId, endpoints);
+  if (isPiModelId(modelId)) return getPiModelInfo(modelId, piModels);
   const m = MODELS.find((x) => x.id === modelId);
   if (!m) throw new Error(`Unknown model: ${modelId}`);
   return m;
@@ -563,12 +629,17 @@ export function isKnownModelId(id: string): id is ModelId {
   return MODELS.some((x) => x.id === id);
 }
 
+export function isPersistableModelId(id: string): boolean {
+  return isKnownModelId(id) || isCompatModelId(id) || isPiModelId(id);
+}
+
 const FREEFORM_PROVIDERS: ReadonlySet<ProviderId> = new Set([
   "openrouter",
   "openai-compatible",
   "lmstudio",
   "mlx",
   "ollama",
+  "pi",
 ]);
 
 // Reasoning models reject tool-call turns whose reasoning was stripped; keep it.
@@ -681,6 +752,7 @@ export const KEYLESS_PROVIDERS: readonly ProviderId[] = [
   "mlx",
   "ollama",
   "openai-compatible",
+  "pi",
 ] as const;
 
 export function providerNeedsKey(id: ProviderId): boolean {

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -207,6 +207,9 @@ export async function buildLanguageModel(
       })(resolvedModelId);
       break;
     }
+    case "pi": {
+      throw new Error("Pi models are available in chat only.");
+    }
     default: {
       const _exhaustive: never = provider;
       throw new Error(`Unsupported provider: ${_exhaustive as ProviderId}`);

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -25,6 +25,7 @@ export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   lmstudio: null,
   mlx: null,
   ollama: null,
+  pi: null,
 };
 
 export async function getKey(provider: ProviderId): Promise<string | null> {

--- a/src/modules/ai/lib/piTransport.ts
+++ b/src/modules/ai/lib/piTransport.ts
@@ -1,0 +1,429 @@
+import { invoke, Channel } from "@tauri-apps/api/core";
+import type { UIMessage } from "@ai-sdk/react";
+import type { ChatTransport, UIMessageChunk } from "ai";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import { parsePiModelId } from "../config";
+
+type LiveSnapshot = {
+  cwd: string | null;
+  terminalPrivate: boolean;
+  workspaceRoot: string | null;
+  activeFile: string | null;
+};
+
+type Deps = {
+  getModelId: () => string;
+  getPiExecutablePath: () => string;
+  getLive: () => LiveSnapshot;
+  getCustomInstructions: () => string;
+  onStep?: (step: string | null) => void;
+};
+
+type SendOptions = {
+  chatId: string;
+  messages: UIMessage[];
+  abortSignal?: AbortSignal;
+};
+
+type PiRunEvent =
+  | { kind: "line"; line: string }
+  | { kind: "stderr"; line: string }
+  | { kind: "end"; exitCode?: number | null; exit_code?: number | null; success?: boolean }
+  | { kind: "error"; message: string };
+
+type PiStreamState = {
+  textIndex: number;
+  activeTextId: string | null;
+  toolInputs: Map<string, { toolName: string; input: unknown }>;
+  reasoningIds: Set<string>;
+  syntheticToolIndex: number;
+};
+
+export function createPiTransport(deps: Deps): ChatTransport<UIMessage> {
+  return {
+    sendMessages: (options) => sendPiMessages(deps, options),
+    async reconnectToStream(): Promise<null> {
+      return null;
+    },
+  };
+}
+
+function sendPiMessages(
+  deps: Deps,
+  options: SendOptions,
+): Promise<ReadableStream<UIMessageChunk>> {
+  const parsed = parsePiModelId(deps.getModelId());
+  if (!parsed) {
+    throw new Error("Pi transport received a non-Pi model id.");
+  }
+  const prompt = buildPrompt(options.messages, deps);
+  if (!prompt.trim()) {
+    throw new Error("No prompt text to send to Pi.");
+  }
+
+  let runId: string | null = null;
+  let finished = false;
+  let sawText = false;
+  const stderr: string[] = [];
+  const streamState: PiStreamState = {
+    textIndex: 0,
+    activeTextId: null,
+    toolInputs: new Map(),
+    reasoningIds: new Set(),
+    syntheticToolIndex: 0,
+  };
+
+  const stream = new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      controller.enqueue({ type: "start" });
+      controller.enqueue({ type: "start-step" });
+
+      const channel = new Channel<PiRunEvent>();
+      channel.onmessage = (event) => {
+        if (finished) return;
+        switch (event.kind) {
+          case "line":
+            handlePiJsonLine(event.line, controller, streamState, (delta) => {
+              sawText = sawText || delta.length > 0;
+            }, deps);
+            break;
+          case "stderr":
+            if (event.line.trim()) stderr.push(event.line);
+            break;
+          case "error":
+            finished = true;
+            controller.error(new Error(event.message));
+            break;
+          case "end":
+            finished = true;
+            deps.onStep?.(null);
+            {
+              const exitCode = event.exitCode ?? event.exit_code ?? null;
+              const success = event.success ?? exitCode === 0;
+              if (!success) {
+                const message = stderr.join("\n").trim() || `Pi exited with code ${exitCode ?? "unknown"}.`;
+                controller.error(new Error(message));
+                return;
+              }
+            }
+            if (!sawText) {
+              controller.error(new Error("Pi completed without streaming assistant text."));
+              return;
+            }
+            closeOpenReasoningParts(controller, streamState);
+            closeOpenTextPart(controller, streamState);
+            controller.enqueue({ type: "finish-step" });
+            controller.enqueue({ type: "finish" });
+            controller.close();
+            break;
+        }
+      };
+
+      const abort = () => {
+        finished = true;
+        deps.onStep?.(null);
+        if (runId) void invoke("pi_cancel", { runId });
+        controller.error(new DOMException("Request aborted", "AbortError"));
+      };
+      options.abortSignal?.addEventListener("abort", abort, { once: true });
+
+      void invoke<string>("pi_run", {
+        executablePath: deps.getPiExecutablePath() || null,
+        cwd: deps.getLive().cwd ?? deps.getLive().workspaceRoot,
+        sessionId: piSessionIdForChat(options.chatId),
+        model: `${parsed.provider}/${parsed.model}`,
+        prompt,
+        workspace: currentWorkspaceEnv(),
+        onEvent: channel,
+      })
+        .then((id) => {
+          runId = id;
+          if (options.abortSignal?.aborted) abort();
+        })
+        .catch((e) => {
+          finished = true;
+          controller.error(e instanceof Error ? e : new Error(String(e)));
+        });
+    },
+    cancel() {
+      finished = true;
+      deps.onStep?.(null);
+      if (runId) void invoke("pi_cancel", { runId });
+    },
+  });
+
+  return Promise.resolve(stream);
+}
+
+function handlePiJsonLine(
+  line: string,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: PiStreamState,
+  markText: (delta: string) => void,
+  deps: Deps,
+): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let event: unknown;
+  try {
+    event = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+  if (!event || typeof event !== "object") return;
+  const rec = event as Record<string, unknown>;
+  if (rec.type === "message_update") {
+    const message = rec.message as Record<string, unknown> | undefined;
+    const update = rec.assistantMessageEvent as Record<string, unknown> | undefined;
+    const updateType = typeof update?.type === "string" ? update.type : "";
+    if (
+      message?.role === "assistant" &&
+      updateType === "text_delta" &&
+      typeof update?.delta === "string"
+    ) {
+      const delta = update.delta;
+      markText(delta);
+      const textId = ensureTextPart(controller, state);
+      controller.enqueue({
+        type: "text-delta",
+        id: textId,
+        delta,
+      });
+      return;
+    }
+    if (
+      message?.role === "assistant" &&
+      (updateType === "thinking_start" || updateType === "reasoning_start")
+    ) {
+      deps.onStep?.("Pi is thinking");
+      ensureReasoningPart(controller, state, piReasoningId(update));
+      return;
+    }
+    if (
+      message?.role === "assistant" &&
+      (updateType === "thinking_delta" || updateType === "reasoning_delta") &&
+      typeof update?.delta === "string"
+    ) {
+      const delta = update.delta;
+      deps.onStep?.("Pi is thinking");
+      const id = piReasoningId(update);
+      ensureReasoningPart(controller, state, id);
+      controller.enqueue({ type: "reasoning-delta", id, delta });
+      return;
+    }
+    if (
+      message?.role === "assistant" &&
+      (updateType === "thinking_end" || updateType === "reasoning_end")
+    ) {
+      const id = piReasoningId(update);
+      if (state.reasoningIds.has(id)) {
+        controller.enqueue({ type: "reasoning-end", id });
+        state.reasoningIds.delete(id);
+      }
+    }
+    return;
+  }
+  if (rec.type === "tool_execution_start" && typeof rec.toolName === "string") {
+    const toolCallId = piToolCallId(rec, state, true);
+    if (!toolCallId) return;
+    const toolName = sanitizePiToolName(rec.toolName);
+    ensureToolInput(controller, state, toolCallId, toolName, compactPiValue(rec.args));
+    deps.onStep?.(`Pi: ${toolName}`);
+    return;
+  }
+  if (rec.type === "tool_execution_update" && typeof rec.toolName === "string") {
+    const toolCallId = piToolCallId(rec, state, false);
+    if (!toolCallId) return;
+    const toolName = sanitizePiToolName(rec.toolName);
+    ensureToolInput(controller, state, toolCallId, toolName, compactPiValue(rec.args));
+    controller.enqueue({
+      type: "tool-output-available",
+      toolCallId,
+      output: compactPiValue(rec.partialResult),
+      dynamic: true,
+      providerExecuted: true,
+      preliminary: true,
+    });
+    deps.onStep?.(`Pi: ${toolName}`);
+    return;
+  }
+  if (rec.type === "tool_execution_end") {
+    const toolCallId = piToolCallId(rec, state, false);
+    if (toolCallId) {
+      const toolName =
+        typeof rec.toolName === "string" ? sanitizePiToolName(rec.toolName) : "tool";
+      ensureToolInput(controller, state, toolCallId, toolName, compactPiValue(rec.args));
+      if (rec.isError) {
+        controller.enqueue({
+          type: "tool-output-error",
+          toolCallId,
+          errorText: compactPiError(rec.result),
+          dynamic: true,
+          providerExecuted: true,
+        });
+      } else {
+        controller.enqueue({
+          type: "tool-output-available",
+          toolCallId,
+          output: compactPiValue(rec.result),
+          dynamic: true,
+          providerExecuted: true,
+        });
+      }
+    }
+    deps.onStep?.("Pi tool finished");
+    return;
+  }
+  if (rec.type === "agent_start" || rec.type === "turn_start") {
+    deps.onStep?.("Pi is working");
+  }
+}
+
+function ensureTextPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: PiStreamState,
+): string {
+  closeOpenReasoningParts(controller, state);
+  if (state.activeTextId) return state.activeTextId;
+  state.textIndex += 1;
+  const id = `pi-text-${state.textIndex}`;
+  state.activeTextId = id;
+  controller.enqueue({ type: "text-start", id });
+  return id;
+}
+
+function closeOpenTextPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: PiStreamState,
+): void {
+  if (!state.activeTextId) return;
+  controller.enqueue({ type: "text-end", id: state.activeTextId });
+  state.activeTextId = null;
+}
+
+function ensureToolInput(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: PiStreamState,
+  toolCallId: string,
+  toolName: string,
+  input: unknown,
+): void {
+  closeOpenReasoningParts(controller, state);
+  closeOpenTextPart(controller, state);
+  if (state.toolInputs.has(toolCallId)) return;
+  state.toolInputs.set(toolCallId, { toolName, input });
+  controller.enqueue({
+    type: "tool-input-available",
+    toolCallId,
+    toolName,
+    input,
+    dynamic: true,
+    providerExecuted: true,
+    title: `Pi: ${toolName}`,
+  });
+}
+
+function ensureReasoningPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: PiStreamState,
+  id: string,
+): void {
+  if (state.reasoningIds.has(id)) return;
+  closeOpenTextPart(controller, state);
+  state.reasoningIds.add(id);
+  controller.enqueue({ type: "reasoning-start", id });
+}
+
+function closeOpenReasoningParts(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: PiStreamState,
+): void {
+  for (const id of state.reasoningIds) {
+    controller.enqueue({ type: "reasoning-end", id });
+  }
+  state.reasoningIds.clear();
+}
+
+function piReasoningId(update: Record<string, unknown> | undefined): string {
+  const index = update?.contentIndex ?? update?.content_index ?? 0;
+  return `pi-reasoning-${typeof index === "number" ? index : 0}`;
+}
+
+function piToolCallId(
+  rec: Record<string, unknown>,
+  state: PiStreamState,
+  allowSynthetic: boolean,
+): string | null {
+  if (typeof rec.toolCallId === "string" && rec.toolCallId.trim()) {
+    return rec.toolCallId;
+  }
+  if (!allowSynthetic) return null;
+  state.syntheticToolIndex += 1;
+  return `pi-tool-${state.syntheticToolIndex}`;
+}
+
+function sanitizePiToolName(name: string): string {
+  return name.trim().replace(/\s+/g, "_") || "tool";
+}
+
+function compactPiError(value: unknown): string {
+  const compact = compactPiValue(value);
+  return typeof compact === "string" ? compact : JSON.stringify(compact);
+}
+
+function compactPiValue(value: unknown): unknown {
+  const maxLength = 4000;
+  if (typeof value === "string") {
+    return value.length > maxLength
+      ? `${value.slice(0, maxLength)}\n\n...[truncated]`
+      : value;
+  }
+  if (value == null || typeof value !== "object") return value;
+  try {
+    const json = JSON.stringify(value);
+    if (json.length <= maxLength) return value;
+    return `${json.slice(0, maxLength)}\n\n...[truncated]`;
+  } catch {
+    return String(value);
+  }
+}
+
+function buildPrompt(messages: UIMessage[], deps: Deps): string {
+  const latest = latestUserText(messages);
+  const live = deps.getLive();
+  const blocks: string[] = [];
+  const envLines: string[] = [];
+  if (live.workspaceRoot) envLines.push(`workspace_root: ${live.workspaceRoot}`);
+  if (live.cwd) envLines.push(`active_terminal_cwd: ${live.cwd}`);
+  if (live.activeFile) envLines.push(`active_file: ${live.activeFile}`);
+  if (live.terminalPrivate) envLines.push("active_terminal_mode: private");
+  if (envLines.length > 0) blocks.push(`<env>\n${envLines.join("\n")}\n</env>`);
+  const instructions = deps.getCustomInstructions().trim();
+  if (instructions) {
+    blocks.push(`<terax-custom-instructions>\n${instructions}\n</terax-custom-instructions>`);
+  }
+  blocks.push(latest);
+  return blocks.filter(Boolean).join("\n\n");
+}
+
+function latestUserText(messages: UIMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user") continue;
+    const text = msg.parts
+      .map((part) => (part.type === "text" ? part.text : ""))
+      .filter(Boolean)
+      .join("\n\n")
+      .trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+function piSessionIdForChat(chatId: string): string {
+  const cleaned = chatId
+    .replace(/[^A-Za-z0-9._-]/g, "-")
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .replace(/[^A-Za-z0-9]+$/, "");
+  return `terax-${cleaned || "chat"}`;
+}

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -9,6 +9,7 @@ import {
   endpointIdFromCompatModel,
   getModel,
   isCompatModelId,
+  isPiModelId,
   providerNeedsKey,
   type ModelId,
   type ProviderId,
@@ -32,6 +33,7 @@ import {
   type SessionMeta,
 } from "../lib/sessions";
 import { pushRecentModel } from "../lib/modelPrefs";
+import { createPiTransport } from "../lib/piTransport";
 import { createContextAwareTransport } from "../lib/transport";
 import type { ToolContext } from "../tools/tools";
 
@@ -239,7 +241,7 @@ function makeChat(sessionId: string): Chat<UIMessage> {
     getSessionId: () => sessionId,
   };
 
-  const transport = createContextAwareTransport({
+  const teraxTransport = createContextAwareTransport({
     getKeys: () => useChatStore.getState().apiKeys,
     toolContext,
     getModelId: () => useChatStore.getState().selectedModelId,
@@ -303,6 +305,34 @@ function makeChat(sessionId: string): Chat<UIMessage> {
       });
     },
   }) as unknown as ChatTransport<UIMessage>;
+  const piTransport = createPiTransport({
+    getModelId: () => useChatStore.getState().selectedModelId,
+    getPiExecutablePath: () => usePreferencesStore.getState().piExecutablePath,
+    getCustomInstructions: () =>
+      usePreferencesStore.getState().customInstructions,
+    getLive: () => {
+      const live = useChatStore.getState().live;
+      return {
+        cwd: live.getCwd(),
+        terminalPrivate: live.isActiveTerminalPrivate(),
+        workspaceRoot: live.getWorkspaceRoot(),
+        activeFile: live.getActiveFile(),
+      };
+    },
+    onStep: (step) => {
+      useChatStore.getState().patchAgentMeta({ step });
+    },
+  });
+  const transport: ChatTransport<UIMessage> = {
+    sendMessages: (options) =>
+      isPiModelId(useChatStore.getState().selectedModelId)
+        ? piTransport.sendMessages(options)
+        : teraxTransport.sendMessages(options),
+    reconnectToStream: (options) =>
+      isPiModelId(useChatStore.getState().selectedModelId)
+        ? piTransport.reconnectToStream(options)
+        : teraxTransport.reconnectToStream(options),
+  };
 
   const initialMessages = seedMessages.get(sessionId);
   seedMessages.delete(sessionId);
@@ -546,6 +576,7 @@ export function getActiveProviderKey(): string | null {
     const eid = endpointIdFromCompatModel(selectedModelId);
     return customEndpointKeys[eid] ?? null;
   }
+  if (isPiModelId(selectedModelId)) return null;
   return apiKeys[getModel(selectedModelId as ModelId).provider] ?? null;
 }
 
@@ -554,6 +585,7 @@ export function hasKeyForModel(modelId: string): boolean {
   if (isCompatModelId(modelId)) {
     return true;
   }
+  if (isPiModelId(modelId)) return true;
   const provider = getModel(modelId as ModelId).provider;
   return providerNeedsKey(provider) ? !!apiKeys[provider] : true;
 }
@@ -579,7 +611,11 @@ export async function sendMessage(text: string): Promise<boolean> {
   const state = useChatStore.getState();
   const sessionId = state.activeSessionId;
   if (!sessionId) return false;
-  if (providerNeedsKey(getModel(state.selectedModelId as ModelId).provider) && !getActiveProviderKey()) return false;
+  if (
+    !isPiModelId(state.selectedModelId) &&
+    providerNeedsKey(getModel(state.selectedModelId as ModelId).provider) &&
+    !getActiveProviderKey()
+  ) return false;
   const c = getOrCreateChat(sessionId);
   await c.sendMessage({ text });
   return true;

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   DEFAULT_MODEL_ID,
+  isPersistableModelId,
   isKnownModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
   MLX_DEFAULT_BASE_URL,
@@ -10,6 +11,7 @@ import {
   type AutocompleteProviderId,
   type CustomEndpoint,
   type ModelId,
+  type PiModelRecord,
 } from "@/modules/ai/config";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -75,6 +77,10 @@ export type Preferences = {
   openaiCompatibleContextLimit: number;
   customEndpoints: CustomEndpoint[];
   openrouterModelId: string;
+  piProviderEnabled: boolean;
+  piExecutablePath: string;
+  piModelId: string;
+  piModels: PiModelRecord[];
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
@@ -118,6 +124,10 @@ const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
 const KEY_OPENAI_COMPAT_CONTEXT_LIMIT = "openaiCompatibleContextLimit";
 const KEY_CUSTOM_ENDPOINTS = "customEndpoints";
 const KEY_OPENROUTER_MODEL_ID = "openrouterModelId";
+const KEY_PI_PROVIDER_ENABLED = "piProviderEnabled";
+const KEY_PI_EXECUTABLE_PATH = "piExecutablePath";
+const KEY_PI_MODEL_ID = "piModelId";
+const KEY_PI_MODELS = "piModels";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
@@ -176,6 +186,10 @@ export const DEFAULT_PREFERENCES: Preferences = {
   openaiCompatibleContextLimit: 128_000,
   customEndpoints: [],
   openrouterModelId: "",
+  piProviderEnabled: false,
+  piExecutablePath: "",
+  piModelId: "",
+  piModels: [],
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
@@ -285,13 +299,21 @@ export async function loadPreferences(): Promise<Preferences> {
     openrouterModelId:
       get<string>(KEY_OPENROUTER_MODEL_ID) ??
       DEFAULT_PREFERENCES.openrouterModelId,
+    piProviderEnabled:
+      get<boolean>(KEY_PI_PROVIDER_ENABLED) ??
+      DEFAULT_PREFERENCES.piProviderEnabled,
+    piExecutablePath:
+      get<string>(KEY_PI_EXECUTABLE_PATH) ??
+      DEFAULT_PREFERENCES.piExecutablePath,
+    piModelId: get<string>(KEY_PI_MODEL_ID) ?? DEFAULT_PREFERENCES.piModelId,
+    piModels: get<PiModelRecord[]>(KEY_PI_MODELS) ?? DEFAULT_PREFERENCES.piModels,
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds
-    ).filter(isKnownModelId),
+    ).filter(isPersistableModelId),
     recentModelIds: (
       get<string[]>(KEY_RECENT_MODELS) ?? DEFAULT_PREFERENCES.recentModelIds
-    ).filter(isKnownModelId),
+    ).filter(isPersistableModelId),
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
     showHidden:
       get<boolean>(KEY_SHOW_HIDDEN) ??
@@ -457,6 +479,22 @@ export async function setOpenrouterModelId(value: string): Promise<void> {
   await writePref(KEY_OPENROUTER_MODEL_ID, value);
 }
 
+export async function setPiProviderEnabled(value: boolean): Promise<void> {
+  await writePref(KEY_PI_PROVIDER_ENABLED, value);
+}
+
+export async function setPiExecutablePath(value: string): Promise<void> {
+  await writePref(KEY_PI_EXECUTABLE_PATH, value.trim());
+}
+
+export async function setPiModelId(value: string): Promise<void> {
+  await writePref(KEY_PI_MODEL_ID, value.trim());
+}
+
+export async function setPiModels(value: PiModelRecord[]): Promise<void> {
+  await writePref(KEY_PI_MODELS, value);
+}
+
 export async function setFavoriteModelIds(value: string[]): Promise<void> {
   await writePref(KEY_FAVORITE_MODELS, value);
 }
@@ -575,6 +613,10 @@ export async function onPreferencesChange(
     [KEY_OPENAI_COMPAT_CONTEXT_LIMIT]: "openaiCompatibleContextLimit",
     [KEY_CUSTOM_ENDPOINTS]: "customEndpoints",
     [KEY_OPENROUTER_MODEL_ID]: "openrouterModelId",
+    [KEY_PI_PROVIDER_ENABLED]: "piProviderEnabled",
+    [KEY_PI_EXECUTABLE_PATH]: "piExecutablePath",
+    [KEY_PI_MODEL_ID]: "piModelId",
+    [KEY_PI_MODELS]: "piModels",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -6,7 +6,7 @@ import {
   type GitStatusSnapshot,
 } from "@/modules/ai/lib/native";
 import { useChatStore } from "@/modules/ai/store/chatStore";
-import { providerNeedsKey, resolveModel } from "@/modules/ai/config";
+import { isPiModelId, providerNeedsKey, resolveModel } from "@/modules/ai/config";
 import {
   invalidateDiff,
   invalidateRepoDiffs,
@@ -369,6 +369,7 @@ export function useSourceControlPanel(
   const selectedModelId = useChatStore((state) => state.selectedModelId);
   const agentStatus = useChatStore((state) => state.agentMeta.status);
   const hasApiKeyForSelected = useChatStore((state) => {
+    if (isPiModelId(state.selectedModelId)) return false;
     const model = resolveModel(state.selectedModelId);
     return !providerNeedsKey(model.provider) || !!state.apiKeys[model.provider];
   });
@@ -470,7 +471,9 @@ export function useSourceControlPanel(
       return "Stage changes to generate a commit message";
     }
     if (!hasApiKeyForSelected) {
-      return "Connect an AI provider to generate commit messages";
+      return isPiModelId(selectedModelId)
+        ? "Pi is available in chat, not commit-message generation"
+        : "Connect an AI provider to generate commit messages";
     }
     if (selectedModel.id === "lmstudio-local" && !lmstudioModelId.trim()) {
       return "Connect an AI provider to generate commit messages";
@@ -500,6 +503,7 @@ export function useSourceControlPanel(
     openaiCompatibleModelId,
     openrouterModelId,
     selectedModel,
+    selectedModelId,
     stagedEntries.length,
   ]);
   const canGenerateCommitMessage =

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -12,6 +12,7 @@ import {
   GlobeIcon,
   MistralIcon,
   PlugIcon,
+  TerminalIcon,
   ServerStack01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -30,6 +31,7 @@ const ICON_BY_PROVIDER = {
   lmstudio: ComputerIcon,
   mlx: AppleIcon,
   ollama: ServerStack01Icon,
+  pi: TerminalIcon,
 } as const satisfies Record<ProviderId, typeof ChatGptIcon>;
 
 type Props = {

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -18,9 +18,12 @@ import {
   getAutocompleteEligibleModels,
   getModel,
   getProvider,
+  getPiModelInfo,
   providerNeedsKey,
+  piModelId,
   type CustomEndpoint,
   type ModelId,
+  type PiModelRecord,
   type ProviderId,
   type ProviderInfo,
 } from "@/modules/ai/config";
@@ -53,6 +56,10 @@ import {
   setOpenaiCompatibleContextLimit,
   setOpenaiCompatibleModelId,
   setOpenrouterModelId,
+  setPiExecutablePath,
+  setPiModelId,
+  setPiModels,
+  setPiProviderEnabled,
   setRecentModelIds,
 } from "@/modules/settings/store";
 import {
@@ -62,6 +69,7 @@ import {
   Cancel01Icon,
   CheckmarkCircle02Icon,
   ChevronDown,
+  RefreshIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
@@ -72,6 +80,12 @@ import { ProviderKeyCard } from "../components/ProviderKeyCard";
 import { SectionHeader } from "../components/SectionHeader";
 
 type KeysMap = Record<ProviderId, string | null>;
+type PiDetectResult = {
+  installed: boolean;
+  path: string | null;
+  version: string | null;
+  error: string | null;
+};
 
 const isLocalProvider = (id: ProviderId): boolean => !providerNeedsKey(id);
 
@@ -148,6 +162,16 @@ export function ModelsSection() {
   );
   const openrouterModelId = usePreferencesStore((s) => s.openrouterModelId);
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+  const piProviderEnabled = usePreferencesStore((s) => s.piProviderEnabled);
+  const piExecutablePath = usePreferencesStore((s) => s.piExecutablePath);
+  const piConfiguredModelId = usePreferencesStore((s) => s.piModelId);
+  const piModels = usePreferencesStore((s) => s.piModels);
+  const [piLiveModels, setPiLiveModels] = useState<PiModelRecord[]>([]);
+  const [piDetect, setPiDetect] = useState<PiDetectResult | null>(null);
+  const [piError, setPiError] = useState<string | null>(null);
+  const [piRefreshStatus, setPiRefreshStatus] = useState<string | null>(null);
+  const [piBusy, setPiBusy] = useState(false);
+  const visiblePiModels = piModels.length > 0 ? piModels : piLiveModels;
 
   useEffect(() => {
     void getAllKeys().then(setKeys);
@@ -156,6 +180,60 @@ export function ModelsSection() {
   useEffect(() => {
     void getAllCustomEndpointKeys(customEndpoints).then(setEpKeys);
   }, [customEndpoints]);
+
+  const refreshPi = async (
+    refreshModels: boolean,
+    executablePathOverride = piExecutablePath,
+  ) => {
+    setPiBusy(true);
+    setPiError(null);
+    setPiRefreshStatus(refreshModels ? "Refreshing models..." : null);
+    try {
+      const detected = await invoke<PiDetectResult>("pi_detect", {
+        executablePath: executablePathOverride || null,
+      });
+      setPiDetect(detected);
+      if (!detected.installed || !refreshModels) {
+        setPiRefreshStatus(null);
+        return;
+      }
+      const models = await invoke<PiModelRecord[]>("pi_list_models", {
+        executablePath: executablePathOverride || null,
+      });
+      setPiLiveModels(models);
+      usePreferencesStore.setState({ piModels: models });
+      await setPiModels(models);
+      setPiRefreshStatus(
+        models.length > 0
+          ? `Loaded ${models.length} models`
+          : "Pi returned no models",
+      );
+      const selectedStillExists =
+        piConfiguredModelId &&
+        models.some(
+          (m) => piModelId(m.provider, m.model) === piConfiguredModelId,
+        );
+      if (!selectedStillExists && models[0]) {
+        const nextId = piModelId(models[0].provider, models[0].model);
+        usePreferencesStore.setState({ piModelId: nextId });
+        await setPiModelId(nextId);
+      }
+    } catch (e) {
+      setPiError(e instanceof Error ? e.message : String(e));
+      setPiRefreshStatus(null);
+    } finally {
+      setPiBusy(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshPi(
+      piProviderEnabled ||
+        piExecutablePath.trim().length > 0 ||
+        piConfiguredModelId.trim().length > 0,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [piExecutablePath, piProviderEnabled]);
 
   const onSaveKey = async (provider: ProviderId, value: string) => {
     await setKey(provider, value);
@@ -282,6 +360,8 @@ export function ModelsSection() {
   };
 
   const isConfigured = (id: ProviderId): boolean => {
+    if (id === "pi")
+      return !!piDetect?.installed && !!piConfiguredModelId.trim();
     if (id === "openrouter")
       return !!keys?.[id] && !!openrouterModelId.trim();
     if (!isLocalProvider(id)) return !!keys?.[id];
@@ -300,6 +380,9 @@ export function ModelsSection() {
     PROVIDERS.filter((p) => isConfigured(p.id)).map((p) => p.id),
   );
   const visibleIds = new Set<ProviderId>(configuredIds);
+  if (piProviderEnabled || piExecutablePath.trim() || visiblePiModels.length > 0) {
+    visibleIds.add("pi");
+  }
   for (const id of adding) visibleIds.add(id);
   const visibleProviders = PROVIDERS.filter(
     (p) => p.id !== "openai-compatible" && visibleIds.has(p.id),
@@ -309,7 +392,19 @@ export function ModelsSection() {
   );
 
   const removeProvider = (id: ProviderId) => {
-    if (id === "openrouter") {
+    if (id === "pi") {
+      usePreferencesStore.setState({
+        piProviderEnabled: false,
+        piExecutablePath: "",
+        piModelId: "",
+        piModels: [],
+      });
+      setPiLiveModels([]);
+      void setPiProviderEnabled(false);
+      void setPiExecutablePath("");
+      void setPiModelId("");
+      void setPiModels([]);
+    } else if (id === "openrouter") {
       void setOpenrouterModelId("");
       void onClearKey(id);
     } else if (isLocalProvider(id)) {
@@ -331,6 +426,11 @@ export function ModelsSection() {
 
   const addProvider = (id: ProviderId) => {
     setAdding((prev) => new Set(prev).add(id));
+    if (id === "pi") {
+      usePreferencesStore.setState({ piProviderEnabled: true });
+      void setPiProviderEnabled(true);
+      void refreshPi(true);
+    }
   };
 
   return (
@@ -353,6 +453,9 @@ export function ModelsSection() {
             providers={addableProviders}
             onAdd={addProvider}
             onAddCompat={addCustomEndpoint}
+            disabledIds={new Set<ProviderId>(
+              piDetect?.installed === false ? ["pi"] : [],
+            )}
           />
         </div>
 
@@ -368,7 +471,24 @@ export function ModelsSection() {
         ) : (
           <div className="flex flex-col gap-2">
             {visibleProviders.map((p) =>
-              p.id === "openrouter" ? (
+              p.id === "pi" ? (
+                <PiProviderCard
+                  key={p.id}
+                  provider={p}
+                  detected={piDetect}
+                  error={piError}
+                  refreshStatus={piRefreshStatus}
+                  busy={piBusy}
+                  executablePath={piExecutablePath}
+                  models={visiblePiModels}
+                  selectedModelId={piConfiguredModelId}
+                  configured={configuredIds.has(p.id)}
+                  onDetect={(path) => refreshPi(true, path)}
+                  onSetExecutablePath={setPiExecutablePath}
+                  onSetModelId={setPiModelId}
+                  onRemove={() => removeProvider(p.id)}
+                />
+              ) : p.id === "openrouter" ? (
                 <LocalProviderCard
                   key={p.id}
                   provider={p}
@@ -430,14 +550,209 @@ type LocalConfig = {
   noBaseURL?: boolean;
 };
 
+function PiProviderCard({
+  provider,
+  detected,
+  error,
+  refreshStatus,
+  busy,
+  executablePath,
+  models,
+  selectedModelId,
+  configured,
+  onDetect,
+  onSetExecutablePath,
+  onSetModelId,
+  onRemove,
+}: {
+  provider: ProviderInfo;
+  detected: PiDetectResult | null;
+  error: string | null;
+  refreshStatus: string | null;
+  busy: boolean;
+  executablePath: string;
+  models: readonly PiModelRecord[];
+  selectedModelId: string;
+  configured: boolean;
+  onDetect: (executablePath?: string) => void;
+  onSetExecutablePath: (v: string) => Promise<void>;
+  onSetModelId: (v: string) => Promise<void>;
+  onRemove: () => void;
+}) {
+  const [pathDraft, setPathDraft] = useState(executablePath);
+  const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
+  useEffect(() => setPathDraft(executablePath), [executablePath]);
+
+  const selected = models.find(
+    (m) => piModelId(m.provider, m.model) === selectedModelId,
+  );
+  const selectedInfo = selected
+    ? getPiModelInfo(selectedModelId, models)
+    : null;
+  const savePath = async (): Promise<string> => {
+    const v = pathDraft.trim();
+    if (v !== executablePath) await onSetExecutablePath(v);
+    return v;
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
+      <div className="flex items-center gap-2">
+        <ProviderIcon provider={provider.id} size={15} />
+        <span className="text-[12.5px] font-medium">{provider.label}</span>
+        {configured ? (
+          <Badge
+            variant="outline"
+            className="ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal text-muted-foreground"
+          >
+            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={9} strokeWidth={2} />
+            Connected
+          </Badge>
+        ) : null}
+        {detected?.version ? (
+          <span className="truncate text-[10.5px] text-muted-foreground">
+            {detected.version}
+          </span>
+        ) : null}
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={onRemove}
+          title="Remove provider"
+          className="ml-auto size-7 text-muted-foreground hover:text-destructive"
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+        </Button>
+      </div>
+
+      <span className="text-[10.5px] leading-relaxed text-muted-foreground">
+        Use Pi's local coding-agent harness, auth, subscriptions, tools, and
+        session history from Terax chat.
+      </span>
+
+      <FieldRow label="Executable">
+        <div className="flex flex-1 gap-1.5">
+          <Input
+            value={pathDraft}
+            onChange={(e) => setPathDraft(e.target.value)}
+            onBlur={() => void savePath()}
+            placeholder="pi from PATH"
+            spellCheck={false}
+            className="h-8 flex-1 font-mono text-[11.5px]"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              void savePath().then((path) => onDetect(path));
+            }}
+            disabled={busy}
+            className="h-8 gap-1.5 px-3 text-[11px]"
+          >
+            <HugeiconsIcon icon={RefreshIcon} size={12} strokeWidth={1.75} />
+            Refresh
+          </Button>
+        </div>
+      </FieldRow>
+
+      {detected?.path ? (
+        <p className="truncate pl-19 font-mono text-[10.5px] text-muted-foreground">
+          {detected.path}
+        </p>
+      ) : null}
+
+      {detected?.installed === false ? (
+        <p className="pl-19 text-[10.5px] text-amber-600 dark:text-amber-400">
+          {detected.error ?? "Pi was not found. Install Pi or set the executable path."}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="pl-19 text-[10.5px] text-amber-600 dark:text-amber-400">
+          {error}
+        </p>
+      ) : null}
+      {!error && refreshStatus ? (
+        <p className="pl-19 text-[10.5px] text-muted-foreground">
+          {refreshStatus}
+        </p>
+      ) : null}
+
+      <FieldRow label="Model">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              disabled={!detected?.installed || models.length === 0}
+              className="h-8 flex-1 justify-between gap-2 px-2.5 text-[11.5px]"
+            >
+              <span className="flex min-w-0 items-center gap-2 truncate">
+                <ProviderIcon provider="pi" size={12} />
+                <span className="truncate">
+                  {selectedInfo?.label ??
+                    (busy ? "Refreshing models..." : "Click Refresh to load models")}
+                </span>
+                {selectedInfo ? (
+                  <span className="text-muted-foreground">
+                    · {selectedInfo.hint}
+                  </span>
+                ) : null}
+              </span>
+              <HugeiconsIcon
+                icon={ArrowDown01Icon}
+                size={11}
+                strokeWidth={2}
+                className="opacity-70"
+              />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            collisionPadding={12}
+            className="max-h-72 min-w-80 overflow-y-auto"
+          >
+            {models.map((model) => {
+              const id = piModelId(model.provider, model.model);
+              const info = getPiModelInfo(id, models);
+              return (
+                <DropdownMenuItem
+                  key={id}
+                  onSelect={() => {
+                    void onSetModelId(id);
+                    setSelectedModelId(id);
+                  }}
+                  className={cn(
+                    "flex items-start gap-2 text-[11.5px]",
+                    id === selectedModelId && "bg-accent/50",
+                  )}
+                >
+                  <span className="flex flex-1 flex-col">
+                    <span>{info.label}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {info.hint}
+                      {model.thinking ? " · reasoning" : ""}
+                      {model.images ? " · images" : ""}
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </FieldRow>
+    </div>
+  );
+}
+
 function AddProviderMenu({
   providers,
   onAdd,
   onAddCompat,
+  disabledIds,
 }: {
   providers: readonly ProviderInfo[];
   onAdd: (id: ProviderId) => void;
   onAddCompat: () => void;
+  disabledIds: ReadonlySet<ProviderId>;
 }) {
   const cloud = providers.filter((p) => !isLocalProvider(p.id));
   const local = providers.filter((p) => isLocalProvider(p.id) && p.id !== "openai-compatible");
@@ -469,7 +784,12 @@ function AddProviderMenu({
           Local & custom
         </DropdownMenuLabel>
         {local.map((p) => (
-          <ProviderMenuItem key={p.id} provider={p} onAdd={onAdd} />
+          <ProviderMenuItem
+            key={p.id}
+            provider={p}
+            disabled={disabledIds.has(p.id)}
+            onAdd={onAdd}
+          />
         ))}
         <DropdownMenuItem
           onSelect={() => onAddCompat()}
@@ -485,18 +805,26 @@ function AddProviderMenu({
 
 function ProviderMenuItem({
   provider,
+  disabled,
   onAdd,
 }: {
   provider: ProviderInfo;
+  disabled?: boolean;
   onAdd: (id: ProviderId) => void;
 }) {
   return (
     <DropdownMenuItem
+      disabled={disabled}
       onSelect={() => onAdd(provider.id)}
       className="flex items-center gap-2 text-[12px]"
     >
       <ProviderIcon provider={provider.id} size={13} />
       <span>{provider.label}</span>
+      {disabled ? (
+        <span className="ml-auto text-[10px] text-muted-foreground">
+          not found
+        </span>
+      ) : null}
     </DropdownMenuItem>
   );
 }


### PR DESCRIPTION
This PR adds Pi as a local coding-agent provider in Terax.

- Adds a keyless Pi provider option in Settings -> Models.
- Detects Pi from the configured executable path and loads available Pi models.
- Runs Pi through its local JSON event stream using Terax chat as the UI harness.
- Preserves Pi session history with stable `terax-*` session IDs per chat.
- Streams assistant text into Terax instead of waiting for a final response block.
- Renders Pi reasoning and tool execution events as native Terax message parts.
- Keeps tool/text ordering sequential, so interleaved reasoning, tools, and output appear in the order Pi emits them.
- Handles Pi process cancellation and non-zero exits through the existing chat error path.

Checks:
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm exec vitest run src/modules/ai/config.test.ts`
- `cargo test modules::pi`
- `git diff --check`