### PR TITLE
chore: limit dependabot dev-dep group to minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     groups:
       npm-dev:
         dependency-type: development
+        update-types:
+          - minor
+          - patch
       npm-prod-minor-patch:
         dependency-type: production
         update-types:


### PR DESCRIPTION
Keeps a breaking major from blocking routine dev-dep bumps; majors now arrive as individual PRs.