### PR TITLE
fix(ui): align borderless window corners

### DIFF
--- a/src/lib/windowChrome.ts
+++ b/src/lib/windowChrome.ts
@@ -1,0 +1,23 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+
+export function initWindowChrome() {
+  if (!USE_CUSTOM_WINDOW_CONTROLS) return;
+
+  document.documentElement.dataset.chrome = "borderless";
+
+  const window = getCurrentWindow();
+  const syncMaximized = () => {
+    void window
+      .isMaximized()
+      .then((maximized) => {
+        document.documentElement.dataset.windowMaximized = String(maximized);
+      })
+      .catch(() => {
+        delete document.documentElement.dataset.windowMaximized;
+      });
+  };
+
+  syncMaximized();
+  void window.onResized(syncMaximized);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,11 +10,9 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import { initLaunchDir } from "./lib/launchDir";
-import { USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
+import { initWindowChrome } from "./lib/windowChrome";
 
-if (USE_CUSTOM_WINDOW_CONTROLS) {
-  document.documentElement.dataset.chrome = "borderless";
-}
+initWindowChrome();
 
 // Reap PTY sessions orphaned by a prior webview load before any tab spawns.
 await invoke("pty_close_all").catch(() => {});

--- a/src/settings/main.tsx
+++ b/src/settings/main.tsx
@@ -7,12 +7,10 @@ import "../styles/globals.css";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import { ThemeProvider } from "@/modules/theme";
-import { USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { initWindowChrome } from "@/lib/windowChrome";
 import { SettingsApp } from "./SettingsApp";
 
-if (USE_CUSTOM_WINDOW_CONTROLS) {
-  document.documentElement.dataset.chrome = "borderless";
-}
+initWindowChrome();
 
 ReactDOM.createRoot(
   document.getElementById("settings-root") as HTMLElement,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -187,8 +187,21 @@ html[data-chrome="borderless"] #settings-root {
   height: 100%;
   border-radius: 12px;
   overflow: hidden;
-  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px var(--border);
   background: var(--background);
+}
+html[data-chrome="borderless"] #settings-root {
+  border-radius: 8px;
+}
+html[data-chrome="borderless"][data-window-maximized="true"] .terax-bg-surface,
+html[data-chrome="borderless"][data-window-maximized="true"] #root,
+html[data-chrome="borderless"][data-window-maximized="true"] #settings-root {
+  border-radius: 0;
+}
+html[data-chrome="borderless"][data-window-maximized="true"] #root,
+html[data-chrome="borderless"][data-window-maximized="true"] #settings-root {
+  height: 100%;
+  box-shadow: none;
 }
 
 /*


### PR DESCRIPTION
## What

Fixes two rounded corner-related issues:
1. Borderless window corners are flattened when the window is maximized.
2. The Settings window outline is adjusted so its corners align better with the Settings UI.

## Why

The settings window and maximized windows look quite bad with previous rounded corners (at least on windows).

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

### Maximized main window

Before:

<img width="312" height="281" alt="terax-maxim-rd-bef" src="https://github.com/user-attachments/assets/62c5f650-ec97-4792-8fec-3c75fab643de" />

After:

<img width="256" height="165" alt="terax-maxim-rd-aft" src="https://github.com/user-attachments/assets/573993bd-e0d8-487b-b505-abb602fc4218" />

### Settings window outline

Before:

<img width="293" height="177" alt="terax-stg-bef" src="https://github.com/user-attachments/assets/1ded46af-1c61-4a9d-ace9-9eebe639414f" />

After:

<img width="255" height="200" alt="terax-stg-aft" src="https://github.com/user-attachments/assets/f73da359-22c8-4d6d-916d-1b8986c168d7" />

## Notes for reviewer

I unfortunately could only test this on windows.