### PR TITLE
feat(view): zen mode to hide header and status bar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1055,6 +1055,8 @@ export default function App() {
     void handleClose(activeId);
   }, [activeId, closeActivePane, handleClose]);
 
+  const [zenMode, setZenMode] = useState(false);
+
   const shortcutHandlers = useMemo<ShortcutHandlers>(
     () => ({
       "tab.new": openNewTab,
@@ -1083,6 +1085,7 @@ export default function App() {
       "view.zoomIn": zoomIn,
       "view.zoomOut": zoomOut,
       "view.zoomReset": zoomReset,
+      "view.zenMode": () => setZenMode((v) => !v),
       "editor.undo": () => editorRefs.current.get(activeId)?.undo(),
       "editor.redo": () => editorRefs.current.get(activeId)?.redo(),
     }),
@@ -1462,7 +1465,8 @@ export default function App() {
     <ThemeProvider>
       <TooltipProvider>
         <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
-          <Header
+          {!zenMode && (
+            <Header
             tabs={tabs}
             activeId={activeId}
             onSelect={setActiveId}
@@ -1485,7 +1489,8 @@ export default function App() {
             onOpenSettings={() => void openSettingsWindow()}
             searchTarget={searchTarget}
             searchRef={searchInlineRef}
-          />
+            />
+          )}
 
           <main className="zoom-content flex min-h-0 flex-1 flex-col">
             <ResizablePanelGroup
@@ -1566,7 +1571,8 @@ export default function App() {
             </ResizablePanelGroup>
           </main>
 
-          <StatusBar
+          {!zenMode && (
+            <StatusBar
             cwd={activeCwd}
             filePath={activeFilePath}
             home={home}
@@ -1577,7 +1583,8 @@ export default function App() {
             privateActive={
               activeTab?.kind === "terminal" && activeTab.private === true
             }
-          />
+            />
+          )}
 
           <AgentNotificationsBridge
             tabs={tabs}

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -25,6 +25,7 @@ export type ShortcutId =
   | "view.zoomIn"
   | "view.zoomOut"
   | "view.zoomReset"
+  | "view.zenMode"
   | "ai.toggle"
   | "ai.askSelection"
   | "shortcuts.open"
@@ -220,6 +221,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Reset zoom",
     group: "View",
     defaultBindings: [{ [MOD_PROP]: true, key: "0" }],
+  },
+  {
+    id: "view.zenMode",
+    label: "Toggle zen mode",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "z" }],
   },
   // Editor entries are display-only: CodeMirror's historyKeymap binds these
   // keys natively. We register them here so the shortcuts dialog can surface


### PR DESCRIPTION
Zen mode (Ctrl+Shift+Z) hides the header and status bar for distraction-free work; the AI chat stays available. Reimplemented from #553 by @Xenos112 (credited as co-author) since the original carried a full-file reformat that conflicts with current main. Closes #553.

Verify: tsc, 102 tests, build green.