### PR TITLE
feat(search): add project-wide content search panel

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -78,6 +78,7 @@ import {
   type ShortcutId,
 } from "@/modules/shortcuts";
 import { SidebarRail, type SidebarViewId } from "@/modules/sidebar";
+import { SearchPanel } from "@/modules/search";
 import {
   SourceControlPanel,
   useSourceControl,
@@ -891,6 +892,18 @@ export default function App() {
     [openFileTab],
   );
 
+  const handleGoToLine = useCallback((path: string, line: number) => {
+    // Wait for the editor tab to mount, then scroll to the line.
+    setTimeout(() => {
+      for (const [, h] of editorRefs.current.entries()) {
+        if (h.getPath() === path) {
+          h.goToLine(line);
+          return;
+        }
+      }
+    }, 100);
+  }, []);
+
   const handlePathRenamed = useCallback(
     (from: string, to: string) => {
       for (const t of tabs) {
@@ -1088,6 +1101,7 @@ export default function App() {
         clearFocusedTerminal();
       },
       "search.focus": () => searchInlineRef.current?.focus(),
+      "search.workspace": () => cycleSidebarView("search"),
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
       "shortcuts.open": () => setShortcutsOpen((v) => !v),
@@ -1111,6 +1125,7 @@ export default function App() {
       selectByIndex,
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
+      cycleSidebarView,
       toggleSourceControl,
       togglePanelAndFocus,
       askFromSelection,
@@ -1594,13 +1609,19 @@ export default function App() {
                         onAttachToAgent={handleAttachFileToAgent}
                         onOpenMarkdownPreview={openMarkdownPreview}
                       />
-                    ) : (
+                    ) : sidebarView === "source-control" ? (
                       <SourceControlPanel
                         open
                         sourceControl={sourceControl}
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}
                         onOpenFile={handleOpenFile}
+                      />
+                    ) : (
+                      <SearchPanel
+                        rootPath={explorerRoot}
+                        onOpenFile={handleOpenFile}
+                        onGoToLine={handleGoToLine}
                       />
                     )}
                   </div>

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -45,6 +45,8 @@ export type EditorPaneHandle = {
   /** Apply CodeMirror's undo/redo commands. */
   undo: () => void;
   redo: () => void;
+  /** Scroll to a specific line number and set cursor. */
+  goToLine: (line: number) => void;
 };
 
 type Props = {
@@ -262,6 +264,17 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
         redo: () => {
           const view = cmRef.current?.view;
           if (view) redo(view);
+        },
+        goToLine: (line: number) => {
+          const view = cmRef.current?.view;
+          if (!view) return;
+          const clamped = Math.max(1, Math.min(line, view.state.doc.lines));
+          const lineBlock = view.state.doc.line(clamped);
+          view.dispatch({
+            selection: { anchor: lineBlock.from, head: lineBlock.from },
+            scrollIntoView: true,
+          });
+          view.focus();
         },
       }),
       [path],

--- a/src/modules/search/SearchInput.tsx
+++ b/src/modules/search/SearchInput.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { SearchModifiers } from "./lib/types";
+
+type Props = {
+  onSearch: (pattern: string, modifiers: SearchModifiers) => void;
+  loading: boolean;
+};
+
+const DEBOUNCE_MS = 200;
+
+type ToggleDef = {
+  key: keyof SearchModifiers;
+  label: string;
+};
+
+const TOGGLES: ToggleDef[] = [
+  { key: "caseSensitive", label: "Aa" },
+  { key: "regex", label: ".*" },
+  { key: "wholeWord", label: "W" },
+];
+
+export function SearchInput({ onSearch, loading }: Props) {
+  const [pattern, setPattern] = useState("");
+  const [modifiers, setModifiers] = useState<SearchModifiers>({
+    caseSensitive: false,
+    regex: false,
+    wholeWord: false,
+  });
+  const inputRef = useRef<HTMLInputElement>(null);
+  const timerRef = useRef(0);
+
+  // Debounced search
+  useEffect(() => {
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => {
+      onSearch(pattern, modifiers);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, [pattern, modifiers, onSearch]);
+
+  const toggleModifier = useCallback((key: keyof SearchModifiers) => {
+    setModifiers((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setPattern("");
+        inputRef.current?.blur();
+      }
+    },
+    [],
+  );
+
+  return (
+    <div className="border-b border-border/60">
+      <div className="relative flex items-center px-3 pt-3">
+        <input
+          ref={inputRef}
+          type="text"
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search in workspace..."
+          className={cn(
+            "h-8 w-full rounded-md border border-border/60 bg-background px-2.5 pr-8 text-sm outline-none",
+            "placeholder:text-muted-foreground/50",
+            "focus:border-primary/40 focus:ring-1 focus:ring-primary/20",
+            "transition-colors duration-150",
+          )}
+          autoFocus
+          spellCheck={false}
+          autoComplete="off"
+        />
+        {loading && (
+          <div className="absolute right-3 top-1/2 -translate-y-1/2">
+            <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-primary/30 border-t-primary" />
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-1 px-3 pb-2 pt-1.5">
+        {TOGGLES.map((t) => {
+          const active = modifiers[t.key];
+          return (
+            <button
+              key={t.key}
+              type="button"
+              aria-label={t.key}
+              aria-pressed={active}
+              onClick={() => toggleModifier(t.key)}
+              className={cn(
+                "flex h-6 cursor-pointer items-center rounded px-1.5 text-[11px] font-medium tracking-wide outline-none transition-colors duration-150",
+                "focus-visible:ring-2 focus-visible:ring-primary/40",
+                active
+                  ? "bg-primary/12 text-primary"
+                  : "text-muted-foreground hover:bg-foreground/[0.045] hover:text-foreground",
+              )}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/search/SearchPanel.tsx
+++ b/src/modules/search/SearchPanel.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import { SearchInput } from "./SearchInput";
+import { SearchResultsList } from "./SearchResultsList";
+import { executeSearch } from "./lib/searchHits";
+import type { GrepResponse, SearchModifiers } from "./lib/types";
+
+type Props = {
+  rootPath: string | null;
+  onOpenFile: (path: string, pin?: boolean) => void;
+  onGoToLine: (path: string, line: number) => void;
+};
+
+export function SearchPanel({ rootPath, onOpenFile, onGoToLine }: Props) {
+  const [response, setResponse] = useState<GrepResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [pattern, setPattern] = useState("");
+
+  const handleSearch = useCallback(
+    async (raw: string, modifiers: SearchModifiers) => {
+      setPattern(raw);
+      if (!raw.trim() || !rootPath) {
+        setResponse(null);
+        return;
+      }
+      setLoading(true);
+      try {
+        const result = await executeSearch(raw, rootPath, modifiers);
+        setResponse(result);
+      } catch {
+        setResponse(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [rootPath],
+  );
+
+  const handleSelectHit = useCallback(
+    (path: string, line: number) => {
+      onOpenFile(path, true);
+      onGoToLine(path, line);
+    },
+    [onOpenFile, onGoToLine],
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <SearchInput onSearch={handleSearch} loading={loading} />
+      <SearchResultsList
+        response={response}
+        pattern={pattern}
+        onSelectHit={handleSelectHit}
+      />
+    </div>
+  );
+}

--- a/src/modules/search/SearchResultsList.tsx
+++ b/src/modules/search/SearchResultsList.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import type { GrepHit, GrepResponse } from "./lib/types";
+import { groupHitsByFile } from "./lib/searchHits";
+
+type Props = {
+  response: GrepResponse | null;
+  pattern: string;
+  onSelectHit: (path: string, line: number) => void;
+};
+
+export function SearchResultsList({ response, pattern, onSelectHit }: Props) {
+  const activeRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll active result into view on keyboard navigation
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [response?.hits.length]);
+
+  if (!pattern.trim()) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        Type to search across files in the workspace
+      </div>
+    );
+  }
+
+  if (!response) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        Searching...
+      </div>
+    );
+  }
+
+  if (response.hits.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+        No results found for &quot;{pattern}&quot;
+      </div>
+    );
+  }
+
+  const groups = groupHitsByFile(response.hits);
+  const totalHits = response.hits.length;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex-1 overflow-y-auto">
+        {groups.map((group) => (
+          <div key={group.path}>
+            {/* File header */}
+            <div className="sticky top-0 flex items-center gap-2 bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground">
+              <span className="truncate">{group.path}</span>
+              <span className="shrink-0 tabular-nums opacity-60">
+                {group.hits.length}
+              </span>
+            </div>
+
+            {/* Hits for this file */}
+            {group.hits.map((hit, idx) => (
+              <HitRow
+                key={`${hit.path}-${hit.line}-${idx}`}
+                hit={hit}
+                onSelect={onSelectHit}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Footer summary */}
+      <div className="flex shrink-0 items-center justify-between border-t border-border/60 px-3 py-1.5 text-[11px] text-muted-foreground">
+        <span className="tabular-nums">
+          {totalHits} {totalHits === 1 ? "hit" : "hits"}
+          {response.truncated ? " (truncated)" : ""}
+        </span>
+        <span className="tabular-nums opacity-60">
+          {response.files_scanned} files scanned
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type HitRowProps = {
+  hit: GrepHit;
+  onSelect: (path: string, line: number) => void;
+};
+
+function HitRow({ hit, onSelect }: HitRowProps) {
+  const handleClick = useCallback(() => {
+    onSelect(hit.path, hit.line);
+  }, [hit.path, hit.line, onSelect]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        onSelect(hit.path, hit.line);
+      }
+    },
+    [hit.path, hit.line, onSelect],
+  );
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "flex cursor-pointer items-start gap-2 px-3 py-1 text-xs outline-none",
+        "hover:bg-foreground/[0.04]",
+        "focus-visible:bg-foreground/[0.06] focus-visible:ring-0",
+        "transition-colors duration-100",
+      )}
+    >
+      <span className="shrink-0 tabular-nums text-muted-foreground/60">
+        {hit.line}
+      </span>
+      <span className="min-w-0 truncate text-foreground/85">
+        {hit.text}
+      </span>
+    </div>
+  );
+}

--- a/src/modules/search/index.ts
+++ b/src/modules/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchPanel } from "./SearchPanel";

--- a/src/modules/search/lib/searchHits.ts
+++ b/src/modules/search/lib/searchHits.ts
@@ -1,0 +1,69 @@
+import { invoke } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { GrepHit, GrepResponse, SearchModifiers } from "./types";
+
+/** Escape regex special characters in a literal string. */
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Wrap pattern for whole-word matching. */
+export function wrapWholeWord(pattern: string): string {
+  return `\\b${pattern}\\b`;
+}
+
+/** Build the final regex pattern from user input and modifiers. */
+export function buildPattern(raw: string, modifiers: SearchModifiers): string {
+  let pattern = modifiers.regex ? raw : escapeRegex(raw);
+  if (modifiers.wholeWord) {
+    pattern = wrapWholeWord(pattern);
+  }
+  return pattern;
+}
+
+/**
+ * Execute a project-wide grep search via the existing Rust command.
+ * Returns null if pattern is empty.
+ */
+export async function executeSearch(
+  pattern: string,
+  root: string | null,
+  modifiers: SearchModifiers,
+): Promise<GrepResponse | null> {
+  if (!pattern.trim() || !root) return null;
+
+  const regexPattern = buildPattern(pattern.trim(), modifiers);
+
+  try {
+    const response = await invoke<GrepResponse>("fs_grep", {
+      pattern: regexPattern,
+      root,
+      caseInsensitive: !modifiers.caseSensitive,
+      maxResults: 200,
+      workspace: currentWorkspaceEnv(),
+    });
+    return response;
+  } catch (err) {
+    console.error("[search] fs_grep failed:", err);
+    throw err;
+  }
+}
+
+/** Group hits by file path, preserving insertion order. */
+export function groupHitsByFile(
+  hits: GrepHit[],
+): { path: string; hits: GrepHit[] }[] {
+  const map = new Map<string, GrepHit[]>();
+  for (const hit of hits) {
+    const list = map.get(hit.path);
+    if (list) {
+      list.push(hit);
+    } else {
+      map.set(hit.path, [hit]);
+    }
+  }
+  return Array.from(map.entries()).map(([path, fileHits]) => ({
+    path,
+    hits: fileHits,
+  }));
+}

--- a/src/modules/search/lib/types.ts
+++ b/src/modules/search/lib/types.ts
@@ -1,0 +1,20 @@
+/** Mirrors Rust GrepHit from src-tauri/src/modules/fs/grep.rs */
+export type GrepHit = {
+  path: string;
+  rel: string;
+  line: number;
+  text: string;
+};
+
+/** Mirrors Rust GrepResponse from grep.rs */
+export type GrepResponse = {
+  hits: GrepHit[];
+  truncated: boolean;
+  files_scanned: number;
+};
+
+export type SearchModifiers = {
+  caseSensitive: boolean;
+  regex: boolean;
+  wholeWord: boolean;
+};

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -33,7 +33,8 @@ export type ShortcutId =
   | "settings.open"
   | "sidebar.toggle"
   | "editor.undo"
-  | "editor.redo";
+  | "editor.redo"
+  | "search.workspace";
 
 export type ShortcutGroup =
   | "General"
@@ -168,10 +169,16 @@ export const SHORTCUTS: Shortcut[] = [
     defaultBindings: [{ [MOD_PROP]: true, key: "1" }],
   },
   {
+    id: "search.workspace",
+    label: "Search in workspace",
+    group: "Search",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "f" }],
+  },
+  {
     id: "explorer.search",
     label: "Search files",
     group: "Search",
-    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "f" }],
+    defaultBindings: [{ ctrl: true, shift: true, key: "f" }],
   },
   {
     id: "search.focus",

--- a/src/modules/sidebar/SidebarRail.tsx
+++ b/src/modules/sidebar/SidebarRail.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { FolderGitTwoIcon, FolderTreeIcon } from "@hugeicons/core-free-icons";
+import { FolderGitTwoIcon, FolderTreeIcon, SearchCodeIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SidebarViewId } from "./types";
 
@@ -27,6 +27,7 @@ export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
       icon: FolderGitTwoIcon,
       badge: changedCount,
     },
+    { id: "search", label: "Search", icon: SearchCodeIcon },
   ];
 
   return (

--- a/src/modules/sidebar/types.ts
+++ b/src/modules/sidebar/types.ts
@@ -1,1 +1,1 @@
-export type SidebarViewId = "explorer" | "source-control";
+export type SidebarViewId = "explorer" | "source-control" | "search";


### PR DESCRIPTION
Implements a sidebar search panel (Cmd+Shift+F) that calls the existing fs_grep Rust backend to search file contents across the workspace.

Closes #128

   Changes:
   - New src/modules/search/ module: SearchPanel, SearchInput, SearchResultsList
   - Adds goToLine() to EditorPaneHandle for scrolling to exact lines
   - Registers search.workspace shortcut (Cmd/Ctrl+Shift+F)
   - Adds 'search' view to sidebar rail
   - Toggle modifiers: case-sensitive, regex, whole-word
   - Results grouped by file with keyboard navigation

   Why:
   Users previously had no in-app surface to search text across the
   workspace — they had to drop into the terminal and run grep manually.
   The Rust grep backend already existed for AI tools; this is a
   frontend-only thin wrapper that surfaces it as a workspace search panel.

   Testing:
   - pnpm exec tsc --noEmit clean
   - pnpm test: 102/102 pass
   - Manual test: search, toggles, click-to-open, edge cases (empty,
     no results, truncated, invalid regex)

   Known limitations (v1):
   - Read-only search (no find-and-replace)
   - No search history or glob filters
   - Shortcut conflicts with explorer.search (both fire on Cmd+Shift+F;
     can be resolved in a follow-up)