### PR TITLE
chore: adopt pnpm 11, add release-age cooldown and grouped dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    groups:
+      npm-dev:
+        dependency-type: development
+      npm-prod-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: "/src-tauri"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    groups:
+      cargo:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:
@@ -26,6 +24,10 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Audit (advisory)
+        run: pnpm audit --prod --audit-level high
+        continue-on-error: true
 
       - name: Type-check
         run: pnpm exec tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "0.7.3",
   "license": "Apache-2.0",
   "type": "module",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 4320
+minimumReleaseAgeStrict: true
 allowBuilds:
   esbuild: true
   msw: true


### PR DESCRIPTION
## What
- Adopt pnpm 11 via `packageManager` (corepack, hash-locked) + `engines.node >=22`
- `minimumReleaseAge: 4320` (3 days) + strict in pnpm-workspace.yaml: cooldown against compromised just-published packages (incl. transitive)
- Advisory `pnpm audit` step in CI (non-blocking)
- Grouped, low-noise dependabot (npm / cargo / github-actions), weekly, 3-day cooldown, no automerge

## Why
The lockfile already gives reproducible installs, so this is supply-chain hardening (cooldown, pinned toolchain) rather than version churn. pnpm 11 enables these defaults and the repo config already matched it (allowBuilds map, no .npmrc).

## Verify
- `pnpm install` clean, lockfile unchanged
- `tsc --noEmit`, `pnpm test` (91), `pnpm build` all green under pnpm 11