### PR TITLE
docs(linux): add X11 GPU compositing workaround for high CPU / sluggish input

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Latest installers are on the [Releases](https://github.com/crynta/terax-ai/relea
 
 - **Arch / AUR:** `yay -S terax-bin` (or `paru`, etc.). Tracks the latest release.
 - **AppImage:** needs FUSE. Without it: `./Terax_*.AppImage --appimage-extract-and-run`. On Wayland with rendering glitches, try `WEBKIT_DISABLE_DMABUF_RENDERER=1`. Otherwise the `.deb` / `.rpm` packages link against the system GTK stack and tend to be smoother.
+- **X11 with high idle CPU or sluggish input:** WebKit's GPU compositing can spin on some drivers (NVIDIA proprietary is the common case). Try setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_COMPOSITING_MODE=1`.
 
 ## Configure AI
 


### PR DESCRIPTION
## What
Adds one bullet to the Linux notes for X11 + NVIDIA proprietary driver users:
set WEBKIT_DISABLE_DMABUF_RENDERER=1 and WEBKIT_DISABLE_COMPOSITING_MODE=1.

## Why
Issues #110 and #318 keep resurfacing after the v0.6.1 fix. Both flags together
bring idle WebKitWebProcess CPU down ~40% on X11. The README currently only
documents the Wayland case, leaving X11 users without guidance.

## Testing
Verified on Debian 13, kernel 6.12.88, NVIDIA RTX 3050 proprietary, X11,
WebKit2GTK 2.52.3, Terax 0.7.3. WebKitWebProcess idle CPU drops from ~24%
to ~10-15% at idle with both flags set.