### PR TITLE
feat(ai): add OpenAI Codex device login

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@replit/codemirror-vim": "^6.3.0",
     "@tanstack/react-virtual": "^3.13.24",
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-autostart": "~2.5.1",
     "@tauri-apps/plugin-log": "~2.8.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
@@ -100,7 +100,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
     "@tailwindcss/vite": "^4.2.3",
-    "@tauri-apps/cli": "^2",
+    "@tauri-apps/cli": "^2.11.0",
     "@types/node": "^25.6.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tauri-apps/api':
-        specifier: ^2
-        version: 2.10.1
+        specifier: ^2.11.0
+        version: 2.11.0
       '@tauri-apps/plugin-autostart':
         specifier: ~2.5.1
         version: 2.5.1
@@ -247,8 +247,8 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@tauri-apps/cli':
-        specifier: ^2
-        version: 2.10.1
+        specifier: ^2.11.0
+        version: 2.11.0
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -2093,79 +2093,82 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
-  '@tauri-apps/cli-darwin-arm64@2.10.1':
-    resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
+
+  '@tauri-apps/cli-darwin-arm64@2.11.0':
+    resolution: {integrity: sha512-UfMeDNlgIP252rm/KSTuu8yHatPua5TjtUEUf+jyIzVwBNcIl7Ywkdpfj+e5jVVg3EfCTp+4gwuL1dNpgF8clg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.10.1':
-    resolution: {integrity: sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==}
+  '@tauri-apps/cli-darwin-x64@2.11.0':
+    resolution: {integrity: sha512-lY1+aPlgyMN7vgjtCdQ3+WODfZkebAcxnrCrO0HjqDpKSXieDkrJbimqeaoM4RwhTSrCLRHfVYiYrfE5E131tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
-    resolution: {integrity: sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.0':
+    resolution: {integrity: sha512-5uCP0AusgN3NrKC8EpkuJwjek1k8pEffBdugJSpXPey/QGbPEb8vZ542n/giJ2mZPjMSllDkdhG2QIDpBY4PpQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
-    resolution: {integrity: sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.0':
+    resolution: {integrity: sha512-loDPqtRHMSbIcrH2VBd4GgHoQlF7jJnrZj7MxA2lj1cixS/jEgMAPFqj83U6Wvjete4HfYplbE/gCpSFifA9jw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
-    resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.0':
+    resolution: {integrity: sha512-DtSE8ZBlB9H+L+eHkfZ3myt00EVEyAB3e41juEHoE2qT88fgVlJvyrwa9SZYc/xTwCS9TnmK+R84tpg+ZsAg7Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
-    resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.0':
+    resolution: {integrity: sha512-5QdgS4LD+kntClI1aj2JmwjW38LosNXxwCe8viIHEwqYIWuMPdNEIau6/cLogI38Yzx9DnfCPRfEWLyI+5li8Q==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
-    resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.0':
+    resolution: {integrity: sha512-5UynPXo3Zq9khjVdAbD+YogeLltdVUeOah2ioSIM3tu6H7wY9vMy6rgGJhv9r5R8ZXmk9GttMippdqYJWrnLnA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-musl@2.10.1':
-    resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.0':
+    resolution: {integrity: sha512-CNz7fHbApz1Zyhhq73jtGn9JqgNEV/lIWnTnUo6h6ujw+mHsTmkLszvJSM8W6JBaDjNpTTFr/RSNoVL5FMwcTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
-    resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.0':
+    resolution: {integrity: sha512-K+br+VXZ+Xx0n/9FdWohpW5Ugq+2FQUpJScqcPl1hTxXfh3fgjYgt4qA2NgrjlJo+zZPNrmUMl+NLvm0ufEqBQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
-    resolution: {integrity: sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.0':
+    resolution: {integrity: sha512-OFV+s3MLZnd75zl0ZAFU5riMpGK4waUEA8ZDuijDsnkU0btz/gHhqh5jVlOn8thyvgdtT3Xyoxqo099MMifH3g==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
-    resolution: {integrity: sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.0':
+    resolution: {integrity: sha512-AeDTWBd2cOZ6TX133BWsoo+LutG9o0JRcgjMsIfLE13ZugpgCMv/2dJbUiBGeRvbPOGin5A3aYmsArPVV6ZSHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.10.1':
-    resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
+  '@tauri-apps/cli@2.11.0':
+    resolution: {integrity: sha512-W5Wbuqsb2pHFPTj4TaRNKTj5rwXhDShPiLSY9T18y4ouSR/NNCptAEFxFsBtyNRgL6Vs1a/q9LzfqqYzEwC+Jw==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -6522,52 +6525,54 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.10.1':
+  '@tauri-apps/api@2.11.0': {}
+
+  '@tauri-apps/cli-darwin-arm64@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.10.1':
+  '@tauri-apps/cli-darwin-x64@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.10.1':
+  '@tauri-apps/cli-linux-x64-musl@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.0':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.0':
     optional: true
 
-  '@tauri-apps/cli@2.10.1':
+  '@tauri-apps/cli@2.11.0':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.10.1
-      '@tauri-apps/cli-darwin-x64': 2.10.1
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.10.1
-      '@tauri-apps/cli-linux-arm64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-arm64-musl': 2.10.1
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-x64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-x64-musl': 2.10.1
-      '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
-      '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
-      '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+      '@tauri-apps/cli-darwin-arm64': 2.11.0
+      '@tauri-apps/cli-darwin-x64': 2.11.0
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.0
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.0
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.0
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.0
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.0
+      '@tauri-apps/cli-linux-x64-musl': 2.11.0
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.0
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.0
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.0
 
   '@tauri-apps/plugin-autostart@2.5.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5351,6 +5351,7 @@ dependencies = [
 name = "terax"
 version = "0.7.3"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "dirs 6.0.0",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 	"stream",
 ] }
 bytes = "1"
+base64 = "0.22"
 futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, codex_auth, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -35,7 +35,7 @@ fn parse_launch_dir() -> Option<String> {
 #[tauri::command]
 async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Result<(), String> {
     let url_path = match tab.as_deref() {
-        Some(t) if !t.is_empty() => format!("settings.html?tab={}", t),
+        Some(t) if !t.is_empty() => format!("settings.html?tab={t}"),
         _ => "settings.html".to_string(),
     };
 
@@ -158,6 +158,7 @@ pub fn run() {
         .manage(pty::PtyState::default())
         .manage(shell::ShellState::default())
         .manage(secrets::SecretsState::default())
+        .manage(codex_auth::CodexAuthState::default())
         .manage(fs::watch::FsWatchState::default())
         .manage({
             let registry = workspace::WorkspaceRegistry::default();
@@ -232,6 +233,12 @@ pub fn run() {
             net::lm_ping,
             net::ai_http_request,
             net::ai_http_stream,
+            codex_auth::openai_codex_auth_start_device,
+            codex_auth::openai_codex_auth_poll,
+            codex_auth::openai_codex_auth_cancel,
+            codex_auth::openai_codex_auth_status,
+            codex_auth::openai_codex_auth_logout,
+            codex_auth::openai_codex_responses_stream,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/codex_auth.rs
+++ b/src-tauri/src/modules/codex_auth.rs
@@ -1,0 +1,1205 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use bytes::Bytes;
+use futures_util::StreamExt;
+use reqwest::header::{
+    HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT,
+};
+use reqwest::redirect::Policy;
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tauri::ipc::Channel;
+use tauri::AppHandle;
+
+use crate::modules::net::AiStreamEvent;
+use crate::modules::secrets::{
+    delete_secret_value, get_secret_value, set_secret_value, SecretsState,
+};
+
+const KEYRING_SERVICE: &str = "terax-ai";
+const CODEX_SECRET_ACCOUNT: &str = "openai-codex-oauth";
+const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const DEVICE_AUTH_BASE_URL: &str = "https://auth.openai.com/api/accounts";
+const DEVICE_VERIFICATION_URL: &str = "https://auth.openai.com/codex/device";
+const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
+const DEVICE_EXPIRES_AFTER_MS: u64 = 15 * 60 * 1000;
+const REFRESH_SKEW_MS: u64 = 2 * 60 * 1000;
+const RATE_LIMIT_BACKOFF_MS: u64 = 60 * 1000;
+const UPSTREAM_ERROR_DETAIL_MAX_CHARS: usize = 180;
+
+pub struct CodexAuthState {
+    pending: Mutex<HashMap<String, PendingDeviceLogin>>,
+    next_login_id: AtomicU64,
+    client: Client,
+}
+
+impl Default for CodexAuthState {
+    fn default() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            next_login_id: AtomicU64::new(1),
+            client: Client::builder()
+                .redirect(Policy::none())
+                .build()
+                .expect("Codex HTTP client should build"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PendingDeviceLogin {
+    device_auth_id: String,
+    user_code: String,
+    expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexAuthStatus {
+    pub signed_in: bool,
+    pub needs_relogin: bool,
+    pub rate_limited_until_ms: Option<u64>,
+    pub account_email: Option<String>,
+    pub plan_type: Option<String>,
+    pub expires_at_ms: Option<u64>,
+    pub last_refresh_ms: Option<u64>,
+    pub message: Option<String>,
+}
+
+impl CodexAuthStatus {
+    fn signed_out() -> Self {
+        Self {
+            signed_in: false,
+            needs_relogin: false,
+            rate_limited_until_ms: None,
+            account_email: None,
+            plan_type: None,
+            expires_at_ms: None,
+            last_refresh_ms: None,
+            message: None,
+        }
+    }
+
+    fn needs_relogin(message: impl Into<String>) -> Self {
+        Self {
+            signed_in: false,
+            needs_relogin: true,
+            rate_limited_until_ms: None,
+            account_email: None,
+            plan_type: None,
+            expires_at_ms: None,
+            last_refresh_ms: None,
+            message: Some(message.into()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexDeviceStart {
+    login_id: String,
+    verification_url: String,
+    user_code: String,
+    expires_at_ms: u64,
+    poll_interval_secs: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexPollResult {
+    status: String,
+    auth: Option<CodexAuthStatus>,
+    message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredCodexSession {
+    access_token: String,
+    refresh_token: String,
+    id_token: Option<String>,
+    expires_at_ms: Option<u64>,
+    account_email: Option<String>,
+    plan_type: Option<String>,
+    last_refresh_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceUserCodeResp {
+    device_auth_id: String,
+    #[serde(alias = "usercode")]
+    user_code: String,
+    #[serde(
+        default = "default_poll_interval_secs",
+        deserialize_with = "deserialize_interval"
+    )]
+    interval: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceTokenResp {
+    authorization_code: String,
+    code_verifier: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResp {
+    access_token: String,
+    refresh_token: Option<String>,
+    id_token: Option<String>,
+    expires_in: Option<u64>,
+}
+
+#[tauri::command]
+pub async fn openai_codex_auth_start_device(
+    state: tauri::State<'_, CodexAuthState>,
+) -> Result<CodexDeviceStart, String> {
+    let resp = request_device_user_code(&state.client).await?;
+    let now = now_ms();
+    let login_id = state.next_login_id.fetch_add(1, Ordering::Relaxed);
+    let login_id = format!("codex-{now}-{login_id}");
+    let expires_at_ms = now.saturating_add(DEVICE_EXPIRES_AFTER_MS);
+    let poll_interval_secs = resp.interval.clamp(1, 15);
+    let pending = PendingDeviceLogin {
+        device_auth_id: resp.device_auth_id,
+        user_code: resp.user_code.clone(),
+        expires_at_ms,
+    };
+    state
+        .pending
+        .lock()
+        .map_err(|e| e.to_string())?
+        .insert(login_id.clone(), pending);
+
+    Ok(CodexDeviceStart {
+        login_id,
+        verification_url: DEVICE_VERIFICATION_URL.to_string(),
+        user_code: resp.user_code,
+        expires_at_ms,
+        poll_interval_secs,
+    })
+}
+
+#[tauri::command]
+pub async fn openai_codex_auth_poll(
+    app: AppHandle,
+    secrets: tauri::State<'_, SecretsState>,
+    state: tauri::State<'_, CodexAuthState>,
+    login_id: String,
+) -> Result<CodexPollResult, String> {
+    let pending = {
+        let guard = state.pending.lock().map_err(|e| e.to_string())?;
+        guard.get(&login_id).cloned()
+    };
+    let Some(pending) = pending else {
+        return Ok(CodexPollResult {
+            status: "expired".to_string(),
+            auth: None,
+            message: Some("Device login expired. Start a new sign-in.".to_string()),
+        });
+    };
+    if pending.expires_at_ms <= now_ms() {
+        let _ = state
+            .pending
+            .lock()
+            .map_err(|e| e.to_string())?
+            .remove(&login_id);
+        return Ok(CodexPollResult {
+            status: "expired".to_string(),
+            auth: None,
+            message: Some("Device login expired. Start a new sign-in.".to_string()),
+        });
+    }
+
+    match poll_device_token(&state.client, &pending).await? {
+        DevicePoll::Pending => Ok(CodexPollResult {
+            status: "pending".to_string(),
+            auth: None,
+            message: None,
+        }),
+        DevicePoll::Complete(code) => {
+            let session = exchange_authorization_code(&state.client, &code).await?;
+            save_session(&app, &secrets, &session)?;
+            let _ = state
+                .pending
+                .lock()
+                .map_err(|e| e.to_string())?
+                .remove(&login_id);
+            Ok(CodexPollResult {
+                status: "complete".to_string(),
+                auth: Some(status_from_session(&session)),
+                message: None,
+            })
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn openai_codex_auth_cancel(
+    state: tauri::State<'_, CodexAuthState>,
+    login_id: String,
+) -> Result<(), String> {
+    let _ = state
+        .pending
+        .lock()
+        .map_err(|e| e.to_string())?
+        .remove(&login_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn openai_codex_auth_status(
+    app: AppHandle,
+    secrets: tauri::State<'_, SecretsState>,
+    state: tauri::State<'_, CodexAuthState>,
+) -> Result<CodexAuthStatus, String> {
+    Ok(resolve_status(&app, &secrets, &state.client).await)
+}
+
+#[tauri::command]
+pub async fn openai_codex_auth_logout(
+    app: AppHandle,
+    secrets: tauri::State<'_, SecretsState>,
+) -> Result<(), String> {
+    delete_secret_value(&app, &secrets, KEYRING_SERVICE, CODEX_SECRET_ACCOUNT)
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn openai_codex_responses_stream(
+    app: AppHandle,
+    secrets: tauri::State<'_, SecretsState>,
+    state: tauri::State<'_, CodexAuthState>,
+    url: String,
+    method: String,
+    headers: Option<HashMap<String, String>>,
+    body: Option<Vec<u8>>,
+    on_event: Channel<AiStreamEvent>,
+) -> Result<(), String> {
+    let parsed = match validate_codex_responses_url(&url, &method) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            let _ = on_event.send(AiStreamEvent::Error { message: e.clone() });
+            return Err(e);
+        }
+    };
+    let token = match fresh_access_token(&app, &secrets, &state.client).await {
+        Ok(token) => token,
+        Err(e) => {
+            let _ = on_event.send(AiStreamEvent::Error { message: e.clone() });
+            return Err(e);
+        }
+    };
+
+    let mut header_map = match sanitize_codex_headers(headers) {
+        Ok(headers) => headers,
+        Err(e) => {
+            let _ = on_event.send(AiStreamEvent::Error { message: e.clone() });
+            return Err(e);
+        }
+    };
+    let bearer = format!("Bearer {token}");
+    header_map.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&bearer).map_err(|e| e.to_string())?,
+    );
+    header_map
+        .entry(CONTENT_TYPE)
+        .or_insert(HeaderValue::from_static("application/json"));
+    header_map
+        .entry(ACCEPT)
+        .or_insert(HeaderValue::from_static("text/event-stream"));
+    header_map
+        .entry(USER_AGENT)
+        .or_insert(HeaderValue::from_static("codex_cli_rs/0.0.0 (Terax)"));
+    header_map.insert(
+        HeaderName::from_static("originator"),
+        HeaderValue::from_static("codex_cli_rs"),
+    );
+
+    let mut req = state.client.post(parsed).headers(header_map);
+    if let Some(body) = body {
+        req = req.body(body);
+    }
+    let resp = match req.send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            let _ = on_event.send(AiStreamEvent::Error {
+                message: e.to_string(),
+            });
+            return Err(e.to_string());
+        }
+    };
+
+    let status = resp.status().as_u16();
+    let headers = codex_response_headers_to_strings(resp.headers());
+    let _ = on_event.send(AiStreamEvent::Headers { status, headers });
+
+    let mut stream = resp.bytes_stream();
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(chunk) => {
+                let bytes: Bytes = chunk;
+                if on_event
+                    .send(AiStreamEvent::Chunk {
+                        bytes: bytes.to_vec(),
+                    })
+                    .is_err()
+                {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                let _ = on_event.send(AiStreamEvent::Error {
+                    message: e.to_string(),
+                });
+                return Err(e.to_string());
+            }
+        }
+    }
+
+    let _ = on_event.send(AiStreamEvent::End);
+    Ok(())
+}
+
+async fn request_device_user_code(client: &Client) -> Result<DeviceUserCodeResp, String> {
+    let url = format!("{DEVICE_AUTH_BASE_URL}/deviceauth/usercode");
+    let body = serde_json::json!({ "client_id": CODEX_CLIENT_ID }).to_string();
+    let resp = client
+        .post(url)
+        .header(CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        if status == StatusCode::NOT_FOUND {
+            return Err(
+                "Codex device-code login is not enabled for this account or workspace.".into(),
+            );
+        }
+        return Err(upstream_auth_error(
+            "Codex device-code request failed",
+            status,
+            &text,
+        ));
+    }
+    serde_json::from_str(&text).map_err(|e| e.to_string())
+}
+
+enum DevicePoll {
+    Pending,
+    Complete(DeviceTokenResp),
+}
+
+async fn poll_device_token(
+    client: &Client,
+    pending: &PendingDeviceLogin,
+) -> Result<DevicePoll, String> {
+    let url = format!("{DEVICE_AUTH_BASE_URL}/deviceauth/token");
+    let body = serde_json::json!({
+        "device_auth_id": pending.device_auth_id.as_str(),
+        "user_code": pending.user_code.as_str(),
+    })
+    .to_string();
+    let resp = client
+        .post(url)
+        .header(CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    if status == StatusCode::FORBIDDEN || status == StatusCode::NOT_FOUND {
+        return Ok(DevicePoll::Pending);
+    }
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(upstream_auth_error(
+            "Codex device-code poll failed",
+            status,
+            &text,
+        ));
+    }
+    let token = serde_json::from_str(&text).map_err(|e| e.to_string())?;
+    Ok(DevicePoll::Complete(token))
+}
+
+async fn exchange_authorization_code(
+    client: &Client,
+    code: &DeviceTokenResp,
+) -> Result<StoredCodexSession, String> {
+    let body = token_exchange_body(&code.authorization_code, &code.code_verifier);
+    let resp = client
+        .post(TOKEN_URL)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| e.to_string())?;
+    if !status.is_success() {
+        return Err(upstream_auth_error(
+            "Codex token exchange failed",
+            status,
+            &text,
+        ));
+    }
+    let token: TokenResp = serde_json::from_str(&text).map_err(|e| e.to_string())?;
+    session_from_token_response(token, None)
+}
+
+async fn refresh_session(
+    client: &Client,
+    current: &StoredCodexSession,
+) -> Result<StoredCodexSession, RefreshError> {
+    let body = token_refresh_body(&current.refresh_token);
+    let resp = client
+        .post(TOKEN_URL)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| RefreshError::Transient(e.to_string()))?;
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| RefreshError::Transient(e.to_string()))?;
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        return Err(RefreshError::RateLimited);
+    }
+    if !status.is_success() {
+        let code = extract_error_code(&text);
+        if status == StatusCode::UNAUTHORIZED
+            || status == StatusCode::FORBIDDEN
+            || status == StatusCode::BAD_REQUEST
+            || is_permanent_refresh_code(code.as_deref())
+        {
+            return Err(RefreshError::Permanent(
+                "Your Codex session expired. Sign in again.".to_string(),
+            ));
+        }
+        return Err(RefreshError::Transient(upstream_auth_error(
+            "Codex token refresh failed",
+            status,
+            &text,
+        )));
+    }
+    let token: TokenResp =
+        serde_json::from_str(&text).map_err(|e| RefreshError::Transient(e.to_string()))?;
+    session_from_token_response(token, Some(current))
+        .map_err(|e| RefreshError::Transient(e.to_string()))
+}
+
+async fn resolve_status(
+    app: &AppHandle,
+    secrets: &SecretsState,
+    client: &Client,
+) -> CodexAuthStatus {
+    match fresh_session(app, secrets, client).await {
+        Ok(Some(session)) => status_from_session(&session),
+        Ok(None) => CodexAuthStatus::signed_out(),
+        Err(RefreshError::RateLimited) => CodexAuthStatus {
+            signed_in: true,
+            needs_relogin: false,
+            rate_limited_until_ms: Some(now_ms().saturating_add(RATE_LIMIT_BACKOFF_MS)),
+            account_email: None,
+            plan_type: None,
+            expires_at_ms: None,
+            last_refresh_ms: None,
+            message: Some("Codex token refresh is rate limited. Try again shortly.".to_string()),
+        },
+        Err(RefreshError::Permanent(message)) => CodexAuthStatus::needs_relogin(message),
+        Err(RefreshError::Transient(message)) => CodexAuthStatus {
+            signed_in: false,
+            needs_relogin: false,
+            rate_limited_until_ms: None,
+            account_email: None,
+            plan_type: None,
+            expires_at_ms: None,
+            last_refresh_ms: None,
+            message: Some(message),
+        },
+    }
+}
+
+async fn fresh_access_token(
+    app: &AppHandle,
+    secrets: &SecretsState,
+    client: &Client,
+) -> Result<String, String> {
+    match fresh_session(app, secrets, client).await {
+        Ok(Some(session)) => Ok(session.access_token),
+        Ok(None) => Err("OpenAI Codex is not signed in. Open Settings and sign in.".to_string()),
+        Err(RefreshError::RateLimited) => {
+            Err("Codex token refresh is rate limited. Try again shortly.".to_string())
+        }
+        Err(RefreshError::Permanent(message)) | Err(RefreshError::Transient(message)) => {
+            Err(message)
+        }
+    }
+}
+
+async fn fresh_session(
+    app: &AppHandle,
+    secrets: &SecretsState,
+    client: &Client,
+) -> Result<Option<StoredCodexSession>, RefreshError> {
+    let Some(mut session) = load_session(app, secrets).map_err(RefreshError::Transient)? else {
+        return Ok(None);
+    };
+    hydrate_session_metadata(&mut session);
+    if !session_needs_refresh(&session) {
+        return Ok(Some(session));
+    }
+    let refreshed = refresh_session(client, &session).await?;
+    save_session(app, secrets, &refreshed).map_err(RefreshError::Transient)?;
+    Ok(Some(refreshed))
+}
+
+fn session_needs_refresh(session: &StoredCodexSession) -> bool {
+    match session.expires_at_ms {
+        Some(expires_at) => expires_at <= now_ms().saturating_add(REFRESH_SKEW_MS),
+        None => true,
+    }
+}
+
+fn session_from_token_response(
+    token: TokenResp,
+    previous: Option<&StoredCodexSession>,
+) -> Result<StoredCodexSession, String> {
+    let expires_at_ms = parse_jwt_expiration_ms(&token.access_token).or_else(|| {
+        token
+            .expires_in
+            .map(|secs| now_ms().saturating_add(secs * 1000))
+    });
+    let mut session = StoredCodexSession {
+        access_token: token.access_token,
+        refresh_token: token
+            .refresh_token
+            .or_else(|| previous.map(|s| s.refresh_token.clone()))
+            .ok_or_else(|| "Codex token response did not include a refresh token".to_string())?,
+        id_token: token
+            .id_token
+            .or_else(|| previous.and_then(|s| s.id_token.clone())),
+        expires_at_ms,
+        account_email: previous.and_then(|s| s.account_email.clone()),
+        plan_type: previous.and_then(|s| s.plan_type.clone()),
+        last_refresh_ms: Some(now_ms()),
+    };
+    hydrate_session_metadata(&mut session);
+    Ok(session)
+}
+
+fn hydrate_session_metadata(session: &mut StoredCodexSession) {
+    if session.expires_at_ms.is_none() {
+        session.expires_at_ms = parse_jwt_expiration_ms(&session.access_token);
+    }
+    if let Some(id_token) = session.id_token.as_deref() {
+        if session.account_email.is_none() {
+            session.account_email = parse_chatgpt_claim(id_token, &["email"]).or_else(|| {
+                parse_nested_chatgpt_claim(id_token, "https://api.openai.com/profile", "email")
+            });
+        }
+        if session.plan_type.is_none() {
+            session.plan_type = parse_nested_chatgpt_claim(
+                id_token,
+                "https://api.openai.com/auth",
+                "chatgpt_plan_type",
+            );
+        }
+    }
+}
+
+fn status_from_session(session: &StoredCodexSession) -> CodexAuthStatus {
+    CodexAuthStatus {
+        signed_in: true,
+        needs_relogin: false,
+        rate_limited_until_ms: None,
+        account_email: session.account_email.clone(),
+        plan_type: session.plan_type.clone(),
+        expires_at_ms: session.expires_at_ms,
+        last_refresh_ms: session.last_refresh_ms,
+        message: None,
+    }
+}
+
+fn load_session(
+    app: &AppHandle,
+    secrets: &SecretsState,
+) -> Result<Option<StoredCodexSession>, String> {
+    let Some(raw) = get_secret_value(app, secrets, KEYRING_SERVICE, CODEX_SECRET_ACCOUNT)? else {
+        return Ok(None);
+    };
+    serde_json::from_str(&raw)
+        .map(Some)
+        .map_err(|e| format!("Stored Codex session is unreadable: {e}"))
+}
+
+fn save_session(
+    app: &AppHandle,
+    secrets: &SecretsState,
+    session: &StoredCodexSession,
+) -> Result<(), String> {
+    let raw = serde_json::to_string(session).map_err(|e| e.to_string())?;
+    set_secret_value(app, secrets, KEYRING_SERVICE, CODEX_SECRET_ACCOUNT, raw)
+}
+
+#[derive(Debug)]
+enum RefreshError {
+    RateLimited,
+    Permanent(String),
+    Transient(String),
+}
+
+fn validate_codex_responses_url(url: &str, method: &str) -> Result<reqwest::Url, String> {
+    if !method.eq_ignore_ascii_case("POST") {
+        return Err("Codex bridge only allows POST requests".to_string());
+    }
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("invalid url: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err("Codex bridge only allows HTTPS".to_string());
+    }
+    if parsed.username() != "" || parsed.password().is_some() {
+        return Err("userinfo in url is not allowed".to_string());
+    }
+    if parsed.host_str() != Some("chatgpt.com") {
+        return Err("Codex bridge only allows chatgpt.com".to_string());
+    }
+    if parsed.port().is_some() {
+        return Err("Codex bridge does not allow custom ports".to_string());
+    }
+    if parsed.path() != "/backend-api/codex/responses" {
+        return Err("Codex bridge only allows the Responses endpoint".to_string());
+    }
+    Ok(parsed)
+}
+
+fn sanitize_codex_headers(headers: Option<HashMap<String, String>>) -> Result<HeaderMap, String> {
+    let mut map = HeaderMap::new();
+    let Some(headers) = headers else {
+        return Ok(map);
+    };
+    for (name, value) in headers {
+        let lower = name.to_ascii_lowercase();
+        if matches!(
+            lower.as_str(),
+            "authorization"
+                | "cookie"
+                | "host"
+                | "content-length"
+                | "connection"
+                | "proxy-authorization"
+                | "proxy-connection"
+                | "te"
+                | "transfer-encoding"
+                | "upgrade"
+                | "trailer"
+                | "expect"
+        ) {
+            continue;
+        }
+        if value
+            .as_bytes()
+            .iter()
+            .any(|b| matches!(b, 0 | b'\r' | b'\n'))
+        {
+            return Err(format!("header value contains control bytes: {name}"));
+        }
+        let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|e| e.to_string())?;
+        let header_value = HeaderValue::from_str(&value).map_err(|e| e.to_string())?;
+        map.insert(header_name, header_value);
+    }
+    Ok(map)
+}
+
+fn codex_response_headers_to_strings(headers: &HeaderMap) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for (k, v) in headers {
+        let name = k.as_str().to_ascii_lowercase();
+        if !codex_response_header_allowed(&name) {
+            continue;
+        }
+        if let Ok(s) = v.to_str() {
+            out.insert(name, s.to_string());
+        }
+    }
+    out
+}
+
+fn codex_response_header_allowed(name: &str) -> bool {
+    matches!(
+        name,
+        "content-type"
+            | "x-request-id"
+            | "request-id"
+            | "x-ratelimit-limit-requests"
+            | "x-ratelimit-remaining-requests"
+            | "x-ratelimit-reset-requests"
+            | "x-ratelimit-limit-tokens"
+            | "x-ratelimit-remaining-tokens"
+            | "x-ratelimit-reset-tokens"
+    )
+}
+
+fn upstream_auth_error(prefix: &str, status: StatusCode, body: &str) -> String {
+    match safe_upstream_error_detail(body) {
+        Some(detail) => format!("{prefix}: {status}: {detail}"),
+        None => format!("{prefix}: {status}"),
+    }
+}
+
+fn safe_upstream_error_detail(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let detail = extract_error_detail(&value)?;
+    let redacted = redact_sensitive_error_text(&detail);
+    let trimmed = redacted.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(truncate_chars(trimmed, UPSTREAM_ERROR_DETAIL_MAX_CHARS))
+}
+
+fn extract_error_detail(value: &Value) -> Option<String> {
+    let error = value.get("error");
+    if let Some(error) = error {
+        if let Some(code) = error.as_str() {
+            return Some(code.to_string());
+        }
+        if let Some(code) = error.get("code").and_then(Value::as_str) {
+            if let Some(message) = error.get("message").and_then(Value::as_str) {
+                return Some(format!("{code}: {message}"));
+            }
+            return Some(code.to_string());
+        }
+        if let Some(message) = error.get("message").and_then(Value::as_str) {
+            return Some(message.to_string());
+        }
+    }
+    if let Some(code) = value.get("error_code").and_then(Value::as_str) {
+        return Some(code.to_string());
+    }
+    if let Some(message) = value.get("message").and_then(Value::as_str) {
+        return Some(message.to_string());
+    }
+    None
+}
+
+fn redact_sensitive_error_text(value: &str) -> String {
+    let mut out = Vec::new();
+    let mut redact_next = false;
+
+    for part in value.split_whitespace() {
+        let lower = part.to_ascii_lowercase();
+        let sensitive_marker = is_sensitive_error_marker(&lower);
+        let redact_current = redact_next || sensitive_marker || looks_like_secret_fragment(part);
+        out.push(if redact_current {
+            "[redacted]".to_string()
+        } else {
+            part.to_string()
+        });
+        redact_next = sensitive_marker && !lower.contains('=') && !lower.contains(':');
+    }
+
+    out.join(" ")
+}
+
+fn is_sensitive_error_marker(lower: &str) -> bool {
+    lower.contains("access_token")
+        || lower.contains("refresh_token")
+        || lower.contains("id_token")
+        || lower.contains("authorization")
+        || lower.contains("bearer")
+        || lower.contains("client_secret")
+        || lower.contains("device_auth_id")
+        || lower.contains("authorization_code")
+        || lower.contains("code_verifier")
+}
+
+fn looks_like_secret_fragment(value: &str) -> bool {
+    let trimmed = value.trim_matches(|c: char| {
+        matches!(
+            c,
+            '"' | '\'' | ',' | ':' | ';' | '(' | ')' | '[' | ']' | '{' | '}'
+        )
+    });
+    if trimmed.len() < 24 {
+        return false;
+    }
+    let allowed = trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '=' | '/' | '+'));
+    allowed
+        && (trimmed.contains('.')
+            || trimmed.contains('_')
+            || trimmed.contains('-')
+            || trimmed.len() >= 40)
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut out = String::with_capacity(value.len().min(max_chars));
+    for (i, ch) in value.chars().enumerate() {
+        if i >= max_chars {
+            out.push_str("...");
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn form_body(fields: &[(&str, &str)]) -> String {
+    fields
+        .iter()
+        .map(|(k, v)| format!("{}={}", percent_encode(k), percent_encode(v)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn token_exchange_body(authorization_code: &str, code_verifier: &str) -> String {
+    form_body(&[
+        ("grant_type", "authorization_code"),
+        ("code", authorization_code),
+        ("redirect_uri", DEVICE_REDIRECT_URI),
+        ("client_id", CODEX_CLIENT_ID),
+        ("code_verifier", code_verifier),
+    ])
+}
+
+fn token_refresh_body(refresh_token: &str) -> String {
+    form_body(&[
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", CODEX_CLIENT_ID),
+    ])
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for b in value.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn parse_jwt_payload(jwt: &str) -> Option<Value> {
+    let mut parts = jwt.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let _sig = parts.next()?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn parse_jwt_expiration_ms(jwt: &str) -> Option<u64> {
+    let payload = parse_jwt_payload(jwt)?;
+    payload
+        .get("exp")?
+        .as_u64()
+        .map(|secs| secs.saturating_mul(1000))
+}
+
+fn parse_chatgpt_claim(jwt: &str, path: &[&str]) -> Option<String> {
+    let payload = parse_jwt_payload(jwt)?;
+    let mut value = &payload;
+    for segment in path {
+        value = value.get(*segment)?;
+    }
+    value.as_str().map(str::to_string)
+}
+
+fn parse_nested_chatgpt_claim(jwt: &str, parent: &str, child: &str) -> Option<String> {
+    parse_chatgpt_claim(jwt, &[parent, child])
+}
+
+fn extract_error_code(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    value
+        .get("error")
+        .and_then(|e| {
+            if let Some(code) = e.as_str() {
+                return Some(code);
+            }
+            e.get("code").and_then(Value::as_str)
+        })
+        .or_else(|| value.get("error_code").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn is_permanent_refresh_code(code: Option<&str>) -> bool {
+    let normalized = code.map(str::to_ascii_lowercase);
+    matches!(
+        normalized.as_deref(),
+        Some(
+            "invalid_grant"
+                | "invalid_token"
+                | "refresh_token_expired"
+                | "refresh_token_reused"
+                | "refresh_token_invalidated"
+        )
+    )
+}
+
+fn default_poll_interval_secs() -> u64 {
+    5
+}
+
+fn deserialize_interval<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    match value {
+        Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| serde::de::Error::custom("interval must be an integer")),
+        Value::String(s) => s.trim().parse::<u64>().map_err(serde::de::Error::custom),
+        _ => Err(serde::de::Error::custom(
+            "interval must be a string or integer",
+        )),
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_jwt(payload: Value) -> String {
+        let header = serde_json::json!({ "alg": "none", "typ": "JWT" });
+        let enc = |value: &Value| {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_vec(value).unwrap())
+        };
+        format!("{}.{}.sig", enc(&header), enc(&payload))
+    }
+
+    #[test]
+    fn parses_jwt_expiration_and_claims() {
+        let jwt = fake_jwt(serde_json::json!({
+            "exp": 1_700_000_000_u64,
+            "email": "user@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "pro"
+            }
+        }));
+
+        assert_eq!(parse_jwt_expiration_ms(&jwt), Some(1_700_000_000_000));
+        assert_eq!(
+            parse_chatgpt_claim(&jwt, &["email"]).as_deref(),
+            Some("user@example.com")
+        );
+        assert_eq!(
+            parse_nested_chatgpt_claim(&jwt, "https://api.openai.com/auth", "chatgpt_plan_type")
+                .as_deref(),
+            Some("pro")
+        );
+    }
+
+    #[test]
+    fn validates_codex_responses_url() {
+        assert!(validate_codex_responses_url(
+            "https://chatgpt.com/backend-api/codex/responses",
+            "POST"
+        )
+        .is_ok());
+        assert!(validate_codex_responses_url(
+            "https://chatgpt.com/backend-api/codex/responses",
+            "GET"
+        )
+        .is_err());
+        assert!(validate_codex_responses_url(
+            "http://chatgpt.com/backend-api/codex/responses",
+            "POST"
+        )
+        .is_err());
+        assert!(validate_codex_responses_url(
+            "https://example.com/backend-api/codex/responses",
+            "POST"
+        )
+        .is_err());
+        assert!(validate_codex_responses_url(
+            "https://chatgpt.com/backend-api/codex/models",
+            "POST"
+        )
+        .is_err());
+        assert!(validate_codex_responses_url(
+            "https://user:pass@chatgpt.com/backend-api/codex/responses",
+            "POST"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn codex_headers_strip_sensitive_values() {
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), "Bearer fake".to_string());
+        headers.insert("cookie".to_string(), "a=b".to_string());
+        headers.insert("content-type".to_string(), "application/json".to_string());
+
+        let sanitized = sanitize_codex_headers(Some(headers)).unwrap();
+        assert!(!sanitized.contains_key("authorization"));
+        assert!(!sanitized.contains_key("cookie"));
+        assert_eq!(
+            sanitized.get("content-type").and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn codex_headers_reject_crlf() {
+        let mut headers = HashMap::new();
+        headers.insert("x-test".to_string(), "ok\r\nbad: yes".to_string());
+        assert!(sanitize_codex_headers(Some(headers)).is_err());
+    }
+
+    #[test]
+    fn codex_response_headers_only_expose_allowlisted_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+        headers.insert(
+            HeaderName::from_static("x-request-id"),
+            HeaderValue::from_static("req_123"),
+        );
+        headers.insert(
+            HeaderName::from_static("set-cookie"),
+            HeaderValue::from_static("session=secret"),
+        );
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
+        headers.insert(
+            HeaderName::from_static("www-authenticate"),
+            HeaderValue::from_static("Bearer error=\"invalid_token\""),
+        );
+
+        let sanitized = codex_response_headers_to_strings(&headers);
+        assert_eq!(
+            sanitized.get("content-type").map(String::as_str),
+            Some("text/event-stream")
+        );
+        assert_eq!(
+            sanitized.get("x-request-id").map(String::as_str),
+            Some("req_123")
+        );
+        assert!(!sanitized.contains_key("set-cookie"));
+        assert!(!sanitized.contains_key("authorization"));
+        assert!(!sanitized.contains_key("www-authenticate"));
+    }
+
+    #[test]
+    fn upstream_auth_errors_do_not_echo_raw_sensitive_body() {
+        let body = serde_json::json!({
+            "refresh_token": "raw-refresh-secret",
+            "error": {
+                "code": "invalid_grant",
+                "message": "refresh_token raw-refresh-secret Bearer eyJhbGciOiJIUzI1NiJ9.secret.payload"
+            }
+        })
+        .to_string();
+
+        let message =
+            upstream_auth_error("Codex token refresh failed", StatusCode::BAD_REQUEST, &body);
+
+        assert!(message.contains("invalid_grant"));
+        assert!(message.contains("[redacted]"));
+        assert!(!message.contains("raw-refresh-secret"));
+        assert!(!message.contains("eyJhbGciOiJIUzI1NiJ9"));
+        assert!(!message.contains("refresh_token"));
+        assert!(!message.contains("Bearer"));
+    }
+
+    #[test]
+    fn upstream_auth_errors_drop_unparseable_raw_body() {
+        let message = upstream_auth_error(
+            "Codex token exchange failed",
+            StatusCode::BAD_GATEWAY,
+            "refresh_token raw-refresh-secret",
+        );
+
+        assert_eq!(message, "Codex token exchange failed: 502 Bad Gateway");
+    }
+
+    #[test]
+    fn form_body_percent_encodes_values() {
+        assert_eq!(
+            form_body(&[(
+                "redirect_uri",
+                "https://auth.openai.com/deviceauth/callback"
+            )]),
+            "redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback"
+        );
+    }
+
+    #[test]
+    fn codex_token_payloads_are_form_encoded() {
+        assert_eq!(
+            token_exchange_body("auth code", "verifier/value"),
+            "grant_type=authorization_code&code=auth%20code&redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback&client_id=app_EMoamEEZ73f0CkXaXp7hrann&code_verifier=verifier%2Fvalue"
+        );
+        assert_eq!(
+            token_refresh_body("refresh token"),
+            "grant_type=refresh_token&refresh_token=refresh%20token&client_id=app_EMoamEEZ73f0CkXaXp7hrann"
+        );
+    }
+
+    #[test]
+    fn refreshed_session_keeps_previous_refresh_token_when_not_rotated() {
+        let previous = StoredCodexSession {
+            access_token: "old".to_string(),
+            refresh_token: "refresh-old".to_string(),
+            id_token: Some(fake_jwt(serde_json::json!({ "email": "old@example.com" }))),
+            expires_at_ms: Some(1),
+            account_email: Some("old@example.com".to_string()),
+            plan_type: None,
+            last_refresh_ms: Some(1),
+        };
+        let token = TokenResp {
+            access_token: fake_jwt(serde_json::json!({ "exp": 1_700_000_000_u64 })),
+            refresh_token: None,
+            id_token: None,
+            expires_in: None,
+        };
+
+        let session = session_from_token_response(token, Some(&previous)).unwrap();
+        assert_eq!(session.refresh_token, "refresh-old");
+        assert_eq!(session.account_email.as_deref(), Some("old@example.com"));
+        assert_eq!(session.expires_at_ms, Some(1_700_000_000_000));
+    }
+
+    #[test]
+    fn refresh_error_codes_are_classified_as_permanent() {
+        let body = serde_json::json!({
+            "error": {
+                "code": "refresh_token_reused"
+            }
+        })
+        .to_string();
+        let code = extract_error_code(&body);
+        assert_eq!(code.as_deref(), Some("refresh_token_reused"));
+        assert!(is_permanent_refresh_code(code.as_deref()));
+        assert!(is_permanent_refresh_code(Some("invalid_grant")));
+    }
+}

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod codex_auth;
 pub mod fs;
 pub mod git;
 pub mod net;

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -204,10 +204,7 @@ mod unix {
                 cmd.arg("-i");
             }
             Shell::Other => {
-                log::info!(
-                    "unsupported shell '{}', spawning without integration",
-                    shell_path
-                );
+                log::info!("unsupported shell '{shell_path}', spawning without integration");
             }
         }
         Ok(cmd)

--- a/src-tauri/src/modules/secrets.rs
+++ b/src-tauri/src/modules/secrets.rs
@@ -112,6 +112,85 @@ fn entry(service: &str, account: &str) -> Result<keyring::Entry, String> {
     keyring::Entry::new(service, account).map_err(|e| e.to_string())
 }
 
+pub(crate) fn get_secret_value(
+    app: &AppHandle,
+    state: &SecretsState,
+    service: &str,
+    account: &str,
+) -> Result<Option<String>, String> {
+    #[cfg(target_os = "linux")]
+    {
+        let key = key(service, account);
+        with_store(app, state, |m| m.get(&key).cloned())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (app, state);
+        let e = entry(service, account)?;
+        match e.get_password() {
+            Ok(v) => Ok(Some(v)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+}
+
+pub(crate) fn set_secret_value(
+    app: &AppHandle,
+    state: &SecretsState,
+    service: &str,
+    account: &str,
+    password: String,
+) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        let key = key(service, account);
+        with_store(app, state, |m| {
+            m.insert(key, password);
+        })?;
+        let snapshot = {
+            let guard = state.cache.lock().map_err(|e| e.to_string())?;
+            guard.as_ref().cloned().unwrap_or_default()
+        };
+        write_store(app, &snapshot)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (app, state);
+        let e = entry(service, account)?;
+        e.set_password(&password).map_err(|e| e.to_string())
+    }
+}
+
+pub(crate) fn delete_secret_value(
+    app: &AppHandle,
+    state: &SecretsState,
+    service: &str,
+    account: &str,
+) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        let key = key(service, account);
+        with_store(app, state, |m| {
+            m.remove(&key);
+        })?;
+        let snapshot = {
+            let guard = state.cache.lock().map_err(|e| e.to_string())?;
+            guard.as_ref().cloned().unwrap_or_default()
+        };
+        write_store(app, &snapshot)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (app, state);
+        let e = entry(service, account)?;
+        match e.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn secrets_get(
     app: AppHandle,
@@ -119,22 +198,7 @@ pub async fn secrets_get(
     service: String,
     account: String,
 ) -> Result<Option<String>, String> {
-    #[cfg(target_os = "linux")]
-    {
-        let _ = state; // capture
-        let key = key(&service, &account);
-        with_store(&app, &state, |m| m.get(&key).cloned())
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (app, state);
-        let e = entry(&service, &account)?;
-        match e.get_password() {
-            Ok(v) => Ok(Some(v)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(err) => Err(err.to_string()),
-        }
-    }
+    get_secret_value(&app, &state, &service, &account)
 }
 
 #[tauri::command]
@@ -145,24 +209,7 @@ pub async fn secrets_set(
     account: String,
     password: String,
 ) -> Result<(), String> {
-    #[cfg(target_os = "linux")]
-    {
-        let key = key(&service, &account);
-        with_store(&app, &state, |m| {
-            m.insert(key, password);
-        })?;
-        let snapshot = {
-            let guard = state.cache.lock().map_err(|e| e.to_string())?;
-            guard.as_ref().cloned().unwrap_or_default()
-        };
-        write_store(&app, &snapshot)
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (app, state);
-        let e = entry(&service, &account)?;
-        e.set_password(&password).map_err(|e| e.to_string())
-    }
+    set_secret_value(&app, &state, &service, &account, password)
 }
 
 #[tauri::command]
@@ -172,27 +219,7 @@ pub async fn secrets_delete(
     service: String,
     account: String,
 ) -> Result<(), String> {
-    #[cfg(target_os = "linux")]
-    {
-        let key = key(&service, &account);
-        with_store(&app, &state, |m| {
-            m.remove(&key);
-        })?;
-        let snapshot = {
-            let guard = state.cache.lock().map_err(|e| e.to_string())?;
-            guard.as_ref().cloned().unwrap_or_default()
-        };
-        write_store(&app, &snapshot)
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (app, state);
-        let e = entry(&service, &account)?;
-        match e.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(err) => Err(err.to_string()),
-        }
-    }
+    delete_secret_value(&app, &state, &service, &account)
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -245,7 +272,10 @@ mod tests {
         write_store_at(&p, &HashMap::new()).unwrap();
 
         let tmp_path = p.with_extension("json.tmp");
-        assert!(!tmp_path.exists(), "tmp file must be renamed away on success");
+        assert!(
+            !tmp_path.exists(),
+            "tmp file must be renamed away on success"
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/shell/session.rs
+++ b/src-tauri/src/modules/shell/session.rs
@@ -41,7 +41,7 @@ fn generate_sentinel() -> String {
     let counter = SENTINEL_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id() as u64;
     let mix = nanos ^ counter.rotate_left(17) ^ pid.rotate_left(31);
-    format!("__TERAX_CWD_{:016x}_{:016x}__", mix, counter)
+    format!("__TERAX_CWD_{mix:016x}_{counter:016x}__")
 }
 
 impl ShellSession {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -30,6 +30,7 @@ import {
   LocalAgentNotificationsBridge,
   SelectionAskAi,
   useChatStore,
+  useCodexAuthStore,
 } from "@/modules/ai";
 import { AiComposerProvider } from "@/modules/ai/lib/composer";
 import { redactSensitive } from "@/modules/ai/lib/redact";
@@ -423,6 +424,8 @@ export default function App() {
   const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
   const setLive = useChatStore((s) => s.setLive);
   const respondToApproval = useChatStore((s) => s.respondToApproval);
+  const codexSignedIn = useCodexAuthStore((s) => s.status.signedIn);
+  const refreshCodexAuthStatus = useCodexAuthStore((s) => s.refreshStatus);
 
   useEffect(() => {
     if (activeSessionId) firePendingReviewForSession(activeSessionId);
@@ -447,7 +450,7 @@ export default function App() {
     (openaiCompatibleBaseURL.trim().length > 0 &&
       openaiCompatibleModelId.trim().length > 0) ||
     customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0);
-  const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
+  const hasComposer = hasAnyKey(apiKeys) || hasLocalModel || codexSignedIn;
 
   const prefsHydrated = usePreferencesStore((s) => s.hydrated);
   const [keysLoaded, setKeysLoaded] = useState(false);
@@ -460,6 +463,7 @@ export default function App() {
         setKeysLoaded(true);
       });
       if (!prefsHydrated) return;
+      void refreshCodexAuthStatus();
       void getAllCustomEndpointKeys(
         usePreferencesStore.getState().customEndpoints,
       ).then((epKeys) => {
@@ -473,7 +477,7 @@ export default function App() {
       alive = false;
       void unlistenP.then((fn) => fn());
     };
-  }, [setApiKeys, setCustomEndpointKeys, prefsHydrated]);
+  }, [setApiKeys, setCustomEndpointKeys, refreshCodexAuthStatus, prefsHydrated]);
 
   // Hydrate the cross-window preference store and mirror the default model
   // into chatStore so the dropdown reflects what the user picked in Settings.

--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -198,6 +198,7 @@ export function AiChatView({
   const patchAgentMeta = useChatStore((s) => s.patchAgentMeta);
   const showContinue =
     !isBusy && hitStepCap && lastMessage?.role === "assistant";
+  const errorMessage = error ? formatChatError(error) : null;
 
   const onApproval = useCallback(
     (id: string, approved: boolean) => addToolApprovalResponse({ id, approved }),
@@ -254,7 +255,7 @@ export function AiChatView({
           <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             <div className="font-medium">Something went wrong.</div>
             <div className="mt-0.5 leading-relaxed opacity-90">
-              {error.message}
+              {errorMessage}
             </div>
             <button
               type="button"
@@ -269,6 +270,43 @@ export function AiChatView({
       <ConversationScrollButton />
     </Conversation>
   );
+}
+
+function formatChatError(error: Error): string {
+  const shaped = error as Error & {
+    responseBody?: unknown;
+    data?: unknown;
+    cause?: unknown;
+  };
+  const candidates = [
+    extractErrorMessage(shaped.responseBody),
+    extractErrorMessage(shaped.data),
+    extractErrorMessage(shaped.cause),
+    error.message,
+    String(error),
+  ];
+  return (
+    candidates.find((message) => message && message.trim().length > 0) ??
+    "AI request failed"
+  );
+}
+
+function extractErrorMessage(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      return extractErrorMessage(JSON.parse(trimmed)) ?? trimmed;
+    } catch {
+      return trimmed;
+    }
+  }
+  if (typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const direct = record.detail ?? record.message ?? record.error_description;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  return extractErrorMessage(record.error) ?? extractErrorMessage(record.cause);
 }
 
 const CompactionNotice = memo(function CompactionNotice({

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -47,9 +47,11 @@ import {
   compatModelIdForEndpoint,
   getCompatModelInfo,
   getModel,
+  getModelWireId,
   isCompatModelId,
   MODELS,
   providerNeedsKey,
+  providerNeedsOAuthSession,
   PROVIDERS,
   type ModelCapabilities,
   type ModelId,
@@ -57,12 +59,20 @@ import {
   type ProviderId,
 } from "../config";
 import { ACCEPTED_FILES, useComposer } from "../lib/composer";
+import {
+  codexModelSupportsFast,
+  CODEX_REASONING_LEVELS,
+  CODEX_SPEED_OPTIONS,
+} from "../lib/codexOptions";
 import { toggleFavoriteModel } from "../lib/modelPrefs";
 import { useChatStore } from "../store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setCodexReasoning, setCodexSpeed } from "@/modules/settings/store";
+import { useCodexAuthStore } from "../store/codexAuthStore";
 
 const PROVIDER_ICON = {
   openai: ChatGptIcon,
+  "openai-codex": ChatGptIcon,
   anthropic: ClaudeIcon,
   google: GoogleGeminiIcon,
   xai: Grok02Icon,
@@ -212,6 +222,7 @@ type Tab = "all" | "favorites" | "recent";
 function ModelDropdown() {
   const selected = useChatStore((s) => s.selectedModelId);
   const apiKeys = useChatStore((s) => s.apiKeys);
+  const codexSignedIn = useCodexAuthStore((s) => s.status.signedIn);
   const setSelected = useChatStore((s) => s.setSelectedModelId);
   const favoriteIds = usePreferencesStore((s) => s.favoriteModelIds);
   const recentIds = usePreferencesStore((s) => s.recentModelIds);
@@ -225,12 +236,19 @@ function ModelDropdown() {
   const inputRef = useRef<HTMLInputElement>(null);
   const currentProviderHasKey = isCompatModelId(selected)
     ? true
+    : providerNeedsOAuthSession(current.provider)
+      ? codexSignedIn
     : providerNeedsKey(current.provider)
       ? !!apiKeys[current.provider]
       : true;
+  const showCodexOptions =
+    activeProvider === "openai-codex" ||
+    (activeProvider === null && current.provider === "openai-codex");
 
-  const hasKeyFor = (id: ProviderId) =>
-    providerNeedsKey(id) ? !!apiKeys[id] : true;
+  const hasKeyFor = (id: ProviderId) => {
+    if (providerNeedsOAuthSession(id)) return codexSignedIn;
+    return providerNeedsKey(id) ? !!apiKeys[id] : true;
+  };
 
   const epModelInfos = useMemo(() => {
     return customEndpoints.map((ep) =>
@@ -247,7 +265,7 @@ function ModelDropdown() {
     }
     return { configured, unconfigured };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKeys]);
+  }, [apiKeys, codexSignedIn]);
 
   const allModels = useMemo(
     () => [...MODELS, ...epModelInfos],
@@ -302,7 +320,7 @@ function ModelDropdown() {
           title={
             currentProviderHasKey
               ? `Model: ${current.label}`
-              : `${current.label} — no key configured`
+              : `${current.label} is not configured`
           }
         >
           {current.label}
@@ -411,6 +429,7 @@ function ModelDropdown() {
             activeProvider !== COMPAT_PROVIDER_ID ? (
               <ProviderHeader providerId={activeProvider as ProviderId} />
             ) : null}
+            {showCodexOptions ? <CodexOptionsPanel model={current} /> : null}
             {activeProvider !== null &&
             activeProvider !== COMPAT_PROVIDER_ID &&
             !hasKeyFor(activeProvider as ProviderId) ? (
@@ -521,6 +540,81 @@ function ProviderPill({
   );
 }
 
+function CodexOptionsPanel({ model }: { model: ModelInfo }) {
+  const reasoning = usePreferencesStore((s) => s.codexReasoning);
+  const speed = usePreferencesStore((s) => s.codexSpeed);
+  const fastAvailable =
+    model.provider === "openai-codex" &&
+    codexModelSupportsFast(getModelWireId(model));
+  const effectiveSpeed = fastAvailable ? speed : "standard";
+
+  return (
+    <div className="mx-2 mb-1 rounded-md border border-border/60 bg-muted/20 p-2">
+      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+        <HugeiconsIcon icon={BrainIcon} size={12} strokeWidth={1.75} />
+        <span>Reasoning</span>
+      </div>
+      <div className="grid grid-cols-4 gap-1">
+        {CODEX_REASONING_LEVELS.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => void setCodexReasoning(option.id)}
+            className={cn(
+              "h-7 rounded-md px-1 text-[11px] font-medium transition-colors",
+              option.id === reasoning
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 mb-2 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
+        <HugeiconsIcon icon={FlashIcon} size={12} strokeWidth={1.75} />
+        <span>Speed</span>
+      </div>
+      <div className="grid grid-cols-2 gap-1">
+        {CODEX_SPEED_OPTIONS.map((option) => {
+          const disabled = option.id === "fast" && !fastAvailable;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => {
+                if (!disabled) void setCodexSpeed(option.id);
+              }}
+              disabled={disabled}
+              title={
+                disabled
+                  ? "Fast mode is available for GPT-5.5 and GPT-5.4"
+                  : undefined
+              }
+              className={cn(
+                "flex h-10 min-w-0 flex-col items-start justify-center rounded-md px-2 text-left transition-colors",
+                option.id === effectiveSpeed
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                disabled &&
+                  "cursor-not-allowed opacity-45 hover:bg-transparent hover:text-muted-foreground",
+              )}
+            >
+              <span className="text-[11px] font-medium leading-none">
+                {option.label}
+              </span>
+              <span className="mt-1 max-w-full truncate text-[10px] leading-none text-muted-foreground/80">
+                {option.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function ProviderHeader({ providerId }: { providerId: ProviderId }) {
   const p = PROVIDERS.find((x) => x.id === providerId);
   if (!p) return null;
@@ -573,6 +667,10 @@ function ModelRow({
   onPick: () => void;
   onToggleFavorite: () => void;
 }) {
+  const fastModeAvailable =
+    model.provider === "openai-codex" &&
+    codexModelSupportsFast(getModelWireId(model));
+
   return (
     <DropdownMenuItem
       onSelect={(e) => {
@@ -618,6 +716,14 @@ function ModelRow({
       ) : null}
 
       <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
+        {fastModeAvailable ? (
+          <HugeiconsIcon
+            icon={FlashIcon}
+            size={11}
+            strokeWidth={1.85}
+            className="shrink-0 text-muted-foreground"
+          />
+        ) : null}
         <span className="shrink-0 text-[12px] font-medium leading-none">
           {model.label}
         </span>

--- a/src/modules/ai/config.test.ts
+++ b/src/modules/ai/config.test.ts
@@ -2,10 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   compatModelIdForEndpoint,
   endpointIdFromCompatModel,
+  getAutocompleteEligibleModels,
+  getModelWireId,
   getModelContextLimit,
   isCompatModelId,
   migrateLegacyCompatEndpoint,
+  MODELS,
   modelKeepsReasoning,
+  providerAuthKind,
+  providerNeedsKey,
+  providerNeedsOAuthSession,
+  providerSupportsKey,
   resolveModel,
   type CustomEndpoint,
 } from "./config";
@@ -51,6 +58,36 @@ describe("resolveModel", () => {
 
   it("throws on an unknown static model id", () => {
     expect(() => resolveModel("nope-not-real")).toThrow();
+  });
+});
+
+describe("provider auth", () => {
+  it("classifies Codex as OAuth instead of API-key auth", () => {
+    expect(providerAuthKind("openai-codex")).toBe("oauth-device-code");
+    expect(providerNeedsOAuthSession("openai-codex")).toBe(true);
+    expect(providerNeedsKey("openai-codex")).toBe(false);
+    expect(providerSupportsKey("openai-codex")).toBe(false);
+  });
+
+  it("keeps model ids unique while mapping Codex to its wire id", () => {
+    const ids = MODELS.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const codexModels = MODELS.filter((m) => m.provider === "openai-codex");
+    expect(codexModels.map((m) => getModelWireId(m))).toEqual([
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex-spark",
+    ]);
+    expect(resolveModel("openai-codex-gpt-5.3-codex-spark").provider).toBe(
+      "openai-codex",
+    );
+  });
+
+  it("omits ChatGPT Codex from autocomplete choices", () => {
+    expect(
+      getAutocompleteEligibleModels().some((m) => m.provider === "openai-codex"),
+    ).toBe(false);
   });
 });
 

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -2,6 +2,7 @@ export const KEYRING_SERVICE = "terax-ai";
 
 export type ProviderId =
   | "openai"
+  | "openai-codex"
   | "anthropic"
   | "google"
   | "xai"
@@ -15,9 +16,16 @@ export type ProviderId =
   | "mlx"
   | "ollama";
 
+export type ProviderAuthKind =
+  | "api-key"
+  | "oauth-device-code"
+  | "local"
+  | "custom";
+
 export type ProviderInfo = {
   id: ProviderId;
   label: string;
+  authKind: ProviderAuthKind;
   keyringAccount: string;
   keyPrefix: string | null;
   consoleUrl: string;
@@ -29,13 +37,23 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "openai",
     label: "OpenAI",
+    authKind: "api-key",
     keyringAccount: "openai-api-key",
     keyPrefix: "sk-",
     consoleUrl: "https://platform.openai.com/api-keys",
   },
   {
+    id: "openai-codex",
+    label: "OpenAI Codex",
+    authKind: "oauth-device-code",
+    keyringAccount: "openai-codex-oauth",
+    keyPrefix: null,
+    consoleUrl: "https://developers.openai.com/codex/auth",
+  },
+  {
     id: "anthropic",
     label: "Anthropic",
+    authKind: "api-key",
     keyringAccount: "anthropic-api-key",
     keyPrefix: "sk-ant-",
     consoleUrl: "https://console.anthropic.com/settings/keys",
@@ -43,6 +61,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "google",
     label: "Google",
+    authKind: "api-key",
     keyringAccount: "google-api-key",
     keyPrefix: null,
     consoleUrl: "https://aistudio.google.com/apikey",
@@ -50,6 +69,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "xai",
     label: "xAI",
+    authKind: "api-key",
     keyringAccount: "xai-api-key",
     keyPrefix: "xai-",
     consoleUrl: "https://console.x.ai/",
@@ -57,6 +77,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "cerebras",
     label: "Cerebras",
+    authKind: "api-key",
     keyringAccount: "cerebras-api-key",
     keyPrefix: "csk-",
     consoleUrl: "https://cloud.cerebras.ai/",
@@ -64,6 +85,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "groq",
     label: "Groq",
+    authKind: "api-key",
     keyringAccount: "groq-api-key",
     keyPrefix: "gsk_",
     consoleUrl: "https://console.groq.com/keys",
@@ -71,6 +93,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "deepseek",
     label: "DeepSeek",
+    authKind: "api-key",
     keyringAccount: "deepseek-api-key",
     keyPrefix: "sk-",
     consoleUrl: "https://platform.deepseek.com/api_keys",
@@ -78,6 +101,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "mistral",
     label: "Mistral",
+    authKind: "api-key",
     keyringAccount: "mistral-api-key",
     keyPrefix: null,
     consoleUrl: "https://console.mistral.ai/api-keys/",
@@ -85,6 +109,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "openrouter",
     label: "OpenRouter",
+    authKind: "api-key",
     keyringAccount: "openrouter-api-key",
     keyPrefix: "sk-or-",
     consoleUrl: "https://openrouter.ai/keys",
@@ -92,6 +117,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "openai-compatible",
     label: "OpenAI Compatible",
+    authKind: "custom",
     keyringAccount: "openai-compatible-api-key",
     keyPrefix: null,
     consoleUrl: "https://platform.openai.com/docs/api-reference",
@@ -100,6 +126,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "lmstudio",
     label: "LM Studio",
+    authKind: "local",
     keyringAccount: "",
     keyPrefix: null,
     consoleUrl: "https://lmstudio.ai/docs/basics/server",
@@ -107,6 +134,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "mlx",
     label: "MLX",
+    authKind: "local",
     keyringAccount: "",
     keyPrefix: null,
     consoleUrl: "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md",
@@ -114,6 +142,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
   {
     id: "ollama",
     label: "Ollama",
+    authKind: "local",
     keyringAccount: "",
     keyPrefix: null,
     consoleUrl: "https://ollama.com/download",
@@ -176,6 +205,7 @@ export type ModelTag = "vision" | "reasoning" | "tools" | "coding";
 
 export type ModelInfo = {
   id: string;
+  wireId?: string;
   provider: ProviderId;
   label: string;
   /** One short word for the dropdown trigger. */
@@ -223,6 +253,46 @@ export const MODELS = [
     description: "Tuned for code and tool use.",
     capabilities: { intelligence: 4, speed: 4, cost: 3 },
     tags: ["tools", "coding"],
+  },
+  {
+    id: "openai-codex-gpt-5.5",
+    wireId: "gpt-5.5",
+    provider: "openai-codex",
+    label: "GPT-5.5",
+    hint: "Codex",
+    description: "ChatGPT Codex frontier model.",
+    capabilities: { intelligence: 5, speed: 3, cost: 1 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+  },
+  {
+    id: "openai-codex-gpt-5.4",
+    wireId: "gpt-5.4",
+    provider: "openai-codex",
+    label: "GPT-5.4",
+    hint: "Codex",
+    description: "ChatGPT Codex model for complex work.",
+    capabilities: { intelligence: 5, speed: 3, cost: 2 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+  },
+  {
+    id: "openai-codex-gpt-5.4-mini",
+    wireId: "gpt-5.4-mini",
+    provider: "openai-codex",
+    label: "GPT-5.4 Mini",
+    hint: "Codex",
+    description: "Faster ChatGPT Codex model.",
+    capabilities: { intelligence: 4, speed: 4, cost: 4 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+  },
+  {
+    id: "openai-codex-gpt-5.3-codex-spark",
+    wireId: "gpt-5.3-codex-spark",
+    provider: "openai-codex",
+    label: "GPT-5.3 Codex Spark",
+    hint: "Fast",
+    description: "Fast ChatGPT Codex coding model.",
+    capabilities: { intelligence: 4, speed: 5, cost: 4 },
+    tags: ["reasoning", "tools", "coding"],
   },
   {
     id: "gpt-4.1-mini",
@@ -553,6 +623,10 @@ export function resolveModel(
   return m;
 }
 
+export function getModelWireId(model: ModelInfo): string {
+  return model.wireId ?? model.id;
+}
+
 export function getModel(id: ModelId): ModelInfo {
   const m = MODELS.find((x) => x.id === id);
   if (!m) throw new Error(`Unknown model: ${id}`);
@@ -586,6 +660,10 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "gpt-5.4-mini": 400_000,
   "gpt-5.4-nano": 400_000,
   "gpt-5.3-codex": 400_000,
+  "openai-codex-gpt-5.5": 272_000,
+  "openai-codex-gpt-5.4": 272_000,
+  "openai-codex-gpt-5.4-mini": 272_000,
+  "openai-codex-gpt-5.3-codex-spark": 272_000,
   "gpt-4.1-mini": 128_000,
   "claude-opus-4-7": 200_000,
   "claude-sonnet-4-6": 200_000,
@@ -681,26 +759,43 @@ export const KEYLESS_PROVIDERS: readonly ProviderId[] = [
   "mlx",
   "ollama",
   "openai-compatible",
+  "openai-codex",
 ] as const;
 
 export function providerNeedsKey(id: ProviderId): boolean {
-  return !KEYLESS_PROVIDERS.includes(id);
+  return getProvider(id).authKind === "api-key";
+}
+
+export function providerNeedsOAuthSession(id: ProviderId): boolean {
+  return getProvider(id).authKind === "oauth-device-code";
+}
+
+export function providerAuthKind(id: ProviderId): ProviderAuthKind {
+  return getProvider(id).authKind;
 }
 
 /** True for providers that accept an API key — required *or* optional.
  *  Used by Settings to decide whether to render a key card at all. */
 export function providerSupportsKey(id: ProviderId): boolean {
-  if (providerNeedsKey(id)) return true;
+  if (getProvider(id).authKind === "api-key") return true;
   const p = getProvider(id);
   return !!p.keyOptional;
 }
 
 /** Any provider can power the editor's inline autocomplete; latency is the
  *  user's choice. The picker filters down to fast tiers in the UI. */
-export type AutocompleteProviderId = ProviderId;
+export type AutocompleteProviderId = Exclude<ProviderId, "openai-codex">;
+
+export function isAutocompleteProvider(
+  id: ProviderId,
+): id is AutocompleteProviderId {
+  return id !== "openai-codex";
+}
 
 /** Sensible default model id per provider for inline autocomplete. */
-export const DEFAULT_AUTOCOMPLETE_MODEL: Partial<Record<ProviderId, string>> = {
+export const DEFAULT_AUTOCOMPLETE_MODEL: Partial<
+  Record<AutocompleteProviderId, string>
+> = {
   cerebras: "gpt-oss-120b",
   groq: "openai/gpt-oss-20b",
   lmstudio: "qwen2.5-coder-7b-instruct",
@@ -716,7 +811,10 @@ export const DEFAULT_AUTOCOMPLETE_MODEL: Partial<Record<ProviderId, string>> = {
 /** Curated list of fast models suitable for inline completion (speed ≥ 4). */
 export function getAutocompleteEligibleModels(): readonly ModelInfo[] {
   return MODELS.filter(
-    (m) => m.capabilities.speed >= 4 && m.id !== "openai-compatible-custom",
+    (m) =>
+      m.capabilities.speed >= 4 &&
+      m.id !== "openai-compatible-custom" &&
+      m.provider !== "openai-codex",
   );
 }
 

--- a/src/modules/ai/index.ts
+++ b/src/modules/ai/index.ts
@@ -28,3 +28,9 @@ export {
   type AgentMeta,
   type AgentRunStatus,
 } from "./store/chatStore";
+export { useCodexAuthStore } from "./store/codexAuthStore";
+export type {
+  CodexAuthStatus,
+  CodexDeviceStart,
+  CodexPollResult,
+} from "./lib/codexAuth";

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -10,6 +10,7 @@ import {
 import {
   DEFAULT_MODEL_ID,
   endpointIdFromCompatModel,
+  getModelWireId,
   getModelContextLimit,
   isCompatModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
@@ -26,9 +27,20 @@ import {
 import { buildTools, type ToolContext } from "../tools/tools";
 import { compactModelMessagesDetailed } from "./compact";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
+import { createCodexProxyFetch } from "./codexFetch";
+import {
+  buildCodexProviderOptions,
+  type CodexReasoning,
+  type CodexSpeed,
+} from "./codexOptions";
 import { createProxyFetch } from "./proxyFetch";
+import {
+  filterReasoningForIssuer,
+  responsesIssuerForProvider,
+} from "./reasoningIssuer";
 
 const localProxyFetch = createProxyFetch({ allowPrivateNetwork: true });
+const codexProxyFetch = createCodexProxyFetch();
 
 const TOOL_LABELS: Record<string, (input: Record<string, unknown>) => string> =
   {
@@ -100,6 +112,16 @@ export async function buildLanguageModel(
     case "openai": {
       const { createOpenAI } = await import("@ai-sdk/openai");
       built = createOpenAI({ apiKey: key })(resolvedModelId);
+      break;
+    }
+    case "openai-codex": {
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      const openai = createOpenAI({
+        apiKey: "terax-codex-session",
+        baseURL: "https://chatgpt.com/backend-api/codex",
+        fetch: codexProxyFetch,
+      });
+      built = openai.responses(resolvedModelId);
       break;
     }
     case "anthropic": {
@@ -253,7 +275,7 @@ export function buildConfiguredLanguageModel(
     );
   }
   const m = resolveModel(modelId);
-  let resolvedId: string = m.id;
+  let resolvedId: string = getModelWireId(m);
   if (m.id === "lmstudio-local") {
     if (!local.lmstudioModelId?.trim()) {
       throw new Error(
@@ -384,6 +406,8 @@ export type RunAgentOptions = {
   customEndpointKeys?: CustomEndpointKeys;
   planMode?: boolean;
   projectMemory?: string | null;
+  codexReasoning?: CodexReasoning;
+  codexSpeed?: CodexSpeed;
   uiMessages: UIMessage[];
   abortSignal?: AbortSignal;
 };
@@ -414,7 +438,11 @@ export async function runAgentStream(opts: RunAgentOptions) {
     opts.projectMemory ?? null,
   );
 
-  const history = await convertToModelMessages(opts.uiMessages);
+  const reasoningIssuer = responsesIssuerForProvider(provider);
+  const uiMessages = reasoningIssuer
+    ? filterReasoningForIssuer(opts.uiMessages, reasoningIssuer)
+    : opts.uiMessages;
+  const history = await convertToModelMessages(uiMessages);
   const keepsReasoning = modelKeepsReasoning(info);
   const prunedHistory = pruneMessages({
     messages: history,
@@ -434,13 +462,26 @@ export async function runAgentStream(opts: RunAgentOptions) {
     opts.onCompact?.({ droppedCount: compact.droppedCount });
   }
 
-  const messages: ModelMessage[] = [{ role: "system", content: stableSystem }];
-  if (opts.planMode) {
+  const codexInstructions = opts.planMode
+    ? `${stableSystem}\n\n${PLAN_MODE_PROMPT}`
+    : stableSystem;
+  const messages: ModelMessage[] =
+    provider === "openai-codex"
+      ? []
+      : [{ role: "system", content: stableSystem }];
+  if (opts.planMode && provider !== "openai-codex") {
     messages.push({ role: "system", content: PLAN_MODE_PROMPT });
   }
   messages.push(...compactedHistory);
 
   const finalMessages = applyCacheBreakpoints(messages, provider);
+  const providerOptions = buildProviderOptions(
+    provider,
+    getModelWireId(info),
+    opts,
+    codexInstructions,
+    opts.toolContext.getSessionId(),
+  );
 
   let stepsSeen = 0;
   return streamText({
@@ -449,6 +490,7 @@ export async function runAgentStream(opts: RunAgentOptions) {
     tools: buildTools(opts.toolContext),
     stopWhen: stepCountIs(MAX_AGENT_STEPS),
     abortSignal: opts.abortSignal,
+    providerOptions,
     onStepFinish: (step) => {
       stepsSeen++;
       if (opts.onStep) {
@@ -487,6 +529,23 @@ export async function runAgentStream(opts: RunAgentOptions) {
       });
     },
   });
+}
+
+function buildProviderOptions(
+  provider: ProviderId,
+  modelWireId: string,
+  opts: Pick<RunAgentOptions, "codexReasoning" | "codexSpeed">,
+  instructions: string,
+  promptCacheKey: string | null,
+) {
+  if (provider !== "openai-codex") return undefined;
+  return buildCodexProviderOptions(
+    opts.codexReasoning,
+    opts.codexSpeed,
+    modelWireId,
+    instructions,
+    promptCacheKey,
+  );
 }
 
 export { EMPTY_USAGE };

--- a/src/modules/ai/lib/codexAuth.ts
+++ b/src/modules/ai/lib/codexAuth.ts
@@ -1,0 +1,59 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type CodexAuthStatus = {
+  signedIn: boolean;
+  needsRelogin: boolean;
+  rateLimitedUntilMs?: number | null;
+  accountEmail?: string | null;
+  planType?: string | null;
+  expiresAtMs?: number | null;
+  lastRefreshMs?: number | null;
+  message?: string | null;
+};
+
+export type CodexDeviceStart = {
+  loginId: string;
+  verificationUrl: string;
+  userCode: string;
+  expiresAtMs: number;
+  pollIntervalSecs: number;
+};
+
+export type CodexPollResult = {
+  status: "pending" | "complete" | "expired" | "error";
+  auth?: CodexAuthStatus | null;
+  message?: string | null;
+};
+
+export const CODEX_DISCONNECTED_STATUS: CodexAuthStatus = {
+  signedIn: false,
+  needsRelogin: false,
+  rateLimitedUntilMs: null,
+  accountEmail: null,
+  planType: null,
+  expiresAtMs: null,
+  lastRefreshMs: null,
+  message: null,
+};
+
+export async function getCodexAuthStatus(): Promise<CodexAuthStatus> {
+  return invoke<CodexAuthStatus>("openai_codex_auth_status");
+}
+
+export async function startCodexDeviceLogin(): Promise<CodexDeviceStart> {
+  return invoke<CodexDeviceStart>("openai_codex_auth_start_device");
+}
+
+export async function pollCodexDeviceLogin(
+  loginId: string,
+): Promise<CodexPollResult> {
+  return invoke<CodexPollResult>("openai_codex_auth_poll", { loginId });
+}
+
+export async function cancelCodexDeviceLogin(loginId: string): Promise<void> {
+  await invoke("openai_codex_auth_cancel", { loginId });
+}
+
+export async function logoutCodex(): Promise<void> {
+  await invoke("openai_codex_auth_logout");
+}

--- a/src/modules/ai/lib/codexFetch.test.ts
+++ b/src/modules/ai/lib/codexFetch.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { prepareCodexProxyRequest } from "./codexFetch";
+
+describe("prepareCodexProxyRequest", () => {
+  it("strips bearer and cookie material before invoking Rust", async () => {
+    const req = await prepareCodexProxyRequest(
+      "https://chatgpt.com/backend-api/codex/responses",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer fake",
+          cookie: "session=fake",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      },
+    );
+
+    expect(req.method).toBe("POST");
+    expect(req.headers).toEqual({ "content-type": "application/json" });
+    expect(req.body).toEqual(Array.from(new TextEncoder().encode("{}")));
+  });
+});

--- a/src/modules/ai/lib/codexFetch.ts
+++ b/src/modules/ai/lib/codexFetch.ts
@@ -1,0 +1,166 @@
+import { Channel, invoke } from "@tauri-apps/api/core";
+
+type CodexStreamEvent =
+  | { kind: "headers"; status: number; headers: Record<string, string> }
+  | { kind: "chunk"; bytes: number[] }
+  | { kind: "end" }
+  | { kind: "error"; message: string };
+
+type RequestHeaders = Record<string, string>;
+
+const FRONTEND_STRIPPED_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "host",
+  "content-length",
+]);
+
+function headerInitToRecord(
+  init: HeadersInit | undefined,
+): RequestHeaders | undefined {
+  if (!init) return undefined;
+  const out: RequestHeaders = {};
+  if (init instanceof Headers) {
+    init.forEach((value, key) => {
+      out[key] = value;
+    });
+  } else if (Array.isArray(init)) {
+    for (const [k, v] of init) out[k] = v;
+  } else {
+    for (const [k, v] of Object.entries(init)) out[k] = String(v);
+  }
+  return out;
+}
+
+function stripSensitiveHeaders(
+  headers: RequestHeaders | undefined,
+): RequestHeaders | undefined {
+  if (!headers) return undefined;
+  const out: RequestHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (FRONTEND_STRIPPED_HEADERS.has(key.toLowerCase())) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+async function bodyToBytes(
+  body: BodyInit | null | undefined,
+): Promise<number[] | undefined> {
+  if (body == null) return undefined;
+  if (typeof body === "string") {
+    return Array.from(new TextEncoder().encode(body));
+  }
+  if (body instanceof ArrayBuffer) return Array.from(new Uint8Array(body));
+  if (ArrayBuffer.isView(body)) {
+    const view = body as ArrayBufferView;
+    return Array.from(
+      new Uint8Array(view.buffer, view.byteOffset, view.byteLength),
+    );
+  }
+  if (body instanceof Blob)
+    return Array.from(new Uint8Array(await body.arrayBuffer()));
+  const text = await new Response(body as BodyInit).text();
+  return Array.from(new TextEncoder().encode(text));
+}
+
+export async function prepareCodexProxyRequest(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+) {
+  const url = input instanceof URL ? input.toString() : String(input);
+  const method = (init?.method ?? "GET").toUpperCase();
+  const headers = stripSensitiveHeaders(headerInitToRecord(init?.headers));
+  const body = await bodyToBytes(init?.body);
+  return { url, method, headers, body };
+}
+
+export function createCodexProxyFetch(): typeof fetch {
+  return async (input, init) => {
+    const { url, method, headers, body } = await prepareCodexProxyRequest(
+      input,
+      init,
+    );
+    const signal = init?.signal;
+    if (signal?.aborted) {
+      throw makeAbortError();
+    }
+
+    return new Promise<Response>((resolve, reject) => {
+      let resolved = false;
+      let streamController: ReadableStreamDefaultController<Uint8Array> | null =
+        null;
+      let cancelled = false;
+
+      const onAbort = () => {
+        cancelled = true;
+        if (!resolved) {
+          reject(makeAbortError());
+        } else if (streamController) {
+          try {
+            streamController.error(makeAbortError());
+          } catch {
+            /* already closed */
+          }
+        }
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      const channel = new Channel<CodexStreamEvent>();
+      channel.onmessage = (event) => {
+        if (cancelled) return;
+        switch (event.kind) {
+          case "headers": {
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                streamController = controller;
+              },
+              cancel() {
+                cancelled = true;
+              },
+            });
+            resolved = true;
+            resolve(
+              new Response(stream, {
+                status: event.status,
+                headers: new Headers(event.headers),
+              }),
+            );
+            break;
+          }
+          case "chunk": {
+            streamController?.enqueue(Uint8Array.from(event.bytes));
+            break;
+          }
+          case "end": {
+            streamController?.close();
+            break;
+          }
+          case "error": {
+            if (!resolved) {
+              reject(new Error(event.message));
+            } else {
+              streamController?.error(new Error(event.message));
+            }
+            break;
+          }
+        }
+      };
+
+      invoke("openai_codex_responses_stream", {
+        url,
+        method,
+        headers,
+        body,
+        onEvent: channel,
+      }).catch((error) => {
+        if (resolved) return;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  };
+}
+
+function makeAbortError(): DOMException {
+  return new DOMException("Request aborted", "AbortError");
+}

--- a/src/modules/ai/lib/codexOptions.test.ts
+++ b/src/modules/ai/lib/codexOptions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildCodexProviderOptions } from "./codexOptions";
+
+describe("buildCodexProviderOptions", () => {
+  it("maps reasoning and only enables Fast for supported Codex models", () => {
+    expect(
+      buildCodexProviderOptions(
+        "extra-high",
+        "fast",
+        "gpt-5.4",
+        "Use Terax tools.",
+        "session-1",
+      ).openai,
+    ).toMatchObject({
+      store: false,
+      reasoningEffort: "xhigh",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+      instructions: "Use Terax tools.",
+      promptCacheKey: "session-1",
+      serviceTier: "priority",
+    });
+
+    expect(
+      buildCodexProviderOptions("high", "fast", "gpt-5.3-codex-spark").openai,
+    ).toEqual({
+      store: false,
+      reasoningEffort: "high",
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+    });
+  });
+});

--- a/src/modules/ai/lib/codexOptions.ts
+++ b/src/modules/ai/lib/codexOptions.ts
@@ -1,0 +1,88 @@
+export const CODEX_REASONING_LEVELS = [
+  { id: "low", label: "Low", requestValue: "low" },
+  { id: "medium", label: "Medium", requestValue: "medium" },
+  { id: "high", label: "High", requestValue: "high" },
+  { id: "extra-high", label: "Extra High", requestValue: "xhigh" },
+] as const;
+
+export type CodexReasoning = (typeof CODEX_REASONING_LEVELS)[number]["id"];
+export type CodexReasoningRequestValue =
+  (typeof CODEX_REASONING_LEVELS)[number]["requestValue"];
+
+export const DEFAULT_CODEX_REASONING: CodexReasoning = "medium";
+
+export const CODEX_SPEED_OPTIONS = [
+  {
+    id: "standard",
+    label: "Standard",
+    description: "Default speed",
+    requestValue: null,
+  },
+  {
+    id: "fast",
+    label: "Fast",
+    description: "1.5x speed, increased usage",
+    requestValue: "priority",
+  },
+] as const;
+
+export type CodexSpeed = (typeof CODEX_SPEED_OPTIONS)[number]["id"];
+export type CodexServiceTier = "priority";
+
+export const DEFAULT_CODEX_SPEED: CodexSpeed = "standard";
+
+export function normalizeCodexReasoning(value: unknown): CodexReasoning {
+  return CODEX_REASONING_LEVELS.some((option) => option.id === value)
+    ? (value as CodexReasoning)
+    : DEFAULT_CODEX_REASONING;
+}
+
+export function normalizeCodexSpeed(value: unknown): CodexSpeed {
+  return CODEX_SPEED_OPTIONS.some((option) => option.id === value)
+    ? (value as CodexSpeed)
+    : DEFAULT_CODEX_SPEED;
+}
+
+export function codexReasoningRequestValue(
+  value: CodexReasoning | undefined,
+): CodexReasoningRequestValue {
+  const normalized = normalizeCodexReasoning(value);
+  return (
+    CODEX_REASONING_LEVELS.find((option) => option.id === normalized)
+      ?.requestValue ?? "medium"
+  );
+}
+
+export function codexServiceTier(
+  value: CodexSpeed | undefined,
+  modelWireId?: string,
+): CodexServiceTier | undefined {
+  if (normalizeCodexSpeed(value) !== "fast") return undefined;
+  return codexModelSupportsFast(modelWireId) ? "priority" : undefined;
+}
+
+export function codexModelSupportsFast(modelWireId: string | undefined): boolean {
+  return modelWireId === "gpt-5.5" || modelWireId === "gpt-5.4";
+}
+
+export function buildCodexProviderOptions(
+  reasoning: CodexReasoning | undefined,
+  speed: CodexSpeed | undefined,
+  modelWireId?: string,
+  instructions?: string,
+  promptCacheKey?: string | null,
+) {
+  const serviceTier = codexServiceTier(speed, modelWireId);
+  const cacheKey = promptCacheKey?.trim();
+  return {
+    openai: {
+      store: false,
+      reasoningEffort: codexReasoningRequestValue(reasoning),
+      reasoningSummary: "auto",
+      include: ["reasoning.encrypted_content"],
+      ...(instructions?.trim() ? { instructions } : {}),
+      ...(cacheKey ? { promptCacheKey: cacheKey } : {}),
+      ...(serviceTier ? { serviceTier } : {}),
+    },
+  };
+}

--- a/src/modules/ai/lib/codexResponses.test.ts
+++ b/src/modules/ai/lib/codexResponses.test.ts
@@ -1,0 +1,85 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText, tool } from "ai";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+type CapturedRequest = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+describe("Codex Responses model wiring", () => {
+  it("uses the Responses endpoint and preserves tool schemas", async () => {
+    const captured: { current?: CapturedRequest } = {};
+
+    const fetchMock: typeof fetch = async (input, init) => {
+      captured.current = {
+        url: input instanceof URL ? input.toString() : String(input),
+        body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>,
+      };
+      return new Response(
+        JSON.stringify({ error: { message: "captured request" } }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+
+    const openai = createOpenAI({
+      apiKey: "test",
+      baseURL: "https://chatgpt.com/backend-api/codex",
+      fetch: fetchMock,
+    });
+    const result = streamText({
+      model: openai.responses("gpt-5.3-codex-spark"),
+      messages: [{ role: "user", content: "read the file" }],
+      providerOptions: {
+        openai: {
+          store: false,
+          reasoningEffort: "medium",
+          reasoningSummary: "auto",
+          include: ["reasoning.encrypted_content"],
+          instructions: "You are concise.",
+        },
+      },
+      tools: {
+        read_file: tool({
+          description: "Read a file",
+          inputSchema: z.object({ path: z.string() }),
+        }),
+      },
+      onError: () => undefined,
+    });
+
+    await Promise.resolve(result.consumeStream()).catch(() => undefined);
+
+    expect(captured.current).toBeDefined();
+    const request = captured.current as CapturedRequest;
+    expect(request.url).toBe(
+      "https://chatgpt.com/backend-api/codex/responses",
+    );
+    expect(request.body.stream).toBe(true);
+    expect(request.body.store).toBe(false);
+    expect(request.body.instructions).toBe("You are concise.");
+    expect(request.body.include).toEqual(["reasoning.encrypted_content"]);
+    expect(request.body.reasoning).toEqual({
+      effort: "medium",
+      summary: "auto",
+    });
+    expect(JSON.stringify(request.body)).not.toContain("chat/completions");
+    expect(request.body.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "function",
+          name: "read_file",
+          parameters: expect.objectContaining({
+            properties: expect.objectContaining({
+              path: expect.objectContaining({ type: "string" }),
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -10,8 +10,16 @@ import { useWhisperRecording } from "../hooks/useWhisperRecording";
 import { expandSnippetTokens, type Snippet } from "../lib/snippets";
 import { tryRunSlashCommand, type SlashCommandMeta } from "./slashCommands";
 import { getOrCreateChat, useChatStore } from "../store/chatStore";
+import { useCodexAuthStore } from "../store/codexAuthStore";
 import { useSnippetsStore } from "../store/snippetsStore";
 import { currentWorkspaceEnv } from "@/modules/workspace";
+import {
+  isCompatModelId,
+  providerNeedsKey,
+  providerNeedsOAuthSession,
+  resolveModel,
+} from "../config";
+import type { ProviderKeys } from "./keyring";
 
 export type FileAttachment = {
   id: string;
@@ -73,6 +81,9 @@ type ProviderProps = {
 export function AiComposerProvider({ children }: ProviderProps) {
   const sessionId = useChatStore((s) => s.activeSessionId);
   const status = useChatStore((s) => s.agentMeta.status);
+  const selectedModelId = useChatStore((s) => s.selectedModelId);
+  const apiKeys = useChatStore((s) => s.apiKeys);
+  const codexSignedIn = useCodexAuthStore((s) => s.status.signedIn);
   const isBusy = status === "thinking" || status === "streaming";
 
   const [value, setValue] = useState("");
@@ -304,6 +315,7 @@ export function AiComposerProvider({ children }: ProviderProps) {
     }
 
     if (!sessionId) return;
+    if (!selectedModelHasAuth(selectedModelId, apiKeys, codexSignedIn)) return;
     const chat = getOrCreateChat(sessionId);
     void chat.sendMessage({ role: "user", parts } as Parameters<
       typeof chat.sendMessage
@@ -326,6 +338,7 @@ export function AiComposerProvider({ children }: ProviderProps) {
 
   const canSend =
     !isBusy &&
+    selectedModelHasAuth(selectedModelId, apiKeys, codexSignedIn) &&
     (value.trim().length > 0 ||
       files.length > 0 ||
       pickedSnippets.length > 0 ||
@@ -353,6 +366,17 @@ export function AiComposerProvider({ children }: ProviderProps) {
   };
 
   return <Ctx.Provider value={ctx}>{children}</Ctx.Provider>;
+}
+
+function selectedModelHasAuth(
+  modelId: string,
+  apiKeys: ProviderKeys,
+  codexSignedIn: boolean,
+): boolean {
+  if (isCompatModelId(modelId)) return true;
+  const provider = resolveModel(modelId).provider;
+  if (providerNeedsOAuthSession(provider)) return codexSignedIn;
+  return providerNeedsKey(provider) ? !!apiKeys[provider] : true;
 }
 
 async function readAttachment(file: File): Promise<FileAttachment | null> {

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -13,6 +13,7 @@ export type CustomEndpointKeys = Record<string, string | null>;
 
 export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   openai: null,
+  "openai-codex": null,
   anthropic: null,
   google: null,
   xai: null,

--- a/src/modules/ai/lib/reasoningIssuer.test.ts
+++ b/src/modules/ai/lib/reasoningIssuer.test.ts
@@ -1,0 +1,137 @@
+import type { UIMessage, UIMessageChunk } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  filterReasoningForIssuer,
+  responsesIssuerForProvider,
+  tagReasoningChunkIssuer,
+} from "./reasoningIssuer";
+
+function assistantMessage(parts: UIMessage["parts"]): UIMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    parts,
+  };
+}
+
+describe("responses reasoning issuer", () => {
+  it("maps OpenAI API and ChatGPT Codex to separate issuers", () => {
+    expect(responsesIssuerForProvider("openai")).toBe("openai_api");
+    expect(responsesIssuerForProvider("openai-codex")).toBe("codex_backend");
+    expect(responsesIssuerForProvider("anthropic")).toBeNull();
+  });
+
+  it("tags streamed reasoning chunks with a Terax issuer", () => {
+    const chunk = tagReasoningChunkIssuer(
+      {
+        type: "reasoning-start",
+        id: "rs_1",
+        providerMetadata: {
+          openai: {
+            itemId: "rs_1",
+            reasoningEncryptedContent: "encrypted",
+          },
+        },
+      } satisfies UIMessageChunk,
+      "codex_backend",
+    );
+
+    expect(chunk.providerMetadata).toEqual({
+      openai: {
+        itemId: "rs_1",
+        reasoningEncryptedContent: "encrypted",
+      },
+      terax: {
+        responsesIssuer: "codex_backend",
+      },
+    });
+  });
+
+  it("keeps only same-issuer Codex reasoning", () => {
+    const [message] = filterReasoningForIssuer(
+      [
+        assistantMessage([
+          {
+            type: "reasoning",
+            text: "codex",
+            providerMetadata: {
+              terax: { responsesIssuer: "codex_backend" },
+            },
+          },
+          {
+            type: "reasoning",
+            text: "openai",
+            providerMetadata: {
+              terax: { responsesIssuer: "openai_api" },
+            },
+          },
+          {
+            type: "reasoning",
+            text: "legacy",
+          },
+          {
+            type: "text",
+            text: "visible",
+          },
+        ]),
+      ],
+      "codex_backend",
+    );
+
+    expect(message.parts).toEqual([
+      {
+        type: "reasoning",
+        text: "codex",
+        providerMetadata: {
+          terax: { responsesIssuer: "codex_backend" },
+        },
+      },
+      {
+        type: "text",
+        text: "visible",
+      },
+    ]);
+  });
+
+  it("keeps legacy untagged OpenAI reasoning but drops Codex reasoning", () => {
+    const [message] = filterReasoningForIssuer(
+      [
+        assistantMessage([
+          {
+            type: "reasoning",
+            text: "legacy openai",
+          },
+          {
+            type: "reasoning",
+            text: "codex",
+            providerMetadata: {
+              terax: { responsesIssuer: "codex_backend" },
+            },
+          },
+          {
+            type: "reasoning",
+            text: "openai",
+            providerMetadata: {
+              terax: { responsesIssuer: "openai_api" },
+            },
+          },
+        ]),
+      ],
+      "openai_api",
+    );
+
+    expect(message.parts).toEqual([
+      {
+        type: "reasoning",
+        text: "legacy openai",
+      },
+      {
+        type: "reasoning",
+        text: "openai",
+        providerMetadata: {
+          terax: { responsesIssuer: "openai_api" },
+        },
+      },
+    ]);
+  });
+});

--- a/src/modules/ai/lib/reasoningIssuer.ts
+++ b/src/modules/ai/lib/reasoningIssuer.ts
@@ -1,0 +1,106 @@
+import type { UIMessage, UIMessageChunk } from "ai";
+import type { ProviderId } from "../config";
+
+export type ResponsesReasoningIssuer = "openai_api" | "codex_backend";
+
+type MetadataRecord = Record<string, unknown>;
+type ReasoningChunk = Extract<
+  UIMessageChunk,
+  { type: "reasoning-start" | "reasoning-delta" | "reasoning-end" }
+>;
+
+export function responsesIssuerForProvider(
+  provider: ProviderId,
+): ResponsesReasoningIssuer | null {
+  if (provider === "openai") return "openai_api";
+  if (provider === "openai-codex") return "codex_backend";
+  return null;
+}
+
+export function filterReasoningForIssuer<T extends UIMessage>(
+  messages: readonly T[],
+  issuer: ResponsesReasoningIssuer,
+): T[] {
+  let changed = false;
+  const next = messages.map((message) => {
+    let partsChanged = false;
+    const parts = message.parts.filter((part) => {
+      if (part.type !== "reasoning") return true;
+      const partIssuer = readResponsesIssuer(part.providerMetadata);
+      const keep =
+        partIssuer === issuer ||
+        (partIssuer == null && issuer === "openai_api");
+      if (!keep) partsChanged = true;
+      return keep;
+    });
+
+    if (!partsChanged) return message;
+    changed = true;
+    return { ...message, parts } as T;
+  });
+  return changed ? next : [...messages];
+}
+
+export function tagReasoningIssuerInStream<T extends UIMessageChunk>(
+  stream: ReadableStream<T>,
+  issuer: ResponsesReasoningIssuer | null,
+): ReadableStream<T> {
+  if (!issuer) return stream;
+  return stream.pipeThrough(
+    new TransformStream<T, T>({
+      transform(chunk, controller) {
+        controller.enqueue(tagReasoningChunkIssuer(chunk, issuer));
+      },
+    }),
+  );
+}
+
+export function tagReasoningChunkIssuer<T extends UIMessageChunk>(
+  chunk: T,
+  issuer: ResponsesReasoningIssuer,
+): T {
+  if (!isReasoningChunk(chunk)) return chunk;
+  return {
+    ...chunk,
+    providerMetadata: withResponsesIssuer(chunk.providerMetadata, issuer),
+  } as T;
+}
+
+function isReasoningChunk(chunk: UIMessageChunk): chunk is ReasoningChunk {
+  return (
+    chunk.type === "reasoning-start" ||
+    chunk.type === "reasoning-delta" ||
+    chunk.type === "reasoning-end"
+  );
+}
+
+function withResponsesIssuer(
+  providerMetadata: unknown,
+  issuer: ResponsesReasoningIssuer,
+): MetadataRecord {
+  const metadata = isRecord(providerMetadata) ? providerMetadata : {};
+  const terax = isRecord(metadata.terax) ? metadata.terax : {};
+  return {
+    ...metadata,
+    terax: {
+      ...terax,
+      responsesIssuer: issuer,
+    },
+  };
+}
+
+function readResponsesIssuer(
+  providerMetadata: unknown,
+): ResponsesReasoningIssuer | null {
+  if (!isRecord(providerMetadata)) return null;
+  const terax = providerMetadata.terax;
+  if (!isRecord(terax)) return null;
+  const issuer = terax.responsesIssuer;
+  return issuer === "openai_api" || issuer === "codex_backend"
+    ? issuer
+    : null;
+}
+
+function isRecord(value: unknown): value is MetadataRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/modules/ai/lib/transport.ts
+++ b/src/modules/ai/lib/transport.ts
@@ -1,9 +1,14 @@
 import type { UIMessage } from "@ai-sdk/react";
-import { type CustomEndpoint } from "../config";
+import { resolveModel, type CustomEndpoint } from "../config";
 import { runAgentStream, type AgentUsageDelta } from "./agent";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
 import { native } from "./native";
 import type { ToolContext } from "../tools/tools";
+import type { CodexReasoning, CodexSpeed } from "./codexOptions";
+import {
+  responsesIssuerForProvider,
+  tagReasoningIssuerInStream,
+} from "./reasoningIssuer";
 
 const TERAX_MD_MAX_BYTES = 32 * 1024;
 type MemoryCacheEntry = { content: string | null; mtime: number };
@@ -56,6 +61,8 @@ type Deps = {
   getOpenaiCompatibleModelId?: () => string | undefined;
   getOpenaiCompatibleContextLimit?: () => number | undefined;
   getOpenrouterModelId?: () => string | undefined;
+  getCodexReasoning?: () => CodexReasoning | undefined;
+  getCodexSpeed?: () => CodexSpeed | undefined;
   getCustomEndpoints?: () => readonly CustomEndpoint[];
   getCustomEndpointKeys?: () => CustomEndpointKeys;
   onStep?: (step: string | null) => void;
@@ -73,6 +80,11 @@ type SendOptions = {
 
 export function createContextAwareTransport(deps: Deps) {
   const run = async (options: SendOptions) => {
+    const modelId = deps.getModelId();
+    const customEndpoints = deps.getCustomEndpoints?.();
+    const issuer = responsesIssuerForProvider(
+      resolveModel(modelId, customEndpoints).provider,
+    );
     const live = deps.getLive();
     const projectMemory = await readTeraxMd(live.workspaceRoot);
     const envBlock = formatEnvBlock(live);
@@ -81,7 +93,7 @@ export function createContextAwareTransport(deps: Deps) {
       : options.messages;
     const result = await runAgentStream({
       keys: deps.getKeys(),
-      modelId: deps.getModelId(),
+      modelId,
       customInstructions: deps.getCustomInstructions(),
       agentPersona: deps.getAgentPersona(),
       toolContext: deps.toolContext,
@@ -99,16 +111,19 @@ export function createContextAwareTransport(deps: Deps) {
       openaiCompatibleModelId: deps.getOpenaiCompatibleModelId?.(),
       openaiCompatibleContextLimit: deps.getOpenaiCompatibleContextLimit?.(),
       openrouterModelId: deps.getOpenrouterModelId?.(),
-      customEndpoints: deps.getCustomEndpoints?.(),
+      codexReasoning: deps.getCodexReasoning?.(),
+      codexSpeed: deps.getCodexSpeed?.(),
+      customEndpoints,
       customEndpointKeys: deps.getCustomEndpointKeys?.(),
       planMode: deps.getPlanMode?.(),
       projectMemory,
       uiMessages: messagesForRun,
       abortSignal: options.abortSignal,
     });
-    return result.toUIMessageStream({
+    const stream = result.toUIMessageStream({
       originalMessages: options.messages,
     });
+    return tagReasoningIssuerInStream(stream, issuer);
   };
 
   return {

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -10,6 +10,7 @@ import {
   getModel,
   isCompatModelId,
   providerNeedsKey,
+  providerNeedsOAuthSession,
   type ModelId,
   type ProviderId,
 } from "../config";
@@ -34,6 +35,7 @@ import {
 import { pushRecentModel } from "../lib/modelPrefs";
 import { createContextAwareTransport } from "../lib/transport";
 import type { ToolContext } from "../tools/tools";
+import { useCodexAuthStore } from "./codexAuthStore";
 
 type Live = {
   getCwd: () => string | null;
@@ -275,6 +277,10 @@ function makeChat(sessionId: string): Chat<UIMessage> {
       usePreferencesStore.getState().openaiCompatibleContextLimit,
     getOpenrouterModelId: () =>
       usePreferencesStore.getState().openrouterModelId,
+    getCodexReasoning: () =>
+      usePreferencesStore.getState().codexReasoning,
+    getCodexSpeed: () =>
+      usePreferencesStore.getState().codexSpeed,
     getCustomEndpoints: () =>
       usePreferencesStore.getState().customEndpoints,
     getCustomEndpointKeys: () =>
@@ -555,6 +561,9 @@ export function hasKeyForModel(modelId: string): boolean {
     return true;
   }
   const provider = getModel(modelId as ModelId).provider;
+  if (providerNeedsOAuthSession(provider)) {
+    return useCodexAuthStore.getState().status.signedIn;
+  }
   return providerNeedsKey(provider) ? !!apiKeys[provider] : true;
 }
 
@@ -579,7 +588,7 @@ export async function sendMessage(text: string): Promise<boolean> {
   const state = useChatStore.getState();
   const sessionId = state.activeSessionId;
   if (!sessionId) return false;
-  if (providerNeedsKey(getModel(state.selectedModelId as ModelId).provider) && !getActiveProviderKey()) return false;
+  if (!hasKeyForModel(state.selectedModelId)) return false;
   const c = getOrCreateChat(sessionId);
   await c.sendMessage({ text });
   return true;

--- a/src/modules/ai/store/codexAuthStore.ts
+++ b/src/modules/ai/store/codexAuthStore.ts
@@ -1,0 +1,105 @@
+import { create } from "zustand";
+import {
+  CODEX_DISCONNECTED_STATUS,
+  cancelCodexDeviceLogin,
+  getCodexAuthStatus,
+  logoutCodex,
+  pollCodexDeviceLogin,
+  startCodexDeviceLogin,
+  type CodexAuthStatus,
+  type CodexDeviceStart,
+  type CodexPollResult,
+} from "../lib/codexAuth";
+
+type CodexAuthState = {
+  status: CodexAuthStatus;
+  pending: CodexDeviceStart | null;
+  loading: boolean;
+  error: string | null;
+  refreshStatus: () => Promise<CodexAuthStatus>;
+  startDeviceLogin: () => Promise<CodexDeviceStart>;
+  pollDeviceLogin: () => Promise<CodexPollResult | null>;
+  cancelDeviceLogin: () => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export const useCodexAuthStore = create<CodexAuthState>((set, get) => ({
+  status: CODEX_DISCONNECTED_STATUS,
+  pending: null,
+  loading: false,
+  error: null,
+
+  refreshStatus: async () => {
+    set({ loading: true, error: null });
+    try {
+      const status = await getCodexAuthStatus();
+      set({ status, loading: false });
+      return status;
+    } catch (error) {
+      const message = errorMessage(error);
+      const status = { ...CODEX_DISCONNECTED_STATUS, message };
+      set({ status, loading: false, error: message });
+      return status;
+    }
+  },
+
+  startDeviceLogin: async () => {
+    set({ loading: true, error: null });
+    try {
+      const pending = await startCodexDeviceLogin();
+      set({ pending, loading: false });
+      return pending;
+    } catch (error) {
+      const message = errorMessage(error);
+      set({ loading: false, error: message });
+      throw error;
+    }
+  },
+
+  pollDeviceLogin: async () => {
+    const pending = get().pending;
+    if (!pending) return null;
+    try {
+      const result = await pollCodexDeviceLogin(pending.loginId);
+      if (result.status === "complete" && result.auth) {
+        set({ status: result.auth, pending: null, error: null });
+      } else if (result.status === "expired" || result.status === "error") {
+        set({
+          pending: null,
+          error: result.message ?? "Codex sign-in did not complete.",
+        });
+      }
+      return result;
+    } catch (error) {
+      const message = errorMessage(error);
+      set({ error: message });
+      throw error;
+    }
+  },
+
+  cancelDeviceLogin: async () => {
+    const pending = get().pending;
+    if (pending) await cancelCodexDeviceLogin(pending.loginId);
+    set({ pending: null });
+  },
+
+  logout: async () => {
+    set({ loading: true, error: null });
+    try {
+      await logoutCodex();
+      set({
+        status: CODEX_DISCONNECTED_STATUS,
+        pending: null,
+        loading: false,
+      });
+    } catch (error) {
+      const message = errorMessage(error);
+      set({ loading: false, error: message });
+      throw error;
+    }
+  },
+}));

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -11,6 +11,14 @@ import {
   type CustomEndpoint,
   type ModelId,
 } from "@/modules/ai/config";
+import {
+  DEFAULT_CODEX_REASONING,
+  DEFAULT_CODEX_SPEED,
+  normalizeCodexReasoning,
+  normalizeCodexSpeed,
+  type CodexReasoning,
+  type CodexSpeed,
+} from "@/modules/ai/lib/codexOptions";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
@@ -75,6 +83,8 @@ export type Preferences = {
   openaiCompatibleContextLimit: number;
   customEndpoints: CustomEndpoint[];
   openrouterModelId: string;
+  codexReasoning: CodexReasoning;
+  codexSpeed: CodexSpeed;
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
@@ -118,6 +128,8 @@ const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
 const KEY_OPENAI_COMPAT_CONTEXT_LIMIT = "openaiCompatibleContextLimit";
 const KEY_CUSTOM_ENDPOINTS = "customEndpoints";
 const KEY_OPENROUTER_MODEL_ID = "openrouterModelId";
+const KEY_CODEX_REASONING = "codexReasoning";
+const KEY_CODEX_SPEED = "codexSpeed";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
@@ -176,6 +188,8 @@ export const DEFAULT_PREFERENCES: Preferences = {
   openaiCompatibleContextLimit: 128_000,
   customEndpoints: [],
   openrouterModelId: "",
+  codexReasoning: DEFAULT_CODEX_REASONING,
+  codexSpeed: DEFAULT_CODEX_SPEED,
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
@@ -285,6 +299,8 @@ export async function loadPreferences(): Promise<Preferences> {
     openrouterModelId:
       get<string>(KEY_OPENROUTER_MODEL_ID) ??
       DEFAULT_PREFERENCES.openrouterModelId,
+    codexReasoning: normalizeCodexReasoning(get<string>(KEY_CODEX_REASONING)),
+    codexSpeed: normalizeCodexSpeed(get<string>(KEY_CODEX_SPEED)),
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds
@@ -457,6 +473,16 @@ export async function setOpenrouterModelId(value: string): Promise<void> {
   await writePref(KEY_OPENROUTER_MODEL_ID, value);
 }
 
+export async function setCodexReasoning(
+  value: CodexReasoning,
+): Promise<void> {
+  await writePref(KEY_CODEX_REASONING, normalizeCodexReasoning(value));
+}
+
+export async function setCodexSpeed(value: CodexSpeed): Promise<void> {
+  await writePref(KEY_CODEX_SPEED, normalizeCodexSpeed(value));
+}
+
 export async function setFavoriteModelIds(value: string[]): Promise<void> {
   await writePref(KEY_FAVORITE_MODELS, value);
 }
@@ -575,6 +601,8 @@ export async function onPreferencesChange(
     [KEY_OPENAI_COMPAT_CONTEXT_LIMIT]: "openaiCompatibleContextLimit",
     [KEY_CUSTOM_ENDPOINTS]: "customEndpoints",
     [KEY_OPENROUTER_MODEL_ID]: "openrouterModelId",
+    [KEY_CODEX_REASONING]: "codexReasoning",
+    [KEY_CODEX_SPEED]: "codexSpeed",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -6,7 +6,14 @@ import {
   type GitStatusSnapshot,
 } from "@/modules/ai/lib/native";
 import { useChatStore } from "@/modules/ai/store/chatStore";
-import { providerNeedsKey, resolveModel } from "@/modules/ai/config";
+import {
+  providerNeedsKey,
+  providerNeedsOAuthSession,
+  getModelWireId,
+  resolveModel,
+} from "@/modules/ai/config";
+import { useCodexAuthStore } from "@/modules/ai/store/codexAuthStore";
+import { buildCodexProviderOptions } from "@/modules/ai/lib/codexOptions";
 import {
   invalidateDiff,
   invalidateRepoDiffs,
@@ -368,8 +375,10 @@ export function useSourceControlPanel(
 ): SourceControlPanelState {
   const selectedModelId = useChatStore((state) => state.selectedModelId);
   const agentStatus = useChatStore((state) => state.agentMeta.status);
+  const codexSignedIn = useCodexAuthStore((state) => state.status.signedIn);
   const hasApiKeyForSelected = useChatStore((state) => {
     const model = resolveModel(state.selectedModelId);
+    if (providerNeedsOAuthSession(model.provider)) return codexSignedIn;
     return !providerNeedsKey(model.provider) || !!state.apiKeys[model.provider];
   });
   const lmstudioModelId = usePreferencesStore((state) => state.lmstudioModelId);
@@ -870,6 +879,17 @@ export function useSourceControlPanel(
       const { text: diffText, truncated } = truncateDiff(diff.diffText);
       const chatState = useChatStore.getState();
       const prefs = usePreferencesStore.getState();
+      const selectedInfo = resolveModel(selectedModelId);
+      const selectedIsCodex = selectedInfo.provider === "openai-codex";
+      const providerOptions =
+        selectedIsCodex
+          ? buildCodexProviderOptions(
+              prefs.codexReasoning,
+              prefs.codexSpeed,
+              getModelWireId(selectedInfo),
+              COMMIT_MESSAGE_SYSTEM_PROMPT,
+            )
+          : undefined;
       const model = await buildConfiguredLanguageModel(
         selectedModelId,
         chatState.apiKeys,
@@ -887,19 +907,21 @@ export function useSourceControlPanel(
       );
       const result = await generateText({
         model,
-        system: COMMIT_MESSAGE_SYSTEM_PROMPT,
+        system: selectedIsCodex ? undefined : COMMIT_MESSAGE_SYSTEM_PROMPT,
         prompt: buildCommitMessagePrompt(stagedEntries, diffText, truncated),
         maxOutputTokens: COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
         temperature: 0.2,
+        providerOptions,
       });
       let message = cleanCommitMessage(result.text);
       if (!isValidCommitMessage(message)) {
         const repair = await generateText({
           model,
-          system: COMMIT_MESSAGE_SYSTEM_PROMPT,
+          system: selectedIsCodex ? undefined : COMMIT_MESSAGE_SYSTEM_PROMPT,
           prompt: buildRepairCommitMessagePrompt(message, stagedEntries),
           maxOutputTokens: COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
           temperature: 0,
+          providerOptions,
         });
         message = cleanCommitMessage(repair.text);
       }

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -18,6 +18,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 
 const ICON_BY_PROVIDER = {
   openai: ChatGptIcon,
+  "openai-codex": ChatGptIcon,
   anthropic: ClaudeIcon,
   google: GoogleGeminiIcon,
   xai: Grok02Icon,

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -16,10 +16,13 @@ import {
   PROVIDERS,
   compatModelIdForEndpoint,
   getAutocompleteEligibleModels,
+  isAutocompleteProvider,
   getModel,
   getProvider,
+  providerAuthKind,
   providerNeedsKey,
   type CustomEndpoint,
+  type AutocompleteProviderId,
   type ModelId,
   type ProviderId,
   type ProviderInfo,
@@ -33,6 +36,7 @@ import {
   setCustomEndpointKey,
   type CustomEndpointKeys,
 } from "@/modules/ai/lib/keyring";
+import { useCodexAuthStore } from "@/modules/ai/store/codexAuthStore";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
@@ -62,6 +66,8 @@ import {
   Cancel01Icon,
   CheckmarkCircle02Icon,
   ChevronDown,
+  Copy01Icon,
+  Refresh01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
@@ -73,7 +79,8 @@ import { SectionHeader } from "../components/SectionHeader";
 
 type KeysMap = Record<ProviderId, string | null>;
 
-const isLocalProvider = (id: ProviderId): boolean => !providerNeedsKey(id);
+const isLocalProvider = (id: ProviderId): boolean =>
+  providerAuthKind(id) === "local" || providerAuthKind(id) === "custom";
 
 type LocalMeta = {
   urlPlaceholder: string;
@@ -133,6 +140,9 @@ export function ModelsSection() {
   const [keys, setKeys] = useState<KeysMap | null>(null);
   const [epKeys, setEpKeys] = useState<CustomEndpointKeys>({});
   const [adding, setAdding] = useState<Set<ProviderId>>(new Set());
+  const codexStatus = useCodexAuthStore((s) => s.status);
+  const refreshCodexStatus = useCodexAuthStore((s) => s.refreshStatus);
+  const logoutCodex = useCodexAuthStore((s) => s.logout);
 
   const defaultModel = usePreferencesStore((s) => s.defaultModelId);
   const lmstudioBaseURL = usePreferencesStore((s) => s.lmstudioBaseURL);
@@ -152,6 +162,10 @@ export function ModelsSection() {
   useEffect(() => {
     void getAllKeys().then(setKeys);
   }, []);
+
+  useEffect(() => {
+    void refreshCodexStatus();
+  }, [refreshCodexStatus]);
 
   useEffect(() => {
     void getAllCustomEndpointKeys(customEndpoints).then(setEpKeys);
@@ -282,6 +296,7 @@ export function ModelsSection() {
   };
 
   const isConfigured = (id: ProviderId): boolean => {
+    if (id === "openai-codex") return codexStatus.signedIn;
     if (id === "openrouter")
       return !!keys?.[id] && !!openrouterModelId.trim();
     if (!isLocalProvider(id)) return !!keys?.[id];
@@ -309,7 +324,15 @@ export function ModelsSection() {
   );
 
   const removeProvider = (id: ProviderId) => {
-    if (id === "openrouter") {
+    if (id === "openai-codex") {
+      void logoutCodex().then(async () => {
+        const { selectedModelId, setSelectedModelId } = useChatStore.getState();
+        if (isOpenAiCodexModelId(selectedModelId)) {
+          setSelectedModelId(DEFAULT_MODEL_ID);
+        }
+        await emitKeysChanged();
+      });
+    } else if (id === "openrouter") {
       void setOpenrouterModelId("");
       void onClearKey(id);
     } else if (isLocalProvider(id)) {
@@ -368,7 +391,13 @@ export function ModelsSection() {
         ) : (
           <div className="flex flex-col gap-2">
             {visibleProviders.map((p) =>
-              p.id === "openrouter" ? (
+              p.id === "openai-codex" ? (
+                <CodexAuthCard
+                  key={p.id}
+                  provider={p}
+                  onRemove={() => removeProvider(p.id)}
+                />
+              ) : p.id === "openrouter" ? (
                 <LocalProviderCard
                   key={p.id}
                   provider={p}
@@ -634,7 +663,7 @@ function AutocompleteRow({
     );
   }, [eligible, provider, modelId]);
 
-  const setModel = (id: string, providerId: ProviderId) => {
+  const setModel = (id: string, providerId: AutocompleteProviderId) => {
     void setAutocompleteProvider(providerId);
     void setAutocompleteModelId(isLocalProvider(providerId) ? "" : id);
   };
@@ -705,7 +734,11 @@ function AutocompleteRow({
                       <DropdownMenuItem
                         key={m.id}
                         disabled={!pConfigured}
-                        onSelect={() => pConfigured && setModel(m.id, p.id)}
+                        onSelect={() => {
+                          if (pConfigured && isAutocompleteProvider(p.id)) {
+                            setModel(m.id, p.id);
+                          }
+                        }}
                         className={cn(
                           "text-[11.5px]",
                           m.id === modelId && "bg-accent/50",
@@ -732,6 +765,202 @@ function AutocompleteRow({
         </p>
       ) : null}
     </>
+  );
+}
+
+function CodexAuthCard({
+  provider,
+  onRemove,
+}: {
+  provider: ProviderInfo;
+  onRemove: () => void;
+}) {
+  const status = useCodexAuthStore((s) => s.status);
+  const pending = useCodexAuthStore((s) => s.pending);
+  const loading = useCodexAuthStore((s) => s.loading);
+  const error = useCodexAuthStore((s) => s.error);
+  const startDeviceLogin = useCodexAuthStore((s) => s.startDeviceLogin);
+  const pollDeviceLogin = useCodexAuthStore((s) => s.pollDeviceLogin);
+  const cancelDeviceLogin = useCodexAuthStore((s) => s.cancelDeviceLogin);
+  const logout = useCodexAuthStore((s) => s.logout);
+  const refreshStatus = useCodexAuthStore((s) => s.refreshStatus);
+
+  useEffect(() => {
+    if (!pending) return;
+    let stopped = false;
+    const tick = async () => {
+      if (stopped) return;
+      const result = await pollDeviceLogin().catch(() => null);
+      if (result?.status === "complete") await emitKeysChanged();
+    };
+    void tick();
+    const interval = window.setInterval(
+      () => void tick(),
+      Math.max(1, pending.pollIntervalSecs) * 1000,
+    );
+    return () => {
+      stopped = true;
+      window.clearInterval(interval);
+    };
+  }, [pending, pollDeviceLogin]);
+
+  const connected = status.signedIn && !status.needsRelogin;
+  const badgeLabel = pending
+    ? "Waiting"
+    : connected
+      ? "Connected"
+      : status.needsRelogin
+        ? "Sign in again"
+        : "Not connected";
+  const detail =
+    pending
+      ? "Enter the code in your browser to finish signing in."
+      : status.message ||
+        (connected
+          ? status.accountEmail || "Signed in with ChatGPT"
+          : "Sign in with ChatGPT using the Codex device-code flow.");
+
+  const start = async () => {
+    await startDeviceLogin();
+  };
+
+  const disconnect = async () => {
+    await logout();
+    const { selectedModelId, setSelectedModelId } = useChatStore.getState();
+    if (isOpenAiCodexModelId(selectedModelId)) {
+      setSelectedModelId(DEFAULT_MODEL_ID);
+    }
+    await emitKeysChanged();
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
+      <div className="flex items-center gap-2">
+        <ProviderIcon provider={provider.id} size={15} />
+        <span className="text-[12.5px] font-medium">{provider.label}</span>
+        <Badge
+          variant="outline"
+          className={cn(
+            "ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal",
+            connected
+              ? "text-muted-foreground"
+              : "text-amber-600 dark:text-amber-400",
+          )}
+        >
+          {connected ? (
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              size={9}
+              strokeWidth={2}
+            />
+          ) : null}
+          {badgeLabel}
+        </Badge>
+        <button
+          type="button"
+          onClick={() => void openUrl(provider.consoleUrl)}
+          className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Docs
+          <HugeiconsIcon icon={ArrowUpRight01Icon} size={11} strokeWidth={1.75} />
+        </button>
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={onRemove}
+          title="Remove provider"
+          className="size-7 text-muted-foreground hover:text-destructive"
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+        </Button>
+      </div>
+
+      <p className="text-[10.5px] text-muted-foreground">{detail}</p>
+
+      {pending ? (
+        <div className="flex items-center gap-1.5">
+          <code className="flex-1 rounded bg-muted/40 px-2 py-1.5 text-center font-mono text-[13px] tracking-[0.18em] text-foreground">
+            {pending.userCode}
+          </code>
+          <Button
+            size="icon"
+            variant="outline"
+            onClick={() => void navigator.clipboard?.writeText(pending.userCode)}
+            title="Copy code"
+            className="size-8"
+          >
+            <HugeiconsIcon icon={Copy01Icon} size={12} strokeWidth={1.75} />
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void openUrl(pending.verificationUrl)}
+            className="h-8 gap-1.5 px-2.5 text-[11px]"
+          >
+            Open
+            <HugeiconsIcon icon={ArrowUpRight01Icon} size={11} strokeWidth={1.75} />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={() => void cancelDeviceLogin()}
+            title="Cancel sign-in"
+            className="size-8 text-muted-foreground hover:text-destructive"
+          >
+            <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-1.5">
+          <Button
+            size="sm"
+            onClick={() => void start()}
+            disabled={loading}
+            className="h-8 gap-1.5 px-3 text-[11px]"
+          >
+            {loading ? <RefreshSpinner /> : null}
+            {connected ? "Sign in again" : "Sign in"}
+          </Button>
+          <Button
+            size="icon"
+            variant="outline"
+            onClick={() => void refreshStatus()}
+            title="Refresh status"
+            className="size-8"
+          >
+            <HugeiconsIcon icon={Refresh01Icon} size={12} strokeWidth={1.75} />
+          </Button>
+          {connected || status.needsRelogin ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void disconnect()}
+              className="h-8 px-2.5 text-[11px] text-muted-foreground hover:text-destructive"
+            >
+              Log out
+            </Button>
+          ) : null}
+        </div>
+      )}
+      {error ? <p className="text-[10.5px] text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
+function isOpenAiCodexModelId(id: string): boolean {
+  return MODELS.some(
+    (model) => model.id === id && model.provider === "openai-codex",
+  );
+}
+
+function RefreshSpinner() {
+  return (
+    <HugeiconsIcon
+      icon={Refresh01Icon}
+      size={12}
+      strokeWidth={1.75}
+      className="animate-spin"
+    />
   );
 }
 


### PR DESCRIPTION
## What
Adds an OpenAI Codex provider backed by ChatGPT device-code login, native secret storage, and a Rust-side Codex Responses bridge so bearer tokens stay out of the webview.


## Why
This lets Terax users select Codex-backed models without pasting a BYOK API key, while keeping auth/session material in the native layer and preserving the existing AI SDK transport shape.

Note: this is a draft because it needs maintainer alignment. `ROADMAP.md` currently calls third-party subscription session bridges out of scope, so this should be reviewed for product direction before implementation details.

## How
- Added a native `codex_auth` module for device login, token refresh, keychain-backed session storage, and Codex Responses streaming.
- Added a frontend Codex auth store, Tauri invokers, provider/model config, speed/reasoning options, and model dropdown/status integration.
- Hardened the Codex bridge by validating the target endpoint, stripping request headers, allowlisting response headers, disabling redirects, and sanitizing upstream auth errors.
- Added reasoning issuer tagging so encrypted reasoning metadata is not mixed between OpenAI API and Codex backend sessions.
- Added focused tests for Codex request wiring, options, proxy request sanitization, reasoning issuer filtering, and Rust auth/header/error helpers.

## Testing
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test`
- [x] `cd src-tauri && cargo test --locked`
- [x] `cd src-tauri && cargo clippy --all-targets --locked -- -D warnings`
- [x] Manual smoke test of Codex device-code sign-in, Codex model selection, Fast/Standard behavior, and available Codex models. Videos linked below.
- [x] Tauri command additions are called out in Notes for reviewer.
- [x] UI tested in local Tauri app on macOS.
- [x] Shells tested: not applicable.

## Screenshots / GIFs
Videos are attached in this PR comment:

https://github.com/crynta/terax-ai/pull/693#issuecomment-4606208708

Direct attachments:

- Login flow: https://github.com/user-attachments/assets/8b9ab949-7302-4da7-b536-782358718075
- Codex model testing: https://github.com/user-attachments/assets/396cf49b-679a-4ccb-aa45-0ab82a64b194

## Notes for reviewer
This intentionally keeps ChatGPT access/refresh/id tokens in Rust-side secret storage and only exposes auth status plus the user device code to the frontend.

New Tauri commands added:

- `openai_codex_auth_start_device`
- `openai_codex_auth_poll`
- `openai_codex_auth_cancel`
- `openai_codex_auth_status`
- `openai_codex_auth_logout`
- `openai_codex_responses_stream`

Note: this PR also includes a small Tauri JS package lockfile alignment (`@tauri-apps/api` / `@tauri-apps/cli` to 2.11.x) so the local production build used for testing does not need `--ignore-version-mismatches`. Happy to split that into a separate `chore(deps)` PR if preferred.

Security-sensitive pieces worth extra review:

- Response header allowlist and request header stripping in `src-tauri/src/modules/codex_auth.rs`
- Redirect-disabled reqwest client for auth/token/Codex bridge requests
- Sanitized upstream auth error handling
- URL validation limiting the bridge to `https://chatgpt.com/backend-api/codex/responses`


