### PR TITLE
feat(source-control): add support for multiple repositories in workspace

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             fs::grep::fs_grep,
             fs::grep::fs_glob,
             git::commands::git_resolve_repo,
+            git::commands::git_discover_repos,
             git::commands::git_panel_snapshot,
             git::commands::git_status,
             git::commands::git_diff,

--- a/src-tauri/src/modules/git/commands.rs
+++ b/src-tauri/src/modules/git/commands.rs
@@ -34,6 +34,20 @@ pub async fn git_resolve_repo(
 }
 
 #[tauri::command]
+pub async fn git_discover_repos(
+    root: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<Vec<GitRepoInfo>, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::discover_repos(r, &root, &workspace).map_err(Into::into)
+    })
+    .await
+}
+
+
+#[tauri::command]
 pub async fn git_panel_snapshot(
     cwd: String,
     workspace: Option<WorkspaceEnv>,

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -30,6 +30,62 @@ pub fn resolve_repo(
     resolve_repo_in_authorized(registry, &cwd)
 }
 
+pub fn discover_repos(
+    registry: &WorkspaceRegistry,
+    root: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<Vec<GitRepoInfo>> {
+    let root_dir = canonical_dir(registry, root, workspace)?;
+    if !registry.is_authorized(&root_dir.local_path) {
+        return Err(GitError::PathOutsideWorkspace(root_dir.local_path));
+    }
+    ensure_git_available(&root_dir.workspace)?;
+
+    let mut repos = Vec::new();
+    let mut to_visit = vec![(root_dir.local_path.clone(), 0)];
+
+    while let Some((dir, depth)) = to_visit.pop() {
+        let git_entry = dir.join(".git");
+        if git_entry.exists() {
+            let git_path_str = super::utils::display_path(&dir);
+            if let Ok(resolved) = canonical_dir(registry, &git_path_str, &root_dir.workspace) {
+                if let Ok(Some(repo_info)) = resolve_repo_in_authorized(registry, &resolved) {
+                    if !repos.iter().any(|r: &GitRepoInfo| r.repo_root == repo_info.repo_root) {
+                        repos.push(repo_info);
+                    }
+                }
+            }
+        }
+
+        if depth < 3 {
+            if let Ok(entries) = std::fs::read_dir(&dir) {
+                for entry in entries.filter_map(std::result::Result::ok) {
+                    if let Ok(ft) = entry.file_type() {
+                        if ft.is_dir() && !ft.is_symlink() {
+                            let path = entry.path();
+                            let name = entry.file_name();
+                            let name_str = name.to_string_lossy();
+                            if name_str != ".git"
+                                && name_str != "node_modules"
+                                && name_str != "target"
+                                && name_str != "dist"
+                                && name_str != "build"
+                                && !name_str.starts_with('.')
+                            {
+                                to_visit.push((path, depth + 1));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    repos.sort_by(|a, b| a.repo_root.cmp(&b.repo_root));
+    Ok(repos)
+}
+
+
 fn resolve_repo_in_authorized(
     registry: &WorkspaceRegistry,
     cwd: &ResolvedGitDirectory,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/modules/ai";
 import { AiComposerProvider } from "@/modules/ai/lib/composer";
 import { redactSensitive } from "@/modules/ai/lib/redact";
-import { native } from "@/modules/ai/lib/native";
+import { native, type GitRepoInfo } from "@/modules/ai/lib/native";
 import { useAgentsStore } from "@/modules/ai/store/agentsStore";
 import { useSnippetsStore } from "@/modules/ai/store/snippetsStore";
 import {
@@ -228,6 +228,8 @@ export default function App() {
     useState<EditorPaneHandle | null>(null);
   const [gitHistoryHandle, setGitHistoryHandle] =
     useState<GitHistorySearchHandle | null>(null);
+  const [discoveredRepos, setDiscoveredRepos] = useState<GitRepoInfo[]>([]);
+  const [selectedRepoRoot, setSelectedRepoRoot] = useState<string | null>(null);
   const { zoomIn, zoomOut, zoomReset } = useZoom();
   const explorerRef = useRef<FileExplorerHandle>(null);
   const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
@@ -968,12 +970,59 @@ export default function App() {
   );
   const sourceControlActive =
     hasOpenGitTab || sidebarView === "source-control";
+  const refreshRepos = useCallback(() => {
+    const root = explorerRoot ?? home;
+    if (!root) {
+      setDiscoveredRepos([]);
+      return;
+    }
+    native.gitDiscoverRepos(root)
+      .then((repos) => {
+        setDiscoveredRepos(repos);
+      })
+      .catch(() => {
+        setDiscoveredRepos([]);
+      });
+  }, [explorerRoot, home]);
+
+  useEffect(() => {
+    refreshRepos();
+  }, [refreshRepos]);
+
+  useEffect(() => {
+    if (sidebarView === "source-control") {
+      refreshRepos();
+    }
+  }, [sidebarView, refreshRepos]);
+
+  const contextRepo = useMemo(() => {
+    if (!sourceControlContextPath || discoveredRepos.length === 0) return null;
+    return (
+      discoveredRepos.find(
+        (r) =>
+          sourceControlContextPath === r.repoRoot ||
+          sourceControlContextPath.startsWith(`${r.repoRoot}/`),
+      ) ?? null
+    );
+  }, [sourceControlContextPath, discoveredRepos]);
+
+  const activeRepoRoot = useMemo(() => {
+    if (contextRepo) return contextRepo.repoRoot;
+    if (selectedRepoRoot && discoveredRepos.some((r) => r.repoRoot === selectedRepoRoot)) {
+      return selectedRepoRoot;
+    }
+    if (discoveredRepos.length > 0) {
+      return discoveredRepos[0].repoRoot;
+    }
+    return null;
+  }, [contextRepo, selectedRepoRoot, discoveredRepos]);
+
   // Stable per-session path so switching tabs / cd-ing in a shell does NOT
   // re-fire git IPC for the badge. The active panel resolves the current
   // context path on its own when the user actually opens git.
   const badgeContextPath = workspaceFallbackPath;
   const sourceControlPath = sourceControlActive
-    ? sourceControlContextPath
+    ? (activeRepoRoot ?? sourceControlContextPath)
     : badgeContextPath;
   const sourceControl = useSourceControl(sourceControlPath, true);
 
@@ -1505,6 +1554,9 @@ export default function App() {
                         sourceControl={sourceControl}
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}
+                        discoveredRepos={discoveredRepos}
+                        activeRepoRoot={activeRepoRoot}
+                        onSelectRepo={setSelectedRepoRoot}
                       />
                     )}
                   </div>

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -250,6 +250,11 @@ export const native = {
       cwd,
       workspace: currentWorkspaceEnv(),
     }),
+  gitDiscoverRepos: (root: string) =>
+    invoke<GitRepoInfo[]>("git_discover_repos", {
+      root,
+      workspace: currentWorkspaceEnv(),
+    }),
   gitPanelSnapshot: (cwd: string) =>
     invoke<GitPanelSnapshot>("git_panel_snapshot", {
       cwd,

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -53,6 +53,14 @@ import {
   type CheckState,
   type SourceControlFileEntry,
 } from "./useSourceControlPanel";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu";
+import type { GitRepoInfo } from "@/modules/ai/lib/native";
 
 type Props = {
   open: boolean;
@@ -65,7 +73,11 @@ type Props = {
     originalPath: string | null;
     title?: string;
   }) => void;
+  discoveredRepos?: GitRepoInfo[];
+  activeRepoRoot?: string | null;
+  onSelectRepo?: (repoRoot: string) => void;
 };
+
 
 const SOURCE_CONTROL_TOOLTIP_CLASS =
   "border border-border/70 bg-zinc-950 text-zinc-100 shadow-lg shadow-black/30 dark:border-border/60 dark:bg-zinc-950 dark:text-zinc-100";
@@ -131,6 +143,9 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   sourceControl,
   onOpenGitGraph,
   onOpenDiff,
+  discoveredRepos = [],
+  activeRepoRoot = null,
+  onSelectRepo,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
   const refreshAnimationRef = useRef<number | null>(null);
@@ -401,15 +416,59 @@ export const SourceControlPanel = memo(function SourceControlPanel({
       <aside className="flex h-full min-w-0 flex-col bg-card/80 backdrop-blur [contain:layout_style]">
         <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border/50 px-3 pb-2.5 pt-3">
           <div className="flex min-w-0 items-center gap-1.5">
-            <div className="inline-flex min-w-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10">
-              <HugeiconsIcon
-                icon={FolderGitTwoIcon}
-                size={12}
-                strokeWidth={1.9}
-                className="shrink-0 text-muted-foreground"
-              />
-              <span className="max-w-[140px] truncate">{repoLabel}</span>
-            </div>
+            {discoveredRepos && discoveredRepos.length > 1 ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button className="inline-flex min-w-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10 cursor-pointer border-0 outline-none">
+                    <HugeiconsIcon
+                      icon={FolderGitTwoIcon}
+                      size={12}
+                      strokeWidth={1.9}
+                      className="shrink-0 text-muted-foreground"
+                    />
+                    <span className="max-w-[120px] truncate">{repoLabel}</span>
+                    <span className="text-[9px] text-muted-foreground/80 font-normal">▼</span>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="min-w-64 max-w-sm p-1 bg-popover text-popover-foreground border border-border shadow-md rounded-md z-50">
+                  <DropdownMenuLabel className="px-2 py-1 text-[10px] tracking-wide text-muted-foreground uppercase">
+                    Repositories
+                  </DropdownMenuLabel>
+                  {discoveredRepos.map((r) => {
+                    const isSelected = r.repoRoot === activeRepoRoot;
+                    return (
+                      <DropdownMenuItem
+                        key={r.repoRoot}
+                        onClick={() => onSelectRepo?.(r.repoRoot)}
+                        className={cn(
+                          "flex flex-col items-start px-2 py-1.5 text-[11px] rounded-sm cursor-pointer transition-colors focus:bg-accent focus:text-accent-foreground",
+                          isSelected && "bg-accent/50 text-accent-foreground font-semibold"
+                        )}
+                      >
+                        <div className="flex w-full items-center justify-between gap-2">
+                          <span className="truncate font-medium">{basename(r.repoRoot)}</span>
+                          <span className="text-[10px] text-muted-foreground/80">{r.branch}</span>
+                        </div>
+                        <span className="w-full truncate text-[9.5px] text-muted-foreground/60 mt-0.5">
+                          {r.repoRoot}
+                        </span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <div className="inline-flex min-w-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10">
+                <HugeiconsIcon
+                  icon={FolderGitTwoIcon}
+                  size={12}
+                  strokeWidth={1.9}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <span className="max-w-[140px] truncate">{repoLabel}</span>
+              </div>
+            )}
+
             {scm.status && (scm.status.ahead > 0 || scm.status.behind > 0) ? (
               <div className="flex shrink-0 items-center gap-0.5 text-[10px] font-semibold tabular-nums leading-none text-muted-foreground">
                 {scm.status.ahead > 0 ? (


### PR DESCRIPTION
## What
This PR adds support for detecting, listing, and switching between multiple Git repositories within the opened workspace. When multiple repositories are discovered, a dropdown selector is rendered in the Source Control panel header, allowing users to switch the active repository view.

## Why
Currently, Terax-AI only resolves the Git repository of the active folder/context. If the active workspace root is not a Git repository itself (e.g. a general `projects` or `Developer` directory), the Source Control panel displays "No repository". This limits the usability of multi-project workspaces, unlike VS Code which detects and lets users switch between nested Git repositories.

## How
- **Backend (Rust/Tauri)**:
  - Added `discover_repos` in `src-tauri/src/modules/git/operations.rs` to recursively search for `.git` folders in the workspace up to depth 3.
  - Performance optimizations: Skip dotfiles and directories starting with `.`, as well as heavy development directories (`node_modules`, `target`, `dist`, `build`).
  - Security: Prevent following symlinks during DFS using `entry.file_type()` check to avoid infinite loops and traversing outside the authorized workspace.
  - Registered the new Tauri command `git_discover_repos` in `commands.rs` and `lib.rs`.
- **Frontend (React)**:
  - Added API wrapper in `native.ts`.
  - Integrated `discoveredRepos` and `selectedRepoRoot` states in `App.tsx`.
  - Implemented **active repository tracking**: if the current file/tab path belongs to one of the discovered repositories, it is automatically focused.
  - Updated `SourceControlPanel.tsx` to render a Radix UI dropdown selector showing the folder name, active branch, and full path of each repository when `discoveredRepos.length > 1`.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS

### Manual Test Steps Executed:
1. Opened a parent folder containing multiple repositories.
2. Verified that the Source Control panel correctly displays the repository dropdown selector.
3. Verified that clicking on a repository in the dropdown switches the active view to that repo's changed files.
4. Verified that focusing on an editor tab with a file in a specific repository automatically switches the active repository in the Source Control panel.
5. Checked that symlinks and heavy folders (`node_modules`) are skipped during DFS repository discovery to prevent performance hits.

## Notes for reviewer
- The recursive search has a strict depth limit of 3. We skip directories starting with `.` and common dependency folders to ensure discovery is extremely fast and doesn't impact startup performance on large workspaces.
- Symlinks are explicitly skipped to enforce safety and authorization boundaries.
