### PR TITLE
fix: remove traffic lights padding when macOS window is fullscreen

### DIFF
--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -24,6 +24,7 @@ import {
   SidebarLeftIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useRef, useState, type RefObject } from "react";
 import {
   SearchInline,
@@ -81,6 +82,7 @@ export function Header({
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
   const userShortcuts = usePreferencesStore((s) => s.shortcuts);
 
   const tokensFor = (id: ShortcutId): string => {
@@ -105,6 +107,33 @@ export function Header({
     return () => ro.disconnect();
   }, []);
 
+  useEffect(() => {
+    if (!IS_MAC) return;
+    const w = getCurrentWindow();
+    let alive = true;
+    let unlisten: (() => void) | undefined;
+
+    void w.isFullscreen().then((v) => {
+      if (alive) setFullscreen(v);
+    });
+
+    void w
+      .onResized(() => {
+        void w.isFullscreen().then((v) => {
+          if (alive) setFullscreen(v);
+        });
+      })
+      .then((u) => {
+        if (alive) unlisten = u;
+        else u();
+      });
+
+    return () => {
+      alive = false;
+      unlisten?.();
+    };
+  }, []);
+
   const settingsButton = (
     <Button
       variant="ghost"
@@ -122,7 +151,7 @@ export function Header({
       ref={rootRef}
       data-tauri-drag-region
       className={`flex h-10 shrink-0 items-center gap-2 border-b border-border/60 bg-card select-none ${
-        IS_MAC ? "pr-2 pl-20" : "pr-0 pl-2"
+        IS_MAC ? (fullscreen ? "pr-2 pl-2" : "pr-2 pl-20") : "pr-0 pl-2"
       }`}
     >
       <div className="flex shrink-0 items-center gap-0.5">


### PR DESCRIPTION
What
Removed unnecessary left padding for macOS traffic light buttons (close/minimize/maximize) when the window is in fullscreen mode.

Why
When the window enters fullscreen on macOS, the traffic lights are hidden but the header still reserves 80px of left padding (pl-20), wasting space.

How
Added a useEffect that listens to Tauri's onResized window event and tracks the fullscreen state via isFullscreen(). The padding class switches between pl-2 (fullscreen) and pl-20 (normal).

Testing
- pnpm exec tsc --noEmit clean
- Manual smoke-test of the affected feature
- pnpm tauri dev — verified header padding changes on fullscreen enter/exit
- Platforms tested: macOS
- Shells tested: zsh

Screenshots / GIFs
N/A — minor layout fix, no visual change in normal mode.

Notes for reviewer
None.