### PR TITLE
feat(terminal): confirm before closing a tab with a running process

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,7 @@ windows-sys = { version = "0.61", features = [
 	"Win32_Security",
 	"Win32_System_JobObjects",
 	"Win32_System_Threading",
+	"Win32_System_Diagnostics_ToolHelp",
 ] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,6 +174,7 @@ pub fn run() {
             pty::pty_resize,
             pty::pty_close,
             pty::pty_close_all,
+            pty::pty_has_foreground_process,
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -159,6 +159,44 @@ pub fn pty_close(state: tauri::State<PtyState>, id: u32) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+pub fn pty_has_foreground_process(state: tauri::State<PtyState>, id: u32) -> Result<bool, String> {
+    let sessions = state.sessions.read().unwrap();
+    let session = sessions.get(&id).ok_or_else(|| {
+        log::warn!("pty_has_foreground_process: unknown session id={id}");
+        "no session".to_string()
+    })?;
+    let shell_pid = session.shell_pid;
+    log::debug!("pty_has_foreground_process id={id} shell_pid={shell_pid}");
+    if shell_pid == 0 {
+        return Ok(false);
+    }
+
+    #[cfg(unix)]
+    {
+        // `pgrep -P <ppid>` exits 0 when at least one child of shell_pid
+        // exists, 1 when none — reliable on macOS and Linux without needing
+        // platform-specific syscall constants.
+        let result = std::process::Command::new("pgrep")
+            .args(["-P", &shell_pid.to_string()])
+            .output();
+        match result {
+            Ok(output) => {
+                let has_children = output.status.success();
+                log::debug!("pty_has_foreground_process id={id}: pgrep exit={}, has_children={has_children}", output.status);
+                return Ok(has_children);
+            }
+            Err(e) => {
+                log::warn!("pty_has_foreground_process id={id}: pgrep failed: {e}");
+                return Ok(false);
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    Ok(false)
+}
+
 // A fresh webview load orphans the previous frontend's sessions in this still
 // running process; reap them on boot before any new tab spawns.
 #[tauri::command]

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -167,34 +167,52 @@ pub fn pty_has_foreground_process(state: tauri::State<PtyState>, id: u32) -> Res
         "no session".to_string()
     })?;
     let shell_pid = session.shell_pid;
-    log::debug!("pty_has_foreground_process id={id} shell_pid={shell_pid}");
     if shell_pid == 0 {
         return Ok(false);
     }
+    Ok(shell_has_children(shell_pid))
+}
 
-    #[cfg(unix)]
-    {
-        // `pgrep -P <ppid>` exits 0 when at least one child of shell_pid
-        // exists, 1 when none — reliable on macOS and Linux without needing
-        // platform-specific syscall constants.
-        let result = std::process::Command::new("pgrep")
-            .args(["-P", &shell_pid.to_string()])
-            .output();
-        match result {
-            Ok(output) => {
-                let has_children = output.status.success();
-                log::debug!("pty_has_foreground_process id={id}: pgrep exit={}, has_children={has_children}", output.status);
-                return Ok(has_children);
-            }
-            Err(e) => {
-                log::warn!("pty_has_foreground_process id={id}: pgrep failed: {e}");
-                return Ok(false);
+// pgrep -P exits 0 when shell_pid has at least one child, 1 when none.
+#[cfg(unix)]
+fn shell_has_children(shell_pid: u32) -> bool {
+    std::process::Command::new("pgrep")
+        .args(["-P", &shell_pid.to_string()])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn shell_has_children(shell_pid: u32) -> bool {
+    use std::mem::{size_of, zeroed};
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32,
+        TH32CS_SNAPPROCESS,
+    };
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return false;
+        }
+        let mut entry: PROCESSENTRY32 = zeroed();
+        entry.dwSize = size_of::<PROCESSENTRY32>() as u32;
+        let mut found = false;
+        if Process32First(snapshot, &mut entry) != 0 {
+            loop {
+                if entry.th32ParentProcessID == shell_pid {
+                    found = true;
+                    break;
+                }
+                if Process32Next(snapshot, &mut entry) == 0 {
+                    break;
+                }
             }
         }
+        CloseHandle(snapshot);
+        found
     }
-
-    #[cfg(not(unix))]
-    Ok(false)
 }
 
 // A fresh webview load orphans the previous frontend's sessions in this still

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -44,6 +44,8 @@ pub struct Session {
     //      is dead and conhost has nothing left to drain.
     #[cfg(windows)]
     _job: Option<super::job::PtyJob>,
+    /// PID of the shell process. 0 means unknown; callers must skip checks when 0.
+    pub shell_pid: u32,
     pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
     pub master: Mutex<Box<dyn MasterPty + Send>>,
@@ -130,6 +132,8 @@ pub fn spawn(
     ));
     guard.disarm();
 
+    let shell_pid = child.process_id().unwrap_or(0);
+
     #[cfg(windows)]
     let job = match child.process_id() {
         Some(pid) => match super::job::PtyJob::create_for(pid) {
@@ -145,6 +149,7 @@ pub fn spawn(
     let session = Arc::new(Session {
         #[cfg(windows)]
         _job: job,
+        shell_pid,
         killer: Mutex::new(killer),
         writer: writer.clone(),
         master: Mutex::new(pair.master),
@@ -318,6 +323,7 @@ mod tests {
             Arc::new(Mutex::new(pair.master.take_writer().expect("writer")));
 
         let session = Arc::new(Session {
+            shell_pid: child.process_id().unwrap_or(0),
             killer: Mutex::new(killer),
             writer,
             master: Mutex::new(pair.master),
@@ -365,6 +371,7 @@ mod tests {
             Arc::new(Mutex::new(pair.master.take_writer().expect("writer")));
 
         let session = Arc::new(Session {
+            shell_pid: 0,
             killer: Mutex::new(killer),
             writer,
             master: Mutex::new(pair.master),

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -85,6 +85,7 @@ import {
   disposeSession,
   findLeafCwd,
   hasLeaf,
+  leafHasForegroundProcess,
   leafIds,
   respawnSession,
   TerminalStack,
@@ -325,6 +326,7 @@ export default function App() {
 
   const [home, setHome] = useState<string | null>(null);
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
+  const [pendingTerminalCloseTab, setPendingTerminalCloseTab] = useState<number | null>(null);
   const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
   const [launchCwd, setLaunchCwd] = useState<string | null>(null);
@@ -685,11 +687,19 @@ export default function App() {
   }, [tabs]);
 
   const handleClose = useCallback(
-    (id: number) => {
+    async (id: number) => {
       const t = tabs.find((x) => x.id === id);
       if (t?.kind === "editor" && t.dirty) {
         setPendingCloseTab(id);
         return;
+      }
+      if (t?.kind === "terminal") {
+        const leaves = leafIds(t.paneTree);
+        const checks = await Promise.all(leaves.map(leafHasForegroundProcess));
+        if (checks.some(Boolean)) {
+          setPendingTerminalCloseTab(id);
+          return;
+        }
       }
       disposeTab(id);
     },
@@ -1042,7 +1052,7 @@ export default function App() {
       closeActivePane(activeId);
       return;
     }
-    handleClose(activeId);
+    void handleClose(activeId);
   }, [activeId, closeActivePane, handleClose]);
 
   const shortcutHandlers = useMemo<ShortcutHandlers>(
@@ -1627,6 +1637,36 @@ export default function App() {
                   Cancel
                 </AlertDialogCancel>
                 <AlertDialogAction onClick={confirmClose}>
+                  Close Anyway
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <AlertDialog
+            open={pendingTerminalCloseTab !== null}
+            onOpenChange={(open) => !open && setPendingTerminalCloseTab(null)}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Close Terminal?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  A process is running. Closing this tab will terminate it.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel
+                  onClick={() => setPendingTerminalCloseTab(null)}
+                >
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => {
+                    if (pendingTerminalCloseTab !== null)
+                      disposeTab(pendingTerminalCloseTab);
+                    setPendingTerminalCloseTab(null);
+                  }}
+                >
                   Close Anyway
                 </AlertDialogAction>
               </AlertDialogFooter>

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -3,6 +3,7 @@ export { TerminalStack } from "./TerminalStack";
 export {
   clearFocusedTerminal,
   disposeSession,
+  leafHasForegroundProcess,
   leafIdForPty,
   respawnSession,
   whenSessionReady,

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { ensureMonoFontsLoaded } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
@@ -359,6 +360,18 @@ export async function respawnSession(
   }
   s.pty = pty;
   if (s.cols > 0 && s.rows > 0) pty.resize(s.cols, s.rows);
+}
+
+export async function leafHasForegroundProcess(leafId: number): Promise<boolean> {
+  const s = sessions.get(leafId);
+  if (!s?.pty || s.shellExited) return false;
+  try {
+    const result = await invoke<boolean>("pty_has_foreground_process", { id: s.pty.id });
+    return result;
+  } catch (e) {
+    console.error("[terax] pty_has_foreground_process failed for leaf", leafId, e);
+    return false;
+  }
 }
 
 export function disposeSession(leafId: number): void {


### PR DESCRIPTION
Builds on #624 by @aditya-thummar-devx (their commit preserved). Adds the missing Windows path (Toolhelp child enumeration of the shell PID) so the prompt fires cross-platform, and simplifies the check into a cfg-split helper. Closes #624.

Verify: clippy clean, 177 Rust tests, tsc + build green; Windows FFI validated by CI.