### PR TITLE
feat(terminal): bracketed-paste dropped paths, quote only when needed

### DIFF
--- a/src/modules/terminal/lib/quoteShellPath.test.ts
+++ b/src/modules/terminal/lib/quoteShellPath.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/platform", () => ({ IS_WINDOWS: false }));
+
+import { formatDroppedPaths, quoteShellPath } from "./quoteShellPath";
+
+describe("quoteShellPath", () => {
+  it("passes a clean path through unquoted so apps can resolve it", () => {
+    expect(quoteShellPath("/Users/me/img.png")).toBe("/Users/me/img.png");
+  });
+
+  it("quotes a path containing spaces", () => {
+    expect(quoteShellPath("/Users/me/My Photos/a.png")).toBe(
+      "'/Users/me/My Photos/a.png'",
+    );
+  });
+
+  it("escapes single quotes inside the path", () => {
+    expect(quoteShellPath("/tmp/it's a file")).toBe(`'/tmp/it'\\''s a file'`);
+  });
+
+  it("leaves a clean Windows drive path unquoted", () => {
+    expect(quoteShellPath("C:\\Users\\me\\img.png")).toBe(
+      "C:\\Users\\me\\img.png",
+    );
+  });
+
+  it("quotes a path with shell metacharacters", () => {
+    expect(quoteShellPath("/tmp/$(whoami).png")).toBe("'/tmp/$(whoami).png'");
+  });
+
+  it("joins multiple paths with a trailing space", () => {
+    expect(formatDroppedPaths(["/a/b.png", "/c/d.png"])).toBe(
+      "/a/b.png /c/d.png ",
+    );
+  });
+});

--- a/src/modules/terminal/lib/quoteShellPath.ts
+++ b/src/modules/terminal/lib/quoteShellPath.ts
@@ -1,13 +1,15 @@
 import { IS_WINDOWS } from "@/lib/platform";
 
-/** Shell-quote an absolute path for pasting into a live terminal prompt. */
+// Quote only when needed, so a clean path stays verbatim for bracketed paste
+// (Claude resolves an image path to "[Image #N]"); spaced/special paths quote.
+const SAFE_PATH = /^[A-Za-z0-9_@%+=:,./\\-]+$/;
+
 export function quoteShellPath(p: string): string {
+  if (SAFE_PATH.test(p)) return p;
   if (IS_WINDOWS) return `"${p.replace(/"/g, '""')}"`;
   return `'${p.replace(/'/g, `'\\''`)}'`;
 }
 
-/** Joined, shell-quoted paths with a trailing space so the cursor lands
- * ready for the next argument. */
 export function formatDroppedPaths(paths: string[]): string {
   return `${paths.map(quoteShellPath).join(" ")} `;
 }

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -73,6 +73,15 @@ export function poolSize(): number {
   return slots.length;
 }
 
+// Bracketed paste via xterm, so an app that enabled it (Claude Code) treats a
+// dropped path as a real paste while a plain shell gets the literal text.
+export function pasteIntoLeaf(leafId: number, text: string): boolean {
+  const slot = slots.find((s) => s.currentLeafId === leafId);
+  if (!slot) return false;
+  slot.term.paste(text);
+  return true;
+}
+
 function getRecycler(): HTMLDivElement {
   if (recyclerEl && recyclerEl.isConnected) return recyclerEl;
   const el = document.createElement("div");

--- a/src/modules/terminal/lib/useTerminalFileDrop.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.ts
@@ -1,7 +1,7 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect } from "react";
 import { formatDroppedPaths } from "./quoteShellPath";
-import { writeToLeafPty } from "./useTerminalSession";
+import { pasteIntoLeaf } from "./rendererPool";
 
 /** Wires native OS file drops into the terminal pane under the cursor.
  * Drops outside any terminal leaf (editor, file explorer, AI input bar,
@@ -28,7 +28,7 @@ export function useTerminalFileDrop(): void {
         const leafId = Number(leafEl.dataset.paneLeaf);
         if (!Number.isFinite(leafId)) return;
 
-        writeToLeafPty(leafId, formatDroppedPaths(paths));
+        pasteIntoLeaf(leafId, formatDroppedPaths(paths));
       })
       .then((fn) => {
         if (disposed) fn();

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -381,13 +381,6 @@ export function disposeSession(leafId: number): void {
   }
 }
 
-export function writeToLeafPty(leafId: number, data: string): boolean {
-  const s = sessions.get(leafId);
-  if (!s || s.disposed || s.shellExited || !s.pty) return false;
-  s.pty.write(data);
-  return true;
-}
-
 type Options = {
   leafId: number;
   container: React.RefObject<HTMLDivElement | null>;


### PR DESCRIPTION
Builds on #491 (dropped file paths into the terminal). Routes the drop through xterm bracketed paste so an app that enabled it (Claude Code) resolves a clean image path to `[Image #N]`, and quotes only paths with spaces or shell metacharacters so a plain shell still gets one intact argument. Adds a test for the quoting logic; removes the now-unused raw `writeToLeafPty`.

Bracketed-paste idea from #576, credited as co-author.

## Verify
- tsc, pnpm test (97, incl new quoteShellPath suite), pnpm build green