### PR TITLE
feat: add Codex login and SSH remote workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,37 @@ jobs:
         working-directory: src-tauri
         run: cargo nextest run --locked --retries 2
 
+  macos-app-build:
+    name: macos-build (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-apple-darwin, x86_64-apple-darwin]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+          key: macos-${{ matrix.target }}
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build macOS app
+        run: pnpm tauri build --no-bundle --target ${{ matrix.target }}
+
   coverage:
     runs-on: ubuntu-22.04
     needs: rust

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-autostart": "~2.5.1",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-log": "~2.8.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@replit/codemirror-vim": "^6.3.0",
     "@tanstack/react-virtual": "^3.13.24",
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-autostart": "~2.5.1",
     "@tauri-apps/plugin-log": "~2.8.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
@@ -100,7 +100,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
     "@tailwindcss/vite": "^4.2.3",
-    "@tauri-apps/cli": "^2",
+    "@tauri-apps/cli": "^2.11.2",
     "@types/node": "^25.6.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@tauri-apps/plugin-autostart':
         specifier: ~2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-log':
         specifier: ~2.8.0
         version: 2.8.0
@@ -2180,6 +2183,9 @@ packages:
 
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-log@2.8.0':
     resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
@@ -6599,6 +6605,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tauri-apps/api':
-        specifier: ^2
-        version: 2.10.1
+        specifier: ^2.11.0
+        version: 2.11.0
       '@tauri-apps/plugin-autostart':
         specifier: ~2.5.1
         version: 2.5.1
@@ -247,8 +247,8 @@ importers:
         specifier: ^4.2.3
         version: 4.2.3(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@tauri-apps/cli':
-        specifier: ^2
-        version: 2.10.1
+        specifier: ^2.11.2
+        version: 2.11.2
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -588,6 +588,9 @@ packages:
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
+  '@codemirror/autocomplete@6.20.2':
+    resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
+
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
@@ -627,6 +630,9 @@ packages:
   '@codemirror/lint@6.9.5':
     resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
 
+  '@codemirror/lint@6.9.6':
+    resolution: {integrity: sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==}
+
   '@codemirror/merge@6.12.1':
     resolution: {integrity: sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w==}
 
@@ -641,6 +647,9 @@ packages:
 
   '@codemirror/view@6.41.1':
     resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
 
   '@dotenvx/dotenvx@1.61.1':
     resolution: {integrity: sha512-2OUX4KDKvQA6oa7oESG8eNcV4K/2C5jgrbxUcT0VoH9Zelg6dT+rDYew4w2GmXRV3db0tUaM4QZG3MyJL3fU5Q==}
@@ -2090,82 +2099,82 @@ packages:
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
-  '@tauri-apps/api@2.10.1':
-    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
 
-  '@tauri-apps/cli-darwin-arm64@2.10.1':
-    resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
+    resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.10.1':
-    resolution: {integrity: sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==}
+  '@tauri-apps/cli-darwin-x64@2.11.2':
+    resolution: {integrity: sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
-    resolution: {integrity: sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+    resolution: {integrity: sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
-    resolution: {integrity: sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+    resolution: {integrity: sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
-    resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+    resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
-    resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+    resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
-    resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+    resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-musl@2.10.1':
-    resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+    resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
-    resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+    resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
-    resolution: {integrity: sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+    resolution: {integrity: sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
-    resolution: {integrity: sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+    resolution: {integrity: sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.10.1':
-    resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
+  '@tauri-apps/cli@2.11.2':
+    resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -5088,6 +5097,13 @@ snapshots:
       '@codemirror/view': 6.41.1
       '@lezer/common': 1.5.2
 
+  '@codemirror/autocomplete@6.20.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.3
@@ -5188,6 +5204,12 @@ snapshots:
       '@codemirror/view': 6.41.1
       crelt: 1.0.6
 
+  '@codemirror/lint@6.9.6':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.6
+
   '@codemirror/merge@6.12.1':
     dependencies:
       '@codemirror/language': 6.12.3
@@ -5210,10 +5232,17 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.41.1
+      '@codemirror/view': 6.43.0
       '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@codemirror/view@6.43.0':
     dependencies:
       '@codemirror/state': 6.6.0
       crelt: 1.0.6
@@ -6520,90 +6549,90 @@ snapshots:
 
   '@tanstack/virtual-core@3.14.0': {}
 
-  '@tauri-apps/api@2.10.1': {}
+  '@tauri-apps/api@2.11.0': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.10.1':
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.10.1':
+  '@tauri-apps/cli-darwin-x64@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.10.1':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.10.1':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.10.1':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.10.1':
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.10.1':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.10.1':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
     optional: true
 
-  '@tauri-apps/cli@2.10.1':
+  '@tauri-apps/cli@2.11.2':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.10.1
-      '@tauri-apps/cli-darwin-x64': 2.10.1
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.10.1
-      '@tauri-apps/cli-linux-arm64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-arm64-musl': 2.10.1
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-x64-gnu': 2.10.1
-      '@tauri-apps/cli-linux-x64-musl': 2.10.1
-      '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
-      '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
-      '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+      '@tauri-apps/cli-darwin-arm64': 2.11.2
+      '@tauri-apps/cli-darwin-x64': 2.11.2
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.2
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.2
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-musl': 2.11.2
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-autostart@2.5.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-log@2.8.0':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-os@2.3.2':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-process@2.3.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-store@2.4.2':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-window-state@2.4.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.0
 
   '@tokenlens/core@1.3.0': {}
 
@@ -7161,13 +7190,13 @@ snapshots:
 
   codemirror@6.0.2:
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.12.3
-      '@codemirror/lint': 6.9.5
+      '@codemirror/lint': 6.9.6
       '@codemirror/search': 6.7.0
       '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.41.1
+      '@codemirror/view': 6.43.0
 
   color-convert@2.0.1:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -85,6 +85,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +775,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1178,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,6 +1251,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1259,6 +1313,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1811,6 +1871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2212,20 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2622,6 +2707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +2796,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "notify"
@@ -2809,6 +2913,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -3142,6 +3247,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3567,10 +3683,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3586,6 +3714,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4150,7 +4287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -5045,6 +5182,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5372,6 +5524,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -5423,6 +5576,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error 2.0.1",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5733,6 +5900,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -6102,6 +6280,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6230,6 +6478,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6806,6 +7060,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6884,6 +7156,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -7076,6 +7365,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"
 notify = "8.2.0"
+tauri-plugin-clipboard-manager = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,8 @@
     "log:default",
     "os:default",
     "notification:default",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
     "store:default",
     "autostart:allow-enable",
     "autostart:allow-disable",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, codex, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -225,6 +225,11 @@ pub fn run() {
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,
+            codex::codex_auth_status,
+            codex::codex_login_chatgpt,
+            codex::codex_logout,
+            codex::codex_app_server_turn,
+            codex::codex_app_server_stream,
             secrets::secrets_get,
             secrets::secrets_set,
             secrets::secrets_delete,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,13 +81,13 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     let builder = builder.decorations(false).transparent(true);
 
-    let window = builder.build().map_err(|e| e.to_string())?;
+    let _window = builder.build().map_err(|e| e.to_string())?;
 
     // Some Linux compositors (GNOME/Mutter with CSD-by-default) ignore the
     // builder-time decorations flag — re-assert it after realize.
     #[cfg(target_os = "linux")]
     {
-        let _ = window.set_decorations(false);
+        let _ = _window.set_decorations(false);
     }
 
     #[cfg(target_os = "macos")]
@@ -95,15 +95,15 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         if let (Ok(main_pos), Ok(main_size), Ok(settings_size)) = (
             main.outer_position(),
             main.outer_size(),
-            window.outer_size(),
+            _window.outer_size(),
         ) {
             let x = main_pos.x
                 + ((main_size.width as i32).saturating_sub(settings_size.width as i32)) / 2;
             let y = main_pos.y
                 + ((main_size.height as i32).saturating_sub(settings_size.height as i32)) / 2;
-            let _ = window.set_position(PhysicalPosition::new(x, y));
+            let _ = _window.set_position(PhysicalPosition::new(x, y));
         } else {
-            let _ = window.center();
+            let _ = _window.center();
         }
     }
 
@@ -130,6 +130,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(tauri_plugin_log::log::LevelFilter::Info)

--- a/src-tauri/src/modules/agent.rs
+++ b/src-tauri/src/modules/agent.rs
@@ -67,7 +67,10 @@ fn merge_hooks(mut root: Value) -> Value {
 fn existing_config(contents: Option<&str>, path: &std::path::Path) -> Result<Value, String> {
     match contents {
         Some(s) if !s.trim().is_empty() => serde_json::from_str::<Value>(s).map_err(|e| {
-            format!("{} is not valid JSON ({e}); refusing to overwrite", path.display())
+            format!(
+                "{} is not valid JSON ({e}); refusing to overwrite",
+                path.display()
+            )
         }),
         _ => Ok(json!({})),
     }

--- a/src-tauri/src/modules/codex.rs
+++ b/src-tauri/src/modules/codex.rs
@@ -1,0 +1,1082 @@
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{mpsc, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use serde_json::{json, Value};
+use tauri::ipc::Channel;
+
+use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
+
+const TURN_TIMEOUT_SECS: u64 = 600;
+const LOGIN_TIMEOUT_SECS: u64 = 600;
+const STDERR_TAIL_LIMIT: usize = 64 * 1024;
+
+#[derive(Serialize)]
+pub struct CodexAuthStatus {
+    pub logged_in: bool,
+    pub detail: String,
+}
+
+#[derive(Serialize)]
+pub struct CodexTurnOutput {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum CodexStreamEvent {
+    TextStart { id: String },
+    TextDelta { id: String, delta: String },
+    TextEnd { id: String },
+    ReasoningStart { id: String },
+    ReasoningDelta { id: String, delta: String },
+    ReasoningEnd { id: String },
+    Step { label: Option<String> },
+    Done,
+    Error { message: String },
+}
+
+#[tauri::command]
+pub async fn codex_auth_status() -> Result<CodexAuthStatus, String> {
+    tauri::async_runtime::spawn_blocking(codex_auth_status_blocking)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn codex_login_chatgpt() -> Result<CodexAuthStatus, String> {
+    tauri::async_runtime::spawn_blocking(codex_login_chatgpt_blocking)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn codex_logout() -> Result<CodexAuthStatus, String> {
+    tauri::async_runtime::spawn_blocking(codex_logout_blocking)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn codex_app_server_turn(
+    prompt: String,
+    cwd: Option<String>,
+    model: Option<String>,
+    developer_instructions: Option<String>,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+) -> Result<CodexTurnOutput, String> {
+    let prompt = prompt.trim().to_string();
+    if prompt.is_empty() {
+        return Err("empty Codex prompt".into());
+    }
+    let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_wsl() {
+        return Err("Codex app-server provider supports local workspaces only for now.".into());
+    }
+    let cwd_path = authorize_spawn_cwd(&registry, cwd.as_deref(), &workspace)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        codex_app_server_turn_blocking(prompt, cwd_path, model, developer_instructions)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn codex_app_server_stream(
+    prompt: String,
+    cwd: Option<String>,
+    model: Option<String>,
+    developer_instructions: Option<String>,
+    workspace: Option<WorkspaceEnv>,
+    registry: tauri::State<'_, WorkspaceRegistry>,
+    on_event: Channel<CodexStreamEvent>,
+) -> Result<(), String> {
+    let prompt = prompt.trim().to_string();
+    if prompt.is_empty() {
+        let message = "empty Codex prompt".to_string();
+        let _ = on_event.send(CodexStreamEvent::Error {
+            message: message.clone(),
+        });
+        return Err(message);
+    }
+    let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_wsl() {
+        let message =
+            "Codex app-server provider supports local workspaces only for now.".to_string();
+        let _ = on_event.send(CodexStreamEvent::Error {
+            message: message.clone(),
+        });
+        return Err(message);
+    }
+    let cwd_path = match authorize_spawn_cwd(&registry, cwd.as_deref(), &workspace) {
+        Ok(path) => path,
+        Err(e) => {
+            let _ = on_event.send(CodexStreamEvent::Error { message: e.clone() });
+            return Err(e);
+        }
+    };
+
+    tauri::async_runtime::spawn_blocking(move || {
+        codex_app_server_stream_blocking(prompt, cwd_path, model, developer_instructions, on_event)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+fn codex_auth_status_blocking() -> Result<CodexAuthStatus, String> {
+    let exe = resolve_codex_executable()?;
+    let mut cmd = Command::new(exe);
+    apply_codex_spawn_env(&mut cmd);
+    let output = cmd
+        .args(["login", "status"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("failed to run codex login status: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let detail = if stdout.is_empty() { stderr } else { stdout };
+    Ok(CodexAuthStatus {
+        logged_in: output.status.success() && detail.to_lowercase().contains("logged in"),
+        detail,
+    })
+}
+
+fn codex_login_chatgpt_blocking() -> Result<CodexAuthStatus, String> {
+    let mut client = CodexAppServerClient::spawn(None)?;
+    client.initialize()?;
+    client.send(json!({
+        "method": "account/login/start",
+        "id": 1,
+        "params": {
+            "type": "chatgpt",
+            "codexStreamlinedLogin": true
+        }
+    }))?;
+
+    let deadline = Instant::now() + Duration::from_secs(LOGIN_TIMEOUT_SECS);
+    let mut opened_url = false;
+
+    loop {
+        let msg = client.recv_until(deadline)?;
+        if let Some(error) = json_rpc_error(&msg) {
+            return Err(error);
+        }
+        if msg.get("id").and_then(Value::as_i64) == Some(1) {
+            let Some(result) = msg.get("result") else {
+                continue;
+            };
+            match result.get("type").and_then(Value::as_str) {
+                Some("chatgpt") => {
+                    if let Some(url) = result.get("authUrl").and_then(Value::as_str) {
+                        open_external_url(url)?;
+                        opened_url = true;
+                    }
+                }
+                Some("chatgptDeviceCode") => {
+                    if let Some(url) = result.get("verificationUrl").and_then(Value::as_str) {
+                        open_external_url(url)?;
+                        opened_url = true;
+                    }
+                }
+                Some("apiKey") | Some("chatgptAuthTokens") => {
+                    return codex_auth_status_blocking();
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if msg.get("method").and_then(Value::as_str) == Some("account/login/completed") {
+            return codex_auth_status_blocking();
+        }
+        if !opened_url && Instant::now() >= deadline {
+            return Err("Codex login did not return an auth URL.".into());
+        }
+    }
+}
+
+fn codex_logout_blocking() -> Result<CodexAuthStatus, String> {
+    let exe = resolve_codex_executable()?;
+    let mut cmd = Command::new(exe);
+    apply_codex_spawn_env(&mut cmd);
+    let output = cmd
+        .arg("logout")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("failed to run codex logout: {e}"))?;
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            "codex logout failed".into()
+        } else {
+            detail
+        });
+    }
+    codex_auth_status_blocking()
+}
+
+fn codex_app_server_turn_blocking(
+    prompt: String,
+    cwd: Option<PathBuf>,
+    model: Option<String>,
+    developer_instructions: Option<String>,
+) -> Result<CodexTurnOutput, String> {
+    let mut client = CodexAppServerClient::spawn(cwd.clone())?;
+    client.initialize()?;
+
+    let mut thread_params = json!({
+        "cwd": cwd.as_ref().map(|p| p.to_string_lossy().to_string()),
+        "approvalPolicy": "never",
+        "sandbox": "read-only",
+        "ephemeral": true
+    });
+    if let Some(instructions) = developer_instructions
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        thread_params["developerInstructions"] = Value::String(instructions.to_string());
+    }
+    if let Some(model) = sanitize_codex_model(model) {
+        thread_params["model"] = Value::String(model);
+    }
+
+    client.send(json!({
+        "method": "thread/start",
+        "id": 1,
+        "params": thread_params
+    }))?;
+
+    let deadline = Instant::now() + Duration::from_secs(TURN_TIMEOUT_SECS);
+    let mut text = String::new();
+
+    loop {
+        let msg = client.recv_until(deadline)?;
+        if let Some(error) = json_rpc_error(&msg) {
+            return Err(error);
+        }
+
+        if msg.get("id").and_then(Value::as_i64) == Some(1) {
+            let thread_id = msg
+                .get("result")
+                .and_then(|r| r.get("thread"))
+                .and_then(|t| t.get("id"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let Some(ref id) = thread_id else {
+                return Err("Codex app-server did not return a thread id.".into());
+            };
+            client.send(json!({
+                "method": "turn/start",
+                "id": 2,
+                "params": {
+                    "threadId": id,
+                    "input": [{
+                        "type": "text",
+                        "text": prompt,
+                        "text_elements": []
+                    }],
+                    "approvalPolicy": "never",
+                    "sandboxPolicy": {
+                        "type": "readOnly",
+                        "networkAccess": false
+                    }
+                }
+            }))?;
+            continue;
+        }
+
+        if msg.get("method").and_then(Value::as_str) == Some("item/agentMessage/delta") {
+            if let Some(delta) = msg
+                .get("params")
+                .and_then(|p| p.get("delta"))
+                .and_then(Value::as_str)
+            {
+                text.push_str(delta);
+            }
+            continue;
+        }
+
+        if msg.get("method").and_then(Value::as_str) == Some("turn/completed") {
+            return Ok(CodexTurnOutput { text });
+        }
+    }
+}
+
+fn codex_app_server_stream_blocking(
+    prompt: String,
+    cwd: Option<PathBuf>,
+    model: Option<String>,
+    developer_instructions: Option<String>,
+    on_event: Channel<CodexStreamEvent>,
+) -> Result<(), String> {
+    let result =
+        codex_app_server_stream_inner(prompt, cwd, model, developer_instructions, &on_event);
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if e == "Codex stream was closed." => Ok(()),
+        Err(e) => {
+            let _ = on_event.send(CodexStreamEvent::Error { message: e.clone() });
+            Err(e)
+        }
+    }
+}
+
+fn codex_app_server_stream_inner(
+    prompt: String,
+    cwd: Option<PathBuf>,
+    model: Option<String>,
+    developer_instructions: Option<String>,
+    on_event: &Channel<CodexStreamEvent>,
+) -> Result<(), String> {
+    send_codex_event(
+        on_event,
+        CodexStreamEvent::Step {
+            label: Some("Starting Codex".to_string()),
+        },
+    )?;
+
+    let mut client = CodexAppServerClient::spawn(cwd.clone())?;
+    client.initialize()?;
+
+    let mut thread_params = json!({
+        "cwd": cwd.as_ref().map(|p| p.to_string_lossy().to_string()),
+        "approvalPolicy": "never",
+        "sandbox": "read-only",
+        "ephemeral": true
+    });
+    if let Some(instructions) = developer_instructions
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        thread_params["developerInstructions"] = Value::String(instructions.to_string());
+    }
+    if let Some(model) = sanitize_codex_model(model) {
+        thread_params["model"] = Value::String(model);
+    }
+
+    client.send(json!({
+        "method": "thread/start",
+        "id": 1,
+        "params": thread_params
+    }))?;
+
+    let deadline = Instant::now() + Duration::from_secs(TURN_TIMEOUT_SECS);
+    let mut text_items = HashSet::<String>::new();
+    let mut reasoning_items = HashSet::<String>::new();
+    let mut reasoning_text = HashMap::<String, String>::new();
+
+    loop {
+        let msg = client.recv_until(deadline)?;
+        if let Some(error) = json_rpc_error(&msg) {
+            return Err(error);
+        }
+
+        if msg.get("id").and_then(Value::as_i64) == Some(1) {
+            let thread_id = msg
+                .get("result")
+                .and_then(|r| r.get("thread"))
+                .and_then(|t| t.get("id"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let Some(ref id) = thread_id else {
+                return Err("Codex app-server did not return a thread id.".into());
+            };
+            send_codex_event(
+                on_event,
+                CodexStreamEvent::Step {
+                    label: Some("Thinking".to_string()),
+                },
+            )?;
+            client.send(json!({
+                "method": "turn/start",
+                "id": 2,
+                "params": {
+                    "threadId": id,
+                    "input": [{
+                        "type": "text",
+                        "text": prompt,
+                        "text_elements": []
+                    }],
+                    "approvalPolicy": "never",
+                    "sandboxPolicy": {
+                        "type": "readOnly",
+                        "networkAccess": false
+                    }
+                }
+            }))?;
+            continue;
+        }
+
+        match msg.get("method").and_then(Value::as_str) {
+            Some("item/started") => {
+                if let Some(item) = msg.get("params").and_then(|p| p.get("item")) {
+                    handle_codex_item_started(
+                        item,
+                        on_event,
+                        &mut text_items,
+                        &mut reasoning_items,
+                        &mut reasoning_text,
+                    )?;
+                }
+            }
+            Some("item/agentMessage/delta") => {
+                let item_id = msg
+                    .get("params")
+                    .and_then(|p| p.get("itemId"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("codex-text")
+                    .to_string();
+                if text_items.insert(item_id.clone()) {
+                    send_codex_event(
+                        on_event,
+                        CodexStreamEvent::TextStart {
+                            id: item_id.clone(),
+                        },
+                    )?;
+                }
+                if let Some(delta) = msg
+                    .get("params")
+                    .and_then(|p| p.get("delta"))
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                {
+                    send_codex_event(
+                        on_event,
+                        CodexStreamEvent::TextDelta {
+                            id: item_id,
+                            delta: delta.to_string(),
+                        },
+                    )?;
+                }
+            }
+            Some("item/completed") => {
+                if let Some(item) = msg.get("params").and_then(|p| p.get("item")) {
+                    handle_codex_item_completed(
+                        item,
+                        on_event,
+                        &mut text_items,
+                        &mut reasoning_items,
+                        &mut reasoning_text,
+                    )?;
+                }
+            }
+            Some("turn/completed") => {
+                for id in text_items.drain() {
+                    send_codex_event(on_event, CodexStreamEvent::TextEnd { id })?;
+                }
+                for id in reasoning_items.drain() {
+                    send_codex_event(on_event, CodexStreamEvent::ReasoningEnd { id })?;
+                }
+                send_codex_event(on_event, CodexStreamEvent::Step { label: None })?;
+                send_codex_event(on_event, CodexStreamEvent::Done)?;
+                return Ok(());
+            }
+            Some("turn/failed") => {
+                return Err(codex_failure_message(&msg));
+            }
+            _ => {}
+        }
+    }
+}
+
+fn handle_codex_item_started(
+    item: &Value,
+    on_event: &Channel<CodexStreamEvent>,
+    text_items: &mut HashSet<String>,
+    reasoning_items: &mut HashSet<String>,
+    reasoning_text: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    match item.get("type").and_then(Value::as_str) {
+        Some("agentMessage") => {
+            if let Some(id) = item.get("id").and_then(Value::as_str) {
+                if text_items.insert(id.to_string()) {
+                    send_codex_event(on_event, CodexStreamEvent::TextStart { id: id.to_string() })?;
+                }
+            }
+            send_codex_event(
+                on_event,
+                CodexStreamEvent::Step {
+                    label: Some("Writing".to_string()),
+                },
+            )?;
+        }
+        Some("reasoning") => {
+            if let Some(id) = item.get("id").and_then(Value::as_str) {
+                if reasoning_items.insert(id.to_string()) {
+                    send_codex_event(
+                        on_event,
+                        CodexStreamEvent::ReasoningStart { id: id.to_string() },
+                    )?;
+                }
+                send_reasoning_delta(id, item, on_event, reasoning_text)?;
+            }
+            send_codex_event(
+                on_event,
+                CodexStreamEvent::Step {
+                    label: Some("Thinking".to_string()),
+                },
+            )?;
+        }
+        Some("commandExecution") => {
+            let command = item
+                .get("command")
+                .and_then(Value::as_str)
+                .map(short_command_label)
+                .unwrap_or_else(|| "Running command".to_string());
+            send_codex_event(
+                on_event,
+                CodexStreamEvent::Step {
+                    label: Some(command),
+                },
+            )?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn handle_codex_item_completed(
+    item: &Value,
+    on_event: &Channel<CodexStreamEvent>,
+    text_items: &mut HashSet<String>,
+    reasoning_items: &mut HashSet<String>,
+    reasoning_text: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    match item.get("type").and_then(Value::as_str) {
+        Some("agentMessage") => {
+            if let Some(id) = item.get("id").and_then(Value::as_str) {
+                if text_items.remove(id) {
+                    send_codex_event(on_event, CodexStreamEvent::TextEnd { id: id.to_string() })?;
+                }
+            }
+        }
+        Some("reasoning") => {
+            if let Some(id) = item.get("id").and_then(Value::as_str) {
+                send_reasoning_delta(id, item, on_event, reasoning_text)?;
+                if reasoning_items.remove(id) {
+                    send_codex_event(
+                        on_event,
+                        CodexStreamEvent::ReasoningEnd { id: id.to_string() },
+                    )?;
+                }
+            }
+            send_codex_event(
+                on_event,
+                CodexStreamEvent::Step {
+                    label: Some("Thinking".to_string()),
+                },
+            )?;
+        }
+        Some("commandExecution") => {
+            send_codex_event(
+                on_event,
+                CodexStreamEvent::Step {
+                    label: Some("Thinking".to_string()),
+                },
+            )?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn send_reasoning_delta(
+    id: &str,
+    item: &Value,
+    on_event: &Channel<CodexStreamEvent>,
+    reasoning_text: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    let next = reasoning_text_from_item(item);
+    if next.is_empty() {
+        return Ok(());
+    }
+    let previous = reasoning_text.get(id).cloned().unwrap_or_default();
+    let delta = next
+        .strip_prefix(&previous)
+        .map(str::to_string)
+        .unwrap_or_else(|| next.clone());
+    if delta.is_empty() {
+        return Ok(());
+    }
+    reasoning_text.insert(id.to_string(), next);
+    send_codex_event(
+        on_event,
+        CodexStreamEvent::ReasoningDelta {
+            id: id.to_string(),
+            delta,
+        },
+    )
+}
+
+fn reasoning_text_from_item(item: &Value) -> String {
+    let mut parts = Vec::new();
+    collect_text_fields(item.get("summary"), &mut parts);
+    collect_text_fields(item.get("content"), &mut parts);
+    parts
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn collect_text_fields(value: Option<&Value>, out: &mut Vec<String>) {
+    match value {
+        Some(Value::String(s)) => out.push(s.clone()),
+        Some(Value::Array(items)) => {
+            for item in items {
+                collect_text_fields(Some(item), out);
+            }
+        }
+        Some(Value::Object(map)) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                out.push(text.to_string());
+            } else {
+                for value in map.values() {
+                    collect_text_fields(Some(value), out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn short_command_label(command: &str) -> String {
+    let compact = command.split_whitespace().collect::<Vec<_>>().join(" ");
+    let shown = if compact.chars().count() > 60 {
+        let mut s = compact.chars().take(59).collect::<String>();
+        s.push_str("...");
+        s
+    } else {
+        compact
+    };
+    format!("Running {shown}")
+}
+
+fn send_codex_event(
+    on_event: &Channel<CodexStreamEvent>,
+    event: CodexStreamEvent,
+) -> Result<(), String> {
+    on_event
+        .send(event)
+        .map_err(|_| "Codex stream was closed.".to_string())
+}
+
+fn codex_failure_message(msg: &Value) -> String {
+    msg.get("params")
+        .and_then(|p| p.get("error"))
+        .and_then(Value::as_str)
+        .or_else(|| {
+            msg.get("params")
+                .and_then(|p| p.get("turn"))
+                .and_then(|t| t.get("error"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("Codex turn failed.")
+        .to_string()
+}
+
+fn sanitize_codex_model(model: Option<String>) -> Option<String> {
+    model
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty() && !m.chars().any(char::is_control))
+}
+
+struct CodexAppServerClient {
+    stdin: std::process::ChildStdin,
+    lines: mpsc::Receiver<Result<String, String>>,
+    stderr: mpsc::Receiver<String>,
+    child: std::process::Child,
+}
+
+impl CodexAppServerClient {
+    fn spawn(cwd: Option<PathBuf>) -> Result<Self, String> {
+        let exe = resolve_codex_executable()?;
+        let mut cmd = Command::new(exe);
+        cmd.arg("app-server")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        apply_codex_spawn_env(&mut cmd);
+        crate::modules::proc::hide_console(&mut cmd);
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("failed to start codex app-server: {e}"))?;
+        let stdin = child.stdin.take().ok_or_else(|| {
+            let _ = child.kill();
+            "Codex app-server stdin was unavailable.".to_string()
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            let _ = child.kill();
+            "Codex app-server stdout was unavailable.".to_string()
+        })?;
+        let stderr = child.stderr.take().ok_or_else(|| {
+            let _ = child.kill();
+            "Codex app-server stderr was unavailable.".to_string()
+        })?;
+
+        let (line_tx, lines) = mpsc::channel();
+        thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                match line {
+                    Ok(line) => {
+                        if line_tx.send(Ok(line)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        let _ = line_tx.send(Err(e.to_string()));
+                        break;
+                    }
+                }
+            }
+        });
+
+        let (stderr_tx, stderr_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let mut tail = String::new();
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                tail.push_str(&line);
+                tail.push('\n');
+                if tail.len() > STDERR_TAIL_LIMIT {
+                    let drain = tail.len() - STDERR_TAIL_LIMIT;
+                    tail.drain(..drain);
+                }
+            }
+            let _ = stderr_tx.send(tail);
+        });
+
+        Ok(Self {
+            stdin,
+            lines,
+            stderr: stderr_rx,
+            child,
+        })
+    }
+
+    fn initialize(&mut self) -> Result<(), String> {
+        self.send(json!({
+            "method": "initialize",
+            "id": 0,
+            "params": {
+                "clientInfo": {
+                    "name": "terax",
+                    "title": "Terax",
+                    "version": env!("CARGO_PKG_VERSION")
+                },
+                "capabilities": {
+                    "experimentalApi": true
+                }
+            }
+        }))?;
+        self.send(json!({ "method": "initialized", "params": {} }))?;
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let msg = self.recv_until(deadline)?;
+            if let Some(error) = json_rpc_error(&msg) {
+                return Err(error);
+            }
+            if msg.get("id").and_then(Value::as_i64) == Some(0) {
+                return Ok(());
+            }
+        }
+    }
+
+    fn send(&mut self, value: Value) -> Result<(), String> {
+        serde_json::to_writer(&mut self.stdin, &value)
+            .map_err(|e| format!("failed to encode Codex app-server message: {e}"))?;
+        self.stdin
+            .write_all(b"\n")
+            .and_then(|_| self.stdin.flush())
+            .map_err(|e| format!("failed to write to Codex app-server: {e}"))
+    }
+
+    fn recv_until(&mut self, deadline: Instant) -> Result<Value, String> {
+        loop {
+            let now = Instant::now();
+            if now >= deadline {
+                let _ = self.child.kill();
+                let stderr = self.stderr.try_recv().unwrap_or_default();
+                return Err(if stderr.trim().is_empty() {
+                    "Timed out waiting for Codex app-server.".into()
+                } else {
+                    format!("Timed out waiting for Codex app-server:\n{}", stderr.trim())
+                });
+            }
+            let timeout = deadline
+                .saturating_duration_since(now)
+                .min(Duration::from_secs(1));
+            match self.lines.recv_timeout(timeout) {
+                Ok(Ok(line)) => {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    return serde_json::from_str::<Value>(&line).map_err(|e| {
+                        format!("Codex app-server returned invalid JSON: {e}\n{line}")
+                    });
+                }
+                Ok(Err(e)) => return Err(format!("failed to read Codex app-server output: {e}")),
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if let Ok(Some(status)) = self.child.try_wait() {
+                        let stderr = self.stderr.try_recv().unwrap_or_default();
+                        return Err(if stderr.trim().is_empty() {
+                            format!("Codex app-server exited with status {status}.")
+                        } else {
+                            format!(
+                                "Codex app-server exited with status {status}:\n{}",
+                                stderr.trim()
+                            )
+                        });
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let stderr = self.stderr.try_recv().unwrap_or_default();
+                    return Err(if stderr.trim().is_empty() {
+                        "Codex app-server output stream closed.".into()
+                    } else {
+                        format!("Codex app-server output stream closed:\n{}", stderr.trim())
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl Drop for CodexAppServerClient {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn json_rpc_error(msg: &Value) -> Option<String> {
+    let error = msg.get("error")?;
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("Codex app-server error");
+    let code = error.get("code").and_then(Value::as_i64);
+    Some(match code {
+        Some(code) => format!("Codex app-server error {code}: {message}"),
+        None => format!("Codex app-server error: {message}"),
+    })
+}
+
+fn resolve_codex_executable() -> Result<PathBuf, String> {
+    if let Some(path) = std::env::var_os("CODEX_EXECUTABLE").map(PathBuf::from) {
+        if is_executable_file(&path) {
+            return Ok(path);
+        }
+    }
+
+    if let Some(path) = find_in_path("codex") {
+        return Ok(path);
+    }
+
+    let mut candidates = vec![
+        PathBuf::from("/opt/homebrew/bin/codex"),
+        PathBuf::from("/usr/local/bin/codex"),
+        PathBuf::from("/usr/bin/codex"),
+    ];
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".codex/bin/codex"));
+        candidates.push(home.join(".local/bin/codex"));
+        candidates.push(home.join(".npm-global/bin/codex"));
+        candidates.push(home.join("Library/pnpm/codex"));
+    }
+    for path in candidates {
+        if is_executable_file(&path) {
+            return Ok(path);
+        }
+    }
+
+    if let Ok(path) = resolve_with_login_shell() {
+        if is_executable_file(&path) {
+            return Ok(path);
+        }
+    }
+
+    Err(
+        "Codex CLI was not found. Install Codex or set CODEX_EXECUTABLE to the codex binary path."
+            .into(),
+    )
+}
+
+fn find_in_path(binary: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let path = dir.join(binary);
+        if is_executable_file(&path) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn resolve_with_login_shell() -> Result<PathBuf, String> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let output = Command::new(shell)
+        .args(["-lc", "command -v codex"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err("login shell could not find codex".into());
+    }
+    let path = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if path.is_empty() {
+        return Err("login shell returned an empty codex path".into());
+    }
+    Ok(PathBuf::from(path))
+}
+
+fn apply_codex_spawn_env(cmd: &mut Command) {
+    if let Some(path) = codex_spawn_path() {
+        cmd.env("PATH", path);
+    }
+}
+
+fn codex_spawn_path() -> Option<OsString> {
+    static PATH: OnceLock<Option<OsString>> = OnceLock::new();
+    PATH.get_or_init(build_codex_spawn_path).clone()
+}
+
+fn build_codex_spawn_path() -> Option<OsString> {
+    let mut paths = vec![
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/usr/local/bin"),
+        PathBuf::from("/usr/bin"),
+        PathBuf::from("/bin"),
+        PathBuf::from("/usr/sbin"),
+        PathBuf::from("/sbin"),
+    ];
+    if let Some(path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&path));
+    }
+    if let Ok(path) = login_shell_path() {
+        paths.extend(std::env::split_paths(&OsString::from(path)));
+    }
+    dedupe_paths(&mut paths);
+    std::env::join_paths(paths).ok()
+}
+
+fn dedupe_paths(paths: &mut Vec<PathBuf>) {
+    let mut seen = std::collections::HashSet::new();
+    paths.retain(|path| seen.insert(path.clone()));
+}
+
+fn login_shell_path() -> Result<String, String> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let output = Command::new(shell)
+        .args(["-lc", "printf %s \"$PATH\""])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err("login shell did not return PATH".into());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn is_executable_file(path: &PathBuf) -> bool {
+    path.is_file()
+}
+
+fn open_external_url(url: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        let mut cmd = Command::new("open");
+        cmd.arg(url);
+        cmd
+    };
+
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", url]);
+        cmd
+    };
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut cmd = {
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(url);
+        cmd
+    };
+
+    crate::modules::proc::hide_console(&mut cmd);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to open Codex login URL: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_reasoning_text_from_summary_and_content() {
+        let item = json!({
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [
+                { "type": "summary_text", "text": "Checked the request." }
+            ],
+            "content": [
+                { "type": "reasoning_text", "text": "Prepared the response." }
+            ]
+        });
+
+        assert_eq!(
+            reasoning_text_from_item(&item),
+            "Checked the request.\nPrepared the response."
+        );
+    }
+
+    #[test]
+    fn empty_reasoning_item_has_no_text() {
+        let item = json!({
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [],
+            "content": []
+        });
+
+        assert_eq!(reasoning_text_from_item(&item), "");
+    }
+}

--- a/src-tauri/src/modules/codex.rs
+++ b/src-tauri/src/modules/codex.rs
@@ -926,13 +926,48 @@ fn resolve_codex_executable() -> Result<PathBuf, String> {
 
 fn find_in_path(binary: &str) -> Option<PathBuf> {
     let path_var = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path_var) {
-        let path = dir.join(binary);
-        if is_executable_file(&path) {
-            return Some(path);
+    find_in_paths(binary, std::env::split_paths(&path_var))
+}
+
+fn find_in_paths<I>(binary: &str, paths: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    #[cfg(windows)]
+    {
+        for dir in paths {
+            for path in windows_binary_candidates(&dir, binary) {
+                if is_executable_file(&path) {
+                    return Some(path);
+                }
+            }
         }
+        None
     }
-    None
+
+    #[cfg(not(windows))]
+    {
+        for dir in paths {
+            let path = dir.join(binary);
+            if is_executable_file(&path) {
+                return Some(path);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(windows)]
+fn windows_binary_candidates(dir: &std::path::Path, binary: &str) -> Vec<PathBuf> {
+    let base = dir.join(binary);
+    if base.extension().is_some() {
+        return vec![base];
+    }
+
+    ["exe", "cmd", "bat", "com"]
+        .into_iter()
+        .map(|ext| base.with_extension(ext))
+        .collect()
 }
 
 fn resolve_with_login_shell() -> Result<PathBuf, String> {
@@ -1009,8 +1044,23 @@ fn login_shell_path() -> Result<String, String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-fn is_executable_file(path: &PathBuf) -> bool {
-    path.is_file()
+fn is_executable_file(path: &std::path::Path) -> bool {
+    #[cfg(windows)]
+    {
+        let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
+            return false;
+        };
+        path.is_file()
+            && matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "exe" | "cmd" | "bat" | "com"
+            )
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.is_file()
+    }
 }
 
 fn open_external_url(url: &str) -> Result<(), String> {
@@ -1023,8 +1073,9 @@ fn open_external_url(url: &str) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     let mut cmd = {
-        let mut cmd = Command::new("cmd");
-        cmd.args(["/C", "start", "", url]);
+        let (program, args) = windows_external_url_command_parts(url);
+        let mut cmd = Command::new(program);
+        cmd.args(args);
         cmd
     };
 
@@ -1044,10 +1095,19 @@ fn open_external_url(url: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(windows)]
+fn windows_external_url_command_parts(url: &str) -> (&'static str, Vec<String>) {
+    (
+        "rundll32.exe",
+        vec!["url.dll,FileProtocolHandler".to_string(), url.to_string()],
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::fs;
 
     #[test]
     fn extracts_reasoning_text_from_summary_and_content() {
@@ -1078,5 +1138,35 @@ mod tests {
         });
 
         assert_eq!(reasoning_text_from_item(&item), "");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn find_in_path_prefers_windows_command_shim_over_extensionless_shell_script() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("codex"), "#!/bin/sh\nexit 0\n").expect("shim");
+        fs::write(dir.path().join("codex.cmd"), "@echo off\r\nexit /b 0\r\n").expect("cmd");
+
+        let old_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", dir.path());
+        let found = find_in_path("codex").expect("codex should be found");
+        if let Some(old_path) = old_path {
+            std::env::set_var("PATH", old_path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+
+        assert_eq!(found, dir.path().join("codex.cmd"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_external_url_command_does_not_route_oauth_url_through_cmd() {
+        let url =
+            "https://auth.openai.com/oauth/authorize?client_id=abc&state=def&code_challenge=ghi";
+        let (program, args) = windows_external_url_command_parts(url);
+
+        assert_ne!(program, "cmd");
+        assert!(args.iter().any(|arg| arg == url));
     }
 }

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -6,12 +6,13 @@ use serde::Serialize;
 use tauri::Emitter;
 use tempfile::NamedTempFile;
 
+use crate::modules::ssh;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
-#[derive(Serialize)]
+#[derive(Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum ReadResult {
     Text {
@@ -28,7 +29,7 @@ pub enum ReadResult {
     },
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum StatKind {
     File,
@@ -36,7 +37,7 @@ pub enum StatKind {
     Symlink,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, serde::Deserialize)]
 pub struct FileStat {
     pub size: u64,
     pub mtime: u64,
@@ -46,6 +47,12 @@ pub struct FileStat {
 #[tauri::command]
 pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<ReadResult, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::read_file(&workspace, &path, 120).map_err(|e| {
+            log::debug!("ssh fs_read_file({path}) failed: {e}");
+            e
+        });
+    }
     let p = resolve_path(&path, &workspace);
     let meta = std::fs::metadata(&p).map_err(|e| {
         log::debug!("fs_read_file stat({}) failed: {e}", p.display());
@@ -107,6 +114,12 @@ pub fn fs_write_file(
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::write_file(&workspace, &path, &content, 120).map_err(|e| {
+            log::warn!("ssh fs_write_file({path}) failed: {e}");
+            e
+        });
+    }
     let target = resolve_path(&path, &workspace);
     let original_permissions = fs::metadata(&target).ok().map(|m| m.permissions());
     write_atomic(&target, content.as_bytes()).map_err(|e| {
@@ -131,6 +144,12 @@ pub fn fs_write_file(
 #[tauri::command]
 pub fn fs_canonicalize(path: String, workspace: Option<WorkspaceEnv>) -> Result<String, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::canonicalize(&workspace, &path, 60).map_err(|e| {
+            log::debug!("ssh fs_canonicalize({path}) failed: {e}");
+            e
+        });
+    }
     let p = resolve_path(&path, &workspace);
     let canon = std::fs::canonicalize(&p).map_err(|e| e.to_string())?;
     Ok(super::to_canon(&canon))
@@ -139,6 +158,12 @@ pub fn fs_canonicalize(path: String, workspace: Option<WorkspaceEnv>) -> Result<
 #[tauri::command]
 pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::stat(&workspace, &path, 60).map_err(|e| {
+            log::debug!("ssh fs_stat({path}) failed: {e}");
+            e
+        });
+    }
     let p = resolve_path(&path, &workspace);
     let meta = std::fs::metadata(&p).map_err(|e| e.to_string())?;
     let kind = if meta.is_dir() {

--- a/src-tauri/src/modules/fs/grep.rs
+++ b/src-tauri/src/modules/fs/grep.rs
@@ -6,16 +6,17 @@ use grep_regex::RegexMatcherBuilder;
 use grep_searcher::sinks::UTF8;
 use grep_searcher::{BinaryDetection, SearcherBuilder};
 use ignore::{WalkBuilder, WalkState};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::to_canon;
+use crate::modules::ssh;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const FILE_SIZE_CAP: u64 = 5 * 1024 * 1024;
 const DEFAULT_MAX_RESULTS: usize = 200;
 const HARD_MAX_RESULTS: usize = 2000;
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GrepHit {
     pub path: String,
     pub rel: String,
@@ -23,7 +24,7 @@ pub struct GrepHit {
     pub text: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GrepResponse {
     pub hits: Vec<GrepHit>,
     pub truncated: bool,
@@ -56,6 +57,21 @@ pub fn fs_grep(
         return Err("empty pattern".into());
     }
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::grep(
+            &workspace,
+            &pattern,
+            &root,
+            glob,
+            case_insensitive,
+            max_results,
+            120,
+        )
+        .map_err(|e| {
+            log::debug!("ssh fs_grep({root}) failed: {e}");
+            e
+        });
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
@@ -167,13 +183,13 @@ pub fn fs_grep(
     })
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GlobHit {
     pub path: String,
     pub rel: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct GlobResponse {
     pub hits: Vec<GlobHit>,
     pub truncated: bool,
@@ -190,6 +206,12 @@ pub fn fs_glob(
         return Err("empty pattern".into());
     }
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::glob(&workspace, &pattern, &root, max_results, 120).map_err(|e| {
+            log::debug!("ssh fs_glob({root}) failed: {e}");
+            e
+        });
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));

--- a/src-tauri/src/modules/fs/mutate.rs
+++ b/src-tauri/src/modules/fs/mutate.rs
@@ -1,9 +1,16 @@
+use crate::modules::ssh;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 /// Creates a new empty file. Fails if the file already exists.
 #[tauri::command]
 pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::create_file(&workspace, &path, 120).map_err(|e| {
+            log::debug!("ssh fs_create_file({path}) failed: {e}");
+            e
+        });
+    }
     let p = resolve_path(&path, &workspace);
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
@@ -20,6 +27,12 @@ pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(
 #[tauri::command]
 pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::create_dir(&workspace, &path, 120).map_err(|e| {
+            log::debug!("ssh fs_create_dir({path}) failed: {e}");
+            e
+        });
+    }
     let p = resolve_path(&path, &workspace);
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
@@ -34,6 +47,12 @@ pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<()
 #[tauri::command]
 pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::rename(&workspace, &from, &to, 120).map_err(|e| {
+            log::debug!("ssh fs_rename({from} -> {to}) failed: {e}");
+            e
+        });
+    }
     let from_p = resolve_path(&from, &workspace);
     let to_p = resolve_path(&to, &workspace);
     if !from_p.exists() {
@@ -57,6 +76,12 @@ pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> R
 #[tauri::command]
 pub fn fs_delete(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::delete(&workspace, &path, 120).map_err(|e| {
+            log::warn!("ssh fs_delete({path}) failed: {e}");
+            e
+        });
+    }
     let p = resolve_path(&path, &workspace);
     let meta = std::fs::symlink_metadata(&p).map_err(|e| {
         log::debug!("fs_delete stat({}) failed: {e}", p.display());

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -1,10 +1,11 @@
 use ignore::WalkBuilder;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::to_canon;
+use crate::modules::ssh;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SearchHit {
     /// Absolute path of the matched file.
     pub path: String,
@@ -15,7 +16,7 @@ pub struct SearchHit {
     pub is_dir: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SearchResult {
     pub hits: Vec<SearchHit>,
     /// True if the scan stopped early (entry budget or hit cap reached).
@@ -60,6 +61,12 @@ pub fn fs_search(
     let cap = limit.unwrap_or(200).min(1000);
     let show_hidden = show_hidden.unwrap_or(false);
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::search(&workspace, &root, &query, Some(cap), show_hidden, 120).map_err(|e| {
+            log::debug!("ssh fs_search({root}) failed: {e}");
+            e
+        });
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
@@ -137,7 +144,7 @@ pub fn fs_search(
     })
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListFilesResult {
     pub files: Vec<String>,
     pub truncated: bool,
@@ -160,6 +167,13 @@ pub fn fs_list_files(
     let depth = max_depth.unwrap_or(DEFAULT_DEPTH).clamp(1, HARD_DEPTH);
     let show_hidden = show_hidden.unwrap_or(false);
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::list_files(&workspace, &root, Some(cap), Some(depth), show_hidden, 120)
+            .map_err(|e| {
+                log::debug!("ssh fs_list_files({root}) failed: {e}");
+                e
+            });
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -1,10 +1,11 @@
 use std::time::UNIX_EPOCH;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
+use crate::modules::ssh;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum EntryKind {
     File,
@@ -12,7 +13,7 @@ pub enum EntryKind {
     Symlink,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct DirEntry {
     pub name: String,
     pub kind: EntryKind,
@@ -31,6 +32,12 @@ pub fn fs_read_dir(
     workspace: Option<WorkspaceEnv>,
 ) -> Result<Vec<DirEntry>, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::read_dir(&workspace, &path, show_hidden, 120).map_err(|e| {
+            log::debug!("ssh fs_read_dir({path}) failed: {e}");
+            e
+        });
+    }
     let root = resolve_path(&path, &workspace);
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("fs_read_dir({}) failed: {e}", root.display());
@@ -106,6 +113,12 @@ pub fn list_subdirs(
     workspace: Option<WorkspaceEnv>,
 ) -> Result<Vec<String>, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return ssh::list_subdirs(&workspace, &path, show_hidden, 120).map_err(|e| {
+            log::debug!("ssh list_subdirs({path}) failed: {e}");
+            e
+        });
+    }
     let root = resolve_path(&path, &workspace);
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("list_subdirs({}) read_dir failed: {e}", root.display());

--- a/src-tauri/src/modules/fs/watch.rs
+++ b/src-tauri/src/modules/fs/watch.rs
@@ -213,12 +213,16 @@ fn prepare_add(
     workspace: &WorkspaceEnv,
     paths: Vec<String>,
 ) -> Vec<PathBuf> {
+    if workspace.is_ssh() {
+        return Vec::new();
+    }
     paths
         .into_iter()
         .filter_map(|raw| {
             let resolved = resolve_path(&raw, workspace);
             let canonical = std::fs::canonicalize(&resolved).ok()?;
-            if !canonical.is_dir() || is_skipped(&canonical) || !registry.is_authorized(&canonical) {
+            if !canonical.is_dir() || is_skipped(&canonical) || !registry.is_authorized(&canonical)
+            {
                 return None;
             }
             Some(canonical)
@@ -235,6 +239,9 @@ pub fn fs_watch_add(
     registry: State<'_, WorkspaceRegistry>,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Ok(());
+    }
     let prepared = prepare_add(&registry, &workspace, paths);
     if prepared.is_empty() {
         return Ok(());
@@ -254,6 +261,9 @@ pub fn fs_watch_remove(
     state: State<'_, FsWatchState>,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Ok(());
+    }
     // A removed/renamed dir no longer canonicalizes; fall back so the refcount
     // entry is still released.
     let prepared: Vec<PathBuf> = paths

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -1,6 +1,7 @@
 use std::ffi::{OsStr, OsString};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use crate::modules::fs::file::ReadResult as RemoteReadResult;
 use crate::modules::git::errors::{GitError, Result};
 use crate::modules::git::parser::parse_porcelain_v2;
 use crate::modules::git::process::{
@@ -13,8 +14,10 @@ use crate::modules::git::types::{
     TextSource, DEFAULT_TIMEOUT_SECS, NETWORK_TIMEOUT_SECS,
 };
 use crate::modules::git::utils::{
-    authorized_repo_root, canonical_dir, resolve_within_repo, split_upstream, ResolvedGitDirectory,
+    authorized_repo_root, canonical_dir, is_safe_pathspec, resolve_within_repo, split_upstream,
+    ResolvedGitDirectory,
 };
+use crate::modules::ssh;
 use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
 
 pub fn resolve_repo(
@@ -178,7 +181,7 @@ fn diff_inner(
         args.push("--cached".into());
     }
     let pathspec = match path.filter(|p| !p.is_empty()) {
-        Some(p) => Some(pathspec_from_input(&repo_root.local_path, p)?),
+        Some(p) => Some(pathspec_from_input(repo_root, p)?),
         None => None,
     };
     if let Some(spec) = pathspec.as_ref() {
@@ -213,14 +216,10 @@ pub fn diff_content(
 ) -> Result<GitDiffContentResult> {
     let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
     ensure_git_available(&repo_root.workspace)?;
-    let worktree_path = resolve_within_repo(&repo_root.local_path, path)?;
-    let rel_path = pathspec(&repo_root.local_path, &worktree_path);
+    let rel_path = pathspec_from_input(&repo_root, path)?;
 
     let original_rel = match original_path {
-        Some(orig) if !orig.is_empty() => {
-            let resolved = resolve_within_repo(&repo_root.local_path, orig)?;
-            Some(pathspec(&repo_root.local_path, &resolved))
-        }
+        Some(orig) if !orig.is_empty() => Some(pathspec_from_input(&repo_root, orig)?),
         _ => None,
     };
 
@@ -244,7 +243,11 @@ pub fn diff_content(
             &repo_root.git_path,
             &format!(":{rel_path}"),
         )?
+    } else if repo_root.workspace.is_ssh() {
+        let path = repo_file_path(&repo_root, path)?;
+        remote_text_source(&repo_root.workspace, &path)?
     } else {
+        let worktree_path = repo_file_path(&repo_root, path)?;
         read_text_file(&worktree_path)?
     };
     let patch = diff_inner(&repo_root, Some(&rel_path), staged)?;
@@ -271,7 +274,7 @@ pub fn stage(
     if paths.is_empty() {
         return Ok(());
     }
-    let resolved = resolve_pathspecs(&repo_root.local_path, paths)?;
+    let resolved = resolve_pathspecs(&repo_root, paths)?;
     let mut args: Vec<OsString> = vec!["add".into(), "--".into()];
     for p in &resolved {
         args.push(p.clone().into());
@@ -296,7 +299,7 @@ pub fn unstage(
     if paths.is_empty() {
         return Ok(());
     }
-    let resolved = resolve_pathspecs(&repo_root.local_path, paths)?;
+    let resolved = resolve_pathspecs(&repo_root, paths)?;
     let mut reset_args: Vec<OsString> = vec!["reset".into(), "HEAD".into(), "--".into()];
     for p in &resolved {
         reset_args.push(p.clone().into());
@@ -313,12 +316,7 @@ pub fn unstage(
     if !looks_like_no_head(&output) {
         return ensure_success(&output, "git reset failed");
     }
-    let mut rm_args: Vec<OsString> = vec![
-        "rm".into(),
-        "--cached".into(),
-        "-r".into(),
-        "--".into(),
-    ];
+    let mut rm_args: Vec<OsString> = vec!["rm".into(), "--cached".into(), "-r".into(), "--".into()];
     for p in &resolved {
         rm_args.push(p.clone().into());
     }
@@ -354,7 +352,7 @@ pub fn discard(
     let mut tracked: Vec<String> = Vec::with_capacity(entries.len());
     let mut untracked: Vec<String> = Vec::new();
     for entry in entries {
-        let resolved = pathspec_from_input(&repo_root.local_path, &entry.path)?;
+        let resolved = pathspec_from_input(&repo_root, &entry.path)?;
         if entry.untracked {
             untracked.push(resolved);
         } else {
@@ -715,20 +713,10 @@ pub fn commit_file_diff(
     if !sha_is_safe(sha) {
         return Err(GitError::command("git show", "invalid commit sha"));
     }
-    let resolved = resolve_within_repo(&repo_root.local_path, path)?;
-    let rel = resolved
-        .strip_prefix(&repo_root.local_path)
-        .map(|p| p.to_string_lossy().replace('\\', "/"))
-        .unwrap_or_else(|_| path.replace('\\', "/"));
+    let rel = pathspec_from_input(&repo_root, path)?;
 
     let original_rel = match original_path {
-        Some(orig) if !orig.is_empty() => {
-            let resolved_orig = resolve_within_repo(&repo_root.local_path, orig)?;
-            resolved_orig
-                .strip_prefix(&repo_root.local_path)
-                .map(|p| p.to_string_lossy().replace('\\', "/"))
-                .unwrap_or_else(|_| orig.replace('\\', "/"))
-        }
+        Some(orig) if !orig.is_empty() => pathspec_from_input(&repo_root, orig)?,
         _ => rel.clone(),
     };
 
@@ -956,7 +944,7 @@ fn nothing_to_commit(output: &GitOutput) -> bool {
     stderr.contains("nothing to commit") || stdout.contains("nothing to commit")
 }
 
-fn resolve_pathspecs(repo_root: &Path, paths: &[String]) -> Result<Vec<String>> {
+fn resolve_pathspecs(repo_root: &ResolvedGitDirectory, paths: &[String]) -> Result<Vec<String>> {
     let mut out = Vec::with_capacity(paths.len());
     for p in paths {
         out.push(pathspec_from_input(repo_root, p)?);
@@ -964,9 +952,11 @@ fn resolve_pathspecs(repo_root: &Path, paths: &[String]) -> Result<Vec<String>> 
     Ok(out)
 }
 
-fn pathspec_from_input(repo_root: &Path, rel: &str) -> Result<String> {
-    let resolved = resolve_within_repo(repo_root, rel)?;
-    Ok(pathspec(repo_root, &resolved))
+fn pathspec_from_input(repo_root: &ResolvedGitDirectory, rel: &str) -> Result<String> {
+    if repo_root.workspace.is_ssh() {
+        return ssh_pathspec_from_input(&repo_root.git_path, rel);
+    }
+    local_pathspec_from_input(&repo_root.local_path, rel)
 }
 
 fn pathspec(repo_root: &Path, absolute: &Path) -> String {
@@ -974,6 +964,131 @@ fn pathspec(repo_root: &Path, absolute: &Path) -> String {
         .strip_prefix(repo_root)
         .map(|rel| rel.to_string_lossy().replace('\\', "/"))
         .unwrap_or_else(|_| absolute.to_string_lossy().replace('\\', "/"))
+}
+
+fn local_pathspec_from_input(repo_root: &Path, rel: &str) -> Result<String> {
+    let normalized = normalize_git_path(rel);
+    if normalized.is_empty() {
+        return Err(GitError::InvalidPath(rel.into()));
+    }
+    let input = Path::new(&normalized);
+    if input.is_absolute() {
+        let canonical = std::fs::canonicalize(input).map_err(GitError::Io)?;
+        if !canonical.starts_with(repo_root) {
+            return Err(GitError::PathOutsideWorkspace(canonical));
+        }
+        return Ok(pathspec(repo_root, &canonical));
+    }
+    let resolved = resolve_within_repo(repo_root, &normalized)?;
+    Ok(pathspec(repo_root, &resolved))
+}
+
+fn ssh_pathspec_from_input(repo_root: &str, rel: &str) -> Result<String> {
+    let normalized = normalize_git_path(rel);
+    if normalized.is_empty() {
+        return Err(GitError::InvalidPath(rel.into()));
+    }
+    let input = Path::new(&normalized);
+    if input.is_absolute() {
+        let root = repo_root.trim_end_matches('/');
+        if normalized == root {
+            return Err(GitError::InvalidPath(rel.into()));
+        }
+        let prefix = format!("{root}/");
+        if !normalized.starts_with(&prefix) {
+            return Err(GitError::PathOutsideWorkspace(PathBuf::from(normalized)));
+        }
+        let rel = normalized[prefix.len()..].to_string();
+        if !is_safe_pathspec(&rel) {
+            return Err(GitError::InvalidPath(rel));
+        }
+        return Ok(rel);
+    }
+    if !is_safe_pathspec(&normalized) {
+        return Err(GitError::InvalidPath(rel.into()));
+    }
+    Ok(normalized)
+}
+
+fn repo_file_path(repo_root: &ResolvedGitDirectory, rel: &str) -> Result<PathBuf> {
+    if repo_root.workspace.is_ssh() {
+        Ok(PathBuf::from(ssh_file_path_from_input(
+            &repo_root.git_path,
+            rel,
+        )?))
+    } else {
+        local_file_path_from_input(&repo_root.local_path, rel)
+    }
+}
+
+fn local_file_path_from_input(repo_root: &Path, rel: &str) -> Result<PathBuf> {
+    let normalized = normalize_git_path(rel);
+    if normalized.is_empty() {
+        return Err(GitError::InvalidPath(rel.into()));
+    }
+    let input = Path::new(&normalized);
+    if input.is_absolute() {
+        let canonical = std::fs::canonicalize(input).map_err(GitError::Io)?;
+        if !canonical.starts_with(repo_root) {
+            return Err(GitError::PathOutsideWorkspace(canonical));
+        }
+        return Ok(canonical);
+    }
+    resolve_within_repo(repo_root, &normalized)
+}
+
+fn ssh_file_path_from_input(repo_root: &str, rel: &str) -> Result<String> {
+    let normalized = normalize_git_path(rel);
+    if normalized.is_empty() {
+        return Err(GitError::InvalidPath(rel.into()));
+    }
+    let input = Path::new(&normalized);
+    if input.is_absolute() {
+        let root = repo_root.trim_end_matches('/');
+        if normalized == root {
+            return Err(GitError::InvalidPath(rel.into()));
+        }
+        let prefix = format!("{root}/");
+        if !normalized.starts_with(&prefix) {
+            return Err(GitError::PathOutsideWorkspace(PathBuf::from(normalized)));
+        }
+        return Ok(normalized);
+    }
+    Ok(join_remote_path(repo_root, &normalized))
+}
+
+fn remote_text_source(workspace: &WorkspaceEnv, path: &Path) -> Result<TextSource> {
+    let read: RemoteReadResult =
+        ssh::read_file(workspace, &path.to_string_lossy(), 120).map_err(GitError::Spawn)?;
+    Ok(match read {
+        RemoteReadResult::Text { content, .. } => TextSource::Text(content),
+        RemoteReadResult::Binary { .. } => TextSource::Binary,
+        RemoteReadResult::TooLarge { size, limit } => {
+            return Err(GitError::FileTooLarge {
+                path: path.to_path_buf(),
+                size,
+                max: limit,
+            })
+        }
+    })
+}
+
+fn normalize_git_path(path: &str) -> String {
+    let mut out = path.trim().replace('\\', "/");
+    while let Some(stripped) = out.strip_prefix("./") {
+        out = stripped.to_string();
+    }
+    out
+}
+
+fn join_remote_path(root: &str, rel: &str) -> String {
+    let root = root.trim_end_matches('/');
+    let rel = rel.trim_start_matches('/');
+    if root.is_empty() {
+        format!("/{rel}")
+    } else {
+        format!("{root}/{rel}")
+    }
 }
 
 #[cfg(test)]
@@ -1053,5 +1168,35 @@ mod tests {
             "fatal: your current branch 'main' does not have any commits yet"
         )));
         assert!(!looks_like_no_head(&mk("fatal: pathspec did not match")));
+    }
+
+    #[test]
+    fn ssh_pathspecs_normalize_relative_and_absolute_inputs() {
+        let repo_root = ResolvedGitDirectory {
+            workspace: WorkspaceEnv::Ssh {
+                id: "ssh-1".into(),
+                label: "ssh".into(),
+                host: "example.com".into(),
+                user: Some("alice".into()),
+                port: Some(22),
+                root_path: "/srv/app".into(),
+                password: None,
+            },
+            git_path: "/srv/app".into(),
+            local_path: PathBuf::from("/srv/app"),
+        };
+
+        assert_eq!(
+            pathspec_from_input(&repo_root, "src/main.rs").unwrap(),
+            "src/main.rs"
+        );
+        assert_eq!(
+            pathspec_from_input(&repo_root, "/srv/app/src/main.rs").unwrap(),
+            "src/main.rs"
+        );
+        assert_eq!(
+            repo_file_path(&repo_root, "src/main.rs").unwrap(),
+            PathBuf::from("/srv/app/src/main.rs")
+        );
     }
 }

--- a/src-tauri/src/modules/git/process.rs
+++ b/src-tauri/src/modules/git/process.rs
@@ -15,9 +15,10 @@ use crate::modules::git::types::{
     GitOutput, TextSource, DEFAULT_TIMEOUT_SECS, MAX_FILE_BYTES, MAX_OUTPUT_BYTES,
     MAX_TIMEOUT_SECS, MIN_GIT_VERSION,
 };
-use crate::modules::workspace::WorkspaceEnv;
+use crate::modules::ssh;
 #[cfg(windows)]
 use crate::modules::workspace::validate_wsl_distro_name;
+use crate::modules::workspace::WorkspaceEnv;
 
 #[derive(Clone)]
 enum Availability {
@@ -47,6 +48,19 @@ fn workspace_cache_key(workspace: &WorkspaceEnv) -> String {
     match workspace {
         WorkspaceEnv::Local => "local".into(),
         WorkspaceEnv::Wsl { distro } => format!("wsl:{distro}"),
+        WorkspaceEnv::Ssh {
+            id,
+            host,
+            user,
+            port,
+            root_path,
+            ..
+        } => format!(
+            "ssh:{id}:{}@{}:{}:{root_path}",
+            user.clone().unwrap_or_default(),
+            host,
+            port.map(|p| p.to_string()).unwrap_or_default()
+        ),
     }
 }
 
@@ -249,6 +263,22 @@ where
         .into_iter()
         .map(|arg| arg.as_ref().to_os_string())
         .collect();
+    if workspace.is_ssh() {
+        let cwd = cwd.filter(|s| !s.is_empty()).unwrap_or_else(|| {
+            if let WorkspaceEnv::Ssh { root_path, .. } = workspace {
+                root_path.as_str()
+            } else {
+                ""
+            }
+        });
+        let args = args
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let output =
+            ssh::git_output(workspace, cwd, args, dur.as_secs()).map_err(GitError::Spawn)?;
+        return Ok(output);
+    }
     let mut cmd = build_git_command(workspace, cwd, &args)?;
     cmd.env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_ASKPASS", "")

--- a/src-tauri/src/modules/git/process.rs
+++ b/src-tauri/src/modules/git/process.rs
@@ -264,7 +264,7 @@ where
         .map(|arg| arg.as_ref().to_os_string())
         .collect();
     if workspace.is_ssh() {
-        let cwd = cwd.filter(|s| !s.is_empty()).unwrap_or_else(|| {
+        let cwd = cwd.filter(|s| !s.is_empty()).unwrap_or({
             if let WorkspaceEnv::Ssh { root_path, .. } = workspace {
                 root_path.as_str()
             } else {

--- a/src-tauri/src/modules/git/utils.rs
+++ b/src-tauri/src/modules/git/utils.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::modules::git::errors::{GitError, Result};
+use crate::modules::ssh;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
 #[derive(Clone, Debug)]
@@ -30,6 +31,14 @@ pub fn canonical_dir(
     path: &str,
     workspace: &WorkspaceEnv,
 ) -> Result<ResolvedGitDirectory> {
+    if workspace.is_ssh() {
+        let git_path = path.replace('\\', "/");
+        return Ok(ResolvedGitDirectory {
+            workspace: workspace.clone(),
+            git_path,
+            local_path: PathBuf::from(path),
+        });
+    }
     let candidate = resolve_path(path, workspace);
     if !candidate.is_dir() {
         return Err(GitError::NotADirectory(path.to_string()));
@@ -55,6 +64,17 @@ pub fn authorized_repo_root(
     workspace: &WorkspaceEnv,
 ) -> Result<ResolvedGitDirectory> {
     let canonical = canonical_dir(registry, path, workspace)?;
+    if workspace.is_ssh() {
+        let Some(root) = ssh::workspace_root(workspace) else {
+            return Err(GitError::PathOutsideWorkspace(canonical.local_path.clone()));
+        };
+        let path_norm = canonical.git_path.trim_end_matches('/');
+        let root_norm = root.trim_end_matches('/');
+        if path_norm != root_norm && !path_norm.starts_with(&format!("{root_norm}/")) {
+            return Err(GitError::PathOutsideWorkspace(canonical.local_path.clone()));
+        }
+        return Ok(canonical);
+    }
     if !registry.is_authorized(&canonical.local_path) {
         return Err(GitError::PathOutsideWorkspace(canonical.local_path.clone()));
     }

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod codex;
 pub mod fs;
 pub mod git;
 pub mod net;
@@ -6,4 +7,5 @@ pub mod proc;
 pub mod pty;
 pub mod secrets;
 pub mod shell;
+pub mod ssh;
 pub mod workspace;

--- a/src-tauri/src/modules/net.rs
+++ b/src-tauri/src/modules/net.rs
@@ -246,8 +246,7 @@ fn build_safe_client(
     allow_private: bool,
     pinned: &[(String, Vec<IpAddr>)],
 ) -> Result<reqwest::Client, String> {
-    let mut builder = reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(10));
+    let mut builder = reqwest::Client::builder().connect_timeout(Duration::from_secs(10));
     // Pin reqwest's resolver to the IPs we just classified. Without this,
     // reqwest's own DNS lookup could return a different (private/metadata) IP
     // for the same hostname between classify and connect — classic DNS
@@ -457,10 +456,7 @@ mod tests {
             IpKind::BlockedMetadata
         );
         // IPv6 link-local fe80::/10
-        assert_eq!(
-            ip_kind("fe80::1".parse().unwrap()),
-            IpKind::BlockedMetadata
-        );
+        assert_eq!(ip_kind("fe80::1".parse().unwrap()), IpKind::BlockedMetadata);
     }
 
     #[test]

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -43,13 +43,31 @@ pub struct AgentSignal {
 impl Transition {
     pub fn into_signal(self, id: u32) -> AgentSignal {
         match self {
-            Transition::Started { agent } => {
-                AgentSignal { id, kind: "started", agent: Some(agent) }
-            }
-            Transition::Working => AgentSignal { id, kind: "working", agent: None },
-            Transition::Attention => AgentSignal { id, kind: "attention", agent: None },
-            Transition::Finished => AgentSignal { id, kind: "finished", agent: None },
-            Transition::Exited => AgentSignal { id, kind: "exited", agent: None },
+            Transition::Started { agent } => AgentSignal {
+                id,
+                kind: "started",
+                agent: Some(agent),
+            },
+            Transition::Working => AgentSignal {
+                id,
+                kind: "working",
+                agent: None,
+            },
+            Transition::Attention => AgentSignal {
+                id,
+                kind: "attention",
+                agent: None,
+            },
+            Transition::Finished => AgentSignal {
+                id,
+                kind: "finished",
+                agent: None,
+            },
+            Transition::Exited => AgentSignal {
+                id,
+                kind: "exited",
+                agent: None,
+            },
         }
     }
 }
@@ -210,7 +228,9 @@ impl AgentDetector {
         if !self.armed {
             self.armed = true;
             self.status = Status::Working;
-            emit(Transition::Started { agent: "claude".into() });
+            emit(Transition::Started {
+                agent: "claude".into(),
+            });
         }
     }
 
@@ -264,13 +284,18 @@ mod tests {
     }
 
     fn started(agent: &str) -> Transition {
-        Transition::Started { agent: agent.into() }
+        Transition::Started {
+            agent: agent.into(),
+        }
     }
 
     #[test]
     fn arms_on_agent_command() {
         let mut d = AgentDetector::new();
-        assert_eq!(run(&mut d, &osc("133;C;claude -p hello")), vec![started("claude")]);
+        assert_eq!(
+            run(&mut d, &osc("133;C;claude -p hello")),
+            vec![started("claude")]
+        );
     }
 
     #[test]
@@ -281,13 +306,19 @@ mod tests {
             vec![started("codex")]
         );
         let mut d2 = AgentDetector::new();
-        assert_eq!(run(&mut d2, &osc("133;C;npx claude")), vec![started("claude")]);
+        assert_eq!(
+            run(&mut d2, &osc("133;C;npx claude")),
+            vec![started("claude")]
+        );
     }
 
     #[test]
     fn arms_on_dash_suffixed_alias() {
         let mut d = AgentDetector::new();
-        assert_eq!(run(&mut d, &osc("133;C;claude-enigma")), vec![started("claude")]);
+        assert_eq!(
+            run(&mut d, &osc("133;C;claude-enigma")),
+            vec![started("claude")]
+        );
     }
 
     #[test]
@@ -310,10 +341,19 @@ mod tests {
     fn terax_marker_drives_status() {
         let mut d = AgentDetector::new();
         run(&mut d, &osc("133;C;claude"));
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;attention")), vec![Transition::Attention]);
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;working")), vec![Transition::Working]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;attention")),
+            vec![Transition::Attention]
+        );
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;working")),
+            vec![Transition::Working]
+        );
         assert!(run(&mut d, &osc("777;notify;Terax;working")).is_empty());
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;finished")), vec![Transition::Finished]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;finished")),
+            vec![Transition::Finished]
+        );
     }
 
     #[test]
@@ -330,8 +370,14 @@ mod tests {
         let mut d = AgentDetector::new();
         assert!(run(&mut d, &osc("777;notify;Other;ready")).is_empty());
         run(&mut d, &osc("133;C;codex"));
-        assert_eq!(run(&mut d, &osc("777;notify;Codex;ready")), vec![Transition::Attention]);
-        assert_eq!(run(&mut d, &osc("9;needs you")), vec![Transition::Attention]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Codex;ready")),
+            vec![Transition::Attention]
+        );
+        assert_eq!(
+            run(&mut d, &osc("9;needs you")),
+            vec![Transition::Attention]
+        );
         assert!(run(&mut d, &osc("9;4;1;50")).is_empty());
     }
 
@@ -383,6 +429,9 @@ mod tests {
         seq.extend(std::iter::repeat_n(b'x', OSC_MAX + 100));
         seq.extend_from_slice(&[ESC, ST_FINAL]);
         assert!(run(&mut d, &seq).is_empty());
-        assert_eq!(run(&mut d, &osc("777;notify;Terax;attention")), vec![Transition::Attention]);
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;attention")),
+            vec![Transition::Attention]
+        );
     }
 }

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -254,16 +254,35 @@ impl AgentDetector {
             if token.starts_with('-') {
                 continue;
             }
-            let base = token.rsplit(['/', '\\']).next().unwrap_or(token);
-            if let Some(agent) = self.agents.iter().find(|a| {
-                base.strip_prefix(a.as_str())
-                    .is_some_and(|rest| rest.is_empty() || rest.starts_with('-'))
-            }) {
+            let base = token
+                .rsplit(['/', '\\'])
+                .next()
+                .unwrap_or(token)
+                .trim_matches(['"', '\'']);
+            let base = strip_windows_command_extension(base);
+            if let Some(agent) = self.agents.iter().find(|a| agent_name_matches(base, a)) {
                 return Some(agent.clone());
             }
         }
         None
     }
+}
+
+fn strip_windows_command_extension(base: &str) -> &str {
+    const EXTS: [&str; 5] = [".exe", ".cmd", ".bat", ".com", ".ps1"];
+    for ext in EXTS {
+        if base.len() > ext.len() && base.to_ascii_lowercase().ends_with(ext) {
+            return &base[..base.len() - ext.len()];
+        }
+    }
+    base
+}
+
+fn agent_name_matches(base: &str, agent: &str) -> bool {
+    let base = base.to_ascii_lowercase();
+    let agent = agent.to_ascii_lowercase();
+    base.strip_prefix(agent.as_str())
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with('-'))
 }
 
 #[cfg(test)]
@@ -308,6 +327,23 @@ mod tests {
         let mut d2 = AgentDetector::new();
         assert_eq!(
             run(&mut d2, &osc("133;C;npx claude")),
+            vec![started("claude")]
+        );
+    }
+
+    #[test]
+    fn arms_on_windows_command_shims() {
+        let mut d = AgentDetector::new();
+        assert_eq!(
+            run(
+                &mut d,
+                &osc(r"133;C;C:\Users\op237\AppData\Roaming\npm\codex.cmd exec")
+            ),
+            vec![started("codex")]
+        );
+        let mut d2 = AgentDetector::new();
+        assert_eq!(
+            run(&mut d2, &osc("133;C;claude.exe --continue")),
             vec![started("claude")]
         );
     }

--- a/src-tauri/src/modules/pty/da_filter.rs
+++ b/src-tauri/src/modules/pty/da_filter.rs
@@ -29,12 +29,7 @@ impl DaFilter {
         }
     }
 
-    pub fn process<F: FnMut(&[u8])>(
-        &mut self,
-        input: &[u8],
-        out: &mut Vec<u8>,
-        mut respond: F,
-    ) {
+    pub fn process<F: FnMut(&[u8])>(&mut self, input: &[u8], out: &mut Vec<u8>, mut respond: F) {
         if matches!(self.state, State::Idle) && !input.contains(&ESC) {
             out.extend_from_slice(input);
             return;
@@ -71,8 +66,7 @@ impl DaFilter {
                     if (0x40..=0x7e).contains(&b) {
                         if b == FINAL_C {
                             let middle = &self.hold[2..self.hold.len() - 1];
-                            let is_response =
-                                middle.contains(&b'?') || middle.contains(&b';');
+                            let is_response = middle.contains(&b'?') || middle.contains(&b';');
                             let prefix = middle.first().copied().unwrap_or(0);
                             if is_response {
                                 out.extend_from_slice(&self.hold);

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -188,8 +188,7 @@ fn shell_has_children(shell_pid: u32) -> bool {
     use std::mem::{size_of, zeroed};
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::System::Diagnostics::ToolHelp::{
-        CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32,
-        TH32CS_SNAPPROCESS,
+        CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS,
     };
     unsafe {
         let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);

--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -51,12 +51,20 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
     *) PROMPT_COMMAND="_terax_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
   esac
 
+  _terax_preexec() {
+    local _terax_cmd="${1:-}"
+    _terax_cmd="${_terax_cmd//$'\e'/ }"
+    _terax_cmd="${_terax_cmd//$'\n'/ }"
+    _terax_cmd="${_terax_cmd//$'\r'/ }"
+    printf '\e]133;C;%s\e\\' "${_terax_cmd:0:256}"
+  }
+
   # Pre-exec marker via PS0 (bash 4.4+). PS0 is expanded just before a command
   # runs — cleaner than a DEBUG trap, which would clobber user traps and fire
   # on every command including inside PROMPT_COMMAND.
   if [ "${BASH_VERSINFO[0]:-0}" -gt 4 ] \
      || { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 4 ]; }; then
-    PS0='\[\e]133;C\e\\\]'"${PS0:-}"
+    PS0='$(_terax_preexec "$BASH_COMMAND")'"${PS0:-}"
   fi
 
   _terax_precmd

--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -32,6 +32,33 @@ function global:__terax_urlencode {
     $sb.ToString()
 }
 
+function global:__terax_emit_preexec {
+    param([string]$line)
+    if ([string]::IsNullOrWhiteSpace($line)) { return $true }
+    $esc = [char]27
+    $cmd = $line -replace '[\x00-\x1f\x7f]', ' '
+    if ($cmd.Length -gt 256) { $cmd = $cmd.Substring(0, 256) }
+    try {
+        [Console]::Write("$esc]133;C;$cmd$esc\")
+    } catch {}
+    return $true
+}
+
+try {
+    if (Get-Command Set-PSReadLineOption -ErrorAction SilentlyContinue) {
+        $global:__TERAX_USER_ADD_TO_HISTORY_HANDLER = (Get-PSReadLineOption).AddToHistoryHandler
+        Set-PSReadLineOption -AddToHistoryHandler {
+            param([string]$line)
+            __terax_emit_preexec $line | Out-Null
+            $handler = $global:__TERAX_USER_ADD_TO_HISTORY_HANDLER
+            if ($null -ne $handler) {
+                try { return [bool](& $handler $line) } catch { return $true }
+            }
+            return $true
+        }
+    }
+} catch {}
+
 function global:prompt {
     $lec = $LASTEXITCODE
     if ($null -eq $lec) { $lec = if ($?) { 0 } else { 1 } }

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -79,7 +79,9 @@ struct ChildKillGuard {
 
 impl ChildKillGuard {
     fn new(killer: Box<dyn ChildKiller + Send + Sync>) -> Self {
-        Self { killer: Some(killer) }
+        Self {
+            killer: Some(killer),
+        }
     }
 
     fn disarm(&mut self) {
@@ -155,10 +157,8 @@ pub fn spawn(
         master: Mutex::new(pair.master),
     });
 
-    let pending: Arc<(Mutex<Vec<u8>>, Condvar)> = Arc::new((
-        Mutex::new(Vec::with_capacity(READ_BUF)),
-        Condvar::new(),
-    ));
+    let pending: Arc<(Mutex<Vec<u8>>, Condvar)> =
+        Arc::new((Mutex::new(Vec::with_capacity(READ_BUF)), Condvar::new()));
     let done = Arc::new(AtomicBool::new(false));
     let spawn_at = Instant::now();
 
@@ -180,7 +180,10 @@ pub fn spawn(
                     Ok(n) => {
                         if !logged_first {
                             logged_first = true;
-                            log::debug!("pty first byte after {}ms", spawn_at.elapsed().as_millis());
+                            log::debug!(
+                                "pty first byte after {}ms",
+                                spawn_at.elapsed().as_millis()
+                            );
                         }
                         agent_detect.process(&buf[..n], |t| {
                             let _ = app_reader.emit(AGENT_EVENT, t.into_signal(id));

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
@@ -48,7 +49,8 @@ pub struct Session {
     pub shell_pid: u32,
     pub killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     pub writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    pub master: Mutex<Box<dyn MasterPty + Send>>,
+    // PtyMaster::drop acquires CONPTY_LIFECYCLE_LOCK before ClosePseudoConsole.
+    pub master: PtyMaster,
 }
 
 impl Drop for Session {
@@ -68,9 +70,46 @@ impl Drop for Session {
 static CONPTY_LIFECYCLE_LOCK: Mutex<()> = Mutex::new(());
 
 pub(super) fn drop_session(session: Arc<Session>) {
-    #[cfg(windows)]
-    let _guard = CONPTY_LIFECYCLE_LOCK.lock().unwrap();
+    // CONPTY_LIFECYCLE_LOCK is acquired inside PtyMaster::drop, just before
+    // ClosePseudoConsole, so we no longer need to hold it here for the full drop.
     drop(session);
+}
+
+/// Wraps the PTY master and serializes Windows ConPTY lifecycle around Drop.
+///
+/// `ClosePseudoConsole` (called when the inner `MasterPty` drops) can block up
+/// to ~60 s if conhost hasn't exited.  Holding `CONPTY_LIFECYCLE_LOCK` for
+/// that entire duration prevented concurrent `CreatePseudoConsole` calls in
+/// new terminals, causing a ~60-second input-echo delay for the next terminal
+/// opened while an old one was closing (issue #356 follow-up).
+///
+/// This wrapper acquires the lock only for `ClosePseudoConsole` itself, not
+/// for the whole session tear-down, so new terminals can be created freely
+/// while an old master is still closing.
+pub(super) struct PtyMaster {
+    inner: ManuallyDrop<Mutex<Box<dyn MasterPty + Send>>>,
+}
+
+impl PtyMaster {
+    pub(super) fn new(master: Box<dyn MasterPty + Send>) -> Self {
+        Self { inner: ManuallyDrop::new(Mutex::new(master)) }
+    }
+
+    pub(super) fn lock(
+        &self,
+    ) -> std::sync::LockResult<std::sync::MutexGuard<'_, Box<dyn MasterPty + Send>>> {
+        self.inner.lock()
+    }
+}
+
+impl Drop for PtyMaster {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        let _guard = CONPTY_LIFECYCLE_LOCK.lock().unwrap();
+        // SAFETY: this is the only drop of `inner`; we are inside PtyMaster::drop.
+        // `_guard` (on Windows) is still alive here and releases only after this line.
+        unsafe { ManuallyDrop::drop(&mut self.inner) };
+    }
 }
 
 struct ChildKillGuard {
@@ -108,9 +147,6 @@ pub fn spawn(
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<(Arc<Session>, PtySize), String> {
-    #[cfg(windows)]
-    let _spawn_guard = CONPTY_LIFECYCLE_LOCK.lock().unwrap();
-
     let pty_system = native_pty_system();
     let size = PtySize {
         rows,
@@ -118,7 +154,13 @@ pub fn spawn(
         pixel_width: 0,
         pixel_height: 0,
     };
-    let pair = pty_system.openpty(size).map_err(|e| e.to_string())?;
+    // Hold the lock only around CreatePseudoConsole (openpty), not for the
+    // entire spawn which includes slow conda/shell startup.
+    let pair = {
+        #[cfg(windows)]
+        let _spawn_guard = CONPTY_LIFECYCLE_LOCK.lock().unwrap();
+        pty_system.openpty(size).map_err(|e| e.to_string())?
+    };
 
     let cmd = shell_init::build_command(cwd, workspace)?;
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
@@ -154,7 +196,7 @@ pub fn spawn(
         shell_pid,
         killer: Mutex::new(killer),
         writer: writer.clone(),
-        master: Mutex::new(pair.master),
+        master: PtyMaster::new(pair.master),
     });
 
     let pending: Arc<(Mutex<Vec<u8>>, Condvar)> =

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -120,6 +120,23 @@ fn ensure_utf8_locale(cmd: &mut CommandBuilder) {
     cmd.env("LANG", fallback);
 }
 
+#[cfg(test)]
+mod notification_script_tests {
+    const BASHRC: &str = include_str!("scripts/bashrc.bash");
+    const ZSHRC: &str = include_str!("scripts/zshrc.zsh");
+    const FISH_INIT: &str = include_str!("scripts/init.fish");
+
+    #[test]
+    fn unix_shell_profiles_emit_command_start_marker_with_command_text() {
+        assert!(BASHRC.contains("BASH_COMMAND"));
+        assert!(BASHRC.contains("]133;C;"));
+        assert!(ZSHRC.contains("add-zsh-hook preexec _terax_preexec"));
+        assert!(ZSHRC.contains("]133;C;"));
+        assert!(FISH_INIT.contains("--on-event fish_preexec"));
+        assert!(FISH_INIT.contains("]133;C;"));
+    }
+}
+
 fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
@@ -372,8 +389,8 @@ mod windows {
                     cmd.arg("-NoExit");
                     cmd.arg("-ExecutionPolicy");
                     cmd.arg("Bypass");
-                    cmd.arg("-File");
-                    cmd.arg(profile);
+                    cmd.arg("-Command");
+                    cmd.arg(powershell_source_profile_command(&profile));
                 }
                 Err(e) => {
                     log::warn!("powershell shell integration disabled: {e}");
@@ -590,6 +607,11 @@ mod windows {
         Ok(file)
     }
 
+    fn powershell_source_profile_command(profile: &Path) -> String {
+        let escaped = profile.to_string_lossy().replace('\'', "''");
+        format!(". '{escaped}'")
+    }
+
     fn write_if_changed(path: &Path, content: &str) -> Result<(), String> {
         if let Ok(existing) = fs::read_to_string(path) {
             if existing == content {
@@ -760,6 +782,43 @@ mod windows {
                     "/usr/bin/nu".to_string(),
                 ]
             );
+        }
+
+        #[test]
+        fn powershell_launch_sources_profile_with_interactive_command() {
+            let cmd = build(None, WorkspaceEnv::Local).expect("build local shell");
+            let argv: Vec<String> = cmd
+                .get_argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().to_string())
+                .collect();
+            let shell = argv
+                .first()
+                .and_then(|arg| std::path::Path::new(arg).file_name())
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            if shell == "cmd.exe" {
+                return;
+            }
+
+            assert!(argv.iter().any(|arg| arg == "-NoExit"));
+            assert!(argv.iter().any(|arg| arg == "-Command"));
+            assert!(!argv.iter().any(|arg| arg == "-File"));
+            assert!(argv.iter().any(|arg| arg.contains("profile.ps1")));
+        }
+
+        #[test]
+        fn powershell_profile_emits_command_start_marker() {
+            assert!(PROFILE_PS1.contains("AddToHistoryHandler"));
+            assert!(PROFILE_PS1.contains("]133;C;"));
+        }
+
+        #[test]
+        fn bash_profile_emits_command_start_marker_with_command_text() {
+            let script = super::super::bashrc_script();
+            assert!(script.contains("BASH_COMMAND"));
+            assert!(script.contains("]133;C;"));
         }
     }
 }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use portable_pty::CommandBuilder;
 
+use crate::modules::ssh;
 use crate::modules::workspace::{self, WorkspaceEnv};
 
 #[cfg(windows)]
@@ -51,6 +52,9 @@ pub fn build_command(
     cwd: Option<String>,
     workspace: WorkspaceEnv,
 ) -> Result<CommandBuilder, String> {
+    if let WorkspaceEnv::Ssh { .. } = workspace {
+        return build_ssh(cwd, workspace);
+    }
     #[cfg(unix)]
     {
         let _ = workspace;
@@ -60,6 +64,40 @@ pub fn build_command(
     {
         windows::build(cwd, workspace)
     }
+}
+
+fn build_ssh(cwd: Option<String>, workspace: WorkspaceEnv) -> Result<CommandBuilder, String> {
+    let (target, port) = ssh::ssh_endpoint(&workspace)?;
+    let remote = ssh::remote_login_command(Some(
+        cwd.as_deref()
+            .filter(|s| !s.is_empty())
+            .or_else(|| ssh::workspace_root(&workspace))
+            .unwrap_or("/"),
+    ));
+    let remote = ssh::remote_shell_invocation(&remote);
+    let mut cmd = CommandBuilder::new("ssh");
+    cmd.arg("-tt");
+    cmd.arg("-o");
+    cmd.arg(format!("ConnectTimeout={}", 10_u64));
+    let (args, envs) = ssh::ssh_auth_options(&workspace)?;
+    for arg in args {
+        cmd.arg(arg);
+    }
+    if let Some(port) = port {
+        cmd.arg("-p");
+        cmd.arg(port.to_string());
+    }
+    cmd.arg(target);
+    cmd.arg(remote);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    cmd.env("TERAX_TERMINAL", "1");
+    ensure_utf8_locale(&mut cmd);
+    log::info!("spawning SSH terminal");
+    Ok(cmd)
 }
 
 fn ensure_utf8_locale(cmd: &mut CommandBuilder) {
@@ -300,7 +338,9 @@ mod windows {
             zdotdir: String,
             user_zdotdir: Option<String>,
         },
-        Bash { rcfile: String },
+        Bash {
+            rcfile: String,
+        },
         Fish,
         None,
     }

--- a/src-tauri/src/modules/secrets.rs
+++ b/src-tauri/src/modules/secrets.rs
@@ -245,7 +245,10 @@ mod tests {
         write_store_at(&p, &HashMap::new()).unwrap();
 
         let tmp_path = p.with_extension("json.tmp");
-        assert!(!tmp_path.exists(), "tmp file must be renamed away on success");
+        assert!(
+            !tmp_path.exists(),
+            "tmp file must be renamed away on success"
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/shell/background.rs
+++ b/src-tauri/src/modules/shell/background.rs
@@ -99,7 +99,7 @@ pub fn spawn(
         return Err("empty command".into());
     }
     if let Some(ref dir) = cwd {
-        if !resolve_path(dir, &workspace).is_dir() {
+        if !workspace.is_ssh() && !resolve_path(dir, &workspace).is_dir() {
             return Err(format!("cwd is not a directory: {dir}"));
         }
     }

--- a/src-tauri/src/modules/shell/mod.rs
+++ b/src-tauri/src/modules/shell/mod.rs
@@ -14,9 +14,10 @@ use std::time::Duration;
 use serde::Serialize;
 use shared_child::SharedChild;
 
-use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
+use crate::modules::ssh;
 #[cfg(windows)]
 use crate::modules::workspace::validate_wsl_distro_name;
+use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
 
 use background::{BackgroundLogResponse, BackgroundProc, BackgroundProcInfo};
 use session::{SessionRunOutput, ShellSession};
@@ -180,7 +181,9 @@ pub fn shell_session_open(
     let initial = match cwd.as_deref().filter(|s| !s.is_empty()) {
         Some(c) => c.to_string(),
         None => {
-            if let WorkspaceEnv::Wsl { distro } = &workspace {
+            if let WorkspaceEnv::Ssh { root_path, .. } = &workspace {
+                root_path.clone()
+            } else if let WorkspaceEnv::Wsl { distro } = &workspace {
                 crate::modules::workspace::wsl_home(distro.clone())?
             } else {
                 crate::modules::fs::to_canon(dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
@@ -210,7 +213,9 @@ pub async fn shell_session_run(
         .get(&id)
         .cloned()
         .ok_or_else(|| "no shell session".to_string())?;
-    let effective_workspace = workspace.clone().unwrap_or_else(|| session.workspace.clone());
+    let effective_workspace = workspace
+        .clone()
+        .unwrap_or_else(|| session.workspace.clone());
     authorize_spawn_cwd(&registry, cwd.as_deref(), &effective_workspace)?;
     let dur = Duration::from_secs(
         timeout_secs
@@ -286,6 +291,28 @@ pub(crate) fn build_oneshot_command(
     #[cfg_attr(not(windows), allow(unused_variables))] workspace: &WorkspaceEnv,
     #[cfg_attr(not(windows), allow(unused_variables))] cwd: Option<&str>,
 ) -> Result<Command, String> {
+    if let WorkspaceEnv::Ssh { .. } = workspace {
+        let (target, port) = ssh::ssh_endpoint(workspace)?;
+        let remote =
+            ssh::remote_shell_command(cwd.or_else(|| ssh::workspace_root(workspace)), command);
+        let remote = ssh::remote_shell_invocation(&remote);
+        let (auth_args, auth_envs) = ssh::ssh_auth_options(workspace)?;
+        let mut cmd = Command::new("ssh");
+        cmd.arg("-T");
+        cmd.arg("-o").arg("ConnectTimeout=10");
+        for arg in auth_args {
+            cmd.arg(arg);
+        }
+        if let Some(port) = port {
+            cmd.arg("-p").arg(port.to_string());
+        }
+        cmd.arg(target);
+        cmd.arg(remote);
+        for (key, value) in auth_envs {
+            cmd.env(key, value);
+        }
+        return Ok(cmd);
+    }
     #[cfg(windows)]
     if let WorkspaceEnv::Wsl { distro } = workspace {
         validate_wsl_distro_name(distro)?;

--- a/src-tauri/src/modules/shell/session.rs
+++ b/src-tauri/src/modules/shell/session.rs
@@ -77,9 +77,13 @@ impl ShellSession {
         if self.pristine.load(Ordering::Acquire) {
             if let Some(hint) = cwd_hint.filter(|s| !s.is_empty()) {
                 let effective_workspace = workspace_hint.as_ref().unwrap_or(&self.workspace);
-                let p = resolve_path(&hint, effective_workspace);
-                if p.is_dir() {
+                if effective_workspace.is_ssh() {
                     *self.cwd.lock().unwrap() = hint;
+                } else {
+                    let p = resolve_path(&hint, effective_workspace);
+                    if p.is_dir() {
+                        *self.cwd.lock().unwrap() = hint;
+                    }
                 }
             }
         }
@@ -102,9 +106,13 @@ impl ShellSession {
 
         let (stdout_clean, cwd_after) = strip_cwd_sentinel(&raw.stdout, &cwd, &self.sentinel);
         if let Some(ref new_cwd) = cwd_after {
-            let p = resolve_path(new_cwd, &self.workspace);
-            if p.is_dir() {
+            if self.workspace.is_ssh() {
                 *self.cwd.lock().unwrap() = new_cwd.clone();
+            } else {
+                let p = resolve_path(new_cwd, &self.workspace);
+                if p.is_dir() {
+                    *self.cwd.lock().unwrap() = new_cwd.clone();
+                }
             }
         }
         let resolved_cwd = to_canon(self.current_cwd());
@@ -175,7 +183,10 @@ mod tests {
         let stdout = format!("{attacker}{trailer}");
         let (clean, cwd) = strip_cwd_sentinel(&stdout, "/fallback", &s.sentinel);
         assert_eq!(cwd.as_deref(), Some("/real"));
-        assert!(clean.contains(attacker), "attacker payload survives in stdout");
+        assert!(
+            clean.contains(attacker),
+            "attacker payload survives in stdout"
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/ssh.rs
+++ b/src-tauri/src/modules/ssh.rs
@@ -1,0 +1,1221 @@
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::sync::OnceLock;
+
+use crate::modules::git::types::GitOutput;
+use crate::modules::workspace::WorkspaceEnv;
+
+const REMOTE_ZSHENV: &str = include_str!("pty/scripts/zshenv.zsh");
+const REMOTE_ZPROFILE: &str = include_str!("pty/scripts/zprofile.zsh");
+const REMOTE_ZLOGIN: &str = include_str!("pty/scripts/zlogin.zsh");
+const REMOTE_ZSHRC: &str = include_str!("pty/scripts/zshrc.zsh");
+const REMOTE_BASHRC: &str = include_str!("pty/scripts/bashrc.bash");
+const REMOTE_FISH_INIT: &str = include_str!("pty/scripts/init.fish");
+
+const SSH_CONNECT_TIMEOUT_SECS: u64 = 10;
+const SSH_COMMAND_TIMEOUT_SECS: u64 = 120;
+const REMOTE_STDOUT_LIMIT: usize = 16 * 1024 * 1024;
+const REMOTE_STDERR_LIMIT: usize = 16 * 1024;
+
+#[derive(Debug, Serialize)]
+struct RemoteRequest<'a> {
+    workspace_root: &'a str,
+    payload: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteEnvelope<T> {
+    ok: bool,
+    data: Option<T>,
+    error: Option<String>,
+}
+
+#[derive(Debug)]
+struct RemoteOutput {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    timed_out: bool,
+}
+
+pub(crate) fn ssh_endpoint(workspace: &WorkspaceEnv) -> Result<(String, Option<u16>), String> {
+    match workspace {
+        WorkspaceEnv::Ssh {
+            host, user, port, ..
+        } => {
+            validate_host(host)?;
+            if let Some(user) = user {
+                validate_user(user)?;
+            }
+            if port.is_some_and(|port| port == 0) {
+                return Err("SSH port must be greater than zero".into());
+            }
+            Ok((
+                match user {
+                    Some(user) => format!("{user}@{host}"),
+                    None => host.clone(),
+                },
+                *port,
+            ))
+        }
+        _ => Err("workspace is not SSH".into()),
+    }
+}
+
+pub(crate) fn quote_posix(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub(crate) fn remote_shell_command(cwd: Option<&str>, command: &str) -> String {
+    let mut out = String::new();
+    if let Some(cwd) = cwd.filter(|s| !s.is_empty()) {
+        out.push_str("cd ");
+        out.push_str(&quote_posix(cwd));
+        out.push_str(" && ");
+    }
+    out.push_str(command);
+    out
+}
+
+pub(crate) fn remote_shell_invocation(command: &str) -> String {
+    format!("sh -lc {}", quote_posix(command))
+}
+
+pub(crate) fn remote_login_command(cwd: Option<&str>) -> String {
+    remote_shell_command(cwd, &remote_login_shell_bootstrap())
+}
+
+pub(crate) fn remote_login_shell_bootstrap() -> String {
+    format!(
+        r#"shell="${{SHELL:-}}"
+if [ -z "$shell" ] || [ ! -x "$shell" ]; then
+  for candidate in /bin/bash /usr/bin/bash /bin/sh; do
+    if [ -x "$candidate" ]; then
+      shell="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$shell" ] || [ ! -x "$shell" ]; then
+  shell=/bin/sh
+fi
+shell_name="${{shell##*/}}"
+tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t terax-ssh)"
+cleanup() {{
+  rm -rf "$tmpdir"
+}}
+trap cleanup EXIT HUP INT TERM
+case "$shell_name" in
+  zsh)
+    mkdir -p "$tmpdir"
+    cat >"$tmpdir/.zshenv" <<'__TERAX_ZSHENV__'
+{REMOTE_ZSHENV}
+__TERAX_ZSHENV__
+    cat >"$tmpdir/.zprofile" <<'__TERAX_ZPROFILE__'
+{REMOTE_ZPROFILE}
+__TERAX_ZPROFILE__
+    cat >"$tmpdir/.zshrc" <<'__TERAX_ZSHRC__'
+{REMOTE_ZSHRC}
+__TERAX_ZSHRC__
+    cat >"$tmpdir/.zlogin" <<'__TERAX_ZLOGIN__'
+{REMOTE_ZLOGIN}
+__TERAX_ZLOGIN__
+    export TERAX_USER_ZDOTDIR="${{TERAX_USER_ZDOTDIR:-$HOME}}"
+    export ZDOTDIR="$tmpdir"
+    export TERAX_TERMINAL=1
+    exec "$shell" -l
+    ;;
+  bash)
+    cat >"$tmpdir/.terax-bashrc" <<'__TERAX_BASHRC__'
+{REMOTE_BASHRC}
+__TERAX_BASHRC__
+    export TERAX_TERMINAL=1
+    exec "$shell" --rcfile "$tmpdir/.terax-bashrc" -i
+    ;;
+  fish)
+    cat >"$tmpdir/.terax-fish.fish" <<'__TERAX_FISH__'
+{REMOTE_FISH_INIT}
+__TERAX_FISH__
+    export TERAX_TERMINAL=1
+    exec "$shell" -i -C "source $tmpdir/.terax-fish.fish"
+    ;;
+  *)
+    export TERAX_TERMINAL=1
+    exec "$shell" -l
+    ;;
+esac"#
+    )
+}
+
+fn ssh_password(workspace: &WorkspaceEnv) -> Option<&str> {
+    match workspace {
+        WorkspaceEnv::Ssh { password, .. } => password.as_deref().filter(|s| !s.is_empty()),
+        _ => None,
+    }
+}
+
+pub(crate) fn ssh_auth_options(
+    workspace: &WorkspaceEnv,
+) -> Result<(Vec<String>, Vec<(String, String)>), String> {
+    let mut args = vec!["-o".into(), "StrictHostKeyChecking=accept-new".into()];
+    args.extend(ssh_multiplex_options()?);
+    if let Some(password) = ssh_password(workspace) {
+        let askpass = ssh_askpass_path()?;
+        args.extend([
+            "-o".into(),
+            "BatchMode=no".into(),
+            "-o".into(),
+            "PubkeyAuthentication=no".into(),
+            "-o".into(),
+            "PreferredAuthentications=password,keyboard-interactive".into(),
+            "-o".into(),
+            "KbdInteractiveAuthentication=yes".into(),
+            "-o".into(),
+            "NumberOfPasswordPrompts=1".into(),
+        ]);
+        Ok((
+            args,
+            vec![
+                ("SSH_ASKPASS".into(), askpass),
+                ("SSH_ASKPASS_REQUIRE".into(), "force".into()),
+                ("DISPLAY".into(), ":0".into()),
+                ("TERAX_SSH_PASSWORD".into(), password.to_string()),
+            ],
+        ))
+    } else {
+        args.extend(["-o".into(), "BatchMode=yes".into()]);
+        Ok((args, Vec::new()))
+    }
+}
+
+#[cfg(unix)]
+fn ssh_multiplex_options() -> Result<Vec<String>, String> {
+    let dir = dirs::home_dir()
+        .ok_or_else(|| "home directory is unavailable".to_string())?
+        .join(".terax")
+        .join("ssh-control");
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&dir).map_err(|e| e.to_string())?.permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&dir, perms).map_err(|e| e.to_string())?;
+    }
+    let path = dir.join("%C");
+    Ok(vec![
+        "-o".into(),
+        "ControlMaster=auto".into(),
+        "-o".into(),
+        "ControlPersist=10m".into(),
+        "-o".into(),
+        format!("ControlPath={}", path.to_string_lossy()),
+    ])
+}
+
+#[cfg(not(unix))]
+fn ssh_multiplex_options() -> Result<Vec<String>, String> {
+    Ok(Vec::new())
+}
+
+fn ssh_askpass_path() -> Result<String, String> {
+    static PATH: OnceLock<Result<String, String>> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let path = std::env::temp_dir().join(if cfg!(windows) {
+            "terax-ssh-askpass.cmd"
+        } else {
+            "terax-ssh-askpass.sh"
+        });
+        let script = if cfg!(windows) {
+            "@echo off\r\nfor %%I in (\"%TERAX_SSH_PASSWORD%\") do @echo %%~I\r\n".to_string()
+        } else {
+            "#!/bin/sh\nprintf '%s\\n' \"$TERAX_SSH_PASSWORD\"\n".to_string()
+        };
+        fs::write(&path, script).map_err(|e| e.to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&path)
+                .map_err(|e| e.to_string())?
+                .permissions();
+            perms.set_mode(0o700);
+            fs::set_permissions(&path, perms).map_err(|e| e.to_string())?;
+        }
+        Ok(path.to_string_lossy().into_owned())
+    })
+    .clone()
+}
+
+fn validate_host(host: &str) -> Result<(), String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return Err("SSH host is required".into());
+    }
+    if trimmed.len() > 255 || trimmed.chars().any(|c| c.is_control() || c.is_whitespace()) {
+        return Err("SSH host contains invalid characters".into());
+    }
+    Ok(())
+}
+
+fn validate_user(user: &str) -> Result<(), String> {
+    let trimmed = user.trim();
+    if trimmed.is_empty() {
+        return Err("SSH user is required".into());
+    }
+    if trimmed.len() > 255
+        || trimmed
+            .chars()
+            .any(|c| c.is_control() || c.is_whitespace() || matches!(c, '@' | ':' | '\\'))
+    {
+        return Err("SSH user contains invalid characters".into());
+    }
+    Ok(())
+}
+
+fn validate_root(root: &str) -> Result<(), String> {
+    if root.trim().is_empty() {
+        return Err("SSH root path is required".into());
+    }
+    if !root.starts_with('/') {
+        return Err("SSH root path must be absolute".into());
+    }
+    Ok(())
+}
+
+fn build_command(
+    workspace: &WorkspaceEnv,
+    op: &str,
+    payload: &serde_json::Value,
+) -> Result<Command, String> {
+    let (target, port) = ssh_endpoint(workspace)?;
+    let root_path = match workspace {
+        WorkspaceEnv::Ssh { root_path, .. } => {
+            validate_root(root_path)?;
+            root_path.as_str()
+        }
+        _ => return Err("workspace is not SSH".into()),
+    };
+    let request = RemoteRequest {
+        workspace_root: root_path,
+        payload: payload.clone(),
+    };
+    let request_json = serde_json::to_string(&request).map_err(|e| e.to_string())?;
+    let remote = remote_shell_invocation(&format!(
+        "python3 - {} {}",
+        quote_posix(op),
+        quote_posix(&request_json)
+    ));
+    let (auth_args, auth_envs) = ssh_auth_options(workspace)?;
+    let mut cmd = Command::new("ssh");
+    cmd.arg("-T");
+    cmd.arg("-o")
+        .arg(format!("ConnectTimeout={SSH_CONNECT_TIMEOUT_SECS}"));
+    for arg in auth_args {
+        cmd.arg(arg);
+    }
+    if let Some(port) = port {
+        cmd.arg("-p").arg(port.to_string());
+    }
+    cmd.arg(target);
+    cmd.arg(remote);
+    for (key, value) in auth_envs {
+        cmd.env(key, value);
+    }
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    Ok(cmd)
+}
+
+fn run_remote_json<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    op: &str,
+    payload: serde_json::Value,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    let mut cmd = build_command(workspace, op, &payload)?;
+    crate::modules::proc::hide_console(&mut cmd);
+
+    let mut child = cmd.spawn().map_err(|e| e.to_string())?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "no stdin pipe".to_string())?;
+    stdin
+        .write_all(REMOTE_PYTHON.as_bytes())
+        .map_err(|e| e.to_string())?;
+    drop(stdin);
+
+    let mut stdout_pipe = child
+        .stdout
+        .take()
+        .ok_or_else(|| "no stdout pipe".to_string())?;
+    let mut stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| "no stderr pipe".to_string())?;
+
+    let stdout_handle = thread::spawn(move || drain(&mut stdout_pipe, REMOTE_STDOUT_LIMIT));
+    let stderr_handle = thread::spawn(move || drain(&mut stderr_pipe, REMOTE_STDERR_LIMIT));
+
+    let start = Instant::now();
+    let dur = Duration::from_secs(timeout_secs.max(1).min(SSH_COMMAND_TIMEOUT_SECS));
+    let timed_out = loop {
+        if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
+            let _ = status.code();
+            break false;
+        }
+        if start.elapsed() >= dur {
+            let _ = child.kill();
+            let _ = child.wait().map_err(|e| e.to_string())?;
+            break true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    };
+
+    let (stdout, _stdout_truncated) = stdout_handle.join().unwrap_or_else(|_| (Vec::new(), false));
+    let (stderr, _stderr_truncated) = stderr_handle.join().unwrap_or_else(|_| (Vec::new(), false));
+
+    let output = RemoteOutput {
+        stdout,
+        stderr,
+        timed_out,
+    };
+
+    if output.timed_out {
+        return Err("SSH command timed out".into());
+    }
+
+    let stdout_text = String::from_utf8_lossy(&output.stdout).to_string();
+    let env: RemoteEnvelope<T> = serde_json::from_str(&stdout_text).map_err(|e| {
+        let stderr_text = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if !stderr_text.is_empty() {
+            format!("{e}: {stderr_text}")
+        } else {
+            e.to_string()
+        }
+    })?;
+    if !env.ok {
+        return Err(env
+            .error
+            .unwrap_or_else(|| "remote SSH command failed".into()));
+    }
+    env.data
+        .ok_or_else(|| "remote SSH command returned no data".into())
+}
+
+fn run_remote_unit(
+    workspace: &WorkspaceEnv,
+    op: &str,
+    payload: serde_json::Value,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    let _: serde_json::Value = run_remote_json(workspace, op, payload, timeout_secs)?;
+    Ok(())
+}
+
+fn drain<R: Read>(reader: &mut R, limit: usize) -> (Vec<u8>, bool) {
+    let mut out: Vec<u8> = Vec::with_capacity(limit.min(4096));
+    let mut buf = [0u8; 16 * 1024];
+    let mut truncated = false;
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if out.len() >= limit {
+                    truncated = true;
+                    continue;
+                }
+                let take = (limit - out.len()).min(n);
+                out.extend_from_slice(&buf[..take]);
+                if take < n {
+                    truncated = true;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    (out, truncated)
+}
+
+pub fn is_ssh(workspace: &WorkspaceEnv) -> bool {
+    matches!(workspace, WorkspaceEnv::Ssh { .. })
+}
+
+pub fn workspace_root(workspace: &WorkspaceEnv) -> Option<&str> {
+    match workspace {
+        WorkspaceEnv::Ssh { root_path, .. } => Some(root_path.as_str()),
+        _ => None,
+    }
+}
+
+pub fn read_dir<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    show_hidden: bool,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "read_dir",
+        serde_json::json!({
+            "path": path,
+            "show_hidden": show_hidden,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn list_subdirs<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    show_hidden: bool,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "list_subdirs",
+        serde_json::json!({
+            "path": path,
+            "show_hidden": show_hidden,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn read_file<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "read_file",
+        serde_json::json!({ "path": path }),
+        timeout_secs,
+    )
+}
+
+pub fn write_file(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    content: &str,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    run_remote_unit(
+        workspace,
+        "write_file",
+        serde_json::json!({
+            "path": path,
+            "content": content,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn stat<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "stat",
+        serde_json::json!({ "path": path }),
+        timeout_secs,
+    )
+}
+
+pub fn canonicalize<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "canonicalize",
+        serde_json::json!({ "path": path }),
+        timeout_secs,
+    )
+}
+
+pub fn create_file(workspace: &WorkspaceEnv, path: &str, timeout_secs: u64) -> Result<(), String> {
+    run_remote_unit(
+        workspace,
+        "create_file",
+        serde_json::json!({ "path": path }),
+        timeout_secs,
+    )
+}
+
+pub fn create_dir(workspace: &WorkspaceEnv, path: &str, timeout_secs: u64) -> Result<(), String> {
+    run_remote_unit(
+        workspace,
+        "create_dir",
+        serde_json::json!({ "path": path }),
+        timeout_secs,
+    )
+}
+
+pub fn rename(
+    workspace: &WorkspaceEnv,
+    from: &str,
+    to: &str,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    run_remote_unit(
+        workspace,
+        "rename",
+        serde_json::json!({
+            "from": from,
+            "to": to,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn delete(workspace: &WorkspaceEnv, path: &str, timeout_secs: u64) -> Result<(), String> {
+    run_remote_unit(
+        workspace,
+        "delete",
+        serde_json::json!({ "path": path }),
+        timeout_secs,
+    )
+}
+
+pub fn search<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    root: &str,
+    query: &str,
+    limit: Option<usize>,
+    show_hidden: bool,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "search",
+        serde_json::json!({
+            "root": root,
+            "query": query,
+            "limit": limit,
+            "show_hidden": show_hidden,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn list_files<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    root: &str,
+    limit: Option<usize>,
+    max_depth: Option<usize>,
+    show_hidden: bool,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "list_files",
+        serde_json::json!({
+            "root": root,
+            "limit": limit,
+            "max_depth": max_depth,
+            "show_hidden": show_hidden,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn grep<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    pattern: &str,
+    root: &str,
+    glob: Option<Vec<String>>,
+    case_insensitive: Option<bool>,
+    max_results: Option<usize>,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "grep",
+        serde_json::json!({
+            "pattern": pattern,
+            "root": root,
+            "glob": glob,
+            "case_insensitive": case_insensitive,
+            "max_results": max_results,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn glob<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    pattern: &str,
+    root: &str,
+    max_results: Option<usize>,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "glob",
+        serde_json::json!({
+            "pattern": pattern,
+            "root": root,
+            "max_results": max_results,
+        }),
+        timeout_secs,
+    )
+}
+
+pub fn git<T: DeserializeOwned>(
+    workspace: &WorkspaceEnv,
+    cwd: &str,
+    args: Vec<String>,
+    timeout_secs: u64,
+) -> Result<T, String> {
+    run_remote_json(
+        workspace,
+        "git",
+        serde_json::json!({
+            "cwd": cwd,
+            "args": args,
+        }),
+        timeout_secs,
+    )
+}
+
+#[derive(Deserialize)]
+struct RemoteGitOutput {
+    stdout: String,
+    stderr: String,
+    exit_code: Option<i32>,
+    timed_out: bool,
+    truncated: bool,
+}
+
+pub(crate) fn git_output(
+    workspace: &WorkspaceEnv,
+    cwd: &str,
+    args: Vec<String>,
+    timeout_secs: u64,
+) -> Result<GitOutput, String> {
+    let out: RemoteGitOutput = git(workspace, cwd, args, timeout_secs)?;
+    Ok(GitOutput {
+        stdout: out.stdout.into_bytes(),
+        stderr: out.stderr.into_bytes(),
+        exit_code: out.exit_code,
+        timed_out: out.timed_out,
+        truncated: out.truncated,
+    })
+}
+
+const REMOTE_PYTHON: &str = r#"
+import fnmatch
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+MAX_READ_BYTES = 10 * 1024 * 1024
+BINARY_SNIFF_BYTES = 8192
+MAX_SCANNED = 50000
+PRUNE_DIRS = {
+    "node_modules",
+    ".git",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".cache",
+    ".venv",
+    "__pycache__",
+}
+
+def emit(ok, data=None, error=None):
+    payload = {"ok": ok, "data": data, "error": error}
+    print(json.dumps(payload, ensure_ascii=False))
+
+def fail(message):
+    emit(False, error=message)
+    sys.exit(1)
+
+def load_request():
+    if len(sys.argv) < 3:
+        fail("missing remote request")
+    op = sys.argv[1]
+    try:
+        req = json.loads(sys.argv[2])
+    except Exception as exc:
+        fail(f"invalid request envelope: {exc}")
+    payload = req.get("payload") or {}
+    root = req.get("workspace_root")
+    if not isinstance(root, str) or not root:
+        fail("workspace root is required")
+    return op, root, payload
+
+def real(path):
+    return os.path.realpath(path)
+
+def within(root, path):
+    root = real(root)
+    path = real(path)
+    if root == os.sep:
+        return True
+    if path == root:
+        return True
+    prefix = root.rstrip(os.sep) + os.sep
+    return path.startswith(prefix)
+
+def assert_under(root, path):
+    if not within(root, path):
+        raise ValueError(f"path escapes workspace root: {path}")
+    return path
+
+def abs_path(root, path):
+    if not isinstance(path, str) or not path:
+        raise ValueError("path is required")
+    if not os.path.isabs(path):
+        raise ValueError("path must be absolute")
+    return assert_under(root, path)
+
+def stat_entry(path):
+    try:
+        st = os.stat(path, follow_symlinks=True)
+        kind = "symlink" if os.path.islink(path) else ("dir" if stat.S_ISDIR(st.st_mode) else "file")
+    except FileNotFoundError:
+        st = os.lstat(path)
+        kind = "symlink" if stat.S_ISLNK(st.st_mode) else ("dir" if stat.S_ISDIR(st.st_mode) else "file")
+    return {
+        "kind": kind,
+        "size": int(st.st_size),
+        "mtime": int(getattr(st, "st_mtime", 0) * 1000),
+    }
+
+def list_dir(root, path, show_hidden):
+    p = abs_path(root, path)
+    if not os.path.isdir(p):
+        raise ValueError(f"not a directory: {path}")
+    entries = []
+    with os.scandir(p) as it:
+        for entry in it:
+            name = entry.name
+            if name.startswith(".") and not show_hidden:
+                continue
+            try:
+                meta = entry.stat(follow_symlinks=True)
+                is_link = entry.is_symlink()
+                kind = "symlink" if is_link else ("dir" if stat.S_ISDIR(meta.st_mode) else "file")
+            except FileNotFoundError:
+                meta = entry.stat(follow_symlinks=False)
+                kind = "symlink" if stat.S_ISLNK(meta.st_mode) else ("dir" if stat.S_ISDIR(meta.st_mode) else "file")
+            entries.append({
+                "name": name,
+                "kind": kind,
+                "size": int(meta.st_size),
+                "mtime": int(getattr(meta, "st_mtime", 0) * 1000),
+            })
+    rank = {"dir": 0, "symlink": 1, "file": 2}
+    entries.sort(key=lambda e: (rank.get(e["kind"], 3), e["name"].lower()))
+    return entries
+
+def list_subdirs(root, path, show_hidden):
+    p = abs_path(root, path)
+    if not os.path.isdir(p):
+        raise ValueError(f"not a directory: {path}")
+    dirs = []
+    with os.scandir(p) as it:
+        for entry in it:
+            name = entry.name
+            if name.startswith(".") and not show_hidden:
+                continue
+            try:
+                is_dir = entry.is_dir(follow_symlinks=True)
+            except FileNotFoundError:
+                is_dir = False
+            if is_dir:
+                dirs.append(name)
+    dirs.sort(key=lambda s: s.lower())
+    return dirs
+
+def classify_bytes(data):
+    sniff = data[:BINARY_SNIFF_BYTES]
+    if b"\0" in sniff:
+        return {"kind": "binary", "size": len(data)}
+    try:
+        return {"kind": "text", "content": data.decode("utf-8"), "size": len(data)}
+    except UnicodeDecodeError:
+        return {"kind": "binary", "size": len(data)}
+
+def read_file(root, path):
+    p = abs_path(root, path)
+    st = os.stat(p, follow_symlinks=True)
+    size = int(st.st_size)
+    if size > MAX_READ_BYTES:
+        return {"kind": "toolarge", "size": size, "limit": MAX_READ_BYTES}
+    with open(p, "rb") as fh:
+        data = fh.read()
+    result = classify_bytes(data)
+    if result["kind"] == "text":
+        result["size"] = size
+    return result
+
+def atomic_write(path, content):
+    parent = os.path.dirname(path)
+    if not parent:
+        raise ValueError("path has no parent")
+    if not os.path.isdir(parent):
+        raise ValueError(f"parent directory missing: {parent}")
+    fd, tmp = tempfile.mkstemp(prefix=".terax-", dir=parent)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        if os.path.exists(path):
+            try:
+                perms = stat.S_IMODE(os.stat(path, follow_symlinks=False).st_mode)
+            except FileNotFoundError:
+                perms = None
+        else:
+            perms = None
+        os.replace(tmp, path)
+        if perms is not None:
+            os.chmod(path, perms)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+def write_file(root, path, content):
+    p = abs_path(root, path)
+    parent = os.path.dirname(p)
+    if not os.path.isdir(parent):
+        raise ValueError(f"parent directory missing: {parent}")
+    atomic_write(p, content.encode("utf-8"))
+    return None
+
+def canonicalize(root, path):
+    p = abs_path(root, path)
+    canon = os.path.realpath(p)
+    return assert_under(root, canon)
+
+def create_file(root, path):
+    p = abs_path(root, path)
+    parent = os.path.dirname(p)
+    if not os.path.isdir(parent):
+        raise ValueError(f"parent directory missing: {parent}")
+    if os.path.exists(p):
+        raise ValueError(f"already exists: {p}")
+    with open(p, "x", encoding="utf-8"):
+        pass
+    return None
+
+def create_dir(root, path):
+    p = abs_path(root, path)
+    if os.path.exists(p):
+        raise ValueError(f"already exists: {p}")
+    os.makedirs(p, exist_ok=False)
+    return None
+
+def rename(root, src, dst):
+    a = abs_path(root, src)
+    b = abs_path(root, dst)
+    if not os.path.exists(a):
+        raise ValueError(f"not found: {a}")
+    if os.path.exists(b):
+        raise ValueError(f"already exists: {b}")
+    os.rename(a, b)
+    return None
+
+def delete(root, path):
+    p = abs_path(root, path)
+    if not os.path.lexists(p):
+        raise ValueError(f"not found: {p}")
+    if os.path.isdir(p) and not os.path.islink(p):
+        shutil.rmtree(p)
+    else:
+        os.unlink(p)
+    return None
+
+def safe_name(name):
+    if not name or len(name) > 255:
+        return False
+    return not any(c in name for c in "\\\x00\r\n\t")
+
+def search(root, query, limit, show_hidden):
+    q = (query or "").strip().lower()
+    if not q:
+        return {"hits": [], "truncated": False}
+    cap = min(int(limit or 200), 1000)
+    hits = []
+    scanned = 0
+    truncated = False
+    for current, dirs, files in os.walk(root, topdown=True, followlinks=False):
+        rel = os.path.relpath(current, root)
+        depth = 0 if rel == "." else rel.count(os.sep) + 1
+        if depth > 64:
+            dirs[:] = []
+            continue
+        dirs[:] = [d for d in dirs if d not in PRUNE_DIRS and (show_hidden or not d.startswith("."))]
+        current_name = os.path.basename(current)
+        if current != root:
+            scanned += 1
+            if scanned > MAX_SCANNED:
+                truncated = True
+                break
+        names = list(dirs) + list(files)
+        for name in names:
+            if not show_hidden and name.startswith("."):
+                continue
+            path = os.path.join(current, name)
+            rel_path = os.path.relpath(path, root).replace(os.sep, "/")
+            if q not in rel_path.lower():
+                continue
+            is_dir = os.path.isdir(path)
+            hits.append({
+                "path": path.replace(os.sep, "/"),
+                "rel": rel_path,
+                "name": name,
+                "is_dir": is_dir,
+            })
+            if len(hits) >= cap:
+                truncated = True
+                return {"hits": hits, "truncated": truncated}
+        if current_name in PRUNE_DIRS:
+            dirs[:] = []
+    hits.sort(key=lambda h: (q not in h["name"].lower(), len(h["rel"])))
+    return {"hits": hits, "truncated": truncated}
+
+def list_files(root, limit, max_depth, show_hidden):
+    cap = max(1, min(int(limit or 2000), 10000))
+    depth_limit = max(1, min(int(max_depth or 8), 16))
+    files = []
+    scanned = 0
+    truncated = False
+    for current, dirs, filenames in os.walk(root, topdown=True, followlinks=False):
+        rel = os.path.relpath(current, root)
+        depth = 0 if rel == "." else rel.count(os.sep) + 1
+        if depth > depth_limit:
+            dirs[:] = []
+            continue
+        dirs[:] = [d for d in dirs if d not in PRUNE_DIRS and (show_hidden or not d.startswith("."))]
+        for name in filenames:
+            if not show_hidden and name.startswith("."):
+                continue
+            path = os.path.join(current, name)
+            rel_path = os.path.relpath(path, root).replace(os.sep, "/")
+            files.append(rel_path)
+            if len(files) >= cap:
+                truncated = True
+                return {"files": sorted(files, key=lambda s: s.lower()), "truncated": truncated}
+        scanned += 1
+        if scanned > MAX_SCANNED:
+            truncated = True
+            break
+    files.sort(key=lambda s: s.lower())
+    return {"files": files, "truncated": truncated}
+
+def matches_globs(rel, globs):
+    if not globs:
+        return True
+    return any(fnmatch.fnmatch(rel, pat) for pat in globs)
+
+def grep(root, pattern, globs, case_insensitive, max_results):
+    pat = pattern or ""
+    if not pat.strip():
+        return {"hits": [], "truncated": False, "files_scanned": 0}
+    if case_insensitive:
+        pat_cmp = pat.lower()
+    else:
+        pat_cmp = pat
+    cap = min(int(max_results or 200), 1000)
+    hits = []
+    files_scanned = 0
+    truncated = False
+    for current, dirs, filenames in os.walk(root, topdown=True, followlinks=False):
+        dirs[:] = [d for d in dirs if d not in PRUNE_DIRS]
+        for name in filenames:
+            rel = os.path.relpath(os.path.join(current, name), root).replace(os.sep, "/")
+            if not matches_globs(rel, globs):
+                continue
+            files_scanned += 1
+            if files_scanned > MAX_SCANNED:
+                truncated = True
+                return {"hits": hits, "truncated": truncated, "files_scanned": files_scanned}
+            try:
+                with open(os.path.join(current, name), "r", encoding="utf-8") as fh:
+                    for idx, line in enumerate(fh, 1):
+                        text = line.rstrip("\n")
+                        cmp = text.lower() if case_insensitive else text
+                        if pat_cmp in cmp:
+                            hits.append({
+                                "path": rel.replace(os.sep, "/"),
+                                "rel": rel.replace(os.sep, "/"),
+                                "line": idx,
+                                "text": text,
+                            })
+                            if len(hits) >= cap:
+                                return {"hits": hits, "truncated": True, "files_scanned": files_scanned}
+            except (UnicodeDecodeError, OSError):
+                continue
+    return {"hits": hits, "truncated": truncated, "files_scanned": files_scanned}
+
+def glob_search(root, pattern, max_results):
+    pat = pattern or ""
+    cap = min(int(max_results or 200), 1000)
+    hits = []
+    for current, dirs, filenames in os.walk(root, topdown=True, followlinks=False):
+        dirs[:] = [d for d in dirs if d not in PRUNE_DIRS]
+        for name in filenames + dirs:
+            rel = os.path.relpath(os.path.join(current, name), root).replace(os.sep, "/")
+            if fnmatch.fnmatch(rel, pat):
+                hits.append({"path": os.path.join(current, name).replace(os.sep, "/"), "rel": rel})
+                if len(hits) >= cap:
+                    return {"hits": hits, "truncated": True}
+    hits.sort(key=lambda h: h["rel"].lower())
+    return {"hits": hits, "truncated": False}
+
+def git_run(cwd, args):
+    if not isinstance(cwd, str) or not cwd:
+        raise ValueError("cwd is required")
+    if not os.path.isabs(cwd):
+        raise ValueError("cwd must be absolute")
+    proc = subprocess.run(
+        ["git"] + list(args or []),
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=False,
+        env=dict(os.environ, GIT_TERMINAL_PROMPT="0", GIT_ASKPASS="", SSH_ASKPASS=""),
+    )
+    return {
+        "stdout": proc.stdout.decode("utf-8", errors="replace"),
+        "stderr": proc.stderr.decode("utf-8", errors="replace"),
+        "exit_code": proc.returncode,
+        "timed_out": False,
+        "truncated": False,
+    }
+
+def main():
+    op, root, payload = load_request()
+    try:
+        if op == "read_dir":
+            emit(True, list_dir(root, payload.get("path"), bool(payload.get("show_hidden"))))
+        elif op == "list_subdirs":
+            emit(True, list_subdirs(root, payload.get("path"), bool(payload.get("show_hidden"))))
+        elif op == "read_file":
+            emit(True, read_file(root, payload.get("path")))
+        elif op == "write_file":
+            write_file(root, payload.get("path"), payload.get("content", ""))
+            emit(True, {})
+        elif op == "stat":
+            p = abs_path(root, payload.get("path"))
+            emit(True, stat_entry(p))
+        elif op == "canonicalize":
+            emit(True, canonicalize(root, payload.get("path")))
+        elif op == "create_file":
+            create_file(root, payload.get("path"))
+            emit(True, {})
+        elif op == "create_dir":
+            create_dir(root, payload.get("path"))
+            emit(True, {})
+        elif op == "rename":
+            rename(root, payload.get("from"), payload.get("to"))
+            emit(True, {})
+        elif op == "delete":
+            delete(root, payload.get("path"))
+            emit(True, {})
+        elif op == "search":
+            target = abs_path(root, payload.get("root"))
+            emit(True, search(target, payload.get("query", ""), payload.get("limit"), bool(payload.get("show_hidden"))))
+        elif op == "list_files":
+            target = abs_path(root, payload.get("root"))
+            emit(True, list_files(target, payload.get("limit"), payload.get("max_depth"), bool(payload.get("show_hidden"))))
+        elif op == "grep":
+            target = abs_path(root, payload.get("root"))
+            emit(True, grep(target, payload.get("pattern", ""), payload.get("glob"), payload.get("case_insensitive"), payload.get("max_results")))
+        elif op == "glob":
+            target = abs_path(root, payload.get("root"))
+            emit(True, glob_search(target, payload.get("pattern", ""), payload.get("max_results")))
+        elif op == "git":
+            cwd = abs_path(root, payload.get("cwd"))
+            emit(True, git_run(cwd, payload.get("args")))
+        else:
+            fail(f"unsupported op: {op}")
+    except Exception as exc:
+        emit(False, error=str(exc))
+
+if __name__ == "__main__":
+    main()
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_login_shell_bootstrap_falls_back_to_common_shells() {
+        let script = remote_login_shell_bootstrap();
+        assert!(script.contains("/bin/bash"));
+        assert!(script.contains("/usr/bin/bash"));
+        assert!(script.contains("/bin/sh"));
+        assert!(script.contains("exec \"$shell\" -l"));
+    }
+
+    #[test]
+    fn remote_shell_invocation_wraps_command_in_single_shell_argument() {
+        assert_eq!(remote_shell_invocation("echo hi"), "sh -lc 'echo hi'");
+    }
+
+    #[test]
+    fn ssh_auth_options_enable_askpass_when_password_present() {
+        let workspace = WorkspaceEnv::Ssh {
+            id: "ssh-1".into(),
+            label: "ssh".into(),
+            host: "example.com".into(),
+            user: Some("alice".into()),
+            port: Some(22),
+            root_path: "/srv/app".into(),
+            password: Some("secret".into()),
+        };
+        let (args, envs) = ssh_auth_options(&workspace).expect("options");
+        assert!(args.windows(2).any(|w| w == ["-o", "ControlMaster=auto"]));
+        assert!(args.windows(2).any(|w| w == ["-o", "ControlPersist=10m"]));
+        assert!(args.windows(2).any(|w| w == ["-o", "BatchMode=no"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-o", "PubkeyAuthentication=no"]));
+        assert!(envs.iter().any(|(k, _)| k == "SSH_ASKPASS"));
+        assert!(envs
+            .iter()
+            .any(|(k, v)| k == "TERAX_SSH_PASSWORD" && v == "secret"));
+    }
+
+    #[test]
+    fn ssh_auth_options_use_batchmode_when_password_missing() {
+        let workspace = WorkspaceEnv::Ssh {
+            id: "ssh-1".into(),
+            label: "ssh".into(),
+            host: "example.com".into(),
+            user: Some("alice".into()),
+            port: Some(22),
+            root_path: "/srv/app".into(),
+            password: None,
+        };
+        let (args, envs) = ssh_auth_options(&workspace).expect("options");
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-o", "StrictHostKeyChecking=accept-new"]));
+        assert!(args.windows(2).any(|w| w == ["-o", "ControlMaster=auto"]));
+        assert!(args.windows(2).any(|w| w == ["-o", "ControlPersist=10m"]));
+        assert!(args.windows(2).any(|w| w == ["-o", "BatchMode=yes"]));
+        assert!(envs.is_empty());
+    }
+}

--- a/src-tauri/src/modules/ssh.rs
+++ b/src-tauri/src/modules/ssh.rs
@@ -159,9 +159,11 @@ fn ssh_password(workspace: &WorkspaceEnv) -> Option<&str> {
     }
 }
 
+pub(crate) type SshAuthOptions = (Vec<String>, Vec<(String, String)>);
+
 pub(crate) fn ssh_auth_options(
     workspace: &WorkspaceEnv,
-) -> Result<(Vec<String>, Vec<(String, String)>), String> {
+) -> Result<SshAuthOptions, String> {
     let mut args = vec!["-o".into(), "StrictHostKeyChecking=accept-new".into()];
     args.extend(ssh_multiplex_options()?);
     if let Some(password) = ssh_password(workspace) {
@@ -363,7 +365,7 @@ fn run_remote_json<T: DeserializeOwned>(
     let stderr_handle = thread::spawn(move || drain(&mut stderr_pipe, REMOTE_STDERR_LIMIT));
 
     let start = Instant::now();
-    let dur = Duration::from_secs(timeout_secs.max(1).min(SSH_COMMAND_TIMEOUT_SECS));
+    let dur = Duration::from_secs(timeout_secs.clamp(1, SSH_COMMAND_TIMEOUT_SECS));
     let timed_out = loop {
         if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
             let _ = status.code();

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -79,6 +79,9 @@ pub fn authorize_spawn_cwd(
     let Some(cwd) = cwd.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
+    if workspace.is_ssh() {
+        return Ok(Some(PathBuf::from(cwd)));
+    }
     let resolved = resolve_path(cwd, workspace);
     let canonical =
         std::fs::canonicalize(&resolved).map_err(|e| format!("cwd not accessible: {e}"))?;
@@ -104,6 +107,9 @@ pub fn authorize_user_spawn_cwd(
     let Some(cwd) = cwd.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
+    if workspace.is_ssh() {
+        return Ok(Some(PathBuf::from(cwd)));
+    }
     let resolved = resolve_path(cwd, workspace);
     let canonical =
         std::fs::canonicalize(&resolved).map_err(|e| format!("cwd not accessible: {e}"))?;
@@ -128,6 +134,9 @@ pub async fn workspace_authorize(
     registry: tauri::State<'_, WorkspaceRegistry>,
 ) -> Result<String, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Ok(crate::modules::fs::to_canon(PathBuf::from(path)));
+    }
     let resolved = resolve_path(&path, &workspace);
     let canonical = registry.authorize(&resolved).map_err(|e| e.to_string())?;
     Ok(crate::modules::fs::to_canon(&canonical))
@@ -215,6 +224,17 @@ pub enum WorkspaceEnv {
     Wsl {
         distro: String,
     },
+    #[serde(rename_all = "camelCase")]
+    Ssh {
+        id: String,
+        label: String,
+        host: String,
+        user: Option<String>,
+        port: Option<u16>,
+        root_path: String,
+        #[serde(default)]
+        password: Option<String>,
+    },
 }
 
 impl WorkspaceEnv {
@@ -224,6 +244,10 @@ impl WorkspaceEnv {
 
     pub fn is_wsl(&self) -> bool {
         matches!(self, Self::Wsl { .. })
+    }
+
+    pub fn is_ssh(&self) -> bool {
+        matches!(self, Self::Ssh { .. })
     }
 }
 
@@ -239,6 +263,7 @@ pub fn resolve_path(path: &str, workspace: &WorkspaceEnv) -> PathBuf {
     match workspace {
         WorkspaceEnv::Local => PathBuf::from(path),
         WorkspaceEnv::Wsl { distro } => wsl_path_to_host(distro, path),
+        WorkspaceEnv::Ssh { .. } => PathBuf::from(path),
     }
 }
 
@@ -749,6 +774,24 @@ mod auth_tests {
         let err = authorize_spawn_cwd(&reg, Some(&s), &WorkspaceEnv::Local)
             .expect_err("symlink-escape must be rejected");
         assert!(err.contains("outside"), "got: {err}");
+    }
+
+    #[test]
+    fn authorize_spawn_cwd_passthrough_for_ssh_workspace() {
+        let reg = WorkspaceRegistry::default();
+        let workspace = WorkspaceEnv::Ssh {
+            id: "ssh-1".into(),
+            label: "Remote".into(),
+            host: "example.com".into(),
+            user: Some("alice".into()),
+            port: Some(22),
+            root_path: "/srv/project".into(),
+            password: None,
+        };
+        let resolved = authorize_spawn_cwd(&reg, Some("/srv/project"), &workspace)
+            .expect("ssh cwd accepted")
+            .expect("path returned");
+        assert_eq!(resolved, PathBuf::from("/srv/project"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
         "minHeight": 280,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "visible": false
+        "visible": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -7,7 +7,7 @@
         "title": "Terax",
         "decorations": false,
         "transparent": true,
-        "visible": false,
+        "visible": true,
         "shadow": false
       }
     ]

--- a/src-tauri/tests/fs_search.rs
+++ b/src-tauri/tests/fs_search.rs
@@ -8,18 +8,13 @@ use terax_lib::modules::fs::tree::{fs_read_dir, list_subdirs, EntryKind};
 #[test]
 fn grep_finds_matches_and_returns_relative_paths() {
     let fx = FsFixture::new();
-    fx.write("src/main.rs", "fn main() {\n    println!(\"hello world\");\n}\n");
+    fx.write(
+        "src/main.rs",
+        "fn main() {\n    println!(\"hello world\");\n}\n",
+    );
     fx.write("src/lib.rs", "pub fn greet() {}\n");
 
-    let res = fs_grep(
-        "hello".into(),
-        fx.root_str(),
-        None,
-        None,
-        None,
-        None,
-    )
-    .expect("grep");
+    let res = fs_grep("hello".into(), fx.root_str(), None, None, None, None).expect("grep");
 
     assert_eq!(res.hits.len(), 1);
     let hit = &res.hits[0];
@@ -35,12 +30,11 @@ fn grep_case_insensitive_finds_mixed_case() {
     let fx = FsFixture::new();
     fx.write("a.txt", "Hello World\n");
 
-    let strict = fs_grep("hello".into(), fx.root_str(), None, Some(false), None, None)
-        .expect("grep");
+    let strict =
+        fs_grep("hello".into(), fx.root_str(), None, Some(false), None, None).expect("grep");
     assert!(strict.hits.is_empty());
 
-    let loose = fs_grep("hello".into(), fx.root_str(), None, Some(true), None, None)
-        .expect("grep");
+    let loose = fs_grep("hello".into(), fx.root_str(), None, Some(true), None, None).expect("grep");
     assert_eq!(loose.hits.len(), 1);
 }
 
@@ -71,8 +65,7 @@ fn grep_max_results_truncates() {
         fx.write(&format!("f{i}.txt"), "needle\n");
     }
 
-    let res = fs_grep("needle".into(), fx.root_str(), None, None, Some(3), None)
-        .expect("grep");
+    let res = fs_grep("needle".into(), fx.root_str(), None, None, Some(3), None).expect("grep");
 
     assert!(res.hits.len() <= 3);
     assert!(res.truncated);
@@ -105,8 +98,7 @@ fn grep_respects_ignore_file() {
     fx.write("ignored.txt", "secret\n");
     fx.write("visible.txt", "secret\n");
 
-    let res = fs_grep("secret".into(), fx.root_str(), None, None, None, None)
-        .expect("grep");
+    let res = fs_grep("secret".into(), fx.root_str(), None, None, None, None).expect("grep");
 
     let rels: Vec<&str> = res.hits.iter().map(|h| h.rel.as_str()).collect();
     assert!(rels.contains(&"visible.txt"));

--- a/src-tauri/tests/git_operations.rs
+++ b/src-tauri/tests/git_operations.rs
@@ -117,13 +117,13 @@ fn stage_then_commit_produces_log_entry() {
     assert!(entry.staged);
     assert!(!entry.untracked);
 
-    let commit = operations::commit(&fx.registry, &fx.repo_str(), "add a", &fx.workspace)
-        .expect("commit");
+    let commit =
+        operations::commit(&fx.registry, &fx.repo_str(), "add a", &fx.workspace).expect("commit");
     assert_eq!(commit.summary, "add a");
     assert_eq!(commit.commit_sha.len(), 40);
 
-    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
-        .expect("log");
+    let entries =
+        operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).expect("log");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].sha, commit.commit_sha);
     assert_eq!(entries[0].subject, "add a");
@@ -203,8 +203,8 @@ fn diff_shows_worktree_change() {
     fx.run_git(&["commit", "-q", "-m", "init"]);
     fx.write_file("a.txt", "alpha\nbeta\n");
 
-    let diff = operations::diff(&fx.registry, &fx.repo_str(), None, false, &fx.workspace)
-        .expect("diff");
+    let diff =
+        operations::diff(&fx.registry, &fx.repo_str(), None, false, &fx.workspace).expect("diff");
     assert!(diff.diff_text.contains("+beta"));
 }
 
@@ -304,9 +304,8 @@ fn panel_snapshot_outside_repo_is_empty() {
     let registry = WorkspaceRegistry::default();
     registry.authorize(&canonical).unwrap();
 
-    let snap =
-        operations::panel_snapshot(&registry, &to_canon(&canonical), &WorkspaceEnv::Local)
-            .expect("panel_snapshot");
+    let snap = operations::panel_snapshot(&registry, &to_canon(&canonical), &WorkspaceEnv::Local)
+        .expect("panel_snapshot");
     assert!(snap.repo.is_none());
     assert!(snap.status.is_none());
 }
@@ -321,8 +320,7 @@ fn show_commit_diff_returns_patch_for_known_sha() {
     fx.run_git(&["add", "a.txt"]);
     fx.run_git(&["commit", "-q", "-m", "seed"]);
 
-    let entries =
-        operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).unwrap();
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).unwrap();
     let sha = &entries[0].sha;
 
     let diff = operations::show_commit_diff(&fx.registry, &fx.repo_str(), sha, &fx.workspace)
@@ -337,12 +335,7 @@ fn show_commit_diff_rejects_invalid_sha() {
         return;
     }
     let fx = GitRepoFixture::new();
-    match operations::show_commit_diff(
-        &fx.registry,
-        &fx.repo_str(),
-        "not-a-sha",
-        &fx.workspace,
-    ) {
+    match operations::show_commit_diff(&fx.registry, &fx.repo_str(), "not-a-sha", &fx.workspace) {
         Err(GitError::CommandFailed { .. }) => {}
         Err(other) => panic!("expected CommandFailed, got {other}"),
         Ok(_) => panic!("expected error for invalid sha"),
@@ -361,8 +354,7 @@ fn log_paginates_with_before_sha_cursor() {
         fx.run_git(&["commit", "-q", "-m", &format!("c{i}")]);
     }
 
-    let first_page =
-        operations::log(&fx.registry, &fx.repo_str(), 1, None, &fx.workspace).unwrap();
+    let first_page = operations::log(&fx.registry, &fx.repo_str(), 1, None, &fx.workspace).unwrap();
     assert_eq!(first_page.len(), 1);
     let cursor = first_page[0].sha.clone();
 
@@ -415,8 +407,7 @@ fn commit_files_reports_added_and_modified() {
     fx.run_git(&["add", "a.txt"]);
     fx.run_git(&["commit", "-q", "-m", "modify"]);
 
-    let entries =
-        operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).unwrap();
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).unwrap();
     let head = &entries[0].sha;
 
     let files =
@@ -440,13 +431,18 @@ fn commit_file_diff_returns_original_and_modified_text() {
     fx.run_git(&["add", "a.txt"]);
     fx.run_git(&["commit", "-q", "-m", "v2"]);
 
-    let entries =
-        operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).unwrap();
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace).unwrap();
     let head = &entries[0].sha;
 
-    let diff =
-        operations::commit_file_diff(&fx.registry, &fx.repo_str(), head, "a.txt", None, &fx.workspace)
-            .unwrap();
+    let diff = operations::commit_file_diff(
+        &fx.registry,
+        &fx.repo_str(),
+        head,
+        "a.txt",
+        None,
+        &fx.workspace,
+    )
+    .unwrap();
     assert_eq!(diff.original_content, "v1\n");
     assert_eq!(diff.modified_content, "v2\n");
     assert!(!diff.is_binary);
@@ -458,8 +454,8 @@ fn remote_url_returns_none_for_missing_remote() {
         return;
     }
     let fx = GitRepoFixture::new();
-    let url = operations::remote_url(&fx.registry, &fx.repo_str(), "origin", &fx.workspace)
-        .unwrap();
+    let url =
+        operations::remote_url(&fx.registry, &fx.repo_str(), "origin", &fx.workspace).unwrap();
     assert!(url.is_none());
 }
 
@@ -469,15 +465,10 @@ fn remote_url_returns_configured_url() {
         return;
     }
     let fx = GitRepoFixture::new();
-    fx.run_git(&[
-        "remote",
-        "add",
-        "origin",
-        "https://example.com/x.git",
-    ]);
+    fx.run_git(&["remote", "add", "origin", "https://example.com/x.git"]);
 
-    let url = operations::remote_url(&fx.registry, &fx.repo_str(), "origin", &fx.workspace)
-        .unwrap();
+    let url =
+        operations::remote_url(&fx.registry, &fx.repo_str(), "origin", &fx.workspace).unwrap();
     assert_eq!(url.as_deref(), Some("https://example.com/x.git"));
 }
 

--- a/src-tauri/tests/shell_background.rs
+++ b/src-tauri/tests/shell_background.rs
@@ -33,12 +33,8 @@ fn spawn_invalid_cwd_errors() {
 
 #[test]
 fn spawn_captures_stdout_and_exits_zero() {
-    let proc = background::spawn(
-        "printf 'hello\\n'".into(),
-        None,
-        WorkspaceEnv::Local,
-    )
-    .expect("spawn");
+    let proc =
+        background::spawn("printf 'hello\\n'".into(), None, WorkspaceEnv::Local).expect("spawn");
 
     assert!(wait_until(Duration::from_secs(5), || {
         proc.read_logs(0).exited
@@ -62,8 +58,7 @@ fn spawn_captures_nonzero_exit() {
 
 #[test]
 fn kill_terminates_a_running_process() {
-    let proc =
-        background::spawn("sleep 30".into(), None, WorkspaceEnv::Local).expect("spawn");
+    let proc = background::spawn("sleep 30".into(), None, WorkspaceEnv::Local).expect("spawn");
 
     proc.kill();
 
@@ -90,7 +85,10 @@ fn read_logs_advances_offset() {
     assert!(first.next_offset > 0);
 
     let next = proc.read_logs(first.next_offset);
-    assert!(next.bytes.is_empty(), "consumed offset must return no bytes");
+    assert!(
+        next.bytes.is_empty(),
+        "consumed offset must return no bytes"
+    );
     assert_eq!(next.next_offset, first.next_offset);
 }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -24,16 +24,24 @@ import {
   AiInputBar,
   AiInputBarConnect,
   AiMiniWindow,
-  getAllKeys,
-  getAllCustomEndpointKeys,
-  hasAnyKey,
   LocalAgentNotificationsBridge,
   SelectionAskAi,
   useChatStore,
 } from "@/modules/ai";
+import {
+  DEFAULT_CODEX_MODEL_ID,
+  endpointIdFromCompatModel,
+  isCodexModelId,
+  isCompatModelId,
+  providerNeedsKey,
+  resolveModel,
+  type CustomEndpoint,
+  type ProviderId,
+} from "@/modules/ai/config";
 import { AiComposerProvider } from "@/modules/ai/lib/composer";
 import { redactSensitive } from "@/modules/ai/lib/redact";
 import { native } from "@/modules/ai/lib/native";
+import { buildTerminalInventory } from "@/modules/ai/lib/terminalInventory";
 import { useAgentsStore } from "@/modules/ai/store/agentsStore";
 import { useSnippetsStore } from "@/modules/ai/store/snippetsStore";
 import {
@@ -70,7 +78,7 @@ import { MarkdownStack } from "@/modules/markdown";
 import { PreviewStack, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import { onKeysChanged, setThemeId as persistThemeId } from "@/modules/settings/store";
+import { setThemeId as persistThemeId } from "@/modules/settings/store";
 import {
   ShortcutsDialog,
   useGlobalShortcuts,
@@ -98,6 +106,7 @@ import {
   type TerminalPaneHandle,
   useTerminalFileDrop,
 } from "@/modules/terminal";
+import { parseSshCommandLine } from "@/modules/terminal/lib/sshCommandTracker";
 import { ThemeProvider } from "@/modules/theme";
 import { listCustomThemes, saveCustomTheme } from "@/modules/theme/customThemes";
 import {
@@ -109,10 +118,13 @@ import {
   writeThemeFile,
 } from "@/modules/theme/themeFiles";
 import { UpdaterDialog } from "@/modules/updater";
+import { hostname } from "@tauri-apps/plugin-os";
 import {
   currentWorkspaceEnv,
   getWslHome,
+  isLocalHost,
   LOCAL_WORKSPACE,
+  sameWorkspaceEnv,
   useWorkspaceEnvStore,
   type WorkspaceEnv,
 } from "@/modules/workspace";
@@ -146,6 +158,56 @@ function dirname(path: string | null): string | null {
   const idx = normalized.lastIndexOf("/");
   if (idx <= 0) return normalized;
   return normalized.slice(0, idx);
+}
+
+type KeylessModelConfig = {
+  lmstudio: boolean;
+  mlx: boolean;
+  ollama: boolean;
+  openaiCompatible: boolean;
+  customEndpoints: readonly CustomEndpoint[];
+};
+
+function isProviderUsableWithoutKey(
+  provider: ProviderId,
+  config: KeylessModelConfig,
+): boolean {
+  switch (provider) {
+    case "codex":
+      return true;
+    case "lmstudio":
+      return config.lmstudio;
+    case "mlx":
+      return config.mlx;
+    case "ollama":
+      return config.ollama;
+    case "openai-compatible":
+      return config.openaiCompatible;
+    default:
+      return !providerNeedsKey(provider);
+  }
+}
+
+function isModelUsableWithoutKey(
+  modelId: string,
+  config: KeylessModelConfig,
+): boolean {
+  if (isCodexModelId(modelId)) return true;
+  if (isCompatModelId(modelId)) {
+    const endpointId = endpointIdFromCompatModel(modelId);
+    return config.customEndpoints.some(
+      (endpoint) =>
+        endpoint.id === endpointId &&
+        endpoint.baseURL.trim().length > 0 &&
+        endpoint.modelId.trim().length > 0,
+    );
+  }
+  try {
+    const provider = resolveModel(modelId).provider;
+    return isProviderUsableWithoutKey(provider, config);
+  } catch {
+    return false;
+  }
 }
 
 const SIDEBAR_DEFAULT_WIDTH = 260;
@@ -209,7 +271,7 @@ export default function App() {
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
-    resetWorkspace,
+    setTerminalTabWorkspace,
   } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
@@ -243,6 +305,7 @@ export default function App() {
   const sidebarWidthRef = useRef(readSidebarWidth());
   const sidebarWidthWriteTimerRef = useRef(0);
   const [sidebarView, setSidebarViewState] = useState<SidebarViewId>(readSidebarView);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const persistSidebarView = useCallback((view: SidebarViewId) => {
     setSidebarViewState(view);
     try {
@@ -254,8 +317,13 @@ export default function App() {
   const toggleSidebar = useCallback(() => {
     const p = sidebarRef.current;
     if (!p) return;
-    if (p.getSize().asPercentage <= 0) p.expand();
-    else p.collapse();
+    if (p.getSize().asPercentage <= 0) {
+      p.expand();
+      setSidebarCollapsed(false);
+    } else {
+      p.collapse();
+      setSidebarCollapsed(true);
+    }
   }, []);
   const cycleSidebarView = useCallback(
     (view: SidebarViewId) => {
@@ -263,11 +331,13 @@ export default function App() {
       const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
       if (collapsed) {
         if (panel) panel.resize(`${sidebarWidthRef.current}px`);
+        setSidebarCollapsed(false);
         if (view !== sidebarView) persistSidebarView(view);
         return;
       }
       if (view === sidebarView) {
         panel?.collapse();
+        setSidebarCollapsed(true);
         return;
       }
       persistSidebarView(view);
@@ -302,6 +372,7 @@ export default function App() {
     const collapsed = panel ? panel.getSize().asPercentage <= 0 : false;
     if (sidebarView !== "explorer" || collapsed) {
       if (panel && collapsed) panel.resize(`${sidebarWidthRef.current}px`);
+      if (collapsed) setSidebarCollapsed(false);
       if (sidebarView !== "explorer") persistSidebarView("explorer");
       const active = document.activeElement;
       explorerReturnFocusRef.current =
@@ -329,9 +400,9 @@ export default function App() {
   }, [persistSidebarView, sidebarView]);
 
   const [home, setHome] = useState<string | null>(null);
+  const [localHostname, setLocalHostname] = useState("");
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
   const [pendingTerminalCloseTab, setPendingTerminalCloseTab] = useState<number | null>(null);
-  const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const setWorkspaceEnv = useWorkspaceEnvStore((s) => s.setEnv);
   const [launchCwd, setLaunchCwd] = useState<string | null>(null);
   const [launchCwdResolved, setLaunchCwdResolved] = useState(false);
@@ -352,18 +423,28 @@ export default function App() {
       .catch(() => setHome(null));
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    hostname()
+      .then((value) => {
+        if (!cancelled) setLocalHostname((value ?? "").trim().toLowerCase());
+      })
+      .catch(() => {
+        if (!cancelled) setLocalHostname("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const switchWorkspace = useCallback(
     async (env: WorkspaceEnv) => {
+      const targetTab = tabsRef.current.find((t) => t.id === activeId) ?? null;
       if (
-        env.kind === workspaceEnv.kind &&
-        (env.kind === "local" ||
-          (workspaceEnv.kind === "wsl" && env.distro === workspaceEnv.distro))
+        targetTab &&
+        sameWorkspaceEnv(env, targetTab.workspace) &&
+        !(env.kind === "ssh" && env.password)
       ) {
-        return;
-      }
-      const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
-      if (dirty) {
-        window.alert("Save or close unsaved editor tabs before switching workspace.");
         return;
       }
 
@@ -371,6 +452,8 @@ export default function App() {
       try {
         if (env.kind === "wsl") {
           nextHome = await getWslHome(env.distro);
+        } else if (env.kind === "ssh") {
+          nextHome = env.rootPath;
         } else {
           nextHome = (await homeDir()).replace(/\\/g, "/");
         }
@@ -379,26 +462,31 @@ export default function App() {
         return;
       }
 
-      for (const id of liveLeavesRef.current) disposeSession(id);
-      searchAddons.current.clear();
-      terminalRefs.current.clear();
-      editorRefs.current.clear();
-      previewRefs.current.clear();
-      setActiveSearchAddon(null);
-      setActiveEditorHandle(null);
-      setWorkspaceEnv(env.kind === "local" ? LOCAL_WORKSPACE : env);
-      setHome(nextHome);
-      setLaunchCwd(nextHome);
-      if (nextHome) {
-        try {
-          await native.workspaceAuthorize(nextHome);
-        } catch {
-          // Non-fatal — git panel will surface "not authorized" if needed.
-        }
+      if (!targetTab) {
+        setWorkspaceEnv(env);
+        return;
       }
-      resetWorkspace(nextHome ?? undefined);
+
+      if (targetTab.kind === "terminal") {
+        setTerminalTabWorkspace(targetTab.id, env, {
+          cwd: nextHome ?? undefined,
+          restartSession: true,
+        });
+        setWorkspaceEnv(env);
+        if (nextHome && env.kind !== "ssh") {
+          try {
+            await native.workspaceAuthorize(nextHome);
+          } catch {
+            // Non-fatal — git panel will surface "not authorized" if needed.
+          }
+        }
+        return;
+      }
+
+      updateTab(targetTab.id, { workspace: env });
+      setWorkspaceEnv(env);
     },
-    [workspaceEnv, setWorkspaceEnv, resetWorkspace],
+    [activeId, setTerminalTabWorkspace, setWorkspaceEnv, updateTab],
   );
   useEffect(() => {
     native
@@ -417,9 +505,6 @@ export default function App() {
   const focusInput = useChatStore((s) => s.focusInput);
   const openPanel = useChatStore((s) => s.openPanel);
   const panelOpen = useChatStore((s) => s.panelOpen);
-  const apiKeys = useChatStore((s) => s.apiKeys);
-  const setApiKeys = useChatStore((s) => s.setApiKeys);
-  const setCustomEndpointKeys = useChatStore((s) => s.setCustomEndpointKeys);
   const setSelectedModelId = useChatStore((s) => s.setSelectedModelId);
   const setLive = useChatStore((s) => s.setLive);
   const respondToApproval = useChatStore((s) => s.respondToApproval);
@@ -440,40 +525,35 @@ export default function App() {
     (s) => s.openaiCompatibleBaseURL,
   );
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
-  const hasLocalModel =
-    (lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0) ||
-    (mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0) ||
-    (ollamaBaseURL.trim().length > 0 && ollamaModelId.trim().length > 0) ||
-    (openaiCompatibleBaseURL.trim().length > 0 &&
-      openaiCompatibleModelId.trim().length > 0) ||
-    customEndpoints.some((e) => e.baseURL.trim().length > 0 && e.modelId.trim().length > 0);
-  const hasComposer = hasAnyKey(apiKeys) || hasLocalModel;
+  const sshWorkspaces = usePreferencesStore((s) => s.sshWorkspaces);
+  const keylessModelConfig = useMemo<KeylessModelConfig>(
+    () => ({
+      lmstudio:
+        lmstudioBaseURL.trim().length > 0 && lmstudioModelId.trim().length > 0,
+      mlx: mlxBaseURL.trim().length > 0 && mlxModelId.trim().length > 0,
+      ollama:
+        ollamaBaseURL.trim().length > 0 && ollamaModelId.trim().length > 0,
+      openaiCompatible:
+        openaiCompatibleBaseURL.trim().length > 0 &&
+        openaiCompatibleModelId.trim().length > 0,
+      customEndpoints,
+    }),
+    [
+      customEndpoints,
+      lmstudioBaseURL,
+      lmstudioModelId,
+      mlxBaseURL,
+      mlxModelId,
+      ollamaBaseURL,
+      ollamaModelId,
+      openaiCompatibleBaseURL,
+      openaiCompatibleModelId,
+    ],
+  );
+  const hasComposer = true;
+  const keysLoaded = true;
 
   const prefsHydrated = usePreferencesStore((s) => s.hydrated);
-  const [keysLoaded, setKeysLoaded] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    const reload = () => {
-      void getAllKeys().then((keys) => {
-        if (!alive) return;
-        setApiKeys(keys);
-        setKeysLoaded(true);
-      });
-      if (!prefsHydrated) return;
-      void getAllCustomEndpointKeys(
-        usePreferencesStore.getState().customEndpoints,
-      ).then((epKeys) => {
-        if (!alive) return;
-        setCustomEndpointKeys(epKeys);
-      });
-    };
-    reload();
-    const unlistenP = onKeysChanged(reload);
-    return () => {
-      alive = false;
-      void unlistenP.then((fn) => fn());
-    };
-  }, [setApiKeys, setCustomEndpointKeys, prefsHydrated]);
 
   // Hydrate the cross-window preference store and mirror the default model
   // into chatStore so the dropdown reflects what the user picked in Settings.
@@ -484,8 +564,12 @@ export default function App() {
   }, [initPrefs]);
   useEffect(() => {
     if (!prefsHydrated) return;
-    setSelectedModelId(prefDefaultModel);
-  }, [prefsHydrated, prefDefaultModel, setSelectedModelId]);
+    setSelectedModelId(
+      isModelUsableWithoutKey(prefDefaultModel, keylessModelConfig)
+        ? prefDefaultModel
+        : DEFAULT_CODEX_MODEL_ID,
+    );
+  }, [keylessModelConfig, prefsHydrated, prefDefaultModel, setSelectedModelId]);
 
   const hydrateSessions = useChatStore((s) => s.hydrateSessions);
   useEffect(() => {
@@ -495,6 +579,7 @@ export default function App() {
   }, [hydrateSessions]);
 
   const activeTab = tabs.find((t) => t.id === activeId);
+  const activeWorkspace = activeTab?.workspace ?? LOCAL_WORKSPACE;
   const isTerminalTab = activeTab?.kind === "terminal";
   const isEditorTab = activeTab?.kind === "editor";
   const isPreviewTab = activeTab?.kind === "preview";
@@ -503,6 +588,14 @@ export default function App() {
   const isGitDiffTab =
     activeTab?.kind === "git-diff" || activeTab?.kind === "git-commit-file";
   const isGitHistoryTab = activeTab?.kind === "git-history";
+
+  useEffect(() => {
+    const nextWorkspace = activeTab?.workspace ?? LOCAL_WORKSPACE;
+    const current = currentWorkspaceEnv();
+    if (!sameWorkspaceEnv(current, nextWorkspace)) {
+      setWorkspaceEnv(nextWorkspace);
+    }
+  }, [activeTab, setWorkspaceEnv]);
 
   // When an AI diff is approved (write_file applied to disk), reload any
   // open editor tabs for that path so the user sees the new content. We
@@ -551,10 +644,10 @@ export default function App() {
     const prev = editorWatchRef.current;
     const toAdd = [...want].filter((d) => !prev.has(d));
     const toRemove = [...prev].filter((d) => !want.has(d));
-    watchAdd(toAdd);
-    watchRemove(toRemove);
+    watchAdd(toAdd, activeWorkspace);
+    watchRemove(toRemove, activeWorkspace);
     editorWatchRef.current = want;
-  }, [tabs]);
+  }, [tabs, activeWorkspace]);
 
   useEffect(() => {
     let alive = true;
@@ -638,10 +731,18 @@ export default function App() {
     };
   }, [openFileTab]);
 
-  const { explorerRoot, inheritedCwdForNewTab } = useWorkspaceCwd(
+  const { explorerRoot } = useWorkspaceCwd(
     activeTab,
     tabs,
     launchCwd ?? home,
+    activeWorkspace.kind === "ssh"
+      ? `ssh:${activeWorkspace.user ?? ""}@${activeWorkspace.host}${
+          activeWorkspace.port ? `:${activeWorkspace.port}` : ""
+        }`
+      : activeWorkspace.kind === "wsl"
+        ? `wsl:${activeWorkspace.distro}`
+        : "local",
+    activeWorkspace.kind === "ssh" ? activeWorkspace.rootPath : null,
   );
 
   useWindowTitle(activeTab, explorerRoot);
@@ -849,12 +950,12 @@ export default function App() {
   }, [askFromSelection]);
 
   const openNewTab = useCallback(() => {
-    newTab(inheritedCwdForNewTab());
-  }, [newTab, inheritedCwdForNewTab]);
+    newTab(home ?? launchCwd ?? undefined);
+  }, [newTab, home, launchCwd]);
 
   const openNewPrivateTab = useCallback(() => {
-    newPrivateTab(inheritedCwdForNewTab());
-  }, [newPrivateTab, inheritedCwdForNewTab]);
+    newPrivateTab(home ?? launchCwd ?? undefined);
+  }, [newPrivateTab, home, launchCwd]);
 
   const sendCd = useCallback(
     (path: string) => {
@@ -870,6 +971,13 @@ export default function App() {
   const cdInNewTab = useCallback(
     (path: string) => {
       const tabId = newTab(path);
+      const workspace = activeTab?.workspace ?? LOCAL_WORKSPACE;
+      if (workspace.kind !== "local") {
+        setTerminalTabWorkspace(tabId, workspace, {
+          cwd: path,
+          restartSession: true,
+        });
+      }
       setTimeout(() => {
         const tab = tabsRef.current.find((x) => x.id === tabId);
         if (!tab || tab.kind !== "terminal") return;
@@ -879,7 +987,7 @@ export default function App() {
         t.focus();
       }, 80);
     },
-    [newTab],
+    [activeTab, newTab, setTerminalTabWorkspace],
   );
 
   const handleOpenFile = useCallback(
@@ -971,7 +1079,12 @@ export default function App() {
     : null;
   const sourceControlContextPath = (() => {
     if (activeTab?.kind === "terminal") {
-      return activeTerminalLeafCwd ?? explorerRoot ?? workspaceFallbackPath;
+      return (
+        activeTerminalLeafCwd ??
+        (activeTab.workspace.kind === "ssh" ? activeTab.workspace.rootPath : null) ??
+        explorerRoot ??
+        workspaceFallbackPath
+      );
     }
     if (activeTab?.kind === "editor") return dirname(activeTab.path);
     if (activeTab?.kind === "git-diff") return activeTab.repoRoot;
@@ -998,7 +1111,11 @@ export default function App() {
   const sourceControlPath = sourceControlActive
     ? sourceControlContextPath
     : badgeContextPath;
-  const sourceControl = useSourceControl(sourceControlPath, true);
+  const sourceControl = useSourceControl(
+    sourceControlPath,
+    activeWorkspace,
+    !sidebarCollapsed,
+  );
 
   const toggleSourceControl = useCallback(() => {
     cycleSidebarView("source-control");
@@ -1194,18 +1311,64 @@ export default function App() {
     [updateTab],
   );
 
-  const authorizedCwds = useRef(new Set<string>());
   const handleTerminalCwd = useCallback(
-    (leafId: number, cwd: string) => {
+    (leafId: number, cwd: string, host: string | null) => {
       setLeafCwd(leafId, cwd);
-      if (cwd && !authorizedCwds.current.has(cwd)) {
-        authorizedCwds.current.add(cwd);
-        native.workspaceAuthorize(cwd).catch(() => {
-          authorizedCwds.current.delete(cwd);
+      const tab = tabsRef.current.find(
+        (t) => t.kind === "terminal" && hasLeaf(t.paneTree, leafId),
+      );
+      if (!tab || tab.kind !== "terminal") return;
+      const remoteHost = host?.trim().toLowerCase() ?? "";
+      if (!localHostname) return;
+      if (
+        remoteHost &&
+        !isLocalHost(remoteHost, localHostname) &&
+        !(tab.workspace.kind === "ssh" && isLocalHost(tab.workspace.host, remoteHost))
+      ) {
+        const nextEnv: WorkspaceEnv = {
+          kind: "ssh",
+          id: `auto:${remoteHost}`,
+          label: `SSH: ${host ?? remoteHost}`,
+          host: host ?? remoteHost,
+          user: null,
+          port: null,
+          rootPath: cwd || "/",
+        };
+        setTerminalTabWorkspace(tab.id, nextEnv, {
+          cwd: cwd || undefined,
+          restartSession: true,
         });
+        return;
       }
     },
-    [setLeafCwd],
+    [setLeafCwd, setTerminalTabWorkspace, localHostname],
+  );
+
+  const handleTerminalCommandStart = useCallback(
+    (leafId: number, command: string) => {
+      const tab = tabsRef.current.find(
+        (t) => t.kind === "terminal" && hasLeaf(t.paneTree, leafId),
+      );
+      if (!tab || tab.kind !== "terminal") return;
+      if (tab.workspace.kind !== "local") return;
+      const spec = parseSshCommandLine(command);
+      if (!spec) return;
+      const host = spec.host.trim();
+      const user = spec.user?.trim() || null;
+      const port = spec.port ?? null;
+      const match = sshWorkspaces.find((profile) => {
+        if (profile.host.trim() !== host) return false;
+        if ((profile.user ?? null) !== user) return false;
+        if ((profile.port ?? null) !== port) return false;
+        return true;
+      });
+      if (!match) return;
+      setTerminalTabWorkspace(tab.id, { kind: "ssh", ...match }, {
+        cwd: match.rootPath,
+        restartSession: true,
+      });
+    },
+    [sshWorkspaces, setTerminalTabWorkspace],
   );
 
   const handleFocusLeaf = useCallback(
@@ -1237,7 +1400,10 @@ export default function App() {
         leafIds(tab.paneTree).length === 1 &&
         all.filter((t) => t.kind === "terminal").length === 1;
       if (isLast) {
-        void respawnSession(leafId, tab.cwd);
+        void respawnSession(
+          leafId,
+          tab.workspace.kind === "ssh" ? tab.workspace.rootPath : tab.cwd,
+        );
       } else {
         closePaneByLeaf(leafId);
       }
@@ -1347,6 +1513,7 @@ export default function App() {
       }
       return explorerRoot ?? launchCwd ?? home ?? null;
     };
+    const getTerminalInventory = () => buildTerminalInventory(tabs, activeId);
 
     setLive({
       getCwd: findCwd,
@@ -1357,6 +1524,7 @@ export default function App() {
         const buf = terminalRefs.current.get(t.activeLeafId)?.getBuffer(300);
         return buf ? redactSensitive(buf) : null;
       },
+      getTerminalInventory,
       isActiveTerminalPrivate: () => {
         const t = tabs.find((x) => x.id === activeId);
         return t?.kind === "terminal" && t.private === true;
@@ -1451,6 +1619,7 @@ export default function App() {
           onSearchReady={handleSearchReady}
           onCwd={handleTerminalCwd}
           onExit={handleLeafExit}
+          onCommandStart={handleTerminalCommandStart}
           onFocusLeaf={handleFocusLeaf}
         />
       </div>
@@ -1577,6 +1746,7 @@ export default function App() {
                 collapsible
                 collapsedSize={0}
                 onResize={(size) => {
+                  setSidebarCollapsed(size.inPixels <= 0);
                   if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
                 }}
               >
@@ -1586,7 +1756,9 @@ export default function App() {
                       <FileExplorer
                         ref={explorerRef}
                         rootPath={explorerRoot}
+                        workspace={activeWorkspace}
                         activeFilePath={explorerActiveFilePath}
+                        enabled={!sidebarCollapsed}
                         onOpenFile={handleOpenFile}
                         onPathRenamed={handlePathRenamed}
                         onPathDeleted={handlePathDeleted}
@@ -1596,7 +1768,7 @@ export default function App() {
                       />
                     ) : (
                       <SourceControlPanel
-                        open
+                        open={!sidebarCollapsed}
                         sourceControl={sourceControl}
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}
@@ -1645,10 +1817,11 @@ export default function App() {
           </main>
 
           {!zenMode && (
-            <StatusBar
+          <StatusBar
             cwd={activeCwd}
             filePath={activeFilePath}
             home={home}
+            workspace={activeWorkspace}
             onCd={sendCd}
             onWorkspaceChange={switchWorkspace}
             onOpenMini={openMini}
@@ -1656,7 +1829,7 @@ export default function App() {
             privateActive={
               activeTab?.kind === "terminal" && activeTab.private === true
             }
-            />
+          />
           )}
 
           <AgentNotificationsBridge

--- a/src/lib/clipboard.test.ts
+++ b/src/lib/clipboard.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  readClipboardText,
+  writeClipboardText,
+  type ClipboardAdapter,
+} from "./clipboard";
+
+function adapter(overrides: Partial<ClipboardAdapter> = {}): ClipboardAdapter {
+  return {
+    readText: vi.fn(() => Promise.resolve("")),
+    writeText: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+describe("clipboard", () => {
+  it("writes through the Tauri clipboard backend", async () => {
+    const primary = adapter();
+
+    await writeClipboardText("selected text", primary, null);
+
+    expect(primary.writeText).toHaveBeenCalledWith("selected text");
+  });
+
+  it("falls back when the Tauri clipboard backend is unavailable", async () => {
+    const primary = adapter({
+      writeText: vi.fn(() => Promise.reject(new Error("unavailable"))),
+    });
+    const fallback = adapter();
+
+    await writeClipboardText("selected text", primary, fallback);
+
+    expect(fallback.writeText).toHaveBeenCalledWith("selected text");
+  });
+
+  it("reads through the fallback when the Tauri backend is unavailable", async () => {
+    const primary = adapter({
+      readText: vi.fn(() => Promise.reject(new Error("unavailable"))),
+    });
+    const fallback = adapter({
+      readText: vi.fn(() => Promise.resolve("clipboard text")),
+    });
+
+    await expect(readClipboardText(primary, fallback)).resolves.toBe(
+      "clipboard text",
+    );
+  });
+});

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,46 @@
+import {
+  readText as readTauriText,
+  writeText as writeTauriText,
+} from "@tauri-apps/plugin-clipboard-manager";
+
+export type ClipboardAdapter = {
+  readText(): Promise<string>;
+  writeText(text: string): Promise<void>;
+};
+
+const tauriClipboard: ClipboardAdapter = {
+  readText: readTauriText,
+  writeText: writeTauriText,
+};
+
+function browserClipboard(): ClipboardAdapter | null {
+  if (typeof navigator === "undefined") return null;
+  const clipboard = navigator.clipboard;
+  if (!clipboard?.readText || !clipboard.writeText) return null;
+  return clipboard;
+}
+
+export async function writeClipboardText(
+  text: string,
+  primary: ClipboardAdapter = tauriClipboard,
+  fallback: ClipboardAdapter | null = browserClipboard(),
+): Promise<void> {
+  try {
+    await primary.writeText(text);
+  } catch (error) {
+    if (!fallback) throw error;
+    await fallback.writeText(text);
+  }
+}
+
+export async function readClipboardText(
+  primary: ClipboardAdapter = tauriClipboard,
+  fallback: ClipboardAdapter | null = browserClipboard(),
+): Promise<string> {
+  try {
+    return await primary.readText();
+  } catch (error) {
+    if (!fallback) throw error;
+    return fallback.readText();
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,29 +11,17 @@ import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import { initLaunchDir } from "./lib/launchDir";
 import { USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
+import { startMainWindow } from "./mainBoot";
 
 if (USE_CUSTOM_WINDOW_CONTROLS) {
   document.documentElement.dataset.chrome = "borderless";
 }
 
-// Reap PTY sessions orphaned by a prior webview load before any tab spawns.
-await invoke("pty_close_all").catch(() => {});
-
-// Seed before first paint so default tab mounts at target cwd (no flicker).
-await initLaunchDir();
-
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <App />,
-);
-
-// Window starts hidden (per tauri.conf.json) so users never see a transparent
-// shadow-only frame before React paints. Use setTimeout — rAF is throttled
-// while the window is hidden and would never fire.
-const showWindow = () => {
-  getCurrentWindow()
-    .show()
-    .catch((e) => console.error("window.show failed:", e));
-};
-setTimeout(showWindow, 50);
-// Safety net: if the first show somehow fails to take effect, force again.
-setTimeout(showWindow, 500);
+void startMainWindow({
+  app: <App />,
+  closeAllPtys: () => invoke("pty_close_all"),
+  createRoot: ReactDOM.createRoot,
+  currentWindow: getCurrentWindow(),
+  initLaunchDir,
+  root: document.getElementById("root"),
+});

--- a/src/mainBoot.test.ts
+++ b/src/mainBoot.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { startMainWindow } from "./mainBoot";
+
+describe("startMainWindow", () => {
+  it("schedules window show and renders before waiting on PTY cleanup", async () => {
+    const timers: Array<() => void> = [];
+    const setTimer = vi.fn((callback: () => void) => {
+      timers.push(callback);
+      return 1;
+    });
+    const show = vi.fn(() => Promise.resolve());
+    const createRoot = vi.fn(() => ({ render: vi.fn() }));
+    const blockedCloseAll = new Promise<void>(() => {});
+
+    const boot = startMainWindow({
+      app: null,
+      closeAllPtys: () => blockedCloseAll,
+      createRoot,
+      currentWindow: { show },
+      initLaunchDir: () => Promise.resolve(),
+      logError: vi.fn(),
+      root: {} as HTMLElement,
+      setTimer,
+    });
+
+    expect(setTimer).toHaveBeenCalledTimes(2);
+    timers[0]?.();
+    expect(show).toHaveBeenCalledTimes(1);
+
+    await boot;
+    expect(createRoot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/mainBoot.tsx
+++ b/src/mainBoot.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+
+type WindowLike = {
+  show: () => Promise<void>;
+};
+
+type RootLike = {
+  render: (children: ReactNode) => void;
+};
+
+type Timer = (callback: () => void, delay: number) => unknown;
+
+type StartMainWindowOptions = {
+  app: ReactNode;
+  closeAllPtys: () => Promise<unknown>;
+  createRoot: (container: HTMLElement) => RootLike;
+  currentWindow: WindowLike;
+  initLaunchDir: () => Promise<void>;
+  logError?: (...data: unknown[]) => void;
+  root: HTMLElement | null;
+  setTimer?: Timer;
+};
+
+const STARTUP_WAIT_MS = 500;
+
+function scheduleWindowShow(
+  currentWindow: WindowLike,
+  setTimer: Timer,
+  logError: (...data: unknown[]) => void,
+) {
+  const showWindow = () => {
+    currentWindow
+      .show()
+      .catch((e) => logError("window.show failed:", e));
+  };
+
+  setTimer(showWindow, 50);
+  setTimer(showWindow, 500);
+}
+
+async function waitForStartupTask(
+  task: Promise<unknown>,
+  logError: (...data: unknown[]) => void,
+) {
+  let timedOut = false;
+  await Promise.race([
+    task.catch((e) => logError("startup task failed:", e)),
+    new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timedOut = true;
+        resolve();
+      }, STARTUP_WAIT_MS);
+    }),
+  ]);
+
+  if (timedOut) {
+    logError(`startup task exceeded ${STARTUP_WAIT_MS}ms; continuing render`);
+  }
+}
+
+export async function startMainWindow({
+  app,
+  closeAllPtys,
+  createRoot,
+  currentWindow,
+  initLaunchDir,
+  logError = console.error,
+  root,
+  setTimer = setTimeout,
+}: StartMainWindowOptions) {
+  scheduleWindowShow(currentWindow, setTimer, logError);
+
+  void closeAllPtys().catch((e) => logError("pty cleanup failed:", e));
+  await waitForStartupTask(initLaunchDir(), logError);
+
+  if (!root) {
+    throw new Error("Missing #root element");
+  }
+
+  createRoot(root).render(app);
+}

--- a/src/modules/agents/components/NotificationBell.tsx
+++ b/src/modules/agents/components/NotificationBell.tsx
@@ -220,7 +220,7 @@ export function NotificationBell({ onActivate, onActivateLocal }: Props) {
           <div className="border-t border-border/60 px-3 py-5 text-center text-xs leading-relaxed text-muted-foreground">
             No agent activity yet.
             <br />
-            Run the Terax agent or Claude Code to track it here.
+            Run the Terax agent, Claude Code, or Codex to track it here.
           </div>
         ) : (
           <div className="max-h-80 overflow-y-auto border-t border-border/60 p-1">

--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -395,7 +395,9 @@ const RenderedMessage = memo(function RenderedMessage({
                 <RenderedPart
                   part={g.part}
                   onApproval={onApproval}
-                  streaming={streaming && g.idx === lastTextIdx}
+                  streaming={
+                    streaming && (partIsStreaming(g.part) || g.idx === lastTextIdx)
+                  }
                 />
               </PartAppear>
             );
@@ -412,6 +414,10 @@ type Group =
 
 function partType(p: AnyPart): string {
   return (p as { type?: string }).type ?? "";
+}
+
+function partIsStreaming(p: AnyPart): boolean {
+  return (p as { state?: string }).state === "streaming";
 }
 
 function isReadFilePart(p: AnyPart): boolean {
@@ -610,7 +616,7 @@ const RenderedPart = memo(function RenderedPart({
 
   if (part.type === "reasoning") {
     return (
-      <Reasoning>
+      <Reasoning isStreaming={streaming}>
         <ReasoningTrigger />
         <ReasoningContent>
           {(part as unknown as { text: string }).text}

--- a/src/modules/ai/components/AiInputBar.test.ts
+++ b/src/modules/ai/components/AiInputBar.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldIgnoreEnterAfterImeCommit,
+  shouldSubmitOnEnter,
+} from "./AiInputBar";
+
+describe("shouldSubmitOnEnter", () => {
+  it("submits plain Enter", () => {
+    expect(
+      shouldSubmitOnEnter({
+        key: "Enter",
+        shiftKey: false,
+        isComposing: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not submit while composing IME text", () => {
+    expect(
+      shouldSubmitOnEnter({
+        key: "Enter",
+        shiftKey: false,
+        isComposing: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not submit on the IME keyCode 229 fallback", () => {
+    expect(
+      shouldSubmitOnEnter({
+        key: "Enter",
+        shiftKey: false,
+        isComposing: false,
+        keyCode: 229,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not submit Shift+Enter", () => {
+    expect(
+      shouldSubmitOnEnter({
+        key: "Enter",
+        shiftKey: true,
+        isComposing: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("swallows the first Enter immediately after an IME commit", () => {
+    expect(
+      shouldIgnoreEnterAfterImeCommit({
+        key: "Enter",
+        now: 100,
+        ignoreUntil: 500,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not swallow a later normal Enter", () => {
+    expect(
+      shouldIgnoreEnterAfterImeCommit({
+        key: "Enter",
+        now: 800,
+        ignoreUntil: 500,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -11,7 +11,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceFiles } from "../hooks/useWorkspaceFiles";
 import { useComposer, type FileAttachment } from "../lib/composer";
 import { SLASH_COMMANDS } from "../lib/slashCommands";
@@ -72,6 +72,9 @@ export function AiInputBar() {
   const c = useComposer();
   const snippets = useSnippetsStore((s) => s.snippets);
   const workspaceRoot = useChatStore((s) => s.live.getWorkspaceRoot());
+  const isComposingRef = useRef(false);
+  const imeEnterIgnoreUntilRef = useRef(0);
+  const IME_ENTER_IGNORE_MS = 50;
 
   const [trigger, setTrigger] = useState<SnippetTrigger | null>(null);
   const [fileTrigger, setFileTrigger] = useState<FileTrigger | null>(null);
@@ -242,10 +245,35 @@ export function AiInputBar() {
                 ref={c.textareaRef}
                 value={c.value}
                 onChange={(e) => c.setValue(e.target.value)}
+                onCompositionStart={() => {
+                  isComposingRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  isComposingRef.current = false;
+                  imeEnterIgnoreUntilRef.current =
+                    performance.now() + IME_ENTER_IGNORE_MS;
+                }}
                 onKeyUp={updateTrigger}
                 onClick={updateTrigger}
                 onSelect={updateTrigger}
                 onKeyDown={(e) => {
+                  const isComposing =
+                    isComposingRef.current ||
+                    e.nativeEvent.isComposing ||
+                    e.keyCode === 229;
+                  if (isComposing) {
+                    return;
+                  }
+                  if (
+                    shouldIgnoreEnterAfterImeCommit({
+                      key: e.key,
+                      now: performance.now(),
+                      ignoreUntil: imeEnterIgnoreUntilRef.current,
+                    })
+                  ) {
+                    e.preventDefault();
+                    return;
+                  }
                   if (pickerOpen) {
                     const items = fileTrigger ? filteredFiles : filteredItems;
                     if (e.key === "ArrowDown") {
@@ -280,7 +308,12 @@ export function AiInputBar() {
                       return;
                     }
                   }
-                  if (e.key === "Enter" && !e.shiftKey) {
+                  if (shouldSubmitOnEnter({
+                    key: e.key,
+                    shiftKey: e.shiftKey,
+                    isComposing,
+                    keyCode: e.keyCode,
+                  })) {
                     e.preventDefault();
                     c.submit();
                   }
@@ -497,4 +530,23 @@ export function AiInputBarConnect({ onAdd }: { onAdd: () => void }) {
       </div>
     </div>
   );
+}
+
+export function shouldSubmitOnEnter(input: {
+  key: string;
+  shiftKey: boolean;
+  isComposing: boolean;
+  keyCode?: number;
+}): boolean {
+  if (input.isComposing) return false;
+  if (input.keyCode === 229) return false;
+  return input.key === "Enter" && !input.shiftKey;
+}
+
+export function shouldIgnoreEnterAfterImeCommit(input: {
+  key: string;
+  now: number;
+  ignoreUntil: number;
+}): boolean {
+  return input.key === "Enter" && input.now < input.ignoreUntil;
 }

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -42,11 +42,13 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { motion } from "motion/react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  DEFAULT_MODEL_ID,
   compatModelIdForEndpoint,
   getCompatModelInfo,
   getModel,
+  isCodexModelId,
   isCompatModelId,
   MODELS,
   providerNeedsKey,
@@ -58,11 +60,13 @@ import {
 } from "../config";
 import { ACCEPTED_FILES, useComposer } from "../lib/composer";
 import { toggleFavoriteModel } from "../lib/modelPrefs";
+import { useCodexAuthStore } from "../store/codexAuthStore";
 import { useChatStore } from "../store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 
 const PROVIDER_ICON = {
   openai: ChatGptIcon,
+  codex: ChatGptIcon,
   anthropic: ClaudeIcon,
   google: GoogleGeminiIcon,
   xai: Grok02Icon,
@@ -142,7 +146,7 @@ export function AiStatusBarControls() {
           disabled={c.isBusy || c.voice.transcribing || !c.voice.hasKey}
           className={cn(
             c.voice.recording &&
-            "bg-destructive/10 text-destructive hover:bg-destructive/15",
+              "bg-destructive/10 text-destructive hover:bg-destructive/15",
           )}
         >
           {c.voice.recording ? (
@@ -216,6 +220,8 @@ function ModelDropdown() {
   const favoriteIds = usePreferencesStore((s) => s.favoriteModelIds);
   const recentIds = usePreferencesStore((s) => s.recentModelIds);
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+  const codexStatus = useCodexAuthStore((s) => s.status);
+  const codexModelsAvailable = codexStatus?.logged_in !== false;
   const current = isCompatModelId(selected)
     ? getCompatModelInfo(selected, customEndpoints)
     : getModel(selected as ModelId);
@@ -232,6 +238,12 @@ function ModelDropdown() {
   const hasKeyFor = (id: ProviderId) =>
     providerNeedsKey(id) ? !!apiKeys[id] : true;
 
+  useEffect(() => {
+    if (codexModelsAvailable) return;
+    if (isCodexModelId(selected)) setSelected(DEFAULT_MODEL_ID);
+    if (activeProvider === "codex") setActiveProvider(null);
+  }, [activeProvider, codexModelsAvailable, selected, setSelected]);
+
   const epModelInfos = useMemo(() => {
     return customEndpoints.map((ep) =>
       getCompatModelInfo(compatModelIdForEndpoint(ep.id), customEndpoints),
@@ -243,16 +255,19 @@ function ModelDropdown() {
     const unconfigured: (typeof PROVIDERS)[number][] = [];
     for (const p of PROVIDERS) {
       if (p.id === "openai-compatible") continue;
+      if (p.id === "codex" && !codexModelsAvailable) continue;
       (hasKeyFor(p.id) ? configured : unconfigured).push(p);
     }
     return { configured, unconfigured };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKeys]);
+  }, [apiKeys, codexModelsAvailable]);
 
-  const allModels = useMemo(
-    () => [...MODELS, ...epModelInfos],
-    [epModelInfos],
-  );
+  const allModels = useMemo(() => {
+    const base = codexModelsAvailable
+      ? MODELS
+      : MODELS.filter((m) => m.provider !== "codex");
+    return [...base, ...epModelInfos];
+  }, [codexModelsAvailable, epModelInfos]);
 
   const COMPAT_PROVIDER_ID = "__compat__";
 
@@ -373,22 +388,21 @@ function ModelDropdown() {
               active={activeProvider === null}
               onClick={() => setActiveProvider(null)}
             />
-            {[...sortedProviders.configured, ...sortedProviders.unconfigured].map(
-              (p) => (
-                <ProviderPill
-                  key={p.id}
-                  icon={PROVIDER_ICON[p.id]}
-                  title={
-                    hasKeyFor(p.id)
-                      ? p.label
-                      : `${p.label} — not configured`
-                  }
-                  active={activeProvider === p.id}
-                  muted={!hasKeyFor(p.id)}
-                  onClick={() => setActiveProvider(p.id)}
-                />
-              ),
-            )}
+            {[
+              ...sortedProviders.configured,
+              ...sortedProviders.unconfigured,
+            ].map((p) => (
+              <ProviderPill
+                key={p.id}
+                icon={PROVIDER_ICON[p.id]}
+                title={
+                  hasKeyFor(p.id) ? p.label : `${p.label} — not configured`
+                }
+                active={activeProvider === p.id}
+                muted={!hasKeyFor(p.id)}
+                onClick={() => setActiveProvider(p.id)}
+              />
+            ))}
             {customEndpoints.length > 0 && (
               <ProviderPill
                 icon={PlugIcon}
@@ -430,10 +444,7 @@ function ModelDropdown() {
                   key={m.id}
                   model={m}
                   selected={m.id === selected}
-                  hasKey={
-                    isCompatModelId(m.id) ||
-                    hasKeyFor(m.provider)
-                  }
+                  hasKey={isCompatModelId(m.id) || hasKeyFor(m.provider)}
                   favorite={favoriteIds.includes(m.id)}
                   showProviderIcon={activeProvider === null}
                   onPick={() => {
@@ -526,11 +537,7 @@ function ProviderHeader({ providerId }: { providerId: ProviderId }) {
   if (!p) return null;
   return (
     <div className="flex items-center gap-1.5 px-3 pt-1 pb-1.5 text-[11px] font-medium tracking-tight text-muted-foreground/90">
-      <HugeiconsIcon
-        icon={PROVIDER_ICON[p.id]}
-        size={13}
-        strokeWidth={1.75}
-      />
+      <HugeiconsIcon icon={PROVIDER_ICON[p.id]} size={13} strokeWidth={1.75} />
       <span>{p.label}</span>
     </div>
   );
@@ -645,11 +652,7 @@ function CapabilityBars({ caps }: { caps: ModelCapabilities }) {
     <div className="ml-auto flex items-center gap-1.5">
       <CapBar icon={BrainIcon} value={caps.intelligence} label="Intelligence" />
       <CapBar icon={FlashIcon} value={caps.speed} label="Speed" />
-      <CapBar
-        icon={CoinsDollarIcon}
-        value={caps.cost}
-        label="Affordability"
-      />
+      <CapBar icon={CoinsDollarIcon} value={caps.cost} label="Affordability" />
     </div>
   );
 }
@@ -664,10 +667,7 @@ function CapBar({
   label: string;
 }) {
   return (
-    <span
-      className="flex items-center gap-0.5"
-      title={`${label}: ${value}/5`}
-    >
+    <span className="flex items-center gap-0.5" title={`${label}: ${value}/5`}>
       <HugeiconsIcon
         icon={icon}
         size={10}

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -2,6 +2,7 @@ export const KEYRING_SERVICE = "terax-ai";
 
 export type ProviderId =
   | "openai"
+  | "codex"
   | "anthropic"
   | "google"
   | "xai"
@@ -32,6 +33,13 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     keyringAccount: "openai-api-key",
     keyPrefix: "sk-",
     consoleUrl: "https://platform.openai.com/api-keys",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    keyringAccount: "",
+    keyPrefix: null,
+    consoleUrl: "https://chatgpt.com/codex",
   },
   {
     id: "anthropic",
@@ -186,7 +194,54 @@ export type ModelInfo = {
   tags?: readonly ModelTag[];
 };
 
+export const CODEX_MODEL_PREFIX = "codex:";
+export const DEFAULT_CODEX_MODEL_ID = "codex:gpt-5.5";
+export const LEGACY_CODEX_MODEL_ID = "codex-app-server";
+
+export function isCodexModelId(modelId: string): boolean {
+  return (
+    modelId === LEGACY_CODEX_MODEL_ID ||
+    modelId.startsWith(CODEX_MODEL_PREFIX)
+  );
+}
+
+export function codexModelSlug(modelId: string): string {
+  if (modelId === LEGACY_CODEX_MODEL_ID) return "gpt-5.5";
+  return modelId.startsWith(CODEX_MODEL_PREFIX)
+    ? modelId.slice(CODEX_MODEL_PREFIX.length)
+    : modelId;
+}
+
 export const MODELS = [
+  // ── Codex app-server (ChatGPT/Codex login, no API key) ───────────────────
+  {
+    id: "codex:gpt-5.5",
+    provider: "codex",
+    label: "GPT-5.5",
+    hint: "Codex",
+    description: "Frontier Codex model for complex coding and research.",
+    capabilities: { intelligence: 5, speed: 3, cost: 5 },
+    tags: ["reasoning", "tools", "coding"],
+  },
+  {
+    id: "codex:gpt-5.4",
+    provider: "codex",
+    label: "GPT-5.4",
+    hint: "Codex",
+    description: "Strong Codex model for everyday coding.",
+    capabilities: { intelligence: 4, speed: 3, cost: 5 },
+    tags: ["reasoning", "tools", "coding"],
+  },
+  {
+    id: "codex:gpt-5.4-mini",
+    provider: "codex",
+    label: "GPT-5.4 Mini",
+    hint: "Codex",
+    description: "Small and fast Codex model for simpler coding tasks.",
+    capabilities: { intelligence: 3, speed: 4, cost: 5 },
+    tags: ["reasoning", "tools", "coding"],
+  },
+
   // ── OpenAI ────────────────────────────────────────────────────────────────
   {
     id: "gpt-5.5",
@@ -611,6 +666,10 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "deepseek-r1-distill-llama-70b": 128_000,
   "openrouter-custom": 256_000,
   "openai-compatible-custom": 128_000,
+  "codex:gpt-5.5": 272_000,
+  "codex:gpt-5.4": 272_000,
+  "codex:gpt-5.4-mini": 272_000,
+  [LEGACY_CODEX_MODEL_ID]: 272_000,
   "lmstudio-local": 32_000,
   "mlx-local": 32_000,
   "ollama-local": 32_000,
@@ -677,6 +736,7 @@ export function estimateCost(
 
 /** Providers that do not require an API key (local servers, key-optional). */
 export const KEYLESS_PROVIDERS: readonly ProviderId[] = [
+  "codex",
   "lmstudio",
   "mlx",
   "ollama",
@@ -716,7 +776,10 @@ export const DEFAULT_AUTOCOMPLETE_MODEL: Partial<Record<ProviderId, string>> = {
 /** Curated list of fast models suitable for inline completion (speed ≥ 4). */
 export function getAutocompleteEligibleModels(): readonly ModelInfo[] {
   return MODELS.filter(
-    (m) => m.capabilities.speed >= 4 && m.id !== "openai-compatible-custom",
+    (m) =>
+      m.capabilities.speed >= 4 &&
+      m.provider !== "codex" &&
+      m.id !== "openai-compatible-custom",
   );
 }
 

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -97,6 +97,11 @@ export async function buildLanguageModel(
 
   let built: LanguageModel;
   switch (provider) {
+    case "codex": {
+      throw new Error(
+        "Codex uses the local app-server transport, not an OpenAI API key provider.",
+      );
+    }
     case "openai": {
       const { createOpenAI } = await import("@ai-sdk/openai");
       built = createOpenAI({ apiKey: key })(resolvedModelId);

--- a/src/modules/ai/lib/codexTransport.ts
+++ b/src/modules/ai/lib/codexTransport.ts
@@ -1,0 +1,312 @@
+import type { UIMessage } from "@ai-sdk/react";
+import {
+  createUIMessageStream,
+  type ChatTransport,
+  type UIMessageChunk,
+} from "ai";
+import {
+  codexModelSlug,
+  DEFAULT_CODEX_MODEL_ID,
+  isCodexModelId as isConfiguredCodexModelId,
+} from "../config";
+import { native, type CodexStreamEvent } from "./native";
+
+type LiveSnapshot = {
+  cwd: string | null;
+  terminalPrivate: boolean;
+  workspaceRoot: string | null;
+  activeFile: string | null;
+};
+
+type CodexTransportOptions = {
+  messages: UIMessage[];
+  originalMessages?: UIMessage[];
+  live: LiveSnapshot;
+  projectMemory: string | null;
+  customInstructions: string;
+  agentPersona: { name: string; instructions: string } | null;
+  planMode: boolean;
+  modelId?: string;
+  abortSignal?: AbortSignal;
+  onStep?: (step: string | null) => void;
+};
+
+export function isCodexModelId(modelId: string): boolean {
+  return isConfiguredCodexModelId(modelId);
+}
+
+export function runCodexAppServerStream({
+  messages,
+  originalMessages,
+  live,
+  projectMemory,
+  customInstructions,
+  agentPersona,
+  planMode,
+  modelId,
+  abortSignal,
+  onStep,
+}: CodexTransportOptions): Promise<ReadableStream<UIMessageChunk>> {
+  const prompt = buildConversationPrompt(messages);
+  const developerInstructions = buildDeveloperInstructions({
+    projectMemory,
+    customInstructions,
+    agentPersona,
+    planMode,
+  });
+  const cwd = live.cwd ?? live.workspaceRoot;
+  const codexModel = codexModelSlug(modelId ?? DEFAULT_CODEX_MODEL_ID);
+
+  return Promise.resolve(
+    createUIMessageStream<UIMessage>({
+      originalMessages: originalMessages ?? messages,
+      async execute({ writer }) {
+        if (abortSignal?.aborted) {
+          writer.write({ type: "abort", reason: "aborted" });
+          return;
+        }
+        onStep?.("Starting Codex");
+        const openTextIds = new Set<string>();
+        const openReasoningIds = new Set<string>();
+        let finished = false;
+        let aborted = false;
+        writer.write({ type: "start" });
+        writer.write({ type: "start-step" });
+
+        const closeOpenParts = () => {
+          for (const id of openTextIds) {
+            writer.write({ type: "text-end", id });
+          }
+          openTextIds.clear();
+          for (const id of openReasoningIds) {
+            writer.write({ type: "reasoning-end", id });
+          }
+          openReasoningIds.clear();
+        };
+
+        const handleEvent = (event: CodexStreamEvent) => {
+          if (aborted || finished) return;
+          switch (event.kind) {
+            case "step": {
+              onStep?.(event.label);
+              break;
+            }
+            case "textStart": {
+              if (!openTextIds.has(event.id)) {
+                openTextIds.add(event.id);
+                writer.write({ type: "text-start", id: event.id });
+              }
+              break;
+            }
+            case "textDelta": {
+              if (!openTextIds.has(event.id)) {
+                openTextIds.add(event.id);
+                writer.write({ type: "text-start", id: event.id });
+              }
+              writer.write({
+                type: "text-delta",
+                id: event.id,
+                delta: event.delta,
+              });
+              break;
+            }
+            case "textEnd": {
+              if (openTextIds.delete(event.id)) {
+                writer.write({ type: "text-end", id: event.id });
+              }
+              break;
+            }
+            case "reasoningStart": {
+              if (!openReasoningIds.has(event.id)) {
+                openReasoningIds.add(event.id);
+                writer.write({ type: "reasoning-start", id: event.id });
+              }
+              break;
+            }
+            case "reasoningDelta": {
+              if (!openReasoningIds.has(event.id)) {
+                openReasoningIds.add(event.id);
+                writer.write({ type: "reasoning-start", id: event.id });
+              }
+              writer.write({
+                type: "reasoning-delta",
+                id: event.id,
+                delta: event.delta,
+              });
+              break;
+            }
+            case "reasoningEnd": {
+              if (openReasoningIds.delete(event.id)) {
+                writer.write({ type: "reasoning-end", id: event.id });
+              }
+              break;
+            }
+            case "error": {
+              finished = true;
+              closeOpenParts();
+              writer.write({ type: "error", errorText: event.message });
+              writer.write({ type: "finish-step" });
+              writer.write({ type: "finish", finishReason: "error" });
+              break;
+            }
+            case "done": {
+              finished = true;
+              closeOpenParts();
+              writer.write({ type: "finish-step" });
+              writer.write({ type: "finish", finishReason: "stop" });
+              break;
+            }
+          }
+        };
+
+        let abortHandler: (() => void) | null = null;
+        const abortPromise = new Promise<"aborted">((resolve) => {
+          if (abortSignal) {
+            abortHandler = () => {
+              aborted = true;
+              resolve("aborted");
+            };
+            abortSignal.addEventListener("abort", abortHandler, { once: true });
+          }
+        });
+
+        try {
+          const streamPromise = native.codexAppServerStream(
+            {
+              prompt,
+              cwd,
+              model: codexModel,
+              developerInstructions,
+            },
+            handleEvent,
+          );
+          streamPromise.catch(() => {});
+          const outcome = await Promise.race([streamPromise, abortPromise]);
+          if (outcome === "aborted") {
+            closeOpenParts();
+            writer.write({ type: "abort", reason: "aborted" });
+            return;
+          }
+          if (!finished) {
+            finished = true;
+            closeOpenParts();
+            writer.write({ type: "finish-step" });
+            writer.write({ type: "finish", finishReason: "stop" });
+          }
+        } catch (error) {
+          if (finished) return;
+          finished = true;
+          closeOpenParts();
+          writer.write({
+            type: "error",
+            errorText: codexErrorMessage(error),
+          });
+          writer.write({ type: "finish-step" });
+          writer.write({ type: "finish", finishReason: "error" });
+        } finally {
+          if (abortHandler) {
+            abortSignal?.removeEventListener("abort", abortHandler);
+          }
+          onStep?.(null);
+        }
+      },
+      onError(error) {
+        return codexErrorMessage(error);
+      },
+    }) as ReadableStream<UIMessageChunk>,
+  );
+}
+
+export function createCodexTransport(
+  getOptions: () => Omit<CodexTransportOptions, "messages" | "abortSignal">,
+): ChatTransport<UIMessage> {
+  return {
+    sendMessages({ messages, abortSignal }) {
+      return runCodexAppServerStream({
+        ...getOptions(),
+        messages,
+        abortSignal,
+      });
+    },
+    async reconnectToStream() {
+      return null;
+    },
+  };
+}
+
+function buildDeveloperInstructions({
+  projectMemory,
+  customInstructions,
+  agentPersona,
+  planMode,
+}: Pick<
+  CodexTransportOptions,
+  "projectMemory" | "customInstructions" | "agentPersona" | "planMode"
+>): string {
+  const sections = [
+    "You are running inside Terax's internal AI agent panel. Reply through the panel, not a terminal. Match the user's language unless they ask otherwise.",
+  ];
+  if (projectMemory?.trim()) {
+    sections.push(`## Project TERAX.md\n${projectMemory.trim()}`);
+  }
+  if (agentPersona?.instructions.trim()) {
+    sections.push(
+      `## Active Agent - ${agentPersona.name}\n${agentPersona.instructions.trim()}`,
+    );
+  }
+  if (customInstructions.trim()) {
+    sections.push(`## User Custom Instructions\n${customInstructions.trim()}`);
+  }
+  if (planMode) {
+    sections.push(
+      "## Plan Mode\nPlan mode is active. Do not make file changes; return a concise plan or analysis.",
+    );
+  }
+  return sections.join("\n\n");
+}
+
+function buildConversationPrompt(messages: UIMessage[]): string {
+  const lines: string[] = [];
+  for (const message of messages) {
+    const text = messageText(message).trim();
+    if (!text) continue;
+    const role =
+      message.role === "assistant"
+        ? "Assistant"
+        : message.role === "system"
+          ? "System"
+          : "User";
+    lines.push(`${role}:\n${text}`);
+  }
+  return lines.length > 0 ? lines.join("\n\n") : "Continue the conversation.";
+}
+
+function messageText(message: UIMessage): string {
+  const parts = (message.parts ?? []) as ReadonlyArray<{
+    type: string;
+    text?: string;
+    mediaType?: string;
+    filename?: string;
+  }>;
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part.type === "text" && part.text) {
+      out.push(part.text);
+    } else if (part.type === "file") {
+      out.push(
+        `[attached file omitted: ${part.filename ?? part.mediaType ?? "file"}]`,
+      );
+    } else if (part.type === "reasoning" && part.text) {
+      out.push(`[reasoning summary]\n${part.text}`);
+    }
+  }
+  return out.join("\n");
+}
+
+function codexErrorMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  if (/not logged in|login|auth/i.test(raw)) {
+    return `${raw}\n\nOpen Settings -> Models -> Codex and sign in with ChatGPT.`;
+  }
+  return raw;
+}

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -13,6 +13,7 @@ export type CustomEndpointKeys = Record<string, string | null>;
 
 export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   openai: null,
+  codex: null,
   anthropic: null,
   google: null,
   xai: null,

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 
 export type ReadResult =
@@ -123,6 +123,26 @@ export type GitDiscardEntry = {
   untracked: boolean;
 };
 
+export type CodexAuthStatus = {
+  logged_in: boolean;
+  detail: string;
+};
+
+export type CodexTurnOutput = {
+  text: string;
+};
+
+export type CodexStreamEvent =
+  | { kind: "textStart"; id: string }
+  | { kind: "textDelta"; id: string; delta: string }
+  | { kind: "textEnd"; id: string }
+  | { kind: "reasoningStart"; id: string }
+  | { kind: "reasoningDelta"; id: string; delta: string }
+  | { kind: "reasoningEnd"; id: string }
+  | { kind: "step"; label: string | null }
+  | { kind: "done" }
+  | { kind: "error"; message: string };
+
 export const native = {
   workspaceCurrentDir: () => invoke<string>("workspace_current_dir"),
   workspaceAuthorize: (path: string) =>
@@ -180,11 +200,7 @@ export const native = {
       maxResults: params.maxResults ?? null,
       workspace: currentWorkspaceEnv(),
     }),
-  runCommand: (
-    command: string,
-    cwd?: string | null,
-    timeoutSecs?: number,
-  ) =>
+  runCommand: (command: string, cwd?: string | null, timeoutSecs?: number) =>
     invoke<CommandOutput>("shell_run_command", {
       command,
       cwd: cwd ?? null,
@@ -245,6 +261,42 @@ export const native = {
         exit_code: number | null;
       }[]
     >("shell_bg_list"),
+  codexAuthStatus: () => invoke<CodexAuthStatus>("codex_auth_status"),
+  codexLoginChatGpt: () => invoke<CodexAuthStatus>("codex_login_chatgpt"),
+  codexLogout: () => invoke<CodexAuthStatus>("codex_logout"),
+  codexAppServerTurn: (params: {
+    prompt: string;
+    cwd?: string | null;
+    model?: string | null;
+    developerInstructions?: string | null;
+  }) =>
+    invoke<CodexTurnOutput>("codex_app_server_turn", {
+      prompt: params.prompt,
+      cwd: params.cwd ?? null,
+      model: params.model ?? null,
+      developerInstructions: params.developerInstructions ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
+  codexAppServerStream: (
+    params: {
+      prompt: string;
+      cwd?: string | null;
+      model?: string | null;
+      developerInstructions?: string | null;
+    },
+    onEvent: (event: CodexStreamEvent) => void,
+  ) => {
+    const channel = new Channel<CodexStreamEvent>();
+    channel.onmessage = onEvent;
+    return invoke<void>("codex_app_server_stream", {
+      prompt: params.prompt,
+      cwd: params.cwd ?? null,
+      model: params.model ?? null,
+      developerInstructions: params.developerInstructions ?? null,
+      workspace: currentWorkspaceEnv(),
+      onEvent: channel,
+    });
+  },
   gitResolveRepo: (cwd: string) =>
     invoke<GitRepoInfo | null>("git_resolve_repo", {
       cwd,
@@ -319,7 +371,10 @@ export const native = {
       repoRoot,
       workspace: currentWorkspaceEnv(),
     }),
-  gitLog: (repoRoot: string, options?: { limit?: number; beforeSha?: string }) =>
+  gitLog: (
+    repoRoot: string,
+    options?: { limit?: number; beforeSha?: string },
+  ) =>
     invoke<GitLogEntry[]>("git_log", {
       repoRoot,
       limit: options?.limit ?? null,

--- a/src/modules/ai/lib/terminalInventory.test.ts
+++ b/src/modules/ai/lib/terminalInventory.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { LOCAL_WORKSPACE } from "@/modules/workspace";
+import {
+  buildTerminalInventory,
+  redactTerminalInventory,
+  resolveTerminalTarget,
+} from "./terminalInventory";
+import type { TerminalTab } from "@/modules/tabs";
+
+function terminalTab(over: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 1,
+    kind: "terminal",
+    title: "shell",
+    paneTree: {
+      kind: "split",
+      id: 10,
+      dir: "row",
+      children: [
+        { kind: "leaf", id: 2, cwd: "/Users/me/proj" },
+        { kind: "leaf", id: 4, cwd: "/Users/me/proj/api" },
+      ],
+    },
+    activeLeafId: 4,
+    cwd: "/Users/me/proj/api",
+    workspace: LOCAL_WORKSPACE,
+    workspaceNonce: 0,
+    ...over,
+  };
+}
+
+describe("buildTerminalInventory", () => {
+  it("lists all terminal tabs and their panes", () => {
+    const inventory = buildTerminalInventory(
+      [
+        terminalTab(),
+        {
+          id: 9,
+          kind: "editor",
+          title: "notes.ts",
+          path: "/tmp/notes.ts",
+          dirty: false,
+          preview: false,
+          workspace: LOCAL_WORKSPACE,
+        },
+      ],
+      9,
+    );
+
+    expect(inventory.activeTabId).toBe(9);
+    expect(inventory.activeTerminalTabId).toBeNull();
+    expect(inventory.tabs).toHaveLength(1);
+    expect(inventory.tabs[0]).toMatchObject({
+      tabId: 1,
+      active: false,
+      private: false,
+      activeLeafId: 4,
+      leafIds: [2, 4],
+      cwd: "/Users/me/proj/api",
+    });
+    expect(inventory.tabs[0].leaves).toEqual([
+      { leafId: 2, cwd: "/Users/me/proj", active: false },
+      { leafId: 4, cwd: "/Users/me/proj/api", active: true },
+    ]);
+  });
+});
+
+describe("resolveTerminalTarget", () => {
+  it("uses the active terminal leaf by default", () => {
+    const inventory = buildTerminalInventory([terminalTab()], 1);
+    const target = resolveTerminalTarget(inventory, {});
+
+    expect(target).toMatchObject({
+      ok: true,
+      target: {
+        tab: { tabId: 1 },
+        leafId: 4,
+      },
+    });
+  });
+
+  it("can target a specific tab or leaf", () => {
+    const inventory = buildTerminalInventory([terminalTab()], 1);
+    expect(resolveTerminalTarget(inventory, { tabId: 1 })).toMatchObject({
+      ok: true,
+      target: { leafId: 4 },
+    });
+    expect(resolveTerminalTarget(inventory, { leafId: 2 })).toMatchObject({
+      ok: true,
+      target: { leafId: 2 },
+    });
+  });
+
+  it("redacts private terminal details", () => {
+    const inventory = buildTerminalInventory(
+      [terminalTab({ private: true })],
+      1,
+    );
+    const redacted = redactTerminalInventory(inventory);
+
+    expect(redacted.tabs[0]).toMatchObject({
+      private: true,
+      cwd: null,
+      activeLeafId: null,
+      leafIds: [],
+      leaves: [],
+    });
+    expect(redacted.activeTerminalLeafId).toBeNull();
+  });
+});

--- a/src/modules/ai/lib/terminalInventory.ts
+++ b/src/modules/ai/lib/terminalInventory.ts
@@ -1,0 +1,144 @@
+import { labelFor } from "@/modules/tabs/lib/tabLabel";
+import type { Tab } from "@/modules/tabs";
+import { findLeafCwd, leafIds } from "@/modules/terminal/lib/panes";
+
+export type TerminalLeafSnapshot = {
+  leafId: number;
+  cwd: string | null;
+  active: boolean;
+};
+
+export type TerminalTabSnapshot = {
+  tabId: number;
+  title: string;
+  label: string;
+  cwd: string | null;
+  active: boolean;
+  private: boolean;
+  activeLeafId: number | null;
+  leafIds: number[];
+  leaves: TerminalLeafSnapshot[];
+};
+
+export type TerminalInventory = {
+  activeTabId: number | null;
+  activeTerminalTabId: number | null;
+  activeTerminalLeafId: number | null;
+  tabs: TerminalTabSnapshot[];
+};
+
+export type TerminalTarget = {
+  tab: TerminalTabSnapshot;
+  leafId: number;
+};
+
+export function buildTerminalInventory(
+  tabs: Tab[],
+  activeId: number,
+): TerminalInventory {
+  const terminalTabs = tabs.filter((t): t is Extract<Tab, { kind: "terminal" }> =>
+    t.kind === "terminal",
+  );
+
+  const activeTerminal = terminalTabs.find((t) => t.id === activeId) ?? null;
+  return {
+    activeTabId: activeId,
+    activeTerminalTabId: activeTerminal?.id ?? null,
+    activeTerminalLeafId: activeTerminal?.private
+      ? null
+      : activeTerminal?.activeLeafId ?? null,
+    tabs: terminalTabs.map((t) => {
+      const leafs = leafIds(t.paneTree);
+      const activeLeafId = t.private ? null : t.activeLeafId;
+      const activeLeafCwd = activeLeafId
+        ? findLeafCwd(t.paneTree, activeLeafId) ?? null
+        : null;
+      return {
+        tabId: t.id,
+        title: t.title,
+        label: labelFor(t),
+        cwd: t.private ? null : activeLeafCwd ?? t.cwd ?? null,
+        active: t.id === activeId,
+        private: t.private === true,
+        activeLeafId,
+        leafIds: t.private ? [] : leafs,
+        leaves: t.private
+          ? []
+          : leafs.map((leafId) => ({
+              leafId,
+              cwd: findLeafCwd(t.paneTree, leafId) ?? null,
+              active: leafId === t.activeLeafId,
+            })),
+      };
+    }),
+  };
+}
+
+export function redactTerminalInventory(
+  inventory: TerminalInventory,
+): TerminalInventory {
+  return {
+    ...inventory,
+    tabs: inventory.tabs.map((tab) =>
+      tab.private
+        ? {
+            ...tab,
+            cwd: null,
+            activeLeafId: null,
+            leafIds: [],
+            leaves: [],
+          }
+        : tab,
+    ),
+  };
+}
+
+export function resolveTerminalTarget(
+  inventory: TerminalInventory,
+  input: { tabId?: number | null; leafId?: number | null },
+): { ok: true; target: TerminalTarget } | { ok: false; error: string } {
+  const { tabId, leafId } = input;
+
+  if (leafId != null) {
+    for (const tab of inventory.tabs) {
+      if (tab.private) continue;
+      const idx = tab.leafIds.indexOf(leafId);
+      if (idx >= 0) {
+        if (tabId != null && tab.tabId !== tabId) {
+          return {
+            ok: false,
+            error: `leaf ${leafId} does not belong to terminal tab ${tabId}`,
+          };
+        }
+        return {
+          ok: true,
+          target: { tab, leafId },
+        };
+      }
+    }
+    return { ok: false, error: `unknown terminal leaf ${leafId}` };
+  }
+
+  if (tabId == null) {
+    if (inventory.activeTerminalTabId == null || inventory.activeTerminalLeafId == null) {
+      return { ok: false, error: "no active terminal tab" };
+    }
+    const tab = inventory.tabs.find((t) => t.tabId === inventory.activeTerminalTabId);
+    if (!tab) return { ok: false, error: "no active terminal tab" };
+    return { ok: true, target: { tab, leafId: inventory.activeTerminalLeafId } };
+  }
+
+  const tab = inventory.tabs.find((t) => t.tabId === tabId);
+  if (!tab) return { ok: false, error: `unknown terminal tab ${tabId}` };
+  if (tab.private) {
+    return {
+      ok: false,
+      error: `terminal tab ${tabId} is in Privacy mode; its buffer is withheld`,
+    };
+  }
+  const targetLeafId = tab.activeLeafId ?? tab.leafIds[0] ?? null;
+  if (targetLeafId == null) {
+    return { ok: false, error: `terminal tab ${tabId} has no visible leaves` };
+  }
+  return { ok: true, target: { tab, leafId: targetLeafId } };
+}

--- a/src/modules/ai/lib/transport.ts
+++ b/src/modules/ai/lib/transport.ts
@@ -1,6 +1,10 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { type CustomEndpoint } from "../config";
 import { runAgentStream, type AgentUsageDelta } from "./agent";
+import {
+  isCodexModelId,
+  runCodexAppServerStream,
+} from "./codexTransport";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
 import { native } from "./native";
 import type { ToolContext } from "../tools/tools";
@@ -79,6 +83,20 @@ export function createContextAwareTransport(deps: Deps) {
     const messagesForRun = envBlock
       ? injectEnvIntoLastUser(options.messages, envBlock)
       : options.messages;
+    if (isCodexModelId(deps.getModelId())) {
+      return runCodexAppServerStream({
+        messages: messagesForRun,
+        originalMessages: options.messages,
+        live,
+        projectMemory,
+        customInstructions: deps.getCustomInstructions(),
+        agentPersona: deps.getAgentPersona(),
+        planMode: deps.getPlanMode?.() ?? false,
+        modelId: deps.getModelId(),
+        abortSignal: options.abortSignal,
+        onStep: deps.onStep,
+      });
+    }
     const result = await runAgentStream({
       keys: deps.getKeys(),
       modelId: deps.getModelId(),

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -19,6 +19,7 @@ import { useAgentsStore } from "./agentsStore";
 import { usePlanStore } from "./planStore";
 import { useTodosStore } from "./todoStore";
 import type { AgentUsage } from "../lib/agent";
+import type { TerminalInventory } from "../lib/terminalInventory";
 import { EMPTY_PROVIDER_KEYS, type ProviderKeys, type CustomEndpointKeys } from "../lib/keyring";
 import {
   deleteSessionData,
@@ -38,7 +39,9 @@ import type { ToolContext } from "../tools/tools";
 type Live = {
   getCwd: () => string | null;
   getTerminalContext: () => string | null;
+  getTerminalInventory: () => TerminalInventory;
   isActiveTerminalPrivate: () => boolean;
+  readLeafBuffer: (leafId: number) => string | null;
   injectIntoActivePty: (text: string) => boolean;
   getWorkspaceRoot: () => string | null;
   getActiveFile: () => string | null;
@@ -47,7 +50,6 @@ type Live = {
     prompt: string,
     sessionId: string,
   ) => { tabId: number; leafId: number } | null;
-  readLeafBuffer: (leafId: number) => string | null;
 };
 
 export type AgentRunStatus =
@@ -164,13 +166,19 @@ type StoreState = {
 const NOOP_LIVE: Live = {
   getCwd: () => null,
   getTerminalContext: () => null,
+  getTerminalInventory: () => ({
+    activeTabId: null,
+    activeTerminalTabId: null,
+    activeTerminalLeafId: null,
+    tabs: [],
+  }),
   isActiveTerminalPrivate: () => false,
+  readLeafBuffer: () => null,
   injectIntoActivePty: () => false,
   getWorkspaceRoot: () => null,
   getActiveFile: () => null,
   openPreview: () => false,
   spawnManagedAgent: () => null,
-  readLeafBuffer: () => null,
 };
 
 const CHATS_LRU_CAP = 8;
@@ -226,8 +234,11 @@ function makeChat(sessionId: string): Chat<UIMessage> {
       useChatStore.getState().live.getWorkspaceRoot(),
     getTerminalContext: () =>
       useChatStore.getState().live.getTerminalContext(),
+    getTerminalInventory: () =>
+      useChatStore.getState().live.getTerminalInventory(),
     isActiveTerminalPrivate: () =>
       useChatStore.getState().live.isActiveTerminalPrivate(),
+    readLeafBuffer: (leafId) => useChatStore.getState().live.readLeafBuffer(leafId),
     injectIntoActivePty: (text) =>
       useChatStore.getState().live.injectIntoActivePty(text),
     openPreview: (url) => useChatStore.getState().live.openPreview(url),

--- a/src/modules/ai/store/codexAuthStore.ts
+++ b/src/modules/ai/store/codexAuthStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import type { CodexAuthStatus } from "@/modules/ai/lib/native";
+
+type State = {
+  status: CodexAuthStatus | null;
+  setStatus: (status: CodexAuthStatus) => void;
+};
+
+export const useCodexAuthStore = create<State>((set) => ({
+  status: null,
+  setStatus: (status) => set({ status }),
+}));

--- a/src/modules/ai/tools/context.ts
+++ b/src/modules/ai/tools/context.ts
@@ -1,3 +1,5 @@
+import type { TerminalInventory } from "../lib/terminalInventory";
+
 export type ToolContext = {
   /** Active terminal tab cwd, used to resolve relative paths. Null = home. */
   getCwd: () => string | null;
@@ -5,7 +7,11 @@ export type ToolContext = {
   getWorkspaceRoot: () => string | null;
   /** Last N lines of the active terminal buffer (or null if not a terminal tab). */
   getTerminalContext: () => string | null;
+  /** Snapshot of all terminal tabs and panes. */
+  getTerminalInventory: () => TerminalInventory;
   isActiveTerminalPrivate: () => boolean;
+  /** Read the scrollback tail for a specific terminal leaf. */
+  readLeafBuffer: (leafId: number) => string | null;
   /**
    * Type a string into the active terminal at the prompt — without executing.
    * Returns false if there is no active terminal tab to inject into.

--- a/src/modules/ai/tools/terminal.ts
+++ b/src/modules/ai/tools/terminal.ts
@@ -1,6 +1,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { checkShellCommand } from "../lib/security";
+import {
+  redactTerminalInventory,
+  resolveTerminalTarget,
+} from "../lib/terminalInventory";
 import type { ToolContext } from "./context";
 
 export function buildTerminalTools(ctx: ToolContext) {
@@ -31,8 +35,20 @@ export function buildTerminalTools(ctx: ToolContext) {
 
     get_terminal_output: tool({
       description:
-        "Return the tail of the active terminal's scrollback. Use this when the user references 'this error', 'the last command', or you need to interpret recent terminal output. Default is 80 lines; raise it only when you genuinely need more. Returns an empty string if there is no active terminal; refuses if the terminal is in Privacy mode.",
+        "Return the tail of a terminal's scrollback. Use this when the user references 'this error', 'the last command', or you need to interpret recent terminal output. If `tabId` or `leafId` is omitted, it reads the active terminal tab. Returns an empty string if the selected terminal has no buffer; refuses if the selected terminal is in Privacy mode.",
       inputSchema: z.object({
+        tabId: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Terminal tab id to read. Defaults to the active terminal tab."),
+        leafId: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Specific terminal leaf id to read. Takes precedence over tabId."),
         lines: z
           .number()
           .int()
@@ -41,22 +57,45 @@ export function buildTerminalTools(ctx: ToolContext) {
           .optional()
           .describe("Number of trailing lines to return. Default 80."),
       }),
-      execute: async ({ lines }) => {
-        if (ctx.isActiveTerminalPrivate()) {
+      execute: async ({ tabId, leafId, lines }) => {
+        const inventory = ctx.getTerminalInventory();
+        const target = resolveTerminalTarget(inventory, { tabId, leafId });
+        if (!target.ok) return { error: target.error };
+        if (target.target.tab.private) {
           return {
             error:
-              "active terminal is in Privacy mode; its buffer is withheld. Ask the user to switch to a regular tab if they want you to see it.",
+              `terminal tab ${target.target.tab.tabId} is in Privacy mode; its buffer is withheld. Ask the user to switch to a regular tab if they want you to see it.`,
           };
         }
-        const buffer = ctx.getTerminalContext();
-        if (!buffer) return { output: "", note: "no active terminal" };
+        const buffer = ctx.readLeafBuffer(target.target.leafId);
+        if (!buffer) {
+          return {
+            output: "",
+            note: `no buffer for terminal leaf ${target.target.leafId}`,
+            terminal: target.target,
+          };
+        }
         const n = lines ?? 80;
         const parts = buffer.split("\n");
         const sliced = parts.length <= n ? buffer : parts.slice(parts.length - n).join("\n");
         const MAX = 24_000;
         const capped =
           sliced.length > MAX ? `…[truncated]…\n${sliced.slice(sliced.length - MAX)}` : sliced;
-        return { output: capped, lines_returned: Math.min(parts.length, n) };
+        return {
+          output: capped,
+          lines_returned: Math.min(parts.length, n),
+          terminal: target.target,
+        };
+      },
+    }),
+
+    list_terminals: tool({
+      description:
+        "List all open terminal tabs and panes, including which terminal tab is active in the app. Use this before reading a specific terminal if the user mentions a tab by title or if multiple terminals are open.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        const inventory = redactTerminalInventory(ctx.getTerminalInventory());
+        return inventory;
       },
     }),
 

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -29,8 +29,7 @@ initVimGlobals();
 import { resolveLanguage } from "./lib/languageResolver";
 import { useDocument } from "./lib/useDocument";
 import { inlineCompletion } from "./lib/autocomplete/inlineExtension";
-import { getKey } from "@/modules/ai/lib/keyring";
-import { onKeysChanged } from "@/modules/settings/store";
+import { useChatStore } from "@/modules/ai/store/chatStore";
 
 export type EditorPaneHandle = {
   setQuery: (q: string) => void;
@@ -69,35 +68,6 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const editorThemeId = usePreferencesStore((s) => s.editorTheme);
     const vimMode = usePreferencesStore((s) => s.vimMode);
     const languageRef = useRef<string | null>(null);
-    const apiKeyRef = useRef<string | null>(null);
-
-    useEffect(() => {
-      let cancelled = false;
-      const refresh = async () => {
-        const provider = usePreferencesStore.getState().autocompleteProvider;
-        if (provider === "lmstudio" || provider === "mlx" || provider === "ollama") {
-          apiKeyRef.current = null;
-          return;
-        }
-        const k = await getKey(provider);
-        if (!cancelled) apiKeyRef.current = k;
-      };
-      void refresh();
-      let unlistenKeys: (() => void) | undefined;
-      void onKeysChanged(() => void refresh()).then((un) => {
-        unlistenKeys = un;
-      });
-      const unsubPrefs = usePreferencesStore.subscribe((state, prev) => {
-        if (state.autocompleteProvider !== prev.autocompleteProvider) {
-          void refresh();
-        }
-      });
-      return () => {
-        cancelled = true;
-        unlistenKeys?.();
-        unsubPrefs();
-      };
-    }, []);
     const themeExt = EDITOR_THEME_EXT[editorThemeId] ?? EDITOR_THEME_EXT.atomone;
 
     // Stabilize save + onSaved via refs so the extensions array never changes
@@ -151,7 +121,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
               enabled: s.autocompleteEnabled,
               provider: p,
               modelId,
-              apiKey: apiKeyRef.current,
+              apiKey: useChatStore.getState().apiKeys[p] ?? null,
               lmstudioBaseURL: s.lmstudioBaseURL,
               mlxBaseURL: s.mlxBaseURL,
               ollamaBaseURL: s.ollamaBaseURL,

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -14,7 +14,6 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
-import { currentWorkspaceEnv } from "@/modules/workspace";
 import { motion } from "motion/react";
 import {
   forwardRef,
@@ -24,6 +23,7 @@ import {
   useState,
 } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import { fileIconUrl } from "./lib/iconResolver";
 import { copyToClipboard, revealInFinder } from "./lib/contextActions";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
@@ -46,6 +46,7 @@ const DEBOUNCE_MS = 300;
 
 type Props = {
   rootPath: string;
+  workspace: WorkspaceEnv;
   onOpenFile: (path: string) => void;
   open: boolean;
   onRequestClose: () => void;
@@ -61,6 +62,7 @@ export type ExplorerSearchHandle = {
 
 export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function ExplorerSearch({
   rootPath,
+  workspace,
   onOpenFile,
   open,
   onRequestClose,
@@ -116,7 +118,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
           query: q,
           limit: 200,
           showHidden,
-          workspace: currentWorkspaceEnv(),
+          workspace,
         });
         if (alive) {
           setResults(res.hits);
@@ -139,7 +141,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
       alive = false;
       clearTimeout(handle);
     };
-  }, [query, rootPath, showHidden]);
+  }, [query, rootPath, showHidden, workspace]);
 
   useImperativeHandle(
     ref,

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -32,6 +32,7 @@ import { fileIconUrl, folderIconUrl } from "./lib/iconResolver";
 import { COMPACT_CONTENT, COMPACT_ITEM } from "./lib/menuItemClass";
 import { useFileTree } from "./lib/useFileTree";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
+import type { WorkspaceEnv } from "@/modules/workspace";
 
 export type FileExplorerHandle = {
   focus: () => void;
@@ -41,6 +42,8 @@ export type FileExplorerHandle = {
 
 type Props = {
   rootPath: string | null;
+  workspace: WorkspaceEnv;
+  enabled?: boolean;
   activeFilePath?: string | null;
   onOpenFile: (path: string, pin?: boolean) => void;
   onPathRenamed?: (from: string, to: string) => void;
@@ -149,6 +152,8 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
   function FileExplorer(
     {
       rootPath,
+      workspace,
+      enabled = true,
       activeFilePath,
       onOpenFile,
       onPathRenamed,
@@ -159,7 +164,12 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
     },
     ref,
   ) {
-    const tree = useFileTree(rootPath, { onPathRenamed, onPathDeleted });
+    const tree = useFileTree(rootPath, {
+      workspace,
+      enabled,
+      onPathRenamed,
+      onPathDeleted,
+    });
     const [selectedPath, setSelectedPath] = useState<string | null>(null);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const [isSearchActive, setIsSearchActive] = useState(false);
@@ -445,6 +455,7 @@ export const FileExplorer = forwardRef<FileExplorerHandle, Props>(
         <ExplorerSearch
           ref={searchRef}
           rootPath={rootPath}
+          workspace={workspace}
           onOpenFile={onOpenFile}
           open={isSearchOpen}
           onRequestClose={() => setIsSearchOpen(false)}

--- a/src/modules/explorer/lib/useFileTree.test.ts
+++ b/src/modules/explorer/lib/useFileTree.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { directoryCacheKey, expansionCacheKey } from "./useFileTree";
+
+describe("file tree cache keys", () => {
+  it("scopes expansion by workspace and root", () => {
+    expect(expansionCacheKey("local", "/Users/me")).toBe("local\0/Users/me");
+    expect(expansionCacheKey("ssh:sean@host:22", "/home/sean")).toBe(
+      "ssh:sean@host:22\0/home/sean",
+    );
+  });
+
+  it("separates directory entries by hidden preference and path", () => {
+    expect(directoryCacheKey("ssh:sean@host:22", false, "/home/sean")).toBe(
+      ["ssh:sean@host:22", "0", "/home/sean"].join("\0"),
+    );
+    expect(directoryCacheKey("ssh:sean@host:22", true, "/home/sean")).toBe(
+      ["ssh:sean@host:22", "1", "/home/sean"].join("\0"),
+    );
+  });
+});

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import { workspaceScopeKey, type WorkspaceEnv } from "@/modules/workspace";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { listenFsChanged, watchAdd, watchRemove } from "./watch";
 
@@ -37,10 +37,24 @@ export function dirname(path: string): string {
 
 const EXPANSION_CACHE_LIMIT = 8;
 const expansionCache = new Map<string, string[]>();
+const DIR_CACHE_LIMIT = 256;
+const dirCache = new Map<string, DirEntry[]>();
 
-function rememberExpansion(root: string, expanded: Set<string>): void {
-  expansionCache.delete(root);
-  if (expanded.size > 0) expansionCache.set(root, [...expanded]);
+export function expansionCacheKey(workspaceKey: string, root: string): string {
+  return `${workspaceKey}\0${root}`;
+}
+
+export function directoryCacheKey(
+  workspaceKey: string,
+  showHidden: boolean,
+  path: string,
+): string {
+  return `${workspaceKey}\0${showHidden ? "1" : "0"}\0${path}`;
+}
+
+function rememberExpansion(key: string, expanded: Set<string>): void {
+  expansionCache.delete(key);
+  if (expanded.size > 0) expansionCache.set(key, [...expanded]);
   while (expansionCache.size > EXPANSION_CACHE_LIMIT) {
     const oldest = expansionCache.keys().next().value;
     if (oldest === undefined) break;
@@ -48,12 +62,30 @@ function rememberExpansion(root: string, expanded: Set<string>): void {
   }
 }
 
-function recallExpansion(root: string): string[] {
-  const v = expansionCache.get(root);
+function recallExpansion(key: string): string[] {
+  const v = expansionCache.get(key);
   if (!v) return [];
-  expansionCache.delete(root);
-  expansionCache.set(root, v);
+  expansionCache.delete(key);
+  expansionCache.set(key, v);
   return v;
+}
+
+function rememberEntries(key: string, entries: DirEntry[]): void {
+  dirCache.delete(key);
+  dirCache.set(key, entries);
+  while (dirCache.size > DIR_CACHE_LIMIT) {
+    const oldest = dirCache.keys().next().value;
+    if (oldest === undefined) break;
+    dirCache.delete(oldest);
+  }
+}
+
+function cachedEntries(key: string): DirEntry[] | null {
+  const entries = dirCache.get(key);
+  if (!entries) return null;
+  dirCache.delete(key);
+  dirCache.set(key, entries);
+  return entries;
 }
 
 function isUnder(key: string, root: string): boolean {
@@ -61,12 +93,17 @@ function isUnder(key: string, root: string): boolean {
 }
 
 type Options = {
+  workspace: WorkspaceEnv;
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
+  enabled?: boolean;
 };
 
-export function useFileTree(rootPath: string | null, options?: Options) {
+export function useFileTree(rootPath: string | null, options: Options) {
+  const workspace = options.workspace;
+  const workspaceKey = workspaceScopeKey(workspace);
   const showHidden = usePreferencesStore((s) => s.showHidden);
+  const enabled = options.enabled ?? true;
   const showHiddenRef = useRef(showHidden);
   const [nodes, setNodes] = useState<TreeState>({});
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -78,6 +115,8 @@ export function useFileTree(rootPath: string | null, options?: Options) {
   const expandedRef = useRef(expanded);
   const nodesRef = useRef(nodes);
   const watchedRef = useRef<Set<string>>(new Set());
+  const treeScopeRef = useRef("");
+  treeScopeRef.current = `${workspaceKey}\0${showHidden ? "1" : "0"}\0${rootPath ?? ""}`;
 
   useEffect(() => {
     showHiddenRef.current = showHidden;
@@ -91,74 +130,103 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     nodesRef.current = nodes;
   }, [nodes]);
 
-  const addWatch = useCallback((path: string) => {
-    if (watchedRef.current.has(path)) return;
-    watchedRef.current.add(path);
-    watchAdd([path]);
-  }, []);
+  const addWatch = useCallback(
+    (path: string) => {
+      if (watchedRef.current.has(path)) return;
+      watchedRef.current.add(path);
+      watchAdd([path], workspace);
+    },
+    [workspace],
+  );
 
-  const removeWatch = useCallback((path: string) => {
-    if (!watchedRef.current.delete(path)) return;
-    watchRemove([path]);
-  }, []);
+  const removeWatch = useCallback(
+    (path: string) => {
+      if (!watchedRef.current.delete(path)) return;
+      watchRemove([path], workspace);
+    },
+    [workspace],
+  );
 
-  const fetchChildren = useCallback(async (path: string) => {
-    setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
-    try {
-      const entries = await invoke<DirEntry[]>("fs_read_dir", {
-        path,
-        showHidden: showHiddenRef.current,
-        workspace: currentWorkspaceEnv(),
-      });
-
-      const liveDirs = new Set(
-        entries.filter((e) => e.kind === "dir").map((e) => joinPath(path, e.name)),
-      );
-      const removedRoots: string[] = [];
-      for (const key of Object.keys(nodesRef.current)) {
-        if (dirname(key) === path && !liveDirs.has(key)) removedRoots.push(key);
+  const fetchChildren = useCallback(
+    async (path: string, opts?: { showLoading?: boolean }) => {
+      const runScope = treeScopeRef.current;
+      const key = directoryCacheKey(workspaceKey, showHiddenRef.current, path);
+      const cached = cachedEntries(key);
+      if (cached && nodesRef.current[path]?.status !== "loaded") {
+        setNodes((s) => ({
+          ...s,
+          [path]: { status: "loaded", entries: cached },
+        }));
+      } else if (opts?.showLoading ?? !cached) {
+        setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
       }
-      const dead = new Set<string>();
-      if (removedRoots.length > 0) {
-        const candidates = new Set<string>([
-          ...Object.keys(nodesRef.current),
-          ...expandedRef.current,
-          ...watchedRef.current,
-        ]);
-        for (const k of candidates) {
-          if (removedRoots.some((r) => isUnder(k, r))) dead.add(k);
-        }
-      }
-
-      setNodes((s) => {
-        const next: TreeState = {};
-        for (const [k, v] of Object.entries(s)) if (!dead.has(k)) next[k] = v;
-        next[path] = { status: "loaded", entries };
-        return next;
-      });
-
-      if (dead.size > 0) {
-        setExpanded((c) => {
-          let changed = false;
-          const n = new Set(c);
-          for (const d of dead) if (n.delete(d)) changed = true;
-          return changed ? n : c;
+      try {
+        const entries = await invoke<DirEntry[]>("fs_read_dir", {
+          path,
+          showHidden: showHiddenRef.current,
+          workspace,
         });
-        const toUnwatch: string[] = [];
-        for (const d of dead) if (watchedRef.current.delete(d)) toUnwatch.push(d);
-        watchRemove(toUnwatch);
-      }
-    } catch (e) {
-      setNodes((s) => ({
-        ...s,
-        [path]: { status: "error", message: String(e) },
-      }));
-    }
-  }, []);
+        if (runScope !== treeScopeRef.current) return;
+        rememberEntries(key, entries);
 
-  // Root change → restore the cached expansion for this root, re-scope watches,
-  // and persist the outgoing root's expansion on the way out.
+        const liveDirs = new Set(
+          entries
+            .filter((e) => e.kind === "dir")
+            .map((e) => joinPath(path, e.name)),
+        );
+        const removedRoots: string[] = [];
+        for (const key of Object.keys(nodesRef.current)) {
+          if (dirname(key) === path && !liveDirs.has(key))
+            removedRoots.push(key);
+        }
+        const dead = new Set<string>();
+        if (removedRoots.length > 0) {
+          const candidates = new Set<string>([
+            ...Object.keys(nodesRef.current),
+            ...expandedRef.current,
+            ...watchedRef.current,
+          ]);
+          for (const k of candidates) {
+            if (removedRoots.some((r) => isUnder(k, r))) dead.add(k);
+          }
+        }
+
+        setNodes((s) => {
+          const next: TreeState = {};
+          for (const [k, v] of Object.entries(s)) {
+            if (!dead.has(k)) next[k] = v;
+          }
+          next[path] = { status: "loaded", entries };
+          return next;
+        });
+
+        if (dead.size > 0) {
+          setExpanded((c) => {
+            let changed = false;
+            const n = new Set(c);
+            for (const d of dead) if (n.delete(d)) changed = true;
+            return changed ? n : c;
+          });
+          const toUnwatch: string[] = [];
+          for (const d of dead)
+            if (watchedRef.current.delete(d)) toUnwatch.push(d);
+          watchRemove(toUnwatch, workspace);
+        }
+      } catch (e) {
+        if (runScope !== treeScopeRef.current || cached) return;
+        setNodes((s) => ({
+          ...s,
+          [path]: { status: "error", message: String(e) },
+        }));
+      }
+    },
+    [workspace, workspaceKey],
+  );
+
+  // Root change: restore cached expansion, re-scope watches, and persist the
+  // outgoing root's expansion on cleanup.
   useEffect(() => {
+    if (!enabled) return;
     if (!rootPath) {
       setNodes({});
       setExpanded(new Set());
@@ -169,26 +237,37 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     setPendingCreate(null);
     setRenaming(null);
 
-    const restored = recallExpansion(rootPath);
+    const expansionKey = expansionCacheKey(workspaceKey, rootPath);
+    const restored = recallExpansion(expansionKey);
     setExpanded(new Set(restored));
-    setNodes({});
+    const seededNodes: TreeState = {};
+    for (const path of [rootPath, ...restored]) {
+      const entries = cachedEntries(
+        directoryCacheKey(workspaceKey, showHiddenRef.current, path),
+      );
+      if (entries) seededNodes[path] = { status: "loaded", entries };
+    }
+    setNodes(seededNodes);
 
     const toWatch = [rootPath, ...restored];
-    void fetchChildren(rootPath);
-    for (const d of restored) void fetchChildren(d);
+    void fetchChildren(rootPath, { showLoading: !seededNodes[rootPath] });
+    for (const d of restored) {
+      void fetchChildren(d, { showLoading: !seededNodes[d] });
+    }
     for (const p of toWatch) watchedRef.current.add(p);
-    watchAdd(toWatch);
+    watchAdd(toWatch, workspace);
 
     return () => {
-      rememberExpansion(rootPath, expandedRef.current);
+      rememberExpansion(expansionKey, expandedRef.current);
       if (watchedRef.current.size > 0) {
-        watchRemove([...watchedRef.current]);
+        watchRemove([...watchedRef.current], workspace);
         watchedRef.current.clear();
       }
     };
-  }, [rootPath, fetchChildren]);
+  }, [rootPath, enabled, fetchChildren, workspace, workspaceKey]);
 
   useEffect(() => {
+    if (!enabled) return;
     let alive = true;
     let unlisten: (() => void) | undefined;
     void listenFsChanged((paths) => {
@@ -208,9 +287,10 @@ export function useFileTree(rootPath: string | null, options?: Options) {
       alive = false;
       unlisten?.();
     };
-  }, [fetchChildren]);
+  }, [enabled, fetchChildren]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (!rootPath) return;
     const loadedPaths = Object.entries(nodes)
       .filter(([, state]) => state.status === "loaded")
@@ -220,7 +300,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     // `nodes` is intentionally omitted so ordinary tree edits don't refetch
     // every expanded directory.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showHidden, rootPath, fetchChildren]);
+  }, [enabled, showHidden, rootPath, fetchChildren]);
 
   const toggle = useCallback(
     (path: string) => {
@@ -303,7 +383,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
       const cmd =
         pendingCreate.kind === "dir" ? "fs_create_dir" : "fs_create_file";
       try {
-        await invoke(cmd, { path, workspace: currentWorkspaceEnv() });
+        await invoke(cmd, { path, workspace });
         await fetchChildren(pendingCreate.parentPath);
       } catch (e) {
         console.error(`${cmd} failed:`, e);
@@ -311,7 +391,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         setPendingCreate(null);
       }
     },
-    [pendingCreate, fetchChildren],
+    [pendingCreate, fetchChildren, workspace],
   );
 
   const beginRename = useCallback((path: string) => {
@@ -336,7 +416,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         await invoke("fs_rename", {
           from: renaming,
           to,
-          workspace: currentWorkspaceEnv(),
+          workspace,
         });
         options?.onPathRenamed?.(renaming, to);
         await fetchChildren(parent);
@@ -346,20 +426,20 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         setRenaming(null);
       }
     },
-    [renaming, fetchChildren, options],
+    [renaming, fetchChildren, options, workspace],
   );
 
   const deletePath = useCallback(
     async (path: string) => {
       try {
-        await invoke("fs_delete", { path, workspace: currentWorkspaceEnv() });
+        await invoke("fs_delete", { path, workspace });
         options?.onPathDeleted?.(path);
         await fetchChildren(dirname(path));
       } catch (e) {
         console.error("fs_delete failed:", e);
       }
     },
-    [fetchChildren, options],
+    [fetchChildren, options, workspace],
   );
 
   return {

--- a/src/modules/explorer/lib/watch.ts
+++ b/src/modules/explorer/lib/watch.ts
@@ -1,24 +1,24 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { WorkspaceEnv } from "@/modules/workspace";
 
 const FS_CHANGED_EVENT = "fs:changed";
 
 type FsChangedPayload = { paths: string[] };
 
-export function watchAdd(paths: string[]): void {
+export function watchAdd(paths: string[], workspace: WorkspaceEnv): void {
   if (paths.length === 0) return;
   void invoke("fs_watch_add", {
     paths,
-    workspace: currentWorkspaceEnv(),
+    workspace,
   }).catch(() => {});
 }
 
-export function watchRemove(paths: string[]): void {
+export function watchRemove(paths: string[], workspace: WorkspaceEnv): void {
   if (paths.length === 0) return;
   void invoke("fs_watch_remove", {
     paths,
-    workspace: currentWorkspaceEnv(),
+    workspace,
   }).catch(() => {});
 }
 

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -12,6 +12,7 @@ import {
   type ModelId,
 } from "@/modules/ai/config";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
+import type { SshWorkspaceProfile } from "@/modules/workspace";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
 
@@ -85,6 +86,7 @@ export type Preferences = {
   terminalFontSize: number;
   terminalScrollback: number;
   lastWslDistro: string | null;
+  sshWorkspaces: SshWorkspaceProfile[];
   zoomLevel: number;
   agentNotifications: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
@@ -129,6 +131,7 @@ const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
+const KEY_SSH_WORKSPACES = "sshWorkspaces";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
 const KEY_SHORTCUTS = "shortcuts";
@@ -186,6 +189,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
   lastWslDistro: null,
+  sshWorkspaces: [],
   zoomLevel: 1.0,
   agentNotifications: true,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
@@ -316,6 +320,9 @@ export async function loadPreferences(): Promise<Preferences> {
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
+    sshWorkspaces:
+      get<SshWorkspaceProfile[]>(KEY_SSH_WORKSPACES) ??
+      DEFAULT_PREFERENCES.sshWorkspaces,
     zoomLevel: get<number>(KEY_ZOOM_LEVEL) ?? DEFAULT_PREFERENCES.zoomLevel,
     agentNotifications:
       get<boolean>(KEY_AGENT_NOTIFICATIONS) ??
@@ -512,6 +519,12 @@ export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
 
+export async function setSshWorkspaces(
+  value: SshWorkspaceProfile[],
+): Promise<void> {
+  await writePref(KEY_SSH_WORKSPACES, value);
+}
+
 export async function setZoomLevel(value: number): Promise<void> {
   await writePref(KEY_ZOOM_LEVEL, value);
 }
@@ -585,6 +598,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
+    [KEY_SSH_WORKSPACES]: "sshWorkspaces",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
     [KEY_SHORTCUTS]: "shortcuts",

--- a/src/modules/source-control/useSourceControl.ts
+++ b/src/modules/source-control/useSourceControl.ts
@@ -3,7 +3,7 @@ import {
   type GitRepoInfo,
   type GitStatusSnapshot,
 } from "@/modules/ai/lib/native";
-import { useWorkspaceEnvStore, workspaceScopeKey } from "@/modules/workspace";
+import { workspaceScopeKey, type WorkspaceEnv } from "@/modules/workspace";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const AUTO_FETCH_THROTTLE_MS = 5 * 60_000;
@@ -145,10 +145,11 @@ function touchAutoFetch(map: Map<string, number>, key: string): void {
 
 export function useSourceControl(
   contextPath: string | null,
+  workspaceEnv: WorkspaceEnv,
   enabled: boolean = true,
 ): SourceControlSummary {
-  const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const workspaceKey = workspaceScopeKey(workspaceEnv);
+  const sshWorkspace = workspaceEnv.kind === "ssh";
   const [state, setState] = useState<SourceControlSummaryState>({
     repo: null,
     status: null,
@@ -205,6 +206,18 @@ export function useSourceControl(
   const doRefresh = useCallback(
     async (remoteMode: SourceControlRefreshMode): Promise<void> => {
       if (!enabledRef.current) return;
+      if (sshWorkspace) {
+        setState({
+          repo: null,
+          status: null,
+          hasRepo: false,
+          isLoading: false,
+          localError: null,
+          busyAction: null,
+          lastRemoteError: null,
+        });
+        return;
+      }
       const requestId = ++requestIdRef.current;
 
       if (!contextPath) {
@@ -338,7 +351,7 @@ export function useSourceControl(
         lastRefreshAtRef.current = Date.now();
       }
     },
-    [contextPath, workspaceKey],
+    [contextPath, sshWorkspace, workspaceKey],
   );
 
   const refresh = useCallback(

--- a/src/modules/statusbar/CwdBreadcrumb.tsx
+++ b/src/modules/statusbar/CwdBreadcrumb.tsx
@@ -22,7 +22,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { segmentsFromCwd } from "./lib/pathUtils";
 
@@ -30,6 +30,7 @@ type Props = {
   cwd: string | null;
   filePath?: string | null;
   home: string | null;
+  workspace: WorkspaceEnv;
   onCd: (path: string) => void;
 };
 
@@ -44,7 +45,7 @@ function basename(path: string): string {
   return i === -1 ? path : path.slice(i + 1);
 }
 
-export function CwdBreadcrumb({ cwd, filePath, home, onCd }: Props) {
+export function CwdBreadcrumb({ cwd, filePath, home, workspace, onCd }: Props) {
   // File mode: dir segments navigate; filename is the terminal leaf.
   if (filePath) {
     const dir = dirname(filePath);
@@ -123,6 +124,7 @@ export function CwdBreadcrumb({ cwd, filePath, home, onCd }: Props) {
           <CurrentSegmentDropdown
             label={current.label}
             path={current.fullPath}
+            workspace={workspace}
             onCd={onCd}
           />
         </BreadcrumbItem>
@@ -173,10 +175,12 @@ function BreadcrumbSegment({
 function CurrentSegmentDropdown({
   label,
   path,
+  workspace,
   onCd,
 }: {
   label: string;
   path: string;
+  workspace: WorkspaceEnv;
   onCd: (p: string) => void;
 }) {
   const showHidden = usePreferencesStore((s) => s.showHidden);
@@ -190,14 +194,14 @@ function CurrentSegmentDropdown({
       const dirs = await invoke<string[]>("list_subdirs", {
         path,
         showHidden,
-        workspace: currentWorkspaceEnv(),
+        workspace,
       });
       setChildren(dirs);
     } catch (e) {
       setError(String(e));
       setChildren([]);
     }
-  }, [path, showHidden]);
+  }, [path, showHidden, workspace]);
 
   useEffect(() => {
     if (open) load();

--- a/src/modules/statusbar/StatusBar.tsx
+++ b/src/modules/statusbar/StatusBar.tsx
@@ -19,6 +19,7 @@ type Props = {
   cwd: string | null;
   filePath?: string | null;
   home: string | null;
+  workspace: WorkspaceEnv;
   onCd: (path: string) => void;
   onWorkspaceChange: (env: WorkspaceEnv) => void;
   onOpenMini: () => void;
@@ -31,6 +32,7 @@ export function StatusBar({
   cwd,
   filePath,
   home,
+  workspace,
   onCd,
   onWorkspaceChange,
   onOpenMini,
@@ -44,7 +46,13 @@ export function StatusBar({
     <footer className="flex h-8 shrink-0 items-center justify-between gap-3 border-t border-border/60 bg-card/60 px-3 text-[11px]">
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <WorkspaceEnvSelector onSelect={onWorkspaceChange} />
-        <CwdBreadcrumb cwd={cwd} filePath={filePath} home={home} onCd={onCd} />
+        <CwdBreadcrumb
+          cwd={cwd}
+          filePath={filePath}
+          home={home}
+          workspace={workspace}
+          onCd={onCd}
+        />
         {privateActive ? (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -2,84 +2,303 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { IS_WINDOWS } from "@/lib/platform";
+import {
+  Add01Icon,
+  Delete02Icon,
+  PencilEdit02Icon,
+  Refresh01Icon,
+  ServerStack03Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
   LOCAL_WORKSPACE,
+  workspaceDisplayLabel,
   useWorkspaceEnvStore,
+  type SshWorkspaceProfile,
   type WorkspaceEnv,
 } from "@/modules/workspace";
-import { Refresh01Icon, ServerStack03Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  clearSshPassword,
+  getSshPassword,
+  setSshPassword,
+} from "@/modules/workspace/sshSecrets";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setSshWorkspaces } from "@/modules/settings/store";
+import { SshWorkspaceDialog } from "@/modules/workspace/SshWorkspaceDialog";
+import { IS_WINDOWS } from "@/lib/platform";
 
 type Props = {
   onSelect: (env: WorkspaceEnv) => void;
 };
 
 export function WorkspaceEnvSelector({ onSelect }: Props) {
-  if (!IS_WINDOWS) return null;
-
   const env = useWorkspaceEnvStore((s) => s.env);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);
   const error = useWorkspaceEnvStore((s) => s.error);
   const refreshDistros = useWorkspaceEnvStore((s) => s.refreshDistros);
+  const sshWorkspaces = usePreferencesStore((s) => s.sshWorkspaces);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogMode, setDialogMode] = useState<"create" | "edit" | "connect">(
+    "create",
+  );
+  const [dialogProfile, setDialogProfile] =
+    useState<SshWorkspaceProfile | null>(null);
+  const [deleteProfile, setDeleteProfile] =
+    useState<SshWorkspaceProfile | null>(null);
 
   const handleOpenChange = (open: boolean) => {
-    if (open && distros.length === 0 && !loading) {
+    if (open && IS_WINDOWS && distros.length === 0 && !loading) {
       void refreshDistros();
     }
   };
 
-  const label = env.kind === "wsl" ? `WSL: ${env.distro}` : "Windows";
+  const label = workspaceDisplayLabel(env);
+
+  const saveSshWorkspace = async (
+    profile: SshWorkspaceProfile,
+    password: string,
+  ) => {
+    if (password.length > 0) {
+      await setSshPassword(profile.id, password);
+    }
+    const next = [...sshWorkspaces, profile];
+    await setSshWorkspaces(next);
+    onSelect({
+      kind: "ssh",
+      ...profile,
+      password: password.length > 0 ? password : null,
+    });
+  };
+
+  const updateSshWorkspace = async (profile: SshWorkspaceProfile) => {
+    const next = sshWorkspaces.map((item) =>
+      item.id === profile.id ? profile : item,
+    );
+    await setSshWorkspaces(next);
+  };
+
+  const deleteSshWorkspace = async (profile: SshWorkspaceProfile) => {
+    const next = sshWorkspaces.filter((item) => item.id !== profile.id);
+    await clearSshPassword(profile.id);
+    await setSshWorkspaces(next);
+    if (env.kind === "ssh" && env.id === profile.id) {
+      onSelect(LOCAL_WORKSPACE);
+    }
+    setDeleteProfile(null);
+  };
+
+  const connectSsh = async (profile: SshWorkspaceProfile) => {
+    const password = await getSshPassword(profile.id);
+    if (password) {
+      onSelect({ kind: "ssh", ...profile, password });
+      return;
+    }
+    setDialogMode("connect");
+    setDialogProfile(profile);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (profile: SshWorkspaceProfile) => {
+    setDialogMode("edit");
+    setDialogProfile(profile);
+    setDialogOpen(true);
+  };
+
+  const openCreate = () => {
+    setDialogMode("create");
+    setDialogProfile(null);
+    setDialogOpen(true);
+  };
 
   return (
-    <DropdownMenu onOpenChange={handleOpenChange}>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="flex h-6 shrink-0 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:bg-accent data-[state=open]:text-foreground"
-          title="Workspace environment"
-        >
-          <HugeiconsIcon
-            icon={ServerStack03Icon}
-            size={13}
-            strokeWidth={1.75}
-          />
-          <span className="max-w-28 truncate">{label}</span>
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-48">
-        <DropdownMenuItem onSelect={() => onSelect(LOCAL_WORKSPACE)}>
-          Windows Local
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        {distros.length === 0 ? (
-          <DropdownMenuItem disabled>
-            {loading
-              ? "Loading WSL distros..."
-              : error
-                ? "WSL unavailable"
-                : "No WSL distros found"}
+    <>
+      <DropdownMenu onOpenChange={handleOpenChange}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex h-6 shrink-0 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus:outline-none focus-visible:outline-none focus-visible:ring-0 data-[state=open]:bg-accent data-[state=open]:text-foreground"
+            title="Workspace environment"
+          >
+            <HugeiconsIcon
+              icon={ServerStack03Icon}
+              size={13}
+              strokeWidth={1.75}
+            />
+            <span className="max-w-28 truncate">{label}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-52">
+          <DropdownMenuItem onSelect={() => onSelect(LOCAL_WORKSPACE)}>
+            Local
           </DropdownMenuItem>
-        ) : (
-          distros.map((distro) => (
-            <DropdownMenuItem
-              key={distro.name}
-              onSelect={() => onSelect({ kind: "wsl", distro: distro.name })}
+          {IS_WINDOWS ? (
+            <>
+              <DropdownMenuSeparator />
+              {distros.length === 0 ? (
+                <DropdownMenuItem disabled>
+                  {loading
+                    ? "Loading WSL distros..."
+                    : error
+                      ? "WSL unavailable"
+                      : "No WSL distros found"}
+                </DropdownMenuItem>
+              ) : (
+                distros.map((distro) => (
+                  <DropdownMenuItem
+                    key={distro.name}
+                    onSelect={() =>
+                      onSelect({ kind: "wsl", distro: distro.name })
+                    }
+                  >
+                    WSL: {distro.name}
+                  </DropdownMenuItem>
+                ))
+              )}
+            </>
+          ) : null}
+          <DropdownMenuSeparator />
+          {sshWorkspaces.length === 0 ? (
+            <DropdownMenuItem disabled>No SSH workspaces</DropdownMenuItem>
+          ) : (
+            sshWorkspaces.map((profile) => (
+              <DropdownMenuSub key={profile.id}>
+                <div className="grid grid-cols-[minmax(0,1fr)_2rem] items-center gap-1">
+                  <DropdownMenuItem
+                    className="min-w-0"
+                    onSelect={() => void connectSsh(profile)}
+                  >
+                    <span className="truncate">{profile.label}</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSubTrigger
+                    aria-label={`Manage ${profile.label}`}
+                    className="h-9 justify-center rounded-2xl px-0 py-0 text-muted-foreground focus:text-foreground data-open:text-foreground [&_svg]:ml-0"
+                  >
+                    <span className="sr-only">Manage {profile.label}</span>
+                  </DropdownMenuSubTrigger>
+                </div>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem onSelect={() => openEdit(profile)}>
+                    <HugeiconsIcon
+                      icon={PencilEdit02Icon}
+                      size={13}
+                      strokeWidth={1.75}
+                    />
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={() => setDeleteProfile(profile)}
+                  >
+                    <HugeiconsIcon
+                      icon={Delete02Icon}
+                      size={13}
+                      strokeWidth={1.75}
+                    />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ))
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={openCreate}>
+            <HugeiconsIcon icon={Add01Icon} size={13} strokeWidth={1.75} />
+            Add SSH workspace
+          </DropdownMenuItem>
+          {IS_WINDOWS ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => void refreshDistros()}>
+                <HugeiconsIcon
+                  icon={Refresh01Icon}
+                  size={13}
+                  strokeWidth={1.75}
+                />
+                Refresh WSL
+              </DropdownMenuItem>
+            </>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SshWorkspaceDialog
+        open={dialogOpen}
+        mode={dialogMode}
+        profile={dialogProfile}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) {
+            setDialogProfile(null);
+            setDialogMode("create");
+          }
+        }}
+        onSubmit={async (profile, password) => {
+          if (dialogMode === "edit") {
+            await updateSshWorkspace(profile);
+            return;
+          }
+          if (dialogMode === "connect") {
+            if (password.length > 0) {
+              await setSshPassword(profile.id, password);
+            }
+            onSelect({
+              kind: "ssh",
+              ...profile,
+              password: password.length > 0 ? password : null,
+            });
+            return;
+          }
+          await saveSshWorkspace(profile, password);
+        }}
+      />
+      <AlertDialog
+        open={deleteProfile !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteProfile(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete SSH workspace?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteProfile
+                ? `Remove ${deleteProfile.label} and its saved password from this device.`
+                : "Remove this SSH workspace and its saved password from this device."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setDeleteProfile(null)}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (!deleteProfile) return;
+                void deleteSshWorkspace(deleteProfile);
+              }}
             >
-              WSL: {distro.name}
-            </DropdownMenuItem>
-          ))
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => void refreshDistros()}>
-          <HugeiconsIcon icon={Refresh01Icon} size={13} strokeWidth={1.75} />
-          Refresh
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/modules/tabs/lib/tabLabel.test.ts
+++ b/src/modules/tabs/lib/tabLabel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { LOCAL_WORKSPACE } from "@/modules/workspace";
 import { labelFor } from "./tabLabel";
 import type { TerminalTab } from "./useTabs";
 
@@ -7,6 +8,8 @@ function terminalTab(over: Partial<TerminalTab> = {}): TerminalTab {
     id: 1,
     kind: "terminal",
     title: "shell",
+    workspace: LOCAL_WORKSPACE,
+    workspaceNonce: 0,
     paneTree: { kind: "leaf", id: 2 },
     activeLeafId: 2,
     ...over,

--- a/src/modules/tabs/lib/useTabs.test.ts
+++ b/src/modules/tabs/lib/useTabs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveTerminalWorkspaceUpdate, type TerminalTab } from "./useTabs";
+import { type WorkspaceEnv } from "@/modules/workspace";
+
+function terminalTab(workspace: WorkspaceEnv): TerminalTab {
+  return {
+    id: 1,
+    kind: "terminal",
+    title: "shell",
+    workspace,
+    workspaceNonce: 0,
+    paneTree: { kind: "leaf", id: 2, cwd: "/Users/hsiangyu" },
+    activeLeafId: 2,
+  };
+}
+
+const local: WorkspaceEnv = { kind: "local" };
+const sshA: WorkspaceEnv = {
+  kind: "ssh",
+  id: "ssh-1",
+  label: "remote",
+  host: "100.72.187.38",
+  user: "sean",
+  port: 22,
+  rootPath: "/home/sean",
+};
+
+describe("resolveTerminalWorkspaceUpdate", () => {
+  it("restarts on workspace identity change", () => {
+    const next = resolveTerminalWorkspaceUpdate(terminalTab(local), sshA);
+    expect(next.restartSession).toBe(true);
+    expect(next.nextCwd).toBe("/home/sean");
+  });
+
+  it("does not restart when only SSH root path changes", () => {
+    const next = resolveTerminalWorkspaceUpdate(terminalTab(sshA), {
+      ...sshA,
+      rootPath: "/home/sean/Github",
+    });
+    expect(next.restartSession).toBe(false);
+    expect(next.nextCwd).toBe("/home/sean/Github");
+  });
+
+  it("honors an explicit restart request even when identity matches", () => {
+    const next = resolveTerminalWorkspaceUpdate(terminalTab(sshA), sshA, {
+      cwd: "/home/sean/Github",
+      restartSession: true,
+    });
+    expect(next.restartSession).toBe(true);
+    expect(next.nextCwd).toBe("/home/sean/Github");
+  });
+});

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  currentWorkspaceEnv,
+  LOCAL_WORKSPACE,
+  sameWorkspaceEnv,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
+import {
   findLeafCwd,
   hasLeaf,
   leafIds,
@@ -21,6 +27,8 @@ export type TerminalTab = {
   kind: "terminal";
   title: string;
   cwd?: string;
+  workspace: WorkspaceEnv;
+  workspaceNonce: number;
   paneTree: PaneNode;
   activeLeafId: number;
   /** AI agent cannot read buffer / context of this terminal. */
@@ -35,6 +43,7 @@ export type EditorTab = {
   title: string;
   path: string;
   dirty: boolean;
+  workspace: WorkspaceEnv;
   /**
    * True while the tab is in the transient "preview" state — opened by a
    * single-click in the explorer and not yet pinned by the user. A preview tab
@@ -48,6 +57,7 @@ export type PreviewTab = {
   kind: "preview";
   title: string;
   url: string;
+  workspace: WorkspaceEnv;
 };
 
 export type MarkdownTab = {
@@ -55,6 +65,7 @@ export type MarkdownTab = {
   kind: "markdown";
   title: string;
   path: string;
+  workspace: WorkspaceEnv;
 };
 
 export type AiDiffStatus = "pending" | "approved" | "rejected";
@@ -71,6 +82,7 @@ export type AiDiffTab = {
   approvalId: string;
   status: AiDiffStatus;
   isNewFile: boolean;
+  workspace: WorkspaceEnv;
 };
 
 export type GitDiffTab = {
@@ -81,6 +93,7 @@ export type GitDiffTab = {
   repoRoot: string;
   mode: "-" | "+";
   originalPath: string | null;
+  workspace: WorkspaceEnv;
 };
 
 export type GitHistoryTab = {
@@ -88,6 +101,7 @@ export type GitHistoryTab = {
   kind: "git-history";
   title: string;
   repoRoot: string;
+  workspace: WorkspaceEnv;
 };
 
 export type GitCommitFileDiffTab = {
@@ -100,6 +114,7 @@ export type GitCommitFileDiffTab = {
   subject: string;
   path: string;
   originalPath: string | null;
+  workspace: WorkspaceEnv;
 };
 
 export type Tab =
@@ -118,6 +133,8 @@ export type TabPatch = Partial<{
   path: string;
   dirty: boolean;
   url: string;
+  workspace: WorkspaceEnv;
+  workspaceNonce: number;
   /** Empty string resets a terminal tab to its cwd-derived name. */
   customTitle: string;
 }>;
@@ -136,16 +153,45 @@ function titleFromUrl(url: string): string {
   }
 }
 
+function mapPaneTreeCwd(tree: PaneNode, cwd?: string): PaneNode {
+  if (tree.kind === "leaf") {
+    return { ...tree, cwd };
+  }
+  return {
+    ...tree,
+    children: tree.children.map((child) => mapPaneTreeCwd(child, cwd)),
+  };
+}
+
+export function resolveTerminalWorkspaceUpdate(
+  tab: TerminalTab,
+  workspace: WorkspaceEnv,
+  options?: { cwd?: string; restartSession?: boolean },
+): {
+  workspaceChanged: boolean;
+  restartSession: boolean;
+  nextCwd: string | undefined;
+} {
+  const workspaceChanged = !sameWorkspaceEnv(tab.workspace, workspace);
+  const restartSession = Boolean(options?.restartSession || workspaceChanged);
+  const nextCwd =
+    options?.cwd ?? (workspace.kind === "ssh" ? workspace.rootPath : undefined);
+  return { workspaceChanged, restartSession, nextCwd };
+}
+
 export function useTabs(initial?: Partial<TerminalTab>) {
   const [tabs, setTabs] = useState<Tab[]>(() => {
     const tabId = 1;
     const leafId = 2;
+    const workspace = initial?.workspace ?? LOCAL_WORKSPACE;
     return [
       {
         id: tabId,
         kind: "terminal",
         title: initial?.title ?? "shell",
         cwd: initial?.cwd,
+        workspace,
+        workspaceNonce: 0,
         paneTree: { kind: "leaf", id: leafId, cwd: initial?.cwd },
         activeLeafId: leafId,
       },
@@ -169,6 +215,8 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         kind: "terminal",
         title: "shell",
         cwd,
+        workspace: LOCAL_WORKSPACE,
+        workspaceNonce: 0,
         paneTree: { kind: "leaf", id: leafId, cwd },
         activeLeafId: leafId,
       },
@@ -188,6 +236,8 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           kind: "terminal",
           title,
           cwd,
+          workspace: LOCAL_WORKSPACE,
+          workspaceNonce: 0,
           paneTree: { kind: "leaf", id: leafId, cwd },
           activeLeafId: leafId,
         },
@@ -203,14 +253,16 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     const leafId = nextIdRef.current++;
     setTabs((t) => [
       ...t,
-      {
-        id: tabId,
-        kind: "terminal",
-        title: "private",
-        cwd,
-        paneTree: { kind: "leaf", id: leafId, cwd },
-        activeLeafId: leafId,
-        private: true,
+        {
+          id: tabId,
+          kind: "terminal",
+          title: "private",
+          cwd,
+          workspace: LOCAL_WORKSPACE,
+          workspaceNonce: 0,
+          paneTree: { kind: "leaf", id: leafId, cwd },
+          activeLeafId: leafId,
+          private: true,
       },
     ]);
     setActiveId(tabId);
@@ -229,11 +281,15 @@ export function useTabs(initial?: Partial<TerminalTab>) {
    */
   const openFileTab = useCallback((path: string, pin = true) => {
     let targetId: number | null = null;
+    const workspace = currentWorkspaceEnv();
     setTabs((curr) => {
       if (pin) {
         // Persistent open: find any existing editor tab, pin it if needed.
         const existing = curr.find(
-          (t) => t.kind === "editor" && t.path === path,
+          (t) =>
+            t.kind === "editor" &&
+            t.path === path &&
+            sameWorkspaceEnv(t.workspace, workspace),
         );
         if (existing) {
           targetId = existing.id;
@@ -255,13 +311,17 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             path,
             dirty: false,
             preview: false,
+            workspace: currentWorkspaceEnv(),
           } satisfies EditorTab,
         ];
       } else {
         // Preview open: persistent tab for this path takes priority.
         const persistent = curr.find(
           (t) =>
-            t.kind === "editor" && t.path === path && !(t as EditorTab).preview,
+            t.kind === "editor" &&
+            t.path === path &&
+            !(t as EditorTab).preview &&
+            sameWorkspaceEnv(t.workspace, workspace),
         );
         if (persistent) {
           targetId = persistent.id;
@@ -270,7 +330,10 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         // Reuse the slot if it already shows the same path.
         const existingPreview = curr.find(
           (t) =>
-            t.kind === "editor" && t.path === path && (t as EditorTab).preview,
+            t.kind === "editor" &&
+            t.path === path &&
+            (t as EditorTab).preview &&
+            sameWorkspaceEnv(t.workspace, workspace),
         );
         if (existingPreview) {
           targetId = existingPreview.id;
@@ -278,7 +341,10 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         }
         // Replace the current preview slot, or append a new one.
         const previewIdx = curr.findIndex(
-          (t) => t.kind === "editor" && (t as EditorTab).preview,
+          (t) =>
+            t.kind === "editor" &&
+            (t as EditorTab).preview &&
+            sameWorkspaceEnv(t.workspace, workspace),
         );
         const id = nextIdRef.current++;
         targetId = id;
@@ -289,6 +355,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           path,
           dirty: false,
           preview: true,
+          workspace: currentWorkspaceEnv(),
         };
         if (previewIdx === -1) return [...curr, tab];
         const next = [...curr];
@@ -321,9 +388,13 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       isNewFile: boolean;
     }) => {
       let targetId: number | null = null;
+      const workspace = currentWorkspaceEnv();
       setTabs((curr) => {
         const existing = curr.find(
-          (t) => t.kind === "ai-diff" && t.approvalId === input.approvalId,
+          (t) =>
+            t.kind === "ai-diff" &&
+            t.approvalId === input.approvalId &&
+            sameWorkspaceEnv(t.workspace, workspace),
         );
         if (existing) {
           targetId = existing.id;
@@ -344,6 +415,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             approvalId: input.approvalId,
             status: "pending",
             isNewFile: input.isNewFile,
+            workspace: currentWorkspaceEnv(),
           },
         ];
       });
@@ -392,7 +464,13 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     const id = nextIdRef.current++;
     setTabs((t) => [
       ...t,
-      { id, kind: "preview", title: titleFromUrl(url), url },
+      {
+        id,
+        kind: "preview",
+        title: titleFromUrl(url),
+        url,
+        workspace: currentWorkspaceEnv(),
+      },
     ]);
     setActiveId(id);
     return id;
@@ -400,9 +478,13 @@ export function useTabs(initial?: Partial<TerminalTab>) {
 
   const newMarkdownTab = useCallback((path: string) => {
     let targetId: number | null = null;
+    const workspace = currentWorkspaceEnv();
     setTabs((curr) => {
       const existing = curr.find(
-        (t) => t.kind === "markdown" && t.path === path,
+        (t) =>
+          t.kind === "markdown" &&
+          t.path === path &&
+          sameWorkspaceEnv(t.workspace, workspace),
       );
       if (existing) {
         targetId = existing.id;
@@ -410,7 +492,16 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       }
       const id = nextIdRef.current++;
       targetId = id;
-      return [...curr, { id, kind: "markdown", title: basename(path), path }];
+      return [
+        ...curr,
+        {
+          id,
+          kind: "markdown",
+          title: basename(path),
+          path,
+          workspace: currentWorkspaceEnv(),
+        },
+      ];
     });
     if (targetId !== null) setActiveId(targetId);
     return targetId;
@@ -425,12 +516,14 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       title?: string;
     }) => {
       const curr = tabsRef.current;
+      const workspace = currentWorkspaceEnv();
       const existing = curr.find(
         (t) =>
           t.kind === "git-diff" &&
           t.repoRoot === input.repoRoot &&
           t.path === input.path &&
-          t.mode === input.mode,
+          t.mode === input.mode &&
+          sameWorkspaceEnv(t.workspace, workspace),
       );
       const computedTitle =
         input.title ?? `${basename(input.path)} (${input.mode})`;
@@ -459,6 +552,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           repoRoot: input.repoRoot,
           mode: input.mode,
           originalPath,
+          workspace: currentWorkspaceEnv(),
         } satisfies GitDiffTab,
       ];
       tabsRef.current = nextTabs;
@@ -472,8 +566,12 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   const openCommitHistoryTab = useCallback(
     (input: { repoRoot: string; branch?: string | null }) => {
       const curr = tabsRef.current;
+      const workspace = currentWorkspaceEnv();
       const existing = curr.find(
-        (t) => t.kind === "git-history" && t.repoRoot === input.repoRoot,
+        (t) =>
+          t.kind === "git-history" &&
+          t.repoRoot === input.repoRoot &&
+          sameWorkspaceEnv(t.workspace, workspace),
       );
       const title = input.branch
         ? `History · ${input.branch}`
@@ -495,6 +593,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           kind: "git-history",
           title,
           repoRoot: input.repoRoot,
+          workspace: currentWorkspaceEnv(),
         } satisfies GitHistoryTab,
       ];
       tabsRef.current = nextTabs;
@@ -515,12 +614,14 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       originalPath: string | null;
     }) => {
       const curr = tabsRef.current;
+      const workspace = currentWorkspaceEnv();
       const existing = curr.find(
         (t) =>
           t.kind === "git-commit-file" &&
           t.repoRoot === input.repoRoot &&
           t.sha === input.sha &&
-          t.path === input.path,
+          t.path === input.path &&
+          sameWorkspaceEnv(t.workspace, workspace),
       );
       const title = `${basename(input.path)} @ ${input.shortSha}`;
       if (existing) {
@@ -552,6 +653,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           subject: input.subject,
           path: input.path,
           originalPath: input.originalPath,
+          workspace: currentWorkspaceEnv(),
         } satisfies GitCommitFileDiffTab,
       ];
       tabsRef.current = nextTabs;
@@ -589,6 +691,10 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             ...x,
             ...(patch.title !== undefined && { title: patch.title }),
             ...(patch.cwd !== undefined && { cwd: patch.cwd }),
+            ...(patch.workspace !== undefined && { workspace: patch.workspace }),
+            ...(patch.workspaceNonce !== undefined && {
+              workspaceNonce: patch.workspaceNonce,
+            }),
             ...(patch.customTitle !== undefined && {
               customTitle: patch.customTitle === "" ? undefined : patch.customTitle,
             }),
@@ -602,12 +708,14 @@ export function useTabs(initial?: Partial<TerminalTab>) {
               url: patch.url,
               title: patch.title ?? titleFromUrl(patch.url),
             }),
+            ...(patch.workspace !== undefined && { workspace: patch.workspace }),
           };
         }
         if (x.kind === "markdown") {
           return {
             ...x,
             ...(patch.title !== undefined && { title: patch.title }),
+            ...(patch.workspace !== undefined && { workspace: patch.workspace }),
           };
         }
         // editor tab: auto-promote from preview the moment the file becomes dirty.
@@ -621,6 +729,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           ...(patch.title !== undefined && { title: patch.title }),
           ...(patch.dirty !== undefined && { dirty: patch.dirty }),
           ...(patch.path !== undefined && { path: patch.path }),
+          ...(patch.workspace !== undefined && { workspace: patch.workspace }),
         };
       }),
     );
@@ -654,6 +763,38 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       return changed ? next : curr;
     });
   }, []);
+
+  const setTerminalTabWorkspace = useCallback(
+    (
+      tabId: number,
+      workspace: WorkspaceEnv,
+      options?: { cwd?: string; restartSession?: boolean },
+    ) => {
+      setTabs((curr) =>
+        curr.map((t) => {
+          if (t.id !== tabId || t.kind !== "terminal") return t;
+          const { restartSession, nextCwd } = resolveTerminalWorkspaceUpdate(
+            t,
+            workspace,
+            options,
+          );
+          return {
+            ...t,
+            workspace,
+            ...(restartSession
+              ? { workspaceNonce: t.workspaceNonce + 1 }
+              : {}),
+            ...(nextCwd !== undefined
+              ? restartSession
+                ? { cwd: nextCwd, paneTree: mapPaneTreeCwd(t.paneTree, nextCwd) }
+                : { cwd: nextCwd }
+              : {}),
+          };
+        }),
+      );
+    },
+    [],
+  );
 
   const focusPane = useCallback((tabId: number, leafId: number) => {
     setTabs((curr) =>
@@ -792,6 +933,8 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           kind: "terminal",
           title: "shell",
           cwd,
+          workspace: LOCAL_WORKSPACE,
+          workspaceNonce: 0,
           paneTree: { kind: "leaf", id: leafId, cwd },
           activeLeafId: leafId,
         },
@@ -828,5 +971,6 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
+    setTerminalTabWorkspace,
   };
 }

--- a/src/modules/tabs/lib/useWorkspaceCwd.test.ts
+++ b/src/modules/tabs/lib/useWorkspaceCwd.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveExplorerRoot } from "./useWorkspaceCwd";
+import type { Tab } from "./useTabs";
+
+function terminalTab(cwd: string | undefined, workspaceRoot: string): Tab {
+  return {
+    id: 1,
+    kind: "terminal",
+    title: "shell",
+    cwd,
+    workspace: {
+      kind: "ssh",
+      id: "ssh-1",
+      label: "remote",
+      host: "100.72.187.38",
+      user: "sean",
+      port: 22,
+      rootPath: workspaceRoot,
+    },
+    workspaceNonce: 0,
+    paneTree: { kind: "leaf", id: 2, cwd },
+    activeLeafId: 2,
+  };
+}
+
+describe("resolveExplorerRoot", () => {
+  it("prefers the active SSH tab cwd over the stored workspace root", () => {
+    const tab = terminalTab("/home/sean/Github", "/Users/hsiangyu");
+    expect(
+      resolveExplorerRoot(tab, [tab], "/Users/hsiangyu", "/Users/hsiangyu", null),
+    ).toBe("/home/sean/Github");
+  });
+
+  it("falls back to the SSH workspace root when cwd is not yet available", () => {
+    const tab = terminalTab(undefined, "/home/sean");
+    expect(
+      resolveExplorerRoot(tab, [tab], "/Users/hsiangyu", null, null),
+    ).toBe("/home/sean");
+  });
+
+  it("falls back to the workspace root when there is no active terminal cwd", () => {
+    const tab = terminalTab(undefined, "/home/sean/Github");
+    expect(
+      resolveExplorerRoot(tab, [tab], "/Users/hsiangyu", "/home/sean/Github", null),
+    ).toBe("/home/sean/Github");
+  });
+});

--- a/src/modules/tabs/lib/useWorkspaceCwd.ts
+++ b/src/modules/tabs/lib/useWorkspaceCwd.ts
@@ -6,26 +6,52 @@ type Result = {
   inheritedCwdForNewTab: () => string | undefined;
 };
 
+export function resolveExplorerRoot(
+  activeTab: Tab | undefined,
+  tabs: Tab[],
+  home: string | null,
+  workspaceRoot?: string | null,
+  lastTerminalCwd?: string | null,
+): string | null {
+  if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
+  if (activeTab?.kind === "terminal" && activeTab.workspace.kind === "ssh") {
+    return activeTab.workspace.rootPath;
+  }
+  if (workspaceRoot) return workspaceRoot;
+  if (lastTerminalCwd) return lastTerminalCwd;
+  const anyTerm = tabs.find((t) => t.kind === "terminal" && t.cwd);
+  if (anyTerm?.kind === "terminal" && anyTerm.cwd) return anyTerm.cwd;
+  return home;
+}
+
 export function useWorkspaceCwd(
   activeTab: Tab | undefined,
   tabs: Tab[],
   home: string | null,
+  workspaceKey: string,
+  workspaceRoot?: string | null,
 ): Result {
   const lastTerminalCwd = useRef<string | null>(null);
+
+  useEffect(() => {
+    lastTerminalCwd.current = null;
+  }, [workspaceKey]);
 
   useEffect(() => {
     if (activeTab?.kind === "terminal" && activeTab.cwd) {
       lastTerminalCwd.current = activeTab.cwd;
     }
-  }, [activeTab]);
+  }, [activeTab, workspaceKey]);
 
   const explorerRoot = useMemo<string | null>(() => {
-    if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
-    if (lastTerminalCwd.current) return lastTerminalCwd.current;
-    const anyTerm = tabs.find((t) => t.kind === "terminal" && t.cwd);
-    if (anyTerm?.kind === "terminal" && anyTerm.cwd) return anyTerm.cwd;
-    return home;
-  }, [activeTab, tabs, home]);
+    return resolveExplorerRoot(
+      activeTab,
+      tabs,
+      home,
+      workspaceRoot,
+      lastTerminalCwd.current,
+    );
+  }, [activeTab, tabs, home, workspaceRoot]);
 
   const inheritedCwdForNewTab = useCallback((): string | undefined => {
     if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
@@ -33,7 +59,7 @@ export function useWorkspaceCwd(
     // the file's folder — opening a new terminal from a file shouldn't
     // hijack the user's working directory context.
     return lastTerminalCwd.current ?? home ?? undefined;
-  }, [activeTab, home]);
+  }, [activeTab, home, workspaceKey]);
 
   return { explorerRoot, inheritedCwdForNewTab };
 }

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -5,6 +5,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import type { SearchAddon } from "@xterm/addon-search";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 import { useTerminalDropStore } from "./lib/dropStore";
 import type { PaneNode } from "./lib/panes";
@@ -12,14 +13,18 @@ import type { PaneNode } from "./lib/panes";
 type LeafBundle = {
   setRef: (h: TerminalPaneHandle | null) => void;
   onSearch: (addon: SearchAddon) => void;
-  onCwd: (cwd: string) => void;
+  onCwd: (cwd: string, host: string | null) => void;
   onExit: (code: number) => void;
+  onCommandStart: (command: string) => void;
 };
 
 type Props = {
   node: PaneNode;
   tabVisible: boolean;
   activeLeafId: number;
+  workspace: WorkspaceEnv;
+  workspaceKey: string;
+  workspaceNonce: number;
   onFocusLeaf: (leafId: number) => void;
   getBundle: (leafId: number) => LeafBundle;
 };
@@ -28,6 +33,9 @@ export function PaneTreeView({
   node,
   tabVisible,
   activeLeafId,
+  workspace,
+  workspaceKey,
+  workspaceNonce,
   onFocusLeaf,
   getBundle,
 }: Props) {
@@ -51,11 +59,15 @@ export function PaneTreeView({
           leafId={node.id}
           visible={tabVisible}
           focused={focused}
+          workspace={workspace}
+          workspaceKey={workspaceKey}
+          workspaceNonce={workspaceNonce}
           initialCwd={node.cwd}
           ref={b.setRef}
           onSearchReady={(_id, addon) => b.onSearch(addon)}
-          onCwd={(_id, cwd) => b.onCwd(cwd)}
+          onCwd={(_id, cwd, host) => b.onCwd(cwd, host)}
           onExit={(_id, code) => b.onExit(code)}
+          onCommandStart={(_id, command) => b.onCommandStart(command)}
         />
         <DropOverlay leafId={node.id} />
       </div>
@@ -74,6 +86,9 @@ export function PaneTreeView({
               node={child}
               tabVisible={tabVisible}
               activeLeafId={activeLeafId}
+              workspace={workspace}
+              workspaceKey={workspaceKey}
+              workspaceNonce={workspaceNonce}
               onFocusLeaf={onFocusLeaf}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "@/modules/theme";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import type { SearchAddon } from "@xterm/addon-search";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { useTerminalSession } from "./lib/useTerminalSession";
@@ -17,10 +18,14 @@ type Props = {
   visible: boolean;
   /** This leaf is the active pane within its tab — receives auto-focus. */
   focused?: boolean;
+  workspace: WorkspaceEnv;
+  workspaceKey: string;
+  workspaceNonce: number;
   initialCwd?: string;
   onSearchReady?: (leafId: number, addon: SearchAddon) => void;
   onExit?: (leafId: number, code: number) => void;
-  onCwd?: (leafId: number, cwd: string) => void;
+  onCwd?: (leafId: number, cwd: string, host: string | null) => void;
+  onCommandStart?: (leafId: number, command: string) => void;
 };
 
 export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
@@ -29,10 +34,14 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       leafId,
       visible,
       focused = true,
+      workspace,
+      workspaceKey,
+      workspaceNonce,
       initialCwd,
       onSearchReady,
       onExit,
       onCwd,
+      onCommandStart,
     },
     ref,
   ) {
@@ -44,10 +53,14 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       container: containerRef,
       visible,
       focused,
+      workspace,
+      workspaceKey,
+      workspaceNonce,
       initialCwd,
       onSearchReady: (a) => onSearchReady?.(leafId, a),
       onExit: (c) => onExit?.(leafId, c),
-      onCwd: (c) => onCwd?.(leafId, c),
+      onCwd: (c, host) => onCwd?.(leafId, c, host),
+      onCommandStart: (command) => onCommandStart?.(leafId, command),
     });
 
     useEffect(() => {

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { PaneTreeView } from "./PaneTreeView";
 import type { TerminalPaneHandle } from "./TerminalPane";
 import { leafIds } from "./lib/panes";
+import { workspaceScopeKey } from "@/modules/workspace";
 
 type Props = {
   tabs: Tab[];
@@ -11,16 +12,18 @@ type Props = {
   /** Register/unregister handle by leaf id (not tab id). */
   registerHandle: (leafId: number, handle: TerminalPaneHandle | null) => void;
   onSearchReady: (leafId: number, addon: SearchAddon) => void;
-  onCwd: (leafId: number, cwd: string) => void;
+  onCwd: (leafId: number, cwd: string, host: string | null) => void;
   onExit: (leafId: number, code: number) => void;
+  onCommandStart: (leafId: number, command: string) => void;
   onFocusLeaf: (tabId: number, leafId: number) => void;
 };
 
 type Bundle = {
   setRef: (h: TerminalPaneHandle | null) => void;
   onSearch: (addon: SearchAddon) => void;
-  onCwd: (cwd: string) => void;
+  onCwd: (cwd: string, host: string | null) => void;
   onExit: (code: number) => void;
+  onCommandStart: (command: string) => void;
 };
 
 export function TerminalStack({
@@ -30,6 +33,7 @@ export function TerminalStack({
   onSearchReady,
   onCwd,
   onExit,
+  onCommandStart,
   onFocusLeaf,
 }: Props) {
   const terminals = useMemo(
@@ -41,6 +45,7 @@ export function TerminalStack({
   const searchReadyRef = useRef(onSearchReady);
   const cwdRef = useRef(onCwd);
   const exitRef = useRef(onExit);
+  const commandStartRef = useRef(onCommandStart);
   useEffect(() => {
     registerRef.current = registerHandle;
   }, [registerHandle]);
@@ -53,6 +58,9 @@ export function TerminalStack({
   useEffect(() => {
     exitRef.current = onExit;
   }, [onExit]);
+  useEffect(() => {
+    commandStartRef.current = onCommandStart;
+  }, [onCommandStart]);
 
   const bundles = useRef(new Map<number, Bundle>());
   const getBundle = (leafId: number): Bundle => {
@@ -61,8 +69,9 @@ export function TerminalStack({
       b = {
         setRef: (h) => registerRef.current(leafId, h),
         onSearch: (addon) => searchReadyRef.current(leafId, addon),
-        onCwd: (cwd) => cwdRef.current(leafId, cwd),
+        onCwd: (cwd, host) => cwdRef.current(leafId, cwd, host),
         onExit: (code) => exitRef.current(leafId, code),
+        onCommandStart: (command) => commandStartRef.current(leafId, command),
       };
       bundles.current.set(leafId, b);
     }
@@ -95,6 +104,9 @@ export function TerminalStack({
               node={t.paneTree}
               tabVisible={tabVisible}
               activeLeafId={t.activeLeafId}
+              workspace={t.workspace}
+              workspaceKey={workspaceScopeKey(t.workspace)}
+              workspaceNonce={t.workspaceNonce}
               onFocusLeaf={(leafId) => onFocusLeaf(t.id, leafId)}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  terminalClipboardAction,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
   terminalWordNavigationSequence,
@@ -11,6 +12,7 @@ const evt = (partial: Partial<TerminalKeyEvent>): TerminalKeyEvent => ({
   altKey: false,
   ctrlKey: false,
   metaKey: false,
+  shiftKey: false,
   key: "",
   code: "",
   ...partial,
@@ -133,5 +135,55 @@ describe("terminalDeleteSequence", () => {
         { isMac: true },
       ),
     ).toBeNull();
+  });
+});
+
+describe("terminalClipboardAction", () => {
+  it("copies with Ctrl+C off macOS when the terminal has a selection", () => {
+    expect(
+      terminalClipboardAction(evt({ ctrlKey: true, key: "c", code: "KeyC" }), {
+        isMac: false,
+        hasSelection: true,
+      }),
+    ).toBe("copy");
+  });
+
+  it("leaves Ctrl+C for SIGINT off macOS when there is no selection", () => {
+    expect(
+      terminalClipboardAction(evt({ ctrlKey: true, key: "c", code: "KeyC" }), {
+        isMac: false,
+        hasSelection: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("copies and pastes with standard macOS shortcuts", () => {
+    expect(
+      terminalClipboardAction(evt({ metaKey: true, key: "c", code: "KeyC" }), {
+        isMac: true,
+        hasSelection: true,
+      }),
+    ).toBe("copy");
+    expect(
+      terminalClipboardAction(evt({ metaKey: true, key: "v", code: "KeyV" }), {
+        isMac: true,
+        hasSelection: false,
+      }),
+    ).toBe("paste");
+  });
+
+  it("keeps Ctrl+Shift+C and Ctrl+Shift+V terminal shortcuts off macOS", () => {
+    expect(
+      terminalClipboardAction(
+        evt({ ctrlKey: true, shiftKey: true, key: "c", code: "KeyC" }),
+        { isMac: false, hasSelection: true },
+      ),
+    ).toBe("copy");
+    expect(
+      terminalClipboardAction(
+        evt({ ctrlKey: true, shiftKey: true, key: "v", code: "KeyV" }),
+        { isMac: false, hasSelection: false },
+      ),
+    ).toBe("paste");
   });
 });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -1,9 +1,33 @@
 export type TerminalKeyEvent = Pick<
   KeyboardEvent,
-  "altKey" | "ctrlKey" | "metaKey" | "key" | "code"
+  "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "key" | "code"
 >;
 
 export type PlatformOpts = { isMac: boolean };
+export type ClipboardOpts = PlatformOpts & { hasSelection: boolean };
+export type TerminalClipboardAction = "copy" | "paste" | null;
+
+export function terminalClipboardAction(
+  event: TerminalKeyEvent,
+  opts: ClipboardOpts,
+): TerminalClipboardAction {
+  const isC = event.code === "KeyC" || event.key.toLowerCase() === "c";
+  const isV = event.code === "KeyV" || event.key.toLowerCase() === "v";
+
+  if (opts.isMac) {
+    if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return null;
+    }
+    if (isC) return "copy";
+    if (isV) return "paste";
+    return null;
+  }
+
+  if (!event.ctrlKey || event.altKey || event.metaKey) return null;
+  if (isC && (event.shiftKey || opts.hasSelection)) return "copy";
+  if (isV && event.shiftKey) return "paste";
+  return null;
+}
 
 export function terminalWordNavigationSequence(event: TerminalKeyEvent): string | null {
   if (!event.altKey || event.ctrlKey || event.metaKey) return null;

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -40,7 +40,10 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     handlers.get(133)?.("A");
     handlers.get(7)?.("file://host/home/me/project");
 
-    expect(onCwd).toHaveBeenCalledWith("/home/me/project");
+    expect(onCwd).toHaveBeenCalledWith({
+      host: "host",
+      cwd: "/home/me/project",
+    });
   });
 
   it("rejects OSC 7 emitted while a command is running", () => {
@@ -73,7 +76,10 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     handlers.get(7)?.("file://host/home/me/new-cwd"); // legitimate post-cmd OSC 7
 
     expect(onCwd).toHaveBeenCalledTimes(1);
-    expect(onCwd).toHaveBeenCalledWith("/home/me/new-cwd");
+    expect(onCwd).toHaveBeenCalledWith({
+      host: "host",
+      cwd: "/home/me/new-cwd",
+    });
   });
 
   it("works without state for backwards compatibility (legacy callers)", () => {
@@ -84,7 +90,10 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     registerCwdHandler(term, onCwd);
 
     handlers.get(7)?.("file://host/home/me/project");
-    expect(onCwd).toHaveBeenCalledWith("/home/me/project");
+    expect(onCwd).toHaveBeenCalledWith({
+      host: "host",
+      cwd: "/home/me/project",
+    });
   });
 
   it("normalizes Windows drive-letter OSC 7 paths", () => {
@@ -93,6 +102,9 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     registerCwdHandler(term, onCwd);
 
     handlers.get(7)?.("file:///C:/Users/me/project");
-    expect(onCwd).toHaveBeenCalledWith("C:/Users/me/project");
+    expect(onCwd).toHaveBeenCalledWith({
+      host: null,
+      cwd: "C:/Users/me/project",
+    });
   });
 });

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -12,13 +12,18 @@ export type ShellIntegrationState = {
   inCommand: boolean;
 };
 
+export type Osc7Location = {
+  host: string | null;
+  cwd: string;
+};
+
 export function createShellIntegrationState(): ShellIntegrationState {
   return { inCommand: false };
 }
 
 export function registerCwdHandler(
   term: Terminal,
-  onCwd: (cwd: string) => void,
+  onCwd: (location: Osc7Location) => void,
   state?: ShellIntegrationState,
 ): () => void {
   const d = term.parser.registerOscHandler(7, (data) => {
@@ -27,8 +32,8 @@ export function registerCwdHandler(
     // of attacker-controlled bytes). The local shell only emits OSC 7
     // between commands via its precmd/PROMPT_COMMAND hook.
     if (state?.inCommand) return true;
-    const cwd = parseOsc7(data);
-    if (cwd) onCwd(cwd);
+    const location = parseOsc7(data);
+    if (location) onCwd(location);
     return true;
   });
   return () => d.dispose();
@@ -39,9 +44,14 @@ export type PromptTracker = {
   dispose: () => void;
 };
 
+export type PromptTrackerOptions = {
+  onCommandStart?: (command: string) => void;
+};
+
 export function registerPromptTracker(
   term: Terminal,
   state?: ShellIntegrationState,
+  options?: PromptTrackerOptions,
 ): PromptTracker {
   let marker: IMarker | null = null;
   const d = term.parser.registerOscHandler(133, (data) => {
@@ -57,6 +67,7 @@ export function registerPromptTracker(
     } else if (data.startsWith("C")) {
       // OSC 133 C — command pre-execution marker; still inside command.
       if (state) state.inCommand = true;
+      options?.onCommandStart?.(data.slice(2));
     } else if (data.startsWith("D")) {
       // OSC 133 D — command ends.
       if (state) state.inCommand = false;
@@ -73,14 +84,25 @@ export function registerPromptTracker(
   };
 }
 
-function parseOsc7(data: string): string | null {
-  const m = data.match(/^file:\/\/[^/]*(\/.*)$/);
+function parseOsc7(data: string): Osc7Location | null {
+  const m = data.match(/^file:\/\/([^/]*)(\/.*)$/);
   if (!m) return null;
-  let path = m[1];
+  const host = decodeHost(m[1]);
+  let path = m[2];
   try {
     path = decodeURIComponent(path);
   } catch {}
   // /C:/Users/foo -> C:/Users/foo so it's a valid Windows path.
   if (/^\/[A-Za-z]:/.test(path)) path = path.slice(1);
-  return path;
+  return { host, cwd: path };
+}
+
+function decodeHost(host: string): string | null {
+  const trimmed = host.trim();
+  if (!trimmed) return null;
+  try {
+    return decodeURIComponent(trimmed);
+  } catch {
+    return trimmed;
+  }
 }

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -1,5 +1,5 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { WorkspaceEnv } from "@/modules/workspace";
 
 export type PtyHandlers = {
   onData: (bytes: Uint8Array) => void;
@@ -17,6 +17,7 @@ export async function openPty(
   cols: number,
   rows: number,
   handlers: PtyHandlers,
+  workspace: WorkspaceEnv,
   cwd?: string,
 ): Promise<PtySession> {
   // Raw bytes — no base64/JSON round-trip; messages arrive as ArrayBuffer.
@@ -42,7 +43,7 @@ export async function openPty(
     cols,
     rows,
     cwd: cwd ?? null,
-    workspace: currentWorkspaceEnv(),
+    workspace,
     onData,
     onExit,
   });

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,4 +1,5 @@
 import { detectMonoFontFamily } from "@/lib/fonts";
+import { readClipboardText, writeClipboardText } from "@/lib/clipboard";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -9,6 +10,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import {
+  terminalClipboardAction,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
   terminalWordNavigationSequence,
@@ -207,18 +209,21 @@ function createSlot(): Slot {
       if (event.type === "keydown") bridge.writeToPty("\x1b\r");
       return false;
     }
-    if (isTerminalCopy(event)) {
+    const clipboardAction = terminalClipboardAction(event, {
+      isMac: IS_MAC,
+      hasSelection: slot.term.hasSelection(),
+    });
+    if (clipboardAction === "copy") {
       if (event.type === "keydown" && slot.term.hasSelection()) {
         const sel = slot.term.getSelection();
-        if (sel) void navigator.clipboard.writeText(sel).catch(() => {});
+        if (sel) void writeClipboardText(sel).catch(() => {});
       }
       event.preventDefault();
       return false;
     }
-    if (isTerminalPaste(event)) {
+    if (clipboardAction === "paste") {
       if (event.type === "keydown") {
-        void navigator.clipboard
-          .readText()
+        void readClipboardText()
           .then((text) => {
             if (text) slot.term.paste(text);
           })
@@ -712,28 +717,6 @@ export function getSlotForLeaf(leafId: number): Slot | null {
 const IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad/.test(navigator.userAgent);
-
-function isTerminalCopy(e: KeyboardEvent): boolean {
-  return (
-    !IS_MAC &&
-    e.ctrlKey &&
-    e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyC" || e.key === "c" || e.key === "C")
-  );
-}
-
-function isTerminalPaste(e: KeyboardEvent): boolean {
-  return (
-    !IS_MAC &&
-    e.ctrlKey &&
-    e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyV" || e.key === "v" || e.key === "V")
-  );
-}
 
 function isShiftEnter(e: KeyboardEvent): boolean {
   return (

--- a/src/modules/terminal/lib/sshCommandTracker.test.ts
+++ b/src/modules/terminal/lib/sshCommandTracker.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { SshCommandTracker } from "./sshCommandTracker";
+
+describe("SshCommandTracker", () => {
+  it("detects a plain ssh command", () => {
+    const tracker = new SshCommandTracker();
+    expect(tracker.feed("ssh sean@100.72.187.38\r")).toEqual({
+      user: "sean",
+      host: "100.72.187.38",
+      port: null,
+      rawTarget: "sean@100.72.187.38",
+    });
+  });
+
+  it("skips common ssh options before the target", () => {
+    const tracker = new SshCommandTracker();
+    expect(tracker.feed("ssh -p 2222 -o StrictHostKeyChecking=accept-new sean@host\r")).toEqual({
+      user: "sean",
+      host: "host",
+      port: 2222,
+      rawTarget: "sean@host",
+    });
+  });
+
+  it("supports backspace edits before enter", () => {
+    const tracker = new SshCommandTracker();
+    expect(tracker.feed("ssh seann\x7f@host\r")).toEqual({
+      user: "sean",
+      host: "host",
+      port: null,
+      rawTarget: "sean@host",
+    });
+  });
+
+  it("ignores non-ssh commands", () => {
+    const tracker = new SshCommandTracker();
+    expect(tracker.feed("git status\r")).toBeNull();
+  });
+});
+

--- a/src/modules/terminal/lib/sshCommandTracker.ts
+++ b/src/modules/terminal/lib/sshCommandTracker.ts
@@ -1,0 +1,223 @@
+export type SshCommandSpec = {
+  user: string | null;
+  host: string;
+  port: number | null;
+  rawTarget: string;
+};
+
+const SSH_OPTIONS_WITH_VALUE = new Set([
+  "-b",
+  "-c",
+  "-D",
+  "-E",
+  "-F",
+  "-I",
+  "-i",
+  "-J",
+  "-L",
+  "-l",
+  "-m",
+  "-O",
+  "-o",
+  "-p",
+  "-Q",
+  "-R",
+  "-S",
+  "-W",
+  "-w",
+]);
+
+type Token = {
+  value: string;
+  quoted: boolean;
+};
+
+export class SshCommandTracker {
+  private buffer = "";
+  private inEscape = false;
+
+  reset(): void {
+    this.buffer = "";
+    this.inEscape = false;
+  }
+
+  feed(data: string): SshCommandSpec | null {
+    for (let i = 0; i < data.length; i++) {
+      const ch = data[i];
+      if (this.inEscape) {
+        if (isEscapeFinalByte(ch)) this.inEscape = false;
+        continue;
+      }
+
+      if (ch === "\u001b") {
+        this.inEscape = true;
+        continue;
+      }
+
+      if (ch === "\r" || ch === "\n") {
+        const cmd = this.buffer;
+        this.reset();
+        const spec = parseSshCommandLine(cmd);
+        if (spec) return spec;
+        continue;
+      }
+
+      if (ch === "\u007f" || ch === "\b") {
+        this.buffer = this.buffer.slice(0, -1);
+        continue;
+      }
+
+      if (ch === "\u0015") {
+        this.buffer = "";
+        continue;
+      }
+
+      if (ch === "\u0017") {
+        this.buffer = this.buffer.replace(/\s+\S*$/, "");
+        continue;
+      }
+
+      if (!isIgnorableControl(ch)) {
+        this.buffer += ch;
+      }
+    }
+    return null;
+  }
+}
+
+function isIgnorableControl(ch: string): boolean {
+  const code = ch.charCodeAt(0);
+  return code < 0x20 && ch !== "\t";
+}
+
+function isEscapeFinalByte(ch: string): boolean {
+  const code = ch.charCodeAt(0);
+  return code >= 0x40 && code <= 0x7e;
+}
+
+function tokenizeShell(line: string): Token[] {
+  const out: Token[] = [];
+  let current = "";
+  let quoted = false;
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  const push = () => {
+    if (!current && !quoted) return;
+    out.push({ value: current, quoted });
+    current = "";
+    quoted = false;
+  };
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (quote === "'") {
+      if (ch === "'") {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (quote === '"') {
+      if (ch === '"') {
+        quote = null;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      quoted = true;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      quoted = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      push();
+      continue;
+    }
+    current += ch;
+  }
+  push();
+  return out;
+}
+
+export function parseSshCommandLine(line: string): SshCommandSpec | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const tokens = tokenizeShell(trimmed);
+  if (tokens.length === 0) return null;
+  if (tokens[0]?.value !== "ssh" || tokens[0].quoted) return null;
+
+  let port: number | null = null;
+  let target: string | null = null;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    const value = token.value;
+    if (!value) continue;
+    if (value === "--") {
+      target = tokens[i + 1]?.value ?? null;
+      break;
+    }
+    if (value.startsWith("-")) {
+      if (value === "-p" && tokens[i + 1]) {
+        const next = tokens[++i];
+        const parsed = Number.parseInt(next.value, 10);
+        if (Number.isFinite(parsed)) port = parsed;
+        continue;
+      }
+      if (SSH_OPTIONS_WITH_VALUE.has(value) && tokens[i + 1]) {
+        i++;
+        continue;
+      }
+      if (/^-[^-]/.test(value) && value.length > 2) {
+        const opt = value.slice(0, 2);
+        if (SSH_OPTIONS_WITH_VALUE.has(opt) && value.length > 2) {
+          if (opt === "-p") {
+            const parsed = Number.parseInt(value.slice(2), 10);
+            if (Number.isFinite(parsed)) port = parsed;
+          }
+          continue;
+        }
+      }
+      continue;
+    }
+    target = value;
+    break;
+  }
+
+  if (!target) return null;
+
+  let user: string | null = null;
+  let host = target;
+  if (host.startsWith("[") && host.includes("]")) {
+    const close = host.indexOf("]");
+    host = host.slice(1, close);
+  }
+  const at = host.indexOf("@");
+  if (at >= 0) {
+    user = host.slice(0, at) || null;
+    host = host.slice(at + 1);
+  }
+  host = host.trim();
+  if (!host) return null;
+  return {
+    user,
+    host,
+    port,
+    rawTarget: target,
+  };
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { ensureMonoFontsLoaded } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { DormantRing } from "./dormantRing";
@@ -8,6 +9,7 @@ import {
   createShellIntegrationState,
   registerCwdHandler,
   registerPromptTracker,
+  type Osc7Location,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
 import {
@@ -29,12 +31,14 @@ import {
 type Callbacks = {
   onSearchReady?: (addon: SearchAddon) => void;
   onExit?: (code: number) => void;
-  onCwd?: (cwd: string) => void;
+  onCwd?: (cwd: string, host: string | null) => void;
+  onCommandStart?: (command: string) => void;
 };
 
 type Session = {
   pty: PtySession | null;
   ptyOpening: boolean;
+  workspace: WorkspaceEnv;
   initialCwd: string | undefined;
   lastCwd: string | null;
   pendingExit: number | null;
@@ -166,6 +170,7 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
   const session: Session = {
     pty: null,
     ptyOpening: false,
+    workspace: { kind: "local" },
     initialCwd,
     lastCwd: null,
     pendingExit: null,
@@ -205,6 +210,7 @@ function deliverPtyBytes(leafId: number, bytes: Uint8Array): void {
 async function openPtyForSession(
   leafId: number,
   s: Session,
+  workspace: WorkspaceEnv,
   cwd: string | undefined,
 ): Promise<PtySession> {
   const startCols = s.cols > 0 ? s.cols : 80;
@@ -223,6 +229,7 @@ async function openPtyForSession(
         else s.pendingExit = code;
       },
     },
+    workspace,
     cwd,
   );
 }
@@ -247,14 +254,16 @@ function bindLeafToSlot(leafId: number, s: Session): void {
       // 7 emitted by untrusted command output (remote SSH, `cat` of an
       // attacker file, etc.).
       const shellState = createShellIntegrationState();
-      const prompt = registerPromptTracker(term, shellState);
+      const prompt = registerPromptTracker(term, shellState, {
+        onCommandStart: (command) => s.callbacks.onCommandStart?.(command),
+      });
       const cwd = registerCwdHandler(
         term,
-        (next) => {
+        (next: Osc7Location) => {
           markSessionReady(leafId);
-          if (s.lastCwd === next) return;
-          s.lastCwd = next;
-          s.callbacks.onCwd?.(next);
+          if (s.lastCwd === next.cwd) return;
+          s.lastCwd = next.cwd;
+          s.callbacks.onCwd?.(next.cwd, next.host);
         },
         shellState,
       );
@@ -264,7 +273,7 @@ function bindLeafToSlot(leafId: number, s: Session): void {
   });
   s.snapshot = null;
   s.hasSlot = true;
-  if (s.lastCwd !== null) s.callbacks.onCwd?.(s.lastCwd);
+  if (s.lastCwd !== null) s.callbacks.onCwd?.(s.lastCwd, null);
   if (s.pendingExit !== null) {
     const code = s.pendingExit;
     s.pendingExit = null;
@@ -287,6 +296,7 @@ function unbindLeafFromSlot(leafId: number, s: Session): void {
 function attachSession(
   leafId: number,
   container: HTMLDivElement,
+  workspace: WorkspaceEnv,
   callbacks: Callbacks,
 ): void {
   const s = sessions.get(leafId);
@@ -298,7 +308,7 @@ function attachSession(
 
   if (!s.pty && !s.ptyOpening && !s.shellExited) {
     s.ptyOpening = true;
-    openPtyForSession(leafId, s, s.initialCwd)
+    openPtyForSession(leafId, s, workspace, s.initialCwd)
       .then((pty) => {
         s.ptyOpening = false;
         if (s.disposed) {
@@ -347,7 +357,7 @@ export async function respawnSession(
   s.ptyOpening = true;
   let pty: PtySession;
   try {
-    pty = await openPtyForSession(leafId, s, cwd ?? s.initialCwd);
+    pty = await openPtyForSession(leafId, s, s.workspace, cwd ?? s.initialCwd);
   } catch (e) {
     s.ptyOpening = false;
     console.error("[terax] respawn openPty failed:", e);
@@ -399,10 +409,14 @@ type Options = {
   container: React.RefObject<HTMLDivElement | null>;
   visible: boolean;
   focused?: boolean;
+  workspace: WorkspaceEnv;
+  workspaceKey: string;
+  workspaceNonce: number;
   initialCwd?: string;
   onSearchReady?: (addon: SearchAddon) => void;
   onExit?: (code: number) => void;
-  onCwd?: (cwd: string) => void;
+  onCwd?: (cwd: string, host: string | null) => void;
+  onCommandStart?: (command: string) => void;
 };
 
 export function useTerminalSession({
@@ -410,25 +424,64 @@ export function useTerminalSession({
   container,
   visible,
   focused = true,
+  workspace,
+  workspaceKey,
+  workspaceNonce,
   initialCwd,
   onSearchReady,
   onExit,
   onCwd,
+  onCommandStart,
 }: Options) {
   const cbRef = useRef({ onSearchReady, onExit, onCwd });
   cbRef.current = { onSearchReady, onExit, onCwd };
+  const commandStartRef = useRef(onCommandStart);
+  commandStartRef.current = onCommandStart;
+  const workspaceRef = useRef(workspace);
+  const workspaceKeyRef = useRef(workspaceKey);
+  const workspaceNonceRef = useRef(workspaceNonce);
+  const visibleRef = useRef(visible);
+  const focusedRef = useRef(focused);
+
+  useEffect(() => {
+    visibleRef.current = visible;
+    focusedRef.current = focused;
+  }, [visible, focused]);
+
+  useEffect(() => {
+    workspaceRef.current = workspace;
+  }, [workspace]);
+
+  useEffect(() => {
+    const s = sessions.get(leafId);
+    if (s) s.workspace = workspace;
+  }, [leafId, workspace]);
 
   useEffect(() => {
     let cancelled = false;
+    const nextWorkspaceKey = workspaceKey;
+    const workspaceChanged = workspaceKeyRef.current !== nextWorkspaceKey;
+    const nonceChanged = workspaceNonceRef.current !== workspaceNonce;
+    if (workspaceChanged || nonceChanged) {
+      workspaceKeyRef.current = nextWorkspaceKey;
+      workspaceNonceRef.current = workspaceNonce;
+      disposeSession(leafId);
+    }
     const s = ensureSession(leafId, initialCwd);
+    s.visibleNow = visibleRef.current;
+    s.focusedNow = focusedRef.current;
     s.ready.then(() => {
       if (cancelled || s.disposed) return;
       const node = container.current;
       if (!node) return;
-      attachSession(leafId, node, {
+      s.workspace = workspaceRef.current;
+      s.visibleNow = visibleRef.current;
+      s.focusedNow = focusedRef.current;
+      attachSession(leafId, node, workspaceRef.current, {
         onSearchReady: (a) => cbRef.current.onSearchReady?.(a),
         onExit: (c) => cbRef.current.onExit?.(c),
-        onCwd: (c) => cbRef.current.onCwd?.(c),
+        onCwd: (c, host) => cbRef.current.onCwd?.(c, host),
+        onCommandStart: (command) => commandStartRef.current?.(command),
       });
       if (s.visibleNow && s.focusedNow) focusSlot(leafId);
     });
@@ -436,7 +489,7 @@ export function useTerminalSession({
       cancelled = true;
       detachSession(leafId);
     };
-  }, [leafId, container, initialCwd]);
+  }, [leafId, container, initialCwd, workspaceKey, workspaceNonce]);
 
   const fontSize = usePreferencesStore((p) => p.terminalFontSize);
   const zoomLevel = usePreferencesStore((p) => p.zoomLevel);
@@ -490,7 +543,13 @@ export function useTerminalSession({
     [leafId],
   );
 
-  const focus = useCallback(() => focusSlot(leafId), [leafId]);
+  const focus = useCallback(() => {
+    const s = sessions.get(leafId);
+    if (s?.visibleNow && s.container && !s.hasSlot) {
+      bindLeafToSlot(leafId, s);
+    }
+    focusSlot(leafId);
+  }, [leafId]);
 
   const getBuffer = useCallback(
     (maxLines = 200): string | null => {

--- a/src/modules/workspace/SshWorkspaceDialog.tsx
+++ b/src/modules/workspace/SshWorkspaceDialog.tsx
@@ -1,0 +1,243 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { SshWorkspaceProfile } from "./env";
+
+type FormState = {
+  label: string;
+  host: string;
+  user: string;
+  port: string;
+  rootPath: string;
+  password: string;
+};
+
+const DEFAULT_ROOT = "/home";
+
+function newId(): string {
+  return crypto.randomUUID().slice(0, 8);
+}
+
+function normalizeRootPath(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return DEFAULT_ROOT;
+  if (trimmed.length > 1 && trimmed.endsWith("/")) return trimmed.replace(/\/+$/, "");
+  return trimmed;
+}
+
+export function makeSshProfile(form: FormState): SshWorkspaceProfile {
+  return makeSshProfileWithId(form, newId());
+}
+
+export function makeSshProfileWithId(
+  form: FormState,
+  id: string,
+): SshWorkspaceProfile {
+  const host = form.host.trim();
+  const user = form.user.trim() || null;
+  const port = form.port.trim() ? Number.parseInt(form.port.trim(), 10) : null;
+  const rootPath = normalizeRootPath(form.rootPath);
+  const label =
+    form.label.trim() ||
+    `SSH: ${user ? `${user}@` : ""}${host}${port ? `:${port}` : ""}`;
+  return {
+    id,
+    label,
+    host,
+    user,
+    port: Number.isFinite(port ?? NaN) ? port : null,
+    rootPath,
+  };
+}
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit" | "connect";
+  profile: SshWorkspaceProfile | null;
+  onSubmit: (
+    profile: SshWorkspaceProfile,
+    password: string,
+  ) => Promise<void> | void;
+};
+
+function emptyForm(): FormState {
+  return {
+    label: "",
+    host: "",
+    user: "",
+    port: "",
+    rootPath: DEFAULT_ROOT,
+    password: "",
+  };
+}
+
+function formFromProfile(profile: SshWorkspaceProfile | null): FormState {
+  if (!profile) return emptyForm();
+  return {
+    label: profile.label,
+    host: profile.host,
+    user: profile.user ?? "",
+    port: profile.port?.toString() ?? "",
+    rootPath: profile.rootPath || DEFAULT_ROOT,
+    password: "",
+  };
+}
+
+function isConnectMode(mode: Props["mode"]): boolean {
+  return mode === "connect";
+}
+
+export function SshWorkspaceDialog({
+  open,
+  onOpenChange,
+  mode,
+  profile,
+  onSubmit,
+}: Props) {
+  const [form, setForm] = useState<FormState>({
+    ...emptyForm(),
+  });
+  const [error, setError] = useState<string | null>(null);
+  const hostRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(formFromProfile(profile));
+    setError(null);
+    setTimeout(() => hostRef.current?.focus(), 0);
+  }, [open, profile]);
+
+  const preview = useMemo(() => {
+    const host = form.host.trim();
+    if (!host) return "SSH";
+    const user = form.user.trim() ? `${form.user.trim()}@` : "";
+    const port = form.port.trim() ? `:${form.port.trim()}` : "";
+    return form.label.trim() || `SSH: ${user}${host}${port}`;
+  }, [form.host, form.label, form.port, form.user]);
+
+  const submit = async () => {
+    const host = form.host.trim();
+    if (!host) {
+      setError("Host is required");
+      return;
+    }
+    const rawPort = form.port.trim();
+    if (rawPort && !/^\d+$/.test(rawPort)) {
+      setError("Port must be numeric");
+      return;
+    }
+    const nextProfile =
+      mode !== "create" && profile
+        ? makeSshProfileWithId(form, profile.id)
+        : makeSshProfile(form);
+    if (!nextProfile.rootPath.startsWith("/")) {
+      setError("Root path must be absolute");
+      return;
+    }
+    try {
+      await onSubmit(nextProfile, form.password);
+      onOpenChange(false);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "edit"
+              ? "Edit SSH workspace"
+              : isConnectMode(mode)
+                ? "Connect SSH workspace"
+                : "New SSH workspace"}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === "connect"
+              ? "Enter the SSH password for this workspace."
+              : "Connect the explorer and source control panels to a remote root."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2">
+          <Input
+            value={form.label}
+            readOnly={mode === "connect"}
+            aria-readonly={mode === "connect"}
+            onChange={(e) => setForm((s) => ({ ...s, label: e.target.value }))}
+            placeholder="Label"
+          />
+          <Input
+            ref={hostRef}
+            value={form.host}
+            readOnly={mode === "connect"}
+            aria-readonly={mode === "connect"}
+            onChange={(e) => setForm((s) => ({ ...s, host: e.target.value }))}
+            placeholder="Host"
+          />
+          <div className="grid grid-cols-[1fr_120px] gap-2">
+            <Input
+              value={form.user}
+              readOnly={mode === "connect"}
+              aria-readonly={mode === "connect"}
+              onChange={(e) => setForm((s) => ({ ...s, user: e.target.value }))}
+              placeholder="User"
+            />
+            <Input
+              value={form.port}
+              readOnly={mode === "connect"}
+              aria-readonly={mode === "connect"}
+              onChange={(e) => setForm((s) => ({ ...s, port: e.target.value }))}
+              placeholder="Port"
+              inputMode="numeric"
+            />
+          </div>
+          <Input
+            value={form.rootPath}
+            readOnly={mode === "connect"}
+            aria-readonly={mode === "connect"}
+            onChange={(e) =>
+              setForm((s) => ({ ...s, rootPath: e.target.value }))
+            }
+            placeholder="/home/project"
+          />
+          <Input
+            type="password"
+            value={form.password}
+            onChange={(e) =>
+              setForm((s) => ({ ...s, password: e.target.value }))
+            }
+            placeholder={mode === "connect" ? "Password" : "Password"}
+            autoComplete="current-password"
+          />
+        </div>
+        {error ? (
+          <div className="text-xs text-destructive">{error}</div>
+        ) : (
+          <div className="text-xs text-muted-foreground truncate">{preview}</div>
+        )}
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()}>
+            {mode === "edit"
+              ? "Update"
+              : mode === "connect"
+                ? "Connect"
+                : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/workspace/env.test.ts
+++ b/src/modules/workspace/env.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { sameWorkspaceEnv, workspaceScopeKey, type WorkspaceEnv } from "./env";
+
+function sshEnv(rootPath: string): WorkspaceEnv {
+  return {
+    kind: "ssh",
+    id: "ssh-1",
+    label: "remote",
+    host: "100.72.187.38",
+    user: "sean",
+    port: 22,
+    rootPath,
+  };
+}
+
+describe("workspace env identity", () => {
+  it("ignores SSH root path when comparing workspace identity", () => {
+    expect(sameWorkspaceEnv(sshEnv("/home/sean"), sshEnv("/home/sean/Github"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps SSH scope stable across cwd changes", () => {
+    expect(workspaceScopeKey(sshEnv("/home/sean"))).toBe(
+      "ssh:sean@100.72.187.38:22",
+    );
+    expect(workspaceScopeKey(sshEnv("/home/sean/Github"))).toBe(
+      "ssh:sean@100.72.187.38:22",
+    );
+  });
+});
+

--- a/src/modules/workspace/env.ts
+++ b/src/modules/workspace/env.ts
@@ -2,9 +2,19 @@ import { invoke } from "@tauri-apps/api/core";
 import { create } from "zustand";
 import { setLastWslDistro } from "@/modules/settings/store";
 
+export type SshWorkspaceProfile = {
+  id: string;
+  label: string;
+  host: string;
+  user: string | null;
+  port: number | null;
+  rootPath: string;
+};
+
 export type WorkspaceEnv =
   | { kind: "local" }
-  | { kind: "wsl"; distro: string };
+  | { kind: "wsl"; distro: string }
+  | ({ kind: "ssh"; password?: string | null } & SshWorkspaceProfile);
 
 export type WslDistro = {
   name: string;
@@ -22,6 +32,22 @@ type State = {
 };
 
 export const LOCAL_WORKSPACE: WorkspaceEnv = { kind: "local" };
+
+export function sameWorkspaceEnv(a: WorkspaceEnv, b: WorkspaceEnv): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "local") return true;
+  if (a.kind === "wsl") {
+    return a.distro === (b as Extract<WorkspaceEnv, { kind: "wsl" }>).distro;
+  }
+  const lhs = a as Extract<WorkspaceEnv, { kind: "ssh" }>;
+  const rhs = b as Extract<WorkspaceEnv, { kind: "ssh" }>;
+  return (
+    lhs.id === rhs.id &&
+    lhs.host === rhs.host &&
+    lhs.user === rhs.user &&
+    lhs.port === rhs.port
+  );
+}
 
 export const useWorkspaceEnvStore = create<State>((set) => ({
   env: LOCAL_WORKSPACE,
@@ -50,13 +76,43 @@ export function currentWorkspaceEnv(): WorkspaceEnv {
 }
 
 export function workspaceScopeKey(env: WorkspaceEnv): string {
-  return env.kind === "wsl" ? `wsl:${env.distro}` : "local";
+  if (env.kind === "wsl") return `wsl:${env.distro}`;
+  if (env.kind === "ssh") {
+    const user = env.user ?? "";
+    const port = env.port ? `:${env.port}` : "";
+    return `ssh:${user}@${env.host}${port}`;
+  }
+  return "local";
 }
 
 export function currentWorkspaceScopeKey(): string {
   return workspaceScopeKey(currentWorkspaceEnv());
 }
 
+export function workspaceDisplayLabel(env: WorkspaceEnv): string {
+  if (env.kind === "local") return "Local";
+  if (env.kind === "wsl") return `WSL: ${env.distro}`;
+  const user = env.user ? `${env.user}@` : "";
+  const port = env.port ? `:${env.port}` : "";
+  return env.label.trim() || `SSH: ${user}${env.host}${port}`;
+}
+
 export async function getWslHome(distro: string): Promise<string> {
   return invoke<string>("wsl_home", { distro });
+}
+
+export function normalizeHostName(value: string | null | undefined): string {
+  const trimmed = value?.trim().toLowerCase() ?? "";
+  if (!trimmed) return "";
+  return trimmed.replace(/\.local$/, "");
+}
+
+export function isLocalHost(
+  remoteHost: string | null | undefined,
+  localHost: string | null | undefined,
+): boolean {
+  const remote = normalizeHostName(remoteHost);
+  const local = normalizeHostName(localHost);
+  if (!remote || !local) return false;
+  return remote === local;
 }

--- a/src/modules/workspace/hostname.test.ts
+++ b/src/modules/workspace/hostname.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isLocalHost, normalizeHostName } from "./hostname";
+
+describe("hostname helpers", () => {
+  it("normalizes case and .local suffix", () => {
+    expect(normalizeHostName("SeanPC.local")).toBe("seanpc");
+    expect(normalizeHostName("  SEANPC  ")).toBe("seanpc");
+  });
+
+  it("treats unresolved local host as non-match", () => {
+    expect(isLocalHost("SeanPC", null)).toBe(false);
+    expect(isLocalHost("SeanPC", "")).toBe(false);
+  });
+
+  it("matches local host after normalization", () => {
+    expect(isLocalHost("SeanPC.local", "seanpc")).toBe(true);
+    expect(isLocalHost("seanpc", "SeanPC.local")).toBe(true);
+  });
+});

--- a/src/modules/workspace/hostname.ts
+++ b/src/modules/workspace/hostname.ts
@@ -1,0 +1,12 @@
+export function normalizeHostName(value: string | null | undefined): string {
+  const trimmed = value?.trim().toLowerCase() ?? "";
+  if (!trimmed) return "";
+  return trimmed.replace(/\.local$/, "");
+}
+
+export function isLocalHost(remoteHost: string | null | undefined, localHost: string | null | undefined): boolean {
+  const remote = normalizeHostName(remoteHost);
+  const local = normalizeHostName(localHost);
+  if (!remote || !local) return false;
+  return remote === local;
+}

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -2,9 +2,13 @@ export {
   currentWorkspaceScopeKey,
   currentWorkspaceEnv,
   getWslHome,
+  isLocalHost,
   LOCAL_WORKSPACE,
+  sameWorkspaceEnv,
+  workspaceDisplayLabel,
   useWorkspaceEnvStore,
   workspaceScopeKey,
   type WorkspaceEnv,
+  type SshWorkspaceProfile,
   type WslDistro,
 } from "./env";

--- a/src/modules/workspace/sshSecrets.ts
+++ b/src/modules/workspace/sshSecrets.ts
@@ -1,0 +1,45 @@
+import { invoke } from "@tauri-apps/api/core";
+import { KEYRING_SERVICE } from "@/modules/ai/config";
+
+const SSH_PASSWORD_PREFIX = "ssh-password";
+
+function accountFor(profileId: string): string {
+  return `${SSH_PASSWORD_PREFIX}:${profileId}`;
+}
+
+export async function getSshPassword(
+  profileId: string,
+): Promise<string | null> {
+  try {
+    const value = await invoke<string | null>("secrets_get", {
+      service: KEYRING_SERVICE,
+      account: accountFor(profileId),
+    });
+    return value && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setSshPassword(
+  profileId: string,
+  password: string,
+): Promise<void> {
+  if (password.length === 0) return;
+  await invoke("secrets_set", {
+    service: KEYRING_SERVICE,
+    account: accountFor(profileId),
+    password,
+  });
+}
+
+export async function clearSshPassword(profileId: string): Promise<void> {
+  try {
+    await invoke("secrets_delete", {
+      service: KEYRING_SERVICE,
+      account: accountFor(profileId),
+    });
+  } catch {
+    // already absent
+  }
+}

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -18,6 +18,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 
 const ICON_BY_PROVIDER = {
   openai: ChatGptIcon,
+  codex: ChatGptIcon,
   anthropic: ClaudeIcon,
   google: GoogleGeminiIcon,
   xai: Grok02Icon,

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -18,6 +18,7 @@ import {
   getAutocompleteEligibleModels,
   getModel,
   getProvider,
+  isCodexModelId,
   providerNeedsKey,
   type CustomEndpoint,
   type ModelId,
@@ -27,12 +28,13 @@ import {
 import {
   clearKey,
   clearCustomEndpointKey,
-  getAllKeys,
-  getAllCustomEndpointKeys,
+  EMPTY_PROVIDER_KEYS,
   setKey,
   setCustomEndpointKey,
   type CustomEndpointKeys,
 } from "@/modules/ai/lib/keyring";
+import { native } from "@/modules/ai/lib/native";
+import { useCodexAuthStore } from "@/modules/ai/store/codexAuthStore";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
@@ -100,9 +102,7 @@ const LOCAL_META: Partial<Record<ProviderId, LocalMeta>> = {
     modelPlaceholder: "mlx-community/Qwen2.5-Coder-7B-Instruct-4bit",
     description:
       "Apple-silicon inference via mlx_lm.server (pip install mlx-lm).",
-    modelHint: (
-      <>The Hugging Face repo path you launched mlx_lm.server with.</>
-    ),
+    modelHint: <>The Hugging Face repo path you launched mlx_lm.server with.</>,
   },
   ollama: {
     urlPlaceholder: "http://localhost:11434/v1",
@@ -122,15 +122,14 @@ const LOCAL_META: Partial<Record<ProviderId, LocalMeta>> = {
     description: "Any model on OpenRouter — type its full provider/model id.",
     modelHint: (
       <>
-        Browse ids at{" "}
-        <span className="font-mono">openrouter.ai/models</span>.
+        Browse ids at <span className="font-mono">openrouter.ai/models</span>.
       </>
     ),
   },
 };
 
 export function ModelsSection() {
-  const [keys, setKeys] = useState<KeysMap | null>(null);
+  const [keys, setKeys] = useState<KeysMap>({ ...EMPTY_PROVIDER_KEYS });
   const [epKeys, setEpKeys] = useState<CustomEndpointKeys>({});
   const [adding, setAdding] = useState<Set<ProviderId>>(new Set());
 
@@ -148,36 +147,45 @@ export function ModelsSection() {
   );
   const openrouterModelId = usePreferencesStore((s) => s.openrouterModelId);
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
+  const codexStatus = useCodexAuthStore((s) => s.status);
+  const codexModelsAvailable = codexStatus?.logged_in !== false;
 
   useEffect(() => {
-    void getAllKeys().then(setKeys);
-  }, []);
-
-  useEffect(() => {
-    void getAllCustomEndpointKeys(customEndpoints).then(setEpKeys);
-  }, [customEndpoints]);
+    if (codexModelsAvailable) return;
+    if (isCodexModelId(defaultModel)) void setDefaultModel(DEFAULT_MODEL_ID);
+  }, [codexModelsAvailable, defaultModel]);
 
   const onSaveKey = async (provider: ProviderId, value: string) => {
     await setKey(provider, value);
-    setKeys((prev) => (prev ? { ...prev, [provider]: value } : prev));
+    setKeys((prev) => ({ ...prev, [provider]: value }));
+    useChatStore.getState().setApiKey(provider, value);
     await emitKeysChanged();
   };
 
   const onClearKey = async (provider: ProviderId) => {
     await clearKey(provider);
-    setKeys((prev) => (prev ? { ...prev, [provider]: null } : prev));
+    setKeys((prev) => ({ ...prev, [provider]: null }));
+    useChatStore.getState().setApiKey(provider, null);
     await emitKeysChanged();
   };
 
   const onSaveEndpointKey = async (endpointId: string, value: string) => {
     await setCustomEndpointKey(endpointId, value);
     setEpKeys((prev) => ({ ...prev, [endpointId]: value }));
+    useChatStore.getState().setCustomEndpointKeys({
+      ...useChatStore.getState().customEndpointKeys,
+      [endpointId]: value,
+    });
     await emitKeysChanged();
   };
 
   const onClearEndpointKey = async (endpointId: string) => {
     await clearCustomEndpointKey(endpointId);
     setEpKeys((prev) => ({ ...prev, [endpointId]: null }));
+    useChatStore.getState().setCustomEndpointKeys({
+      ...useChatStore.getState().customEndpointKeys,
+      [endpointId]: null,
+    });
     await emitKeysChanged();
   };
 
@@ -208,6 +216,15 @@ export function ModelsSection() {
       delete next[id];
       return next;
     });
+    useChatStore
+      .getState()
+      .setCustomEndpointKeys(
+        Object.fromEntries(
+          Object.entries(useChatStore.getState().customEndpointKeys).filter(
+            ([key]) => key !== id,
+          ),
+        ),
+      );
 
     // Drop the now-dead model id from favorites/recents before touching the
     // selection, so the recents push from a selection reset can't race it.
@@ -229,7 +246,9 @@ export function ModelsSection() {
     const { selectedModelId, setSelectedModelId } = useChatStore.getState();
     if (selectedModelId === deadModelId) {
       setSelectedModelId(
-        remaining[0] ? compatModelIdForEndpoint(remaining[0].id) : DEFAULT_MODEL_ID,
+        remaining[0]
+          ? compatModelIdForEndpoint(remaining[0].id)
+          : DEFAULT_MODEL_ID,
       );
     }
 
@@ -282,8 +301,8 @@ export function ModelsSection() {
   };
 
   const isConfigured = (id: ProviderId): boolean => {
-    if (id === "openrouter")
-      return !!keys?.[id] && !!openrouterModelId.trim();
+    if (id === "codex") return true;
+    if (id === "openrouter") return !!keys?.[id] && !!openrouterModelId.trim();
     if (!isLocalProvider(id)) return !!keys?.[id];
     const cfg = localConfig(id);
     if (!cfg) return false;
@@ -291,10 +310,6 @@ export function ModelsSection() {
       return !!cfg.baseURL.trim() && !!cfg.modelId.trim();
     return !!cfg.modelId.trim();
   };
-
-  if (!keys) {
-    return <div className="text-[12px] text-muted-foreground">Loading…</div>;
-  }
 
   const configuredIds = new Set(
     PROVIDERS.filter((p) => isConfigured(p.id)).map((p) => p.id),
@@ -344,6 +359,7 @@ export function ModelsSection() {
         defaultModel={defaultModel}
         configuredIds={configuredIds}
         keys={keys}
+        codexModelsAvailable={codexModelsAvailable}
       />
 
       <div className="flex flex-col gap-3">
@@ -368,7 +384,9 @@ export function ModelsSection() {
         ) : (
           <div className="flex flex-col gap-2">
             {visibleProviders.map((p) =>
-              p.id === "openrouter" ? (
+              p.id === "codex" ? (
+                <CodexProviderCard key={p.id} provider={p} />
+              ) : p.id === "openrouter" ? (
                 <LocalProviderCard
                   key={p.id}
                   provider={p}
@@ -440,7 +458,10 @@ function AddProviderMenu({
   onAddCompat: () => void;
 }) {
   const cloud = providers.filter((p) => !isLocalProvider(p.id));
-  const local = providers.filter((p) => isLocalProvider(p.id) && p.id !== "openai-compatible");
+  const local = providers.filter(
+    (p) =>
+      isLocalProvider(p.id) && p.id !== "codex" && p.id !== "openai-compatible",
+  );
 
   return (
     <DropdownMenu>
@@ -505,10 +526,12 @@ function DefaultsBlock({
   defaultModel,
   configuredIds,
   keys,
+  codexModelsAvailable,
 }: {
   defaultModel: ModelId;
   configuredIds: Set<ProviderId>;
   keys: KeysMap;
+  codexModelsAvailable: boolean;
 }) {
   return (
     <div className="flex flex-col gap-3">
@@ -518,6 +541,7 @@ function DefaultsBlock({
           <DefaultModelPicker
             defaultModel={defaultModel}
             configuredIds={configuredIds}
+            codexModelsAvailable={codexModelsAvailable}
           />
         </FieldRow>
         <AutocompleteRow keys={keys} configuredIds={configuredIds} />
@@ -529,9 +553,11 @@ function DefaultsBlock({
 function DefaultModelPicker({
   defaultModel,
   configuredIds,
+  codexModelsAvailable,
 }: {
   defaultModel: ModelId;
   configuredIds: Set<ProviderId>;
+  codexModelsAvailable: boolean;
 }) {
   const m = getModel(defaultModel);
   const hasAny = configuredIds.size > 0;
@@ -565,7 +591,11 @@ function DefaultModelPicker({
         className="min-w-70 p-1"
       >
         <div className="max-h-72 overflow-y-auto overscroll-contain pr-1">
-          {PROVIDERS.filter((p) => configuredIds.has(p.id)).map((p) => {
+          {PROVIDERS.filter(
+            (p) =>
+              configuredIds.has(p.id) &&
+              (p.id !== "codex" || codexModelsAvailable),
+          ).map((p) => {
             const models = MODELS.filter((x) => x.provider === p.id);
             if (models.length === 0) return null;
             return (
@@ -615,7 +645,8 @@ function AutocompleteRow({
   // Fast cloud tiers + any configured local provider (one model id each).
   const items = useMemo(() => {
     const local = PROVIDERS.filter(
-      (p) => isLocalProvider(p.id) && configuredIds.has(p.id),
+      (p) =>
+        isLocalProvider(p.id) && p.id !== "codex" && configuredIds.has(p.id),
     ).flatMap((p) => {
       const m = MODELS.find((x) => x.provider === p.id);
       return m ? [m] : [];
@@ -735,6 +766,137 @@ function AutocompleteRow({
   );
 }
 
+function CodexProviderCard({ provider }: { provider: ProviderInfo }) {
+  const status = useCodexAuthStore((s) => s.status);
+  const setStatus = useCodexAuthStore((s) => s.setStatus);
+  const [busy, setBusy] = useState<"idle" | "refresh" | "login" | "logout">(
+    "idle",
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setBusy("refresh");
+    setError(null);
+    try {
+      setStatus(await native.codexAuthStatus());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy("idle");
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const login = async () => {
+    setBusy("login");
+    setError(null);
+    try {
+      setStatus(await native.codexLoginChatGpt());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy("idle");
+    }
+  };
+
+  const logout = async () => {
+    setBusy("logout");
+    setError(null);
+    try {
+      const next = await native.codexLogout();
+      setStatus(next);
+      if (!next.logged_in) {
+        const { selectedModelId, setSelectedModelId } = useChatStore.getState();
+        if (isCodexModelId(selectedModelId)) {
+          setSelectedModelId(DEFAULT_MODEL_ID);
+        }
+        if (isCodexModelId(usePreferencesStore.getState().defaultModelId)) {
+          await setDefaultModel(DEFAULT_MODEL_ID);
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy("idle");
+    }
+  };
+
+  const loggedIn = status?.logged_in ?? false;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
+      <div className="flex items-center gap-2">
+        <ProviderIcon provider={provider.id} size={15} />
+        <span className="text-[12.5px] font-medium">{provider.label}</span>
+        {loggedIn ? (
+          <Badge
+            variant="outline"
+            className="ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal text-muted-foreground"
+          >
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              size={9}
+              strokeWidth={2}
+            />
+            Connected
+          </Badge>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => void openUrl(provider.consoleUrl)}
+          className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Codex
+          <HugeiconsIcon
+            icon={ArrowUpRight01Icon}
+            size={11}
+            strokeWidth={1.75}
+          />
+        </button>
+      </div>
+
+      <span className="text-[10.5px] leading-relaxed text-muted-foreground">
+        Uses the local Codex app-server with your ChatGPT/Codex login. No OpenAI
+        API key is stored or required.
+      </span>
+
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={() => (loggedIn ? void refresh() : void login())}
+          disabled={busy !== "idle"}
+          className="h-8 px-3 text-[11px]"
+        >
+          {busy === "login"
+            ? "Waiting for browser..."
+            : busy === "refresh"
+              ? "Checking..."
+              : loggedIn
+                ? "Refresh status"
+                : "Sign in with ChatGPT"}
+        </Button>
+        {loggedIn ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => void logout()}
+            disabled={busy !== "idle"}
+            className="h-8 px-3 text-[11px] text-muted-foreground hover:text-destructive"
+          >
+            {busy === "logout" ? "Signing out..." : "Sign out"}
+          </Button>
+        ) : null}
+        <span className="min-w-0 flex-1 truncate text-[10.5px] text-muted-foreground">
+          {error ?? status?.detail ?? "Checking Codex login..."}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function LocalProviderCard({
   provider,
   configured,
@@ -798,7 +960,11 @@ function LocalProviderCard({
             variant="outline"
             className="ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal text-muted-foreground"
           >
-            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={9} strokeWidth={2} />
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              size={9}
+              strokeWidth={2}
+            />
             Connected
           </Badge>
         ) : null}
@@ -808,7 +974,11 @@ function LocalProviderCard({
           className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-muted-foreground transition-colors hover:text-foreground"
         >
           Docs
-          <HugeiconsIcon icon={ArrowUpRight01Icon} size={11} strokeWidth={1.75} />
+          <HugeiconsIcon
+            icon={ArrowUpRight01Icon}
+            size={11}
+            strokeWidth={1.75}
+          />
         </button>
         <Button
           size="icon"
@@ -882,7 +1052,9 @@ function LocalProviderCard({
                 spellCheck={false}
                 className="h-8 w-28 font-mono text-[11.5px]"
               />
-              <span className="text-[10.5px] text-muted-foreground">tokens</span>
+              <span className="text-[10.5px] text-muted-foreground">
+                tokens
+              </span>
             </div>
           </FieldRow>
         ) : null}
@@ -901,7 +1073,11 @@ function LocalProviderCard({
                   title="Remove key"
                   className="size-7 text-muted-foreground hover:text-destructive"
                 >
-                  <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+                  <HugeiconsIcon
+                    icon={Cancel01Icon}
+                    size={12}
+                    strokeWidth={1.75}
+                  />
                 </Button>
               </div>
             ) : (
@@ -979,8 +1155,7 @@ function CustomEndpointCard({
     [endpoint.contextLimit],
   );
 
-  const configured =
-    !!endpoint.baseURL.trim() && !!endpoint.modelId.trim();
+  const configured = !!endpoint.baseURL.trim() && !!endpoint.modelId.trim();
 
   const test = async () => {
     setTestStatus("testing");
@@ -1022,7 +1197,11 @@ function CustomEndpointCard({
             variant="outline"
             className="ml-1 h-4 gap-1 border-border/60 bg-muted/40 px-1.5 text-[10px] font-normal text-muted-foreground"
           >
-            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={9} strokeWidth={2} />
+            <HugeiconsIcon
+              icon={CheckmarkCircle02Icon}
+              size={9}
+              strokeWidth={2}
+            />
             Connected
           </Badge>
         ) : null}
@@ -1110,7 +1289,9 @@ function CustomEndpointCard({
                 spellCheck={false}
                 className="h-8 w-28 font-mono text-[11.5px]"
               />
-              <span className="text-[10.5px] text-muted-foreground">tokens</span>
+              <span className="text-[10.5px] text-muted-foreground">
+                tokens
+              </span>
             </div>
           </FieldRow>
 
@@ -1127,7 +1308,11 @@ function CustomEndpointCard({
                   title="Remove key"
                   className="size-7 text-muted-foreground hover:text-destructive"
                 >
-                  <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+                  <HugeiconsIcon
+                    icon={Cancel01Icon}
+                    size={12}
+                    strokeWidth={1.75}
+                  />
                 </Button>
               </div>
             ) : (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,6 @@
     }
   },
   "include": ["src"],
+  "exclude": ["src/**/* 2.*"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary

This builds on the existing Terax codebase with two major additions:

- Codex app-server provider support using the local Codex CLI and ChatGPT/Codex OAuth login, including login status, browser sign-in, sign-out, model selection, streaming output, and reasoning event rendering.
- SSH remote workspace support for terminals, the file explorer, source control, file operations, search, and shell/git commands. SSH profiles can be added, edited, deleted, and connected from the workspace selector; terminal `ssh user@host` can also switch the active tab/workspace context.

## Additional work included

- Per-tab workspace state so local and SSH tabs can stay independent.
- Remote cwd tracking from terminal shell integration.
- SSH file operations via a remote helper plus OpenSSH connection multiplexing for faster explorer refreshes.
- Sidebar/explorer caching for remote directories to reduce visible lag.
- Terminal context inventory for the agent.
- Tests for workspace scoping, SSH command parsing, terminal inventory, and explorer cache keys.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm test -- --runInBand src/modules/ai/config.test.ts src/modules/ai/components/AiInputBar.test.ts`
- `cargo test --locked --lib codex`
- `cargo test --locked --lib ssh_auth_options`

Note: this is a large feature branch from a fork. I am sending it for review in case any of the Codex login or SSH remote workspace pieces are useful upstream.