### PR TITLE
feat(agents): add Gemini CLI notification hooks

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, agents, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -225,6 +225,8 @@ pub fn run() {
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,
+            agents::gemini::agent_enable_gemini_hooks,
+            agents::gemini::agent_gemini_hooks_status,
             secrets::secrets_get,
             secrets::secrets_set,
             secrets::secrets_delete,

--- a/src-tauri/src/modules/agents/gemini.rs
+++ b/src-tauri/src/modules/agents/gemini.rs
@@ -1,0 +1,142 @@
+use serde_json::{json, Value};
+
+const GEMINI_EVENTS: [(&str, &str); 3] = [
+    ("BeforeAgent", "working"),
+    ("AfterAgent", "finished"),
+    ("Notification", "attention"),
+];
+
+fn settings_path() -> Result<std::path::PathBuf, String> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| "no home dir".to_string())?
+        .join(".gemini")
+        .join("settings.json"))
+}
+
+fn hook_cmd(event: &str) -> String {
+    format!(
+        r#"[ -n "$TERAX_TERMINAL" ] && printf '\033]777;notify;Terax;gemini;{}\007' || true"#,
+        event
+    )
+}
+
+fn hook_name(event: &str) -> String {
+    format!("terax-{}", event)
+}
+
+fn is_ours(group: &Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hs| {
+            hs.iter().any(|h| {
+                h.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|n| n.starts_with("terax-"))
+            })
+        })
+}
+
+fn hook_group(event: &str) -> Value {
+    json!({
+        "hooks": [{
+            "type": "command",
+            "command": hook_cmd(event),
+            "name": hook_name(event),
+            "timeout": 5000
+        }]
+    })
+}
+
+fn is_empty_group(group: &Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_none_or(|hs| hs.is_empty())
+}
+
+fn merge_hooks(mut root: Value) -> Value {
+    if !root.is_object() {
+        root = json!({});
+    }
+    let obj = root.as_object_mut().unwrap();
+    let hooks = obj.entry("hooks").or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let hooks_obj = hooks.as_object_mut().unwrap();
+
+    for (event, marker) in GEMINI_EVENTS {
+        let arr = hooks_obj.entry(event).or_insert_with(|| json!([]));
+        let arr = arr.as_array_mut().unwrap();
+        arr.retain(|g| !is_ours(g) && !is_empty_group(g));
+        arr.push(hook_group(marker));
+    }
+    root
+}
+
+/// Enable Gemini CLI hooks by writing to ~/.gemini/settings.json.
+#[tauri::command]
+pub fn agent_enable_gemini_hooks() -> Result<(), String> {
+    let path = settings_path()?;
+    std::fs::create_dir_all(path.parent().unwrap())
+        .map_err(|e| format!("mkdir: {e}"))?;
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(s) if !s.trim().is_empty() => {
+            serde_json::from_str(&s).map_err(|e| format!("invalid JSON: {e}"))?
+        }
+        Ok(_) | Err(_) => json!({}),
+    };
+    let merged = merge_hooks(existing);
+    let out = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("json.terax-tmp");
+    std::fs::write(&tmp, out).map_err(|e| format!("write: {e}"))?;
+    std::fs::rename(&tmp, &path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename: {e}")
+    })?;
+    Ok(())
+}
+
+/// Check if Gemini CLI hooks are installed.
+#[tauri::command]
+pub fn agent_gemini_hooks_status() -> bool {
+    settings_path()
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .is_some_and(|c| {
+            GEMINI_EVENTS
+                .iter()
+                .all(|(_, m)| c.contains(&format!("notify;Terax;gemini;{m}")))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_all_events_to_empty_config() {
+        let out = merge_hooks(json!({}));
+        for (event, marker) in GEMINI_EVENTS {
+            let arr = out["hooks"][event].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "missing event: {event}");
+            let cmd = arr[0]["hooks"][0]["command"].as_str().unwrap();
+            assert!(cmd.contains(&format!("gemini;{marker}")));
+        }
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let once = merge_hooks(json!({}));
+        let twice = merge_hooks(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn preserves_foreign_settings() {
+        let input = json!({"security": {"approvalMode": "yolo"}});
+        let out = merge_hooks(input);
+        assert_eq!(out["security"]["approvalMode"], "yolo");
+    }
+}

--- a/src-tauri/src/modules/agents/mod.rs
+++ b/src-tauri/src/modules/agents/mod.rs
@@ -1,0 +1,1 @@
+pub mod gemini;

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod agents;
 pub mod fs;
 pub mod git;
 pub mod net;

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -5,7 +5,7 @@ const ST_FINAL: u8 = b'\\';
 
 const OSC_MAX: usize = 2048;
 
-const DEFAULT_AGENTS: &[&str] = &["claude", "codex"];
+const DEFAULT_AGENTS: &[&str] = &["claude", "codex", "gemini"];
 
 // OSC 777 marker our Claude Code hooks emit via `terminalSequence`.
 const TERAX_MARKER: &[u8] = b"notify;Terax;";
@@ -160,21 +160,36 @@ impl AgentDetector {
     }
 
     fn handle_osc777<F: FnMut(Transition)>(&mut self, pt: &[u8], emit: &mut F) {
-        if let Some(event) = pt.strip_prefix(TERAX_MARKER) {
-            // Self-arms so notifications work even when no shell preexec fired
-            // (bash, Windows, tmux, wrappers).
+        // Parse: notify;Terax;[<agent_id>;]<event>
+        // Legacy: notify;Terax;working  → agent=claude, event=working
+        // New:    notify;Terax;gemini;finished → agent=gemini, event=finished
+        if let Some(body) = pt.strip_prefix(TERAX_MARKER) {
+            let (agent_id, event) = if let Some(semi) = body.iter().position(|&c| c == b';') {
+                let id = std::str::from_utf8(&body[..semi]).unwrap_or("claude");
+                let ev = std::str::from_utf8(&body[semi + 1..]).unwrap_or("");
+                (id, ev)
+            } else {
+                let ev = std::str::from_utf8(body).unwrap_or("");
+                ("claude", ev)
+            };
+            let agent_name = match agent_id {
+                "claude" => "Claude Code",
+                "codex" => "Codex CLI",
+                "gemini" => "Gemini CLI",
+                other => other,
+            };
             match event {
-                b"working" => {
-                    self.ensure_armed(emit);
+                "working" => {
+                    self.ensure_armed(emit, agent_name);
                     self.set_working(emit);
                 }
-                b"attention" => {
-                    self.ensure_armed(emit);
+                "attention" => {
+                    self.ensure_armed(emit, agent_name);
                     self.status = Status::Waiting;
                     emit(Transition::Attention);
                 }
-                b"finished" => {
-                    self.ensure_armed(emit);
+                "finished" => {
+                    self.ensure_armed(emit, agent_name);
                     self.status = Status::Waiting;
                     emit(Transition::Finished);
                 }
@@ -206,11 +221,11 @@ impl AgentDetector {
         }
     }
 
-    fn ensure_armed<F: FnMut(Transition)>(&mut self, emit: &mut F) {
+    fn ensure_armed<F: FnMut(Transition)>(&mut self, emit: &mut F, agent_name: &str) {
         if !self.armed {
             self.armed = true;
             self.status = Status::Working;
-            emit(Transition::Started { agent: "claude".into() });
+            emit(Transition::Started { agent: agent_name.to_string() });
         }
     }
 
@@ -321,7 +336,7 @@ mod tests {
         let mut d = AgentDetector::new();
         assert_eq!(
             run(&mut d, &osc("777;notify;Terax;attention")),
-            vec![started("claude"), Transition::Attention]
+            vec![started("Claude Code"), Transition::Attention]
         );
     }
 


### PR DESCRIPTION
## What

Adds native hook support for Gemini CLI, same pattern as the existing Claude Code hooks. Writes to ~/.gemini/settings.json using Gemini's own hook schema.

## Why

Gemini CLI has a full hook system with lifecycle events. This wires it into Terax's notification bell so the agent emits working/attention/finished markers just like Claude Code does.

## How

Three events: BeforeAgent (working), AfterAgent (finished), Notification (attention). Also refactors the OSC 777 parser in agent_detect.rs to be generic -- extracts agent_id from semicolons instead of per-agent constants. Codex and future agents work without further detector changes.

## Changes (5 files)

- agents/gemini.rs: New, isolated hook installer, 3 tests
- agents/mod.rs: New, module declaration  
- mod.rs: Added pub mod agents
- agent_detect.rs: Generic OSC 777 parser, gemini in DEFAULT_AGENTS
- lib.rs: Registered 2 new Tauri commands

## Testing

cargo check: 0 errors. cargo test --lib: all pass.

Does NOT touch agent.rs -- zero merge conflicts with PR #625 (Codex hooks).