### PR TITLE
fix(terminal): stop RIS hard reset wiping scrollback on overflow notices

### DIFF
--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -25,10 +25,14 @@ const READ_BUF: usize = 16 * 1024;
 // Dropping a partial prefix would slice a CSI sequence in half and corrupt
 // xterm's screen state. 4 MiB is ~1000 full 80x24 screens.
 const MAX_PENDING: usize = 4 * 1024 * 1024;
-// Hard reset (ESC c) + dim notice. Written verbatim into the stream when
-// we're forced to discard backlog.
+// CAN (0x18) + dim notice. Written verbatim into the stream when we're
+// forced to discard backlog. CAN aborts any half-received escape sequence
+// in xterm's parser; the whole pending buffer is already dropped above so
+// no CSI is sliced. We deliberately avoid a \x1bc (RIS) hard reset here:
+// RIS wiped the user's scrollback and terminal modes on every overflow.
+// See #660.
 const OVERFLOW_NOTICE: &[u8] =
-    b"\x1bc\x1b[2m[terax: dropped output due to backpressure]\x1b[0m\r\n";
+    b"\x18\x1b[0m\r\n\x1b[2m[terax: dropped output due to backpressure]\x1b[0m\r\n";
 
 pub struct Session {
     // Field drop order is intentional. Rust drops fields top-to-bottom:
@@ -300,6 +304,19 @@ pub fn spawn(
 mod tests {
     use super::*;
     use portable_pty::CommandBuilder;
+
+    #[test]
+    fn overflow_notice_has_no_hard_reset() {
+        // A \x1bc (RIS) hard reset in the backpressure notice wiped the
+        // user's scrollback and terminal modes on every overflow. The
+        // notice must only abort a half-received escape sequence with CAN
+        // (0x18) and reset SGR — never RIS. See #660.
+        assert!(
+            !OVERFLOW_NOTICE.windows(2).any(|w| w == b"\x1bc"),
+            "overflow notice must not contain a RIS hard reset",
+        );
+        assert_eq!(OVERFLOW_NOTICE[0], 0x18, "notice must lead with CAN");
+    }
 
     #[test]
     fn drop_kills_child_process() {

--- a/src/modules/terminal/lib/dormantRing.test.ts
+++ b/src/modules/terminal/lib/dormantRing.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { DormantRing } from "./dormantRing";
+
+const decode = (chunks: Uint8Array[]): string =>
+  chunks.map((c) => new TextDecoder().decode(c)).join("");
+
+const drainToString = (ring: DormantRing): string => {
+  const out: Uint8Array[] = [];
+  ring.drain((b) => out.push(b));
+  return decode(out);
+};
+
+const RIS = "\x1bc"; // ESC c — full hard reset (wipes screen + scrollback + modes)
+
+describe("DormantRing", () => {
+  it("replays buffered chunks in order when it has not overflowed", () => {
+    const ring = new DormantRing(1024, 64);
+    ring.push(new TextEncoder().encode("hello "));
+    ring.push(new TextEncoder().encode("world"));
+    expect(drainToString(ring)).toBe("hello world");
+  });
+
+  it("does not emit a notice when nothing was dropped", () => {
+    const ring = new DormantRing(1024, 64);
+    ring.push(new TextEncoder().encode("abc"));
+    const out = drainToString(ring);
+    expect(out).not.toContain("dropped output");
+    expect(out).not.toContain(RIS);
+  });
+
+  it("never emits a RIS hard reset that would wipe scrollback (#660)", () => {
+    // A single push larger than the byte cap takes the overflow fast-path.
+    const ring = new DormantRing(64, 8);
+    ring.push(new Uint8Array(256).fill(0x41)); // 256 × 'A'
+    const out = drainToString(ring);
+    expect(out).not.toContain(RIS);
+    expect(out.charCodeAt(0)).toBe(0x18); // leads with CAN, not RIS
+    expect(out).toContain("dropped output during hibernation");
+    expect(out).toContain("A".repeat(64)); // tail (last byteCap bytes) preserved
+  });
+
+  it("emits the overflow notice exactly once when chunks are evicted (#660)", () => {
+    const ring = new DormantRing(64, 4);
+    for (let i = 0; i < 50; i++) {
+      ring.push(new TextEncoder().encode(`chunk-${i};`));
+    }
+    const out = drainToString(ring);
+    expect(out).not.toContain(RIS);
+    expect(out.match(/dropped output during hibernation/g)?.length).toBe(1);
+    expect(out.indexOf("dropped output")).toBeLessThan(out.indexOf("chunk-49"));
+    expect(out).toContain("chunk-49;"); // newest survivor kept
+    expect(out).not.toContain("chunk-0;"); // oldest evicted
+  });
+
+  it("resets internal state after draining", () => {
+    const ring = new DormantRing(1024, 64);
+    ring.push(new TextEncoder().encode("once"));
+    expect(drainToString(ring)).toBe("once");
+    expect(ring.byteLength()).toBe(0);
+    expect(drainToString(ring)).toBe(""); // second drain yields nothing
+  });
+});

--- a/src/modules/terminal/lib/dormantRing.ts
+++ b/src/modules/terminal/lib/dormantRing.ts
@@ -1,8 +1,14 @@
 const DEFAULT_BYTE_CAP = 256 * 1024;
 const DEFAULT_CHUNK_CAP = 256;
 
+// CAN (0x18) aborts any half-received escape sequence in xterm's parser
+// without touching the screen, scrollback, or modes. The previous \x1bc
+// (RIS, full hard reset) wiped the scrollback that bindSlot had just
+// restored from the serialized snapshot, so resuming a hibernated inline
+// TUI (Claude Code, Codex — they render in the normal buffer, not the
+// alt-screen) lost all history and could no longer be scrolled. See #660.
 const OVERFLOW_NOTICE = new TextEncoder().encode(
-  "\x1bc\x1b[2m[terax: dropped output during hibernation]\x1b[0m\r\n",
+  "\x18\x1b[0m\r\n\x1b[2m[terax: dropped output during hibernation]\x1b[0m\r\n",
 );
 
 export class DormantRing {


### PR DESCRIPTION
## Problem

Running an inline coding-agent TUI (Claude Code, Codex) in the terminal, the display corrupts after the webview hibernates / a tab goes dormant: previous content disappears, lines overlap, and **scrollback is lost** (can't scroll up). A resize repaints the garble but scrollback stays gone. One corrupted frame literally reads `[terax: dropped output during hibernation]`.

Root cause: both overflow notices prefix their message with `\x1bc` — **RIS (Reset to Initial State)**, a full hard reset that clears the screen, the **scrollback**, and all terminal modes. That's far more than an informational "output dropped" notice should do.

- **Frontend — `dormantRing.ts`:** on resume, `bindSlot` restores the serialized snapshot (`term.write(p.snapshot)`) and *then* drains the dormant ring. When the ring overflowed, the notice's `\x1bc` wiped the scrollback that had just been restored. Inline TUIs render in the **normal buffer** (not the alt-screen), so they take the ring-replay branch rather than the SIGWINCH-repaint branch added in #360 — which is why #443's "fixed in 0.7.3" (alt-screen only) didn't cover them.
- **Backend — `session.rs`:** the backpressure notice did the same on every 4 MiB overflow, destroying scrollback and modes mid-stream.

## Fix

Replace `\x1bc` (RIS) with `\x18` (**CAN**) + SGR reset + newline. CAN only aborts a half-received escape sequence in xterm's parser — it does **not** touch the screen, scrollback, or modes. Scrollback and restored history survive the overflow notice.

## Tests

- `dormantRing.test.ts` (new): notice contains no RIS and leads with CAN, notice emitted exactly once on eviction, tail preserved on the big-chunk fast path, chunk ordering, post-drain reset.
- `session.rs`: `overflow_notice_has_no_hard_reset` regression test.

Verified locally: `vitest run` (29/29 terminal-lib tests pass) and `cargo test` (Rust test passes).

## Scope / follow-up

This fixes the **scrollback-loss + RIS-garble** half of the symptoms. A separate, larger issue remains: replaying raw dormant bytes for an inline TUI in the normal buffer can still leave minor overlap, because the maintainer's #360 repaint path only triggers for the alt-screen. Detecting inline TUIs (or issuing a SIGWINCH repaint for normal-buffer leaves with an active foreground app) would be a good follow-up — intentionally left out of this PR to keep it minimal and low-risk.

Refs #660, #573, #604, #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
