### PR TITLE
feat(terminal): drop overlay and DPI-correct hit detection

### DIFF
--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/resizable";
 import type { SearchAddon } from "@xterm/addon-search";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
+import { useTerminalDropStore } from "./lib/dropStore";
 import type { PaneNode } from "./lib/panes";
 
 type LeafBundle = {
@@ -56,6 +57,7 @@ export function PaneTreeView({
           onCwd={(_id, cwd) => b.onCwd(cwd)}
           onExit={(_id, code) => b.onExit(code)}
         />
+        <DropOverlay leafId={node.id} />
       </div>
     );
   }
@@ -79,5 +81,15 @@ export function PaneTreeView({
         </Fragment>
       ))}
     </ResizablePanelGroup>
+  );
+}
+
+function DropOverlay({ leafId }: { leafId: number }) {
+  const active = useTerminalDropStore((s) => s.targetLeafId === leafId);
+  if (!active) return null;
+  return (
+    <div className="pointer-events-none absolute inset-2 grid place-items-center rounded-lg border border-primary/45 bg-background/70 text-xs font-medium text-foreground shadow-lg backdrop-blur-sm">
+      Drop file path here
+    </div>
   );
 }

--- a/src/modules/terminal/lib/dropStore.ts
+++ b/src/modules/terminal/lib/dropStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+
+type TerminalDropState = {
+  targetLeafId: number | null;
+  setTarget: (leafId: number | null) => void;
+};
+
+export const useTerminalDropStore = create<TerminalDropState>((set) => ({
+  targetLeafId: null,
+  setTarget: (leafId) =>
+    set((s) => (s.targetLeafId === leafId ? s : { targetLeafId: leafId })),
+}));

--- a/src/modules/terminal/lib/useTerminalFileDrop.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.ts
@@ -1,34 +1,54 @@
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect } from "react";
+import { useTerminalDropStore } from "./dropStore";
 import { formatDroppedPaths } from "./quoteShellPath";
 import { pasteIntoLeaf } from "./rendererPool";
 
-/** Wires native OS file drops into the terminal pane under the cursor.
- * Drops outside any terminal leaf (editor, file explorer, AI input bar,
- * tabbar, etc.) are intentionally ignored. */
+// Tauri reports the drop point in physical pixels on some platforms and logical
+// on others; only scale down when it overflows the logical viewport.
+function leafIdAt(x: number, y: number): number | null {
+  let lx = x;
+  let ly = y;
+  if (x > window.innerWidth || y > window.innerHeight) {
+    const dpr = window.devicePixelRatio || 1;
+    lx = x / dpr;
+    ly = y / dpr;
+  }
+  const el = document.elementFromPoint(lx, ly);
+  const leafEl = el?.closest<HTMLElement>("[data-pane-leaf]");
+  if (!leafEl) return null;
+  const id = Number(leafEl.dataset.paneLeaf);
+  return Number.isFinite(id) ? id : null;
+}
+
+/** Wires native OS file drops into the terminal pane under the cursor: shows a
+ * drop overlay on that pane while dragging, and bracketed-pastes the
+ * shell-quoted path(s) on drop. Drops outside any terminal leaf are ignored. */
 export function useTerminalFileDrop(): void {
   useEffect(() => {
     let disposed = false;
     let unlisten: (() => void) | null = null;
+    const setTarget = useTerminalDropStore.getState().setTarget;
 
     void getCurrentWebview()
       .onDragDropEvent((e) => {
-        if (e.payload.type !== "drop") return;
-        const paths = e.payload.paths;
-        if (!paths.length) return;
-
-        // Tauri reports PhysicalPosition; elementFromPoint expects CSS px.
-        const dpr = window.devicePixelRatio || 1;
-        const x = e.payload.position.x / dpr;
-        const y = e.payload.position.y / dpr;
-        const el = document.elementFromPoint(x, y);
-        const leafEl = el?.closest<HTMLElement>("[data-pane-leaf]");
-        if (!leafEl) return;
-
-        const leafId = Number(leafEl.dataset.paneLeaf);
-        if (!Number.isFinite(leafId)) return;
-
-        pasteIntoLeaf(leafId, formatDroppedPaths(paths));
+        const p = e.payload;
+        if (p.type === "enter" || p.type === "over") {
+          setTarget(leafIdAt(p.position.x, p.position.y));
+          return;
+        }
+        if (p.type === "leave") {
+          setTarget(null);
+          return;
+        }
+        if (p.type === "drop") {
+          setTarget(null);
+          if (!p.paths.length) return;
+          const leafId = leafIdAt(p.position.x, p.position.y);
+          if (leafId !== null) {
+            pasteIntoLeaf(leafId, formatDroppedPaths(p.paths));
+          }
+        }
       })
       .then((fn) => {
         if (disposed) fn();
@@ -38,6 +58,7 @@ export function useTerminalFileDrop(): void {
 
     return () => {
       disposed = true;
+      setTarget(null);
       unlisten?.();
     };
   }, []);


### PR DESCRIPTION
Final form of terminal file drop, combining the strongest pieces of the three drop PRs: #491's pane routing, #645/#576's bracketed paste + conditional quoting, and #86's DPI-correct hit detection plus a drag-over overlay. Single global listener (one, not one per pane) with the overlay driven by a small store so only the targeted pane re-renders. Co-author @Ffinnis (#86).

Verify: tsc, 102 tests, build green.