### PR TITLE
feat(agents): add Antigravity CLI notification hooks

### DIFF
--- a/.claude/skills/generated/ai-elements/SKILL.md
+++ b/.claude/skills/generated/ai-elements/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: ai-elements
+description: "Skill for the Ai-elements area of terax-ai. 80 symbols across 14 files."
+---
+
+# Ai-elements
+
+80 symbols | 14 files | Cohesion: 75%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how MessageResponse, useReasoning, Reasoning work
+- Modifying ai-elements-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/components/ai-elements/tool.tsx` | ToolImpl, ToolInput, ToolOutput, CodeBlockMini, deriveSummary (+8) |
+| `src/components/ai-elements/context.tsx` | useContextValue, ContextIcon, ContextTrigger, TokensWithCost, ContextInputUsage (+6) |
+| `src/components/ai-elements/chat-code.tsx` | FinalizedCodeBlock, HighlightedPre, shellPrompt, normalizeLangLabel, ChatCodeBlock (+5) |
+| `src/modules/ai/components/AiChat.tsx` | basename, ReadGroup, RenderedPart, AiChatView, patchAgentMeta (+4) |
+| `src/components/ai-elements/message.tsx` | MessageResponse, useMessageBranch, MessageBranchContent, MessageBranchPrevious, MessageBranchNext (+3) |
+| `src/components/ai-elements/conversation.tsx` | Conversation, ConversationContent, ConversationEmptyState, ConversationScrollButton, getMessageText (+3) |
+| `src/components/ai-elements/chat-code-lezer.ts` | resolve, isHighlightable, getLezer, getStream, highlightStream (+2) |
+| `src/components/ai-elements/reasoning.tsx` | useReasoning, Reasoning, ReasoningTrigger, ReasoningContent |
+| `src/components/ui/collapsible.tsx` | Collapsible, CollapsibleTrigger, CollapsibleContent |
+| `src/components/ui/hover-card.tsx` | HoverCardTrigger, HoverCard |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`MessageResponse`** (Function) — `src/components/ai-elements/message.tsx:325`
+- **`useReasoning`** (Function) — `src/components/ai-elements/reasoning.tsx:33`
+- **`Reasoning`** (Function) — `src/components/ai-elements/reasoning.tsx:52`
+- **`ReasoningTrigger`** (Function) — `src/components/ai-elements/reasoning.tsx:161`
+- **`ReasoningContent`** (Function) — `src/components/ai-elements/reasoning.tsx:203`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `MessageResponse` | Function | `src/components/ai-elements/message.tsx` | 325 |
+| `useReasoning` | Function | `src/components/ai-elements/reasoning.tsx` | 33 |
+| `Reasoning` | Function | `src/components/ai-elements/reasoning.tsx` | 52 |
+| `ReasoningTrigger` | Function | `src/components/ai-elements/reasoning.tsx` | 161 |
+| `ReasoningContent` | Function | `src/components/ai-elements/reasoning.tsx` | 203 |
+| `isHighlightable` | Function | `src/components/ai-elements/chat-code-lezer.ts` | 166 |
+| `highlight` | Function | `src/components/ai-elements/chat-code-lezer.ts` | 292 |
+| `ChatCodeBlock` | Function | `src/components/ai-elements/chat-code.tsx` | 60 |
+| `MarkdownCode` | Function | `src/components/ai-elements/markdown-code.tsx` | 11 |
+| `ContextTrigger` | Function | `src/components/ai-elements/context.tsx` | 106 |
+| `ContextInputUsage` | Function | `src/components/ai-elements/context.tsx` | 252 |
+| `ContextOutputUsage` | Function | `src/components/ai-elements/context.tsx` | 292 |
+| `ContextReasoningUsage` | Function | `src/components/ai-elements/context.tsx` | 332 |
+| `ContextCacheUsage` | Function | `src/components/ai-elements/context.tsx` | 372 |
+| `Conversation` | Function | `src/components/ai-elements/conversation.tsx` | 13 |
+| `ConversationContent` | Function | `src/components/ai-elements/conversation.tsx` | 27 |
+| `ConversationEmptyState` | Function | `src/components/ai-elements/conversation.tsx` | 43 |
+| `ConversationScrollButton` | Function | `src/components/ai-elements/conversation.tsx` | 74 |
+| `AiChatView` | Function | `src/modules/ai/components/AiChat.tsx` | 180 |
+| `patchAgentMeta` | Function | `src/modules/ai/components/AiChat.tsx` | 197 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 29 calls |
+| Components | 3 calls |
+| Ai | 2 calls |
+| Theme | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "MessageResponse"})` — see callers and callees
+2. `gitnexus_query({query: "ai-elements"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/app/SKILL.md
+++ b/.claude/skills/generated/app/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: app
+description: "Skill for the App area of terax-ai. 136 symbols across 29 files."
+---
+
+# App
+
+136 symbols | 29 files | Cohesion: 76%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how getLaunchDir, parentDir, useSourceControl work
+- Modifying app-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/app/App.tsx` | dirname, clampSidebarWidth, readSidebarWidth, App, persistSidebarWidth (+62) |
+| `src/modules/tabs/lib/useTabs.ts` | useTabs, closeTab, splitActivePane, closePaneByLeaf, closeActivePane (+5) |
+| `src/modules/terminal/lib/panes.ts` | isLeaf, leafIds, splitLeaf, removeLeaf, siblingLeafOf (+5) |
+| `src/modules/terminal/lib/useTerminalSession.ts` | disposeSession, clearFocusedTerminal, deliverPtyBytes, onData, onExit (+5) |
+| `src/modules/ai/components/lazy.tsx` | AgentRunBridgeInner, AiMiniWindowInner, SelectionAskAiInner, AgentRunBridge, AiMiniWindow (+1) |
+| `src/modules/tabs/lib/useWindowTitle.ts` | basename, tabLabel, useWindowTitle |
+| `src/modules/theme/themeFiles.ts` | starterTheme, onThemeEdit |
+| `src/modules/workspace/env.ts` | useWorkspaceEnvStore, getWslHome |
+| `src/modules/editor/AiDiffStackLazy.tsx` | AiDiffStackInner, AiDiffStack |
+| `src/modules/editor/EditorStackLazy.tsx` | EditorStackInner, EditorStack |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`getLaunchDir`** (Function) — `src/lib/launchDir.ts:11`
+- **`parentDir`** (Function) — `src/modules/explorer/lib/watch.ts:33`
+- **`useSourceControl`** (Function) — `src/modules/source-control/useSourceControl.ts:145`
+- **`useTabs`** (Function) — `src/modules/tabs/lib/useTabs.ts:138`
+- **`useWorkspaceCwd`** (Function) — `src/modules/tabs/lib/useWorkspaceCwd.ts:8`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `DormantRing` | Class | `src/modules/terminal/lib/dormantRing.ts` | 7 |
+| `getLaunchDir` | Function | `src/lib/launchDir.ts` | 11 |
+| `parentDir` | Function | `src/modules/explorer/lib/watch.ts` | 33 |
+| `useSourceControl` | Function | `src/modules/source-control/useSourceControl.ts` | 145 |
+| `useTabs` | Function | `src/modules/tabs/lib/useTabs.ts` | 138 |
+| `useWorkspaceCwd` | Function | `src/modules/tabs/lib/useWorkspaceCwd.ts` | 8 |
+| `starterTheme` | Function | `src/modules/theme/themeFiles.ts` | 67 |
+| `onThemeEdit` | Function | `src/modules/theme/themeFiles.ts` | 114 |
+| `useWorkspaceEnvStore` | Function | `src/modules/workspace/env.ts` | 25 |
+| `App` | Function | `src/app/App.tsx` | 185 |
+| `persistSidebarWidth` | Function | `src/app/App.tsx` | 276 |
+| `setSelectedModelId` | Function | `src/app/App.tsx` | 422 |
+| `setLive` | Function | `src/app/App.tsx` | 423 |
+| `respondToApproval` | Function | `src/app/App.tsx` | 424 |
+| `initPrefs` | Function | `src/app/App.tsx` | 479 |
+| `hydrateSessions` | Function | `src/app/App.tsx` | 489 |
+| `cancelClose` | Function | `src/app/App.tsx` | 722 |
+| `cancelDeleteClose` | Function | `src/app/App.tsx` | 921 |
+| `AgentRunBridge` | Function | `src/modules/ai/components/lazy.tsx` | 26 |
+| `AiMiniWindow` | Function | `src/modules/ai/components/lazy.tsx` | 34 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `SwitchWorkspace → IsAltScreen` | cross_community | 6 |
+| `SwitchWorkspace → CancelPendingUnhide` | cross_community | 6 |
+| `SwitchWorkspace → GetRecycler` | cross_community | 6 |
+| `ClosePaneByLeaf → IsAltScreen` | cross_community | 6 |
+| `ClosePaneByLeaf → CancelPendingUnhide` | cross_community | 6 |
+| `ClosePaneByLeaf → GetRecycler` | cross_community | 6 |
+| `CloseActivePane → IsAltScreen` | cross_community | 6 |
+| `CloseActivePane → CancelPendingUnhide` | cross_community | 6 |
+| `CloseActivePane → GetRecycler` | cross_community | 6 |
+| `ModelsSection → ProviderNeedsKey` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 21 calls |
+| Theme | 8 calls |
+| Components | 6 calls |
+| Editor | 2 calls |
+| Explorer | 2 calls |
+| Cluster_180 | 1 calls |
+| Cluster_68 | 1 calls |
+| Ai | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "getLaunchDir"})` — see callers and callees
+2. `gitnexus_query({query: "app"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/autocomplete/SKILL.md
+++ b/.claude/skills/generated/autocomplete/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: autocomplete
+description: "Skill for the Autocomplete area of terax-ai. 34 symbols across 9 files."
+---
+
+# Autocomplete
+
+34 symbols | 9 files | Cohesion: 84%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how detectMonoFontFamily, inlineCompletion, buildSharedExtensions work
+- Modifying autocomplete-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/editor/lib/autocomplete/inlineExtension.ts` | suggestionKey, hasProviderKey, shouldTrigger, clearGhost, fire (+19) |
+| `src/modules/editor/lib/autocomplete/prompt.ts` | trimContext, buildUserPrompt |
+| `src/modules/editor/lib/autocomplete/provider.ts` | requestCompletion, cleanCompletion |
+| `src/lib/fonts.ts` | detectMonoFontFamily |
+| `src/modules/editor/lib/extensions.ts` | buildSharedExtensions |
+| `src/modules/editor/lib/vim.ts` | vimHandlersExtension |
+| `src/modules/terminal/lib/rendererPool.ts` | applyFontFamily |
+| `src/modules/editor/EditorPane.tsx` | extensions |
+| `src/modules/ai/lib/agent.ts` | buildLanguageModel |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`detectMonoFontFamily`** (Function) — `src/lib/fonts.ts:36`
+- **`inlineCompletion`** (Function) — `src/modules/editor/lib/autocomplete/inlineExtension.ts:463`
+- **`buildSharedExtensions`** (Function) — `src/modules/editor/lib/extensions.ts:17`
+- **`vimHandlersExtension`** (Function) — `src/modules/editor/lib/vim.ts:9`
+- **`applyFontFamily`** (Function) — `src/modules/terminal/lib/rendererPool.ts:661`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `detectMonoFontFamily` | Function | `src/lib/fonts.ts` | 36 |
+| `inlineCompletion` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 463 |
+| `buildSharedExtensions` | Function | `src/modules/editor/lib/extensions.ts` | 17 |
+| `vimHandlersExtension` | Function | `src/modules/editor/lib/vim.ts` | 9 |
+| `applyFontFamily` | Function | `src/modules/terminal/lib/rendererPool.ts` | 661 |
+| `extensions` | Function | `src/modules/editor/EditorPane.tsx` | 115 |
+| `buildLanguageModel` | Function | `src/modules/ai/lib/agent.ts` | 75 |
+| `trimContext` | Function | `src/modules/editor/lib/autocomplete/prompt.ts` | 10 |
+| `buildUserPrompt` | Function | `src/modules/editor/lib/autocomplete/prompt.ts` | 57 |
+| `requestCompletion` | Function | `src/modules/editor/lib/autocomplete/provider.ts` | 30 |
+| `plugin` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 464 |
+| `manualTrigger` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 466 |
+| `LRU` | Class | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 132 |
+| `CompletionDriver` | Class | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 195 |
+| `GhostWidget` | Class | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 78 |
+| `suggestionKey` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 155 |
+| `hasProviderKey` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 161 |
+| `shouldTrigger` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 166 |
+| `trimSuggestion` | Function | `src/modules/editor/lib/autocomplete/inlineExtension.ts` | 359 |
+| `cleanCompletion` | Function | `src/modules/editor/lib/autocomplete/provider.ts` | 75 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Run → ProviderNeedsKey` | cross_community | 5 |
+| `Run → LRU` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Components | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "detectMonoFontFamily"})` — see callers and callees
+2. `gitnexus_query({query: "autocomplete"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/components/SKILL.md
+++ b/.claude/skills/generated/components/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: components
+description: "Skill for the Components area of terax-ai. 161 symbols across 44 files."
+---
+
+# Components
+
+161 symbols | 44 files | Cohesion: 69%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how setDefaultModel, setAutocompleteEnabled, WindowControls work
+- Modifying components-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/ai/components/AiChat.tsx` | CommandSnippet, countLines, stripUserContextBlocks, ContextChips, chipIcon (+12) |
+| `src/modules/ai/components/AiMiniWindow.tsx` | SessionPicker, switchSession, newSession, deleteSession, SessionRow (+8) |
+| `src/modules/ai/components/AiInputBar.tsx` | AiInputBar, onPickItem, onPickFile, pickActive, ChipsRow (+6) |
+| `src/modules/ai/components/AiStatusBarControls.tsx` | AiOpenButton, AiStatusBarControls, IconBtn, ModelDropdown, setSelected (+5) |
+| `src/modules/agents/components/NotificationBell.tsx` | relativeTime, NotificationRow, NotificationBell, activate, activateLocal (+5) |
+| `src/modules/ai/components/AgentRunBridge.tsx` | AgentRunBridge, Bridge, patch, openMini, persistMessages (+4) |
+| `src/modules/ai/components/PlanDiffReview.tsx` | PlanDiffReview, removeOne, clear, basename, diffStats (+4) |
+| `src/components/ui/dropdown-menu.tsx` | DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel (+1) |
+| `src/modules/ai/lib/security.ts` | basename, comparisonForm, isUnderProtected, describeProtected, checkReadable (+1) |
+| `src/modules/preview/PreviewAddressBar.tsx` | PreviewAddressBar, submit, tryPort, probeUrl, normalizeUrl |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`setDefaultModel`** (Function) — `src/modules/settings/store.ts:374`
+- **`setAutocompleteEnabled`** (Function) — `src/modules/settings/store.ts:394`
+- **`WindowControls`** (Function) — `src/components/WindowControls.tsx:17`
+- **`AgentSwitcher`** (Function) — `src/modules/ai/components/AgentSwitcher.tsx:34`
+- **`setActiveId`** (Function) — `src/modules/ai/components/AgentSwitcher.tsx:38`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `setDefaultModel` | Function | `src/modules/settings/store.ts` | 374 |
+| `setAutocompleteEnabled` | Function | `src/modules/settings/store.ts` | 394 |
+| `WindowControls` | Function | `src/components/WindowControls.tsx` | 17 |
+| `AgentSwitcher` | Function | `src/modules/ai/components/AgentSwitcher.tsx` | 34 |
+| `setActiveId` | Function | `src/modules/ai/components/AgentSwitcher.tsx` | 38 |
+| `Header` | Function | `src/modules/header/Header.tsx` | 60 |
+| `PreviewAddressBar` | Function | `src/modules/preview/PreviewAddressBar.tsx` | 59 |
+| `submit` | Function | `src/modules/preview/PreviewAddressBar.tsx` | 86 |
+| `tryPort` | Function | `src/modules/preview/PreviewAddressBar.tsx` | 97 |
+| `AiTools` | Function | `src/modules/statusbar/AiTools.tsx` | 32 |
+| `WorkspaceEnvSelector` | Function | `src/modules/statusbar/WorkspaceEnvSelector.tsx` | 20 |
+| `refreshDistros` | Function | `src/modules/statusbar/WorkspaceEnvSelector.tsx` | 27 |
+| `handleOpenChange` | Function | `src/modules/statusbar/WorkspaceEnvSelector.tsx` | 29 |
+| `ProviderIcon` | Function | `src/settings/components/ProviderIcon.tsx` | 40 |
+| `ProviderKeyCard` | Function | `src/settings/components/ProviderKeyCard.tsx` | 32 |
+| `submit` | Function | `src/settings/components/ProviderKeyCard.tsx` | 49 |
+| `Message` | Function | `src/components/ai-elements/message.tsx` | 32 |
+| `MessageContent` | Function | `src/components/ai-elements/message.tsx` | 47 |
+| `useWorkspaceFiles` | Function | `src/modules/ai/hooks/useWorkspaceFiles.ts` | 49 |
+| `AiInputBar` | Function | `src/modules/ai/components/AiInputBar.tsx` | 70 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `EditorStack → ProviderNeedsKey` | cross_community | 6 |
+| `LocalAgentNotificationsBridge → IconFor` | cross_community | 6 |
+| `ModelsSection → ProviderNeedsKey` | cross_community | 5 |
+| `Run → ProviderNeedsKey` | cross_community | 5 |
+| `Execute → Basename` | cross_community | 5 |
+| `Execute → ComparisonForm` | cross_community | 5 |
+| `Execute → IsUnderProtected` | cross_community | 5 |
+| `Execute → DescribeProtected` | cross_community | 5 |
+| `Reload → ProviderNeedsKey` | cross_community | 5 |
+| `Bridge → MessagesKey` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 58 calls |
+| Ai | 6 calls |
+| App | 5 calls |
+| Theme | 4 calls |
+| Settings | 4 calls |
+| Sections | 4 calls |
+| Header | 3 calls |
+| Ai-elements | 2 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "setDefaultModel"})` — see callers and callees
+2. `gitnexus_query({query: "components"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/editor/SKILL.md
+++ b/.claude/skills/generated/editor/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: editor
+description: "Skill for the Editor area of terax-ai. 38 symbols across 11 files."
+---
+
+# Editor
+
+38 symbols | 11 files | Cohesion: 81%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how getCachedDiff, workingDiffKey, commitDiffKey work
+- Modifying editor-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/editor/EditorPane.tsx` | resolve, formatBytes, EditorPane, refresh, unsubPrefs (+2) |
+| `src/modules/editor/lib/diffCache.ts` | touch, getCachedDiff, workingDiffKey, commitDiffKey, fetchWorkingDiff (+1) |
+| `src/modules/editor/GitDiffPane.tsx` | cacheKey, loadStateFromCache, GitDiffPane, initialLang, countDiffLines (+1) |
+| `src/modules/editor/lib/languageResolver.ts` | extOf, isStreamParser, cacheKey, resolveLanguageSync, resolveLanguage (+1) |
+| `src/modules/editor/AiDiffPane.tsx` | initialLang, stats, computeLineStats, countLines |
+| `src/modules/editor/EditorStack.tsx` | EditorStack, getRefCallback, getDirtyCallback, getCloseCallback |
+| `src/modules/workspace/env.ts` | currentWorkspaceScopeKey |
+| `src/modules/editor/GitDiffStack.tsx` | GitDiffStack |
+| `src/modules/ai/lib/keyring.ts` | getKey |
+| `src/modules/editor/lib/useDocument.ts` | useDocument |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`getCachedDiff`** (Function) — `src/modules/editor/lib/diffCache.ts:20`
+- **`workingDiffKey`** (Function) — `src/modules/editor/lib/diffCache.ts:40`
+- **`commitDiffKey`** (Function) — `src/modules/editor/lib/diffCache.ts:48`
+- **`fetchWorkingDiff`** (Function) — `src/modules/editor/lib/diffCache.ts:56`
+- **`fetchCommitDiff`** (Function) — `src/modules/editor/lib/diffCache.ts:80`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `getCachedDiff` | Function | `src/modules/editor/lib/diffCache.ts` | 20 |
+| `workingDiffKey` | Function | `src/modules/editor/lib/diffCache.ts` | 40 |
+| `commitDiffKey` | Function | `src/modules/editor/lib/diffCache.ts` | 48 |
+| `fetchWorkingDiff` | Function | `src/modules/editor/lib/diffCache.ts` | 56 |
+| `fetchCommitDiff` | Function | `src/modules/editor/lib/diffCache.ts` | 80 |
+| `currentWorkspaceScopeKey` | Function | `src/modules/workspace/env.ts` | 55 |
+| `GitDiffPane` | Function | `src/modules/editor/GitDiffPane.tsx` | 127 |
+| `GitDiffStack` | Function | `src/modules/editor/GitDiffStack.tsx` | 12 |
+| `resolveLanguageSync` | Function | `src/modules/editor/lib/languageResolver.ts` | 157 |
+| `resolveLanguage` | Function | `src/modules/editor/lib/languageResolver.ts` | 162 |
+| `preloadLanguages` | Function | `src/modules/editor/lib/languageResolver.ts` | 192 |
+| `initialLang` | Function | `src/modules/editor/AiDiffPane.tsx` | 97 |
+| `resolve` | Function | `src/modules/editor/EditorPane.tsx` | 194 |
+| `initialLang` | Function | `src/modules/editor/GitDiffPane.tsx` | 200 |
+| `getKey` | Function | `src/modules/ai/lib/keyring.ts` | 29 |
+| `useDocument` | Function | `src/modules/editor/lib/useDocument.ts` | 22 |
+| `onKeysChanged` | Function | `src/modules/settings/store.ts` | 620 |
+| `EditorPane` | Function | `src/modules/editor/EditorPane.tsx` | 62 |
+| `refresh` | Function | `src/modules/editor/EditorPane.tsx` | 75 |
+| `unsubPrefs` | Function | `src/modules/editor/EditorPane.tsx` | 89 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `EditorStack → ProviderNeedsKey` | cross_community | 6 |
+| `EditorStack → GetProvider` | cross_community | 6 |
+| `GitDiffPane → WorkspaceScopeKey` | cross_community | 6 |
+| `GitDiffPane → CurrentWorkspaceEnv` | cross_community | 6 |
+| `ModelsSection → ProviderNeedsKey` | cross_community | 5 |
+| `ModelsSection → GetProvider` | cross_community | 5 |
+| `Reload → ProviderNeedsKey` | cross_community | 5 |
+| `Reload → GetProvider` | cross_community | 5 |
+| `EditorStack → UsePreferencesStore` | cross_community | 4 |
+| `EditorStack → CurrentWorkspaceEnv` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Theme | 3 calls |
+| Ui | 3 calls |
+| Workspace | 2 calls |
+| Ai | 2 calls |
+| Tools | 1 calls |
+| Sections | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "getCachedDiff"})` — see callers and callees
+2. `gitnexus_query({query: "editor"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/fs/SKILL.md
+++ b/.claude/skills/generated/fs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: fs
+description: "Skill for the Fs area of terax-ai. 34 symbols across 8 files."
+---
+
+# Fs
+
+34 symbols | 8 files | Cohesion: 62%
+
+## When to Use
+
+- Working with code in `src-tauri/`
+- Understanding how fs_read_file, fs_stat, fs_create_file work
+- Modifying fs-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src-tauri/src/modules/fs/mutate.rs` | fs_create_file, fs_create_dir, fs_rename, fs_delete, s (+5) |
+| `src-tauri/src/modules/fs/watch.rs` | remove_paths, fs_watch_remove, collect, is_skipped, ensure_started (+4) |
+| `src-tauri/src/modules/fs/file.rs` | fs_read_file, fs_stat, read_file_classifies_utf8_as_text, write_atomic, fs_write_file (+2) |
+| `src-tauri/src/modules/workspace.rs` | resolve_path, workspace_authorize, is_wsl |
+| `src-tauri/src/modules/fs/mod.rs` | to_canon, strip_verbatim |
+| `src-tauri/src/modules/fs/grep.rs` | display_path |
+| `src-tauri/src/modules/fs/search.rs` | display_path |
+| `src-tauri/src/modules/git/utils.rs` | display_path |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`fs_read_file`** (Function) — `src-tauri/src/modules/fs/file.rs:46`
+- **`fs_stat`** (Function) — `src-tauri/src/modules/fs/file.rs:139`
+- **`fs_create_file`** (Function) — `src-tauri/src/modules/fs/mutate.rs:4`
+- **`fs_create_dir`** (Function) — `src-tauri/src/modules/fs/mutate.rs:20`
+- **`fs_rename`** (Function) — `src-tauri/src/modules/fs/mutate.rs:34`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `fs_read_file` | Function | `src-tauri/src/modules/fs/file.rs` | 46 |
+| `fs_stat` | Function | `src-tauri/src/modules/fs/file.rs` | 139 |
+| `fs_create_file` | Function | `src-tauri/src/modules/fs/mutate.rs` | 4 |
+| `fs_create_dir` | Function | `src-tauri/src/modules/fs/mutate.rs` | 20 |
+| `fs_rename` | Function | `src-tauri/src/modules/fs/mutate.rs` | 34 |
+| `fs_delete` | Function | `src-tauri/src/modules/fs/mutate.rs` | 57 |
+| `fs_watch_remove` | Function | `src-tauri/src/modules/fs/watch.rs` | 250 |
+| `resolve_path` | Function | `src-tauri/src/modules/workspace.rs` | 237 |
+| `to_canon` | Function | `src-tauri/src/modules/fs/mod.rs` | 11 |
+| `display_path` | Function | `src-tauri/src/modules/git/utils.rs` | 19 |
+| `workspace_authorize` | Function | `src-tauri/src/modules/workspace.rs` | 124 |
+| `is_wsl` | Function | `src-tauri/src/modules/workspace.rs` | 224 |
+| `fs_watch_add` | Function | `src-tauri/src/modules/fs/watch.rs` | 229 |
+| `fs_write_file` | Function | `src-tauri/src/modules/fs/file.rs` | 101 |
+| `read_file_classifies_utf8_as_text` | Function | `src-tauri/src/modules/fs/file.rs` | 168 |
+| `s` | Function | `src-tauri/src/modules/fs/mutate.rs` | 81 |
+| `create_file_makes_empty_and_refuses_to_clobber` | Function | `src-tauri/src/modules/fs/mutate.rs` | 86 |
+| `create_dir_builds_nested_chain_and_refuses_existing` | Function | `src-tauri/src/modules/fs/mutate.rs` | 101 |
+| `rename_moves_and_never_overwrites` | Function | `src-tauri/src/modules/fs/mutate.rs` | 111 |
+| `delete_removes_file_then_dir_recursively` | Function | `src-tauri/src/modules/fs/mutate.rs` | 135 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Fs_watch_add → Is_safe_distro_name` | cross_community | 6 |
+| `Git_panel_snapshot → Wsl_drvfs_to_windows` | cross_community | 6 |
+| `Spawn → Is_safe_distro_name` | cross_community | 5 |
+| `Fs_write_file → Is_safe_distro_name` | cross_community | 5 |
+| `Fs_canonicalize → Is_safe_distro_name` | cross_community | 5 |
+| `Fs_watch_add → Wsl_drvfs_to_windows` | cross_community | 5 |
+| `Fs_watch_remove → Is_safe_distro_name` | cross_community | 5 |
+| `Fs_stat → Is_safe_distro_name` | cross_community | 5 |
+| `Git_resolve_repo → Is_wsl` | cross_community | 5 |
+| `Git_diff_content → Is_wsl` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Git | 11 calls |
+| Shell | 2 calls |
+| Modules | 2 calls |
+| Pty | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "fs_read_file"})` — see callers and callees
+2. `gitnexus_query({query: "fs"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/git-history/SKILL.md
+++ b/.claude/skills/generated/git-history/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: git-history
+description: "Skill for the Git-history area of terax-ai. 34 symbols across 5 files."
+---
+
+# Git-history
+
+34 symbols | 5 files | Cohesion: 70%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how bumpFiles, loadInitial, loadMore work
+- Modifying git-history-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/git-history/GitHistoryPane.tsx` | normalizeError, bumpFiles, loadInitial, loadMore, handleScroll (+19) |
+| `src/modules/git-history/GraphRail.tsx` | laneX, railWidth, renderTopEdge, renderBottomEdge, GraphRail |
+| `src/modules/git-history/lib/remoteWebUrl.ts` | parseRemoteWebUrl, commitWebUrl, hostLabel |
+| `src/components/ui/popover.tsx` | PopoverAnchor |
+| `src/modules/git-history/GitHistoryStack.tsx` | GitHistoryStack |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`bumpFiles`** (Function) — `src/modules/git-history/GitHistoryPane.tsx:223`
+- **`loadInitial`** (Function) — `src/modules/git-history/GitHistoryPane.tsx:316`
+- **`loadMore`** (Function) — `src/modules/git-history/GitHistoryPane.tsx:334`
+- **`handleScroll`** (Function) — `src/modules/git-history/GitHistoryPane.tsx:388`
+- **`id`** (Function) — `src/modules/git-history/GitHistoryPane.tsx:411`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `bumpFiles` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 223 |
+| `loadInitial` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 316 |
+| `loadMore` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 334 |
+| `handleScroll` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 388 |
+| `id` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 411 |
+| `handleRefresh` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 417 |
+| `fetchFiles` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 424 |
+| `handleRowClick` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 452 |
+| `parseRemoteWebUrl` | Function | `src/modules/git-history/lib/remoteWebUrl.ts` | 19 |
+| `GitHistoryPane` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 191 |
+| `closePopover` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 476 |
+| `GitHistoryStack` | Function | `src/modules/git-history/GitHistoryStack.tsx` | 19 |
+| `railWidth` | Function | `src/modules/git-history/GraphRail.tsx` | 14 |
+| `GraphRail` | Function | `src/modules/git-history/GraphRail.tsx` | 98 |
+| `commitWebUrl` | Function | `src/modules/git-history/lib/remoteWebUrl.ts` | 61 |
+| `hostLabel` | Function | `src/modules/git-history/lib/remoteWebUrl.ts` | 72 |
+| `normalizeError` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 98 |
+| `PopoverAnchor` | Function | `src/components/ui/popover.tsx` | 41 |
+| `CenterPlaceholder` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 678 |
+| `basename` | Function | `src/modules/git-history/GitHistoryPane.tsx` | 86 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 9 calls |
+| Cluster_145 | 1 calls |
+| Components | 1 calls |
+| Explorer | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "bumpFiles"})` — see callers and callees
+2. `gitnexus_query({query: "git-history"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/git/SKILL.md
+++ b/.claude/skills/generated/git/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: git
+description: "Skill for the Git area of terax-ai. 104 symbols across 8 files."
+---
+
+# Git
+
+104 symbols | 8 files | Cohesion: 71%
+
+## When to Use
+
+- Working with code in `src-tauri/`
+- Understanding how command, resolve_repo, panel_snapshot work
+- Modifying git-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src-tauri/src/modules/git/operations.rs` | resolve_repo, resolve_repo_in_authorized, panel_snapshot, status, status_inner (+23) |
+| `src-tauri/src/modules/git/process.rs` | availability_cell, prune_expired_availability_entries, workspace_cache_key, ensure_git_available, git_stdout_line_opt (+16) |
+| `src-tauri/src/modules/git/parser.rs` | parse_porcelain_v2, ordinary, porcelain_v2_parses_branch_and_files, handles_detached_head, empty_input_yields_safe_defaults (+16) |
+| `src-tauri/src/modules/git/commands.rs` | blocking, git_resolve_repo, git_panel_snapshot, git_status, git_diff (+13) |
+| `src-tauri/src/modules/git/utils.rs` | split_upstream, normalize_git_path, canonical_dir, authorized_repo_root, resolve_within_repo (+4) |
+| `src-tauri/src/modules/workspace.rs` | is_authorized, canonicalize_cached, from_option, is_safe_distro_name, validate_wsl_distro_name |
+| `src-tauri/src/modules/git/errors.rs` | command |
+| `src-tauri/src/modules/git/types.rs` | into_text |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`command`** (Function) — `src-tauri/src/modules/git/errors.rs:33`
+- **`resolve_repo`** (Function) — `src-tauri/src/modules/git/operations.rs:19`
+- **`panel_snapshot`** (Function) — `src-tauri/src/modules/git/operations.rs:81`
+- **`status`** (Function) — `src-tauri/src/modules/git/operations.rs:118`
+- **`diff`** (Function) — `src-tauri/src/modules/git/operations.rs:158`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `command` | Function | `src-tauri/src/modules/git/errors.rs` | 33 |
+| `resolve_repo` | Function | `src-tauri/src/modules/git/operations.rs` | 19 |
+| `panel_snapshot` | Function | `src-tauri/src/modules/git/operations.rs` | 81 |
+| `status` | Function | `src-tauri/src/modules/git/operations.rs` | 118 |
+| `diff` | Function | `src-tauri/src/modules/git/operations.rs` | 158 |
+| `stage` | Function | `src-tauri/src/modules/git/operations.rs` | 262 |
+| `unstage` | Function | `src-tauri/src/modules/git/operations.rs` | 287 |
+| `discard` | Function | `src-tauri/src/modules/git/operations.rs` | 341 |
+| `commit` | Function | `src-tauri/src/modules/git/operations.rs` | 395 |
+| `push` | Function | `src-tauri/src/modules/git/operations.rs` | 436 |
+| `show_commit_diff` | Function | `src-tauri/src/modules/git/operations.rs` | 580 |
+| `commit_files` | Function | `src-tauri/src/modules/git/operations.rs` | 646 |
+| `commit_file_diff` | Function | `src-tauri/src/modules/git/operations.rs` | 704 |
+| `fetch` | Function | `src-tauri/src/modules/git/operations.rs` | 920 |
+| `pull_ff_only` | Function | `src-tauri/src/modules/git/operations.rs` | 936 |
+| `ensure_git_available` | Function | `src-tauri/src/modules/git/process.rs` | 52 |
+| `git_stdout_line_opt` | Function | `src-tauri/src/modules/git/process.rs` | 154 |
+| `git_stdout_lines` | Function | `src-tauri/src/modules/git/process.rs` | 180 |
+| `run_git` | Function | `src-tauri/src/modules/git/process.rs` | 223 |
+| `ensure_success` | Function | `src-tauri/src/modules/git/process.rs` | 333 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Shell_session_open → Is_safe_distro_name` | cross_community | 6 |
+| `Fs_watch_add → Is_safe_distro_name` | cross_community | 6 |
+| `Git_panel_snapshot → Wsl_drvfs_to_windows` | cross_community | 6 |
+| `Git_panel_snapshot → Clamp` | cross_community | 6 |
+| `Git_panel_snapshot → Env` | cross_community | 6 |
+| `Git_log → Clamp` | cross_community | 6 |
+| `Git_show_commit → Clamp` | cross_community | 6 |
+| `Git_commit_files → Clamp` | cross_community | 6 |
+| `Git_commit_file_diff → Clamp` | cross_community | 6 |
+| `Git_remote_url → Clamp` | cross_community | 6 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Modules | 5 calls |
+| Tests | 3 calls |
+| Fs | 3 calls |
+| Pty | 2 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "command"})` — see callers and callees
+2. `gitnexus_query({query: "git"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/modules/SKILL.md
+++ b/.claude/skills/generated/modules/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: modules
+description: "Skill for the Modules area of terax-ai. 90 symbols across 16 files."
+---
+
+# Modules
+
+90 symbols | 16 files | Cohesion: 75%
+
+## When to Use
+
+- Working with code in `src-tauri/`
+- Understanding how run, fs_canonicalize, shell_bg_spawn work
+- Modifying modules-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src-tauri/src/modules/workspace.rs` | authorize, authorize_spawn_cwd, bootstrap_registry, tempdir, authorize_spawn_cwd_accepts_authorized_path (+27) |
+| `src-tauri/src/modules/secrets.rs` | key, store_path, read_store, write_store, with_store (+12) |
+| `src-tauri/src/modules/agent.rs` | is_ours, is_empty_group, merge_hooks, adds_all_event_hooks_to_empty_config, is_idempotent (+8) |
+| `src-tauri/src/modules/net.rs` | is_blocked_host_name, ip_kind, resolve_and_classify, validate_url, classify_and_collect_safe_ips (+7) |
+| `src-tauri/tests/git_operations.rs` | resolve_repo_returns_none_outside_repo, panel_snapshot_outside_repo_is_empty, unauthorized_path_is_rejected |
+| `src-tauri/src/lib.rs` | parse_launch_dir, run |
+| `src-tauri/src/modules/shell/mod.rs` | shell_bg_spawn, shell_session_open |
+| `src-tauri/src/modules/fs/file.rs` | fs_canonicalize |
+| `src/modules/ai/lib/native.ts` | canonicalize |
+| `src/modules/ai/components/AgentSwitcher.tsx` | custom |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`run`** (Function) — `src-tauri/src/lib.rs:113`
+- **`fs_canonicalize`** (Function) — `src-tauri/src/modules/fs/file.rs:131`
+- **`shell_bg_spawn`** (Function) — `src-tauri/src/modules/shell/mod.rs:233`
+- **`authorize`** (Function) — `src-tauri/src/modules/workspace.rs:24`
+- **`authorize_spawn_cwd`** (Function) — `src-tauri/src/modules/workspace.rs:73`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `run` | Function | `src-tauri/src/lib.rs` | 113 |
+| `fs_canonicalize` | Function | `src-tauri/src/modules/fs/file.rs` | 131 |
+| `shell_bg_spawn` | Function | `src-tauri/src/modules/shell/mod.rs` | 233 |
+| `authorize` | Function | `src-tauri/src/modules/workspace.rs` | 24 |
+| `authorize_spawn_cwd` | Function | `src-tauri/src/modules/workspace.rs` | 73 |
+| `bootstrap_registry` | Function | `src-tauri/src/modules/workspace.rs` | 116 |
+| `canonicalize` | Function | `src/modules/ai/lib/native.ts` | 143 |
+| `lm_ping` | Function | `src-tauri/src/modules/net.rs` | 191 |
+| `ai_http_request` | Function | `src-tauri/src/modules/net.rs` | 312 |
+| `ai_http_stream` | Function | `src-tauri/src/modules/net.rs` | 359 |
+| `custom` | Function | `src/modules/ai/components/AgentSwitcher.tsx` | 45 |
+| `key` | Function | `src-tauri/src/modules/secrets.rs` | 41 |
+| `secrets_get` | Function | `src-tauri/src/modules/secrets.rs` | 115 |
+| `secrets_set` | Function | `src-tauri/src/modules/secrets.rs` | 140 |
+| `secrets_delete` | Function | `src-tauri/src/modules/secrets.rs` | 168 |
+| `secrets_get_all` | Function | `src-tauri/src/modules/secrets.rs` | 279 |
+| `workspace_current_dir` | Function | `src-tauri/src/modules/workspace.rs` | 136 |
+| `init_launch_cwd` | Function | `src-tauri/src/modules/workspace.rs` | 148 |
+| `launch_cwd_snapshot` | Function | `src-tauri/src/modules/workspace.rs` | 162 |
+| `hide_console` | Function | `src-tauri/src/modules/proc.rs` | 3 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Run → CurrentWorkspaceEnv` | cross_community | 7 |
+| `Shell_session_open → Is_safe_distro_name` | cross_community | 6 |
+| `Shell_session_open → Looks_utf16le` | cross_community | 6 |
+| `Git_remote_url → Hide_console` | cross_community | 6 |
+| `Spawn → Launch_cwd_snapshot` | cross_community | 5 |
+| `Shell_session_open → Hide_console` | cross_community | 5 |
+| `Fs_canonicalize → Is_safe_distro_name` | cross_community | 5 |
+| `Commit_file_diff → Hide_console` | cross_community | 5 |
+| `Git_diff_content → CurrentWorkspaceEnv` | cross_community | 5 |
+| `Commit_files → Hide_console` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Fs | 8 calls |
+| Git | 8 calls |
+| Shell | 5 calls |
+| Tests | 3 calls |
+| Autocomplete | 1 calls |
+| Workspace | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "run"})` — see callers and callees
+2. `gitnexus_query({query: "modules"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/pty/SKILL.md
+++ b/.claude/skills/generated/pty/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: pty
+description: "Skill for the Pty area of terax-ai. 90 symbols across 14 files."
+---
+
+# Pty
+
+90 symbols | 14 files | Cohesion: 83%
+
+## When to Use
+
+- Working with code in `src-tauri/`
+- Understanding how new, finish, new work
+- Modifying pty-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src-tauri/src/modules/pty/shell_init.rs` | bashrc_script, fish_init_script, prepare_wsl_integration_dir, normalize_script, prepare_wsl_bash_rcfile (+24) |
+| `src-tauri/src/modules/pty/agent_detect.rs` | new, finish, run, osc, arms_on_agent_command (+14) |
+| `src-tauri/src/modules/pty/da_filter.rs` | new, run, da1_bare, da1_with_zero_param, da2_secondary (+12) |
+| `src-tauri/src/modules/pty/session.rs` | new, disarm, spawn, drop_kills_child_process, drop_session_succeeds_after_child_already_exited (+1) |
+| `src-tauri/src/modules/workspace.rs` | wsl_drvfs_to_windows, wsl_path_to_unc, wsl_path_to_host, wsl_path_to_unc_blocks_traversal_distro, wsl_path_to_unc_accepts_valid_distro |
+| `src-tauri/src/modules/pty/job.rs` | create_for, create_for_invalid_pid_errors, drop_kills_assigned_process_tree |
+| `src-tauri/src/modules/pty/mod.rs` | pty_close, pty_close_all, pty_resize |
+| `src/modules/terminal/lib/useTerminalSession.ts` | markSessionReady, cwd |
+| `src/modules/statusbar/CwdBreadcrumb.tsx` | load |
+| `src-tauri/src/modules/shell/background.rs` | kill |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`new`** (Function) — `src-tauri/src/modules/pty/agent_detect.rs:65`
+- **`finish`** (Function) — `src-tauri/src/modules/pty/agent_detect.rs:134`
+- **`new`** (Function) — `src-tauri/src/modules/pty/da_filter.rs:24`
+- **`wsl_path_to_unc`** (Function) — `src-tauri/src/modules/workspace.rs:297`
+- **`wsl_path_to_host`** (Function) — `src-tauri/src/modules/workspace.rs:321`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `new` | Function | `src-tauri/src/modules/pty/agent_detect.rs` | 65 |
+| `finish` | Function | `src-tauri/src/modules/pty/agent_detect.rs` | 134 |
+| `new` | Function | `src-tauri/src/modules/pty/da_filter.rs` | 24 |
+| `wsl_path_to_unc` | Function | `src-tauri/src/modules/workspace.rs` | 297 |
+| `wsl_path_to_host` | Function | `src-tauri/src/modules/workspace.rs` | 321 |
+| `into_signal` | Function | `src-tauri/src/modules/pty/agent_detect.rs` | 43 |
+| `process` | Function | `src-tauri/src/modules/pty/agent_detect.rs` | 82 |
+| `process` | Function | `src-tauri/src/modules/pty/da_filter.rs` | 31 |
+| `spawn` | Function | `src-tauri/src/modules/pty/session.rs` | 98 |
+| `create_for` | Function | `src-tauri/src/modules/pty/job.rs` | 25 |
+| `pty_close` | Function | `src-tauri/src/modules/pty/mod.rs` | 133 |
+| `pty_close_all` | Function | `src-tauri/src/modules/pty/mod.rs` | 220 |
+| `drop_session` | Function | `src-tauri/src/modules/pty/session.rs` | 69 |
+| `kill` | Function | `src-tauri/src/modules/shell/background.rs` | 63 |
+| `shell_bg_kill` | Function | `src-tauri/src/modules/shell/mod.rs` | 265 |
+| `build_command` | Function | `src-tauri/src/modules/pty/shell_init.rs` | 49 |
+| `detect` | Function | `src-tauri/src/modules/pty/shell_init.rs` | 128 |
+| `build` | Function | `src-tauri/src/modules/pty/shell_init.rs` | 160 |
+| `env` | Function | `src/modules/statusbar/WorkspaceEnvSelector.tsx` | 23 |
+| `pty_resize` | Function | `src-tauri/src/modules/pty/mod.rs` | 99 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Spawn → Env` | cross_community | 6 |
+| `Spawn → MarkSessionReady` | cross_community | 6 |
+| `Fs_watch_add → Is_safe_distro_name` | cross_community | 6 |
+| `Git_panel_snapshot → Wsl_drvfs_to_windows` | cross_community | 6 |
+| `Git_panel_snapshot → Env` | cross_community | 6 |
+| `Git_remote_url → Env` | cross_community | 6 |
+| `Spawn → Launch_cwd_snapshot` | cross_community | 5 |
+| `Spawn → Is_safe_distro_name` | cross_community | 5 |
+| `Fs_write_file → Is_safe_distro_name` | cross_community | 5 |
+| `Fs_canonicalize → Is_safe_distro_name` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Modules | 5 calls |
+| Git | 2 calls |
+| Shell | 1 calls |
+| Workspace | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "new"})` — see callers and callees
+2. `gitnexus_query({query: "pty"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/sections/SKILL.md
+++ b/.claude/skills/generated/sections/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: sections
+description: "Skill for the Sections area of terax-ai. 57 symbols across 14 files."
+---
+
+# Sections
+
+57 symbols | 14 files | Cohesion: 61%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how getCustomEndpointKey, setCustomEndpointKey, clearCustomEndpointKey work
+- Modifying sections-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/settings/sections/ModelsSection.tsx` | ModelsSection, onClearKey, onSaveEndpointKey, onClearEndpointKey, localConfig (+15) |
+| `src/settings/sections/AgentsSection.tsx` | AgentsSection, setActiveAgentId, upsertAgent, removeAgent, hydrateAgents (+4) |
+| `src/modules/ai/lib/keyring.ts` | compatKeyringAccount, getCustomEndpointKey, setCustomEndpointKey, clearCustomEndpointKey, getAllCustomEndpointKeys (+1) |
+| `src/modules/settings/store.ts` | setOpenrouterModelId, emitKeysChanged, clampBgOpacity, setBackgroundOpacity, setShortcuts |
+| `src/settings/sections/ShortcutsSection.tsx` | onRecord, onClear, onResetShortcut, onResetAll, onDown |
+| `src/settings/sections/ThemesSection.tsx` | ThemesSection, onCreateTheme, onEditTheme, Label |
+| `src/modules/ai/store/agentsStore.ts` | useAgentsStore |
+| `src/modules/ai/store/snippetsStore.ts` | useSnippetsStore |
+| `src/modules/theme/themeFiles.ts` | emitThemeEdit |
+| `src/modules/theme/themes/index.ts` | listBuiltinThemes |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`getCustomEndpointKey`** (Function) — `src/modules/ai/lib/keyring.ts:97`
+- **`setCustomEndpointKey`** (Function) — `src/modules/ai/lib/keyring.ts:111`
+- **`clearCustomEndpointKey`** (Function) — `src/modules/ai/lib/keyring.ts:124`
+- **`getAllCustomEndpointKeys`** (Function) — `src/modules/ai/lib/keyring.ts:135`
+- **`accounts`** (Function) — `src/modules/ai/lib/keyring.ts:141`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `getCustomEndpointKey` | Function | `src/modules/ai/lib/keyring.ts` | 97 |
+| `setCustomEndpointKey` | Function | `src/modules/ai/lib/keyring.ts` | 111 |
+| `clearCustomEndpointKey` | Function | `src/modules/ai/lib/keyring.ts` | 124 |
+| `getAllCustomEndpointKeys` | Function | `src/modules/ai/lib/keyring.ts` | 135 |
+| `accounts` | Function | `src/modules/ai/lib/keyring.ts` | 141 |
+| `setOpenrouterModelId` | Function | `src/modules/settings/store.ts` | 455 |
+| `emitKeysChanged` | Function | `src/modules/settings/store.ts` | 616 |
+| `ModelsSection` | Function | `src/settings/sections/ModelsSection.tsx` | 131 |
+| `onClearKey` | Function | `src/settings/sections/ModelsSection.tsx` | 165 |
+| `onSaveEndpointKey` | Function | `src/settings/sections/ModelsSection.tsx` | 171 |
+| `onClearEndpointKey` | Function | `src/settings/sections/ModelsSection.tsx` | 177 |
+| `localConfig` | Function | `src/settings/sections/ModelsSection.tsx` | 238 |
+| `isConfigured` | Function | `src/settings/sections/ModelsSection.tsx` | 283 |
+| `removeProvider` | Function | `src/settings/sections/ModelsSection.tsx` | 310 |
+| `useAgentsStore` | Function | `src/modules/ai/store/agentsStore.ts` | 31 |
+| `useSnippetsStore` | Function | `src/modules/ai/store/snippetsStore.ts` | 21 |
+| `AgentsSection` | Function | `src/settings/sections/AgentsSection.tsx` | 49 |
+| `setActiveAgentId` | Function | `src/settings/sections/AgentsSection.tsx` | 53 |
+| `upsertAgent` | Function | `src/settings/sections/AgentsSection.tsx` | 54 |
+| `removeAgent` | Function | `src/settings/sections/AgentsSection.tsx` | 55 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `ModelsSection → ProviderNeedsKey` | cross_community | 5 |
+| `ModelsSection → GetProvider` | cross_community | 5 |
+| `ModelsSection → CompatKeyringAccount` | intra_community | 4 |
+| `Reload → CompatKeyringAccount` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 18 calls |
+| Settings | 8 calls |
+| Components | 7 calls |
+| Theme | 6 calls |
+| Ai | 4 calls |
+| Updater | 3 calls |
+| Editor | 1 calls |
+| App | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "getCustomEndpointKey"})` — see callers and callees
+2. `gitnexus_query({query: "sections"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/settings/SKILL.md
+++ b/.claude/skills/generated/settings/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: settings
+description: "Skill for the Settings area of terax-ai. 74 symbols across 15 files."
+---
+
+# Settings
+
+74 symbols | 15 files | Cohesion: 65%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how setCustomInstructions, setAutocompleteProvider, setAutocompleteModelId work
+- Modifying settings-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/settings/store.ts` | writePref, setCustomInstructions, setAutocompleteProvider, setAutocompleteModelId, setLmstudioBaseURL (+37) |
+| `src/settings/sections/ModelsSection.tsx` | setModel, addCustomEndpoint, updateCustomEndpoint, removeCustomEndpoint |
+| `src/components/ui/select.tsx` | Select, SelectValue, SelectTrigger, SelectItem |
+| `src/settings/sections/GeneralSection.tsx` | GeneralSection, onToggleAutostart, Label, AutoSaveDelayInput |
+| `src/lib/useZoom.ts` | clampZoom, zoomIn, zoomOut, zoomReset |
+| `src/modules/ai/config.ts` | compatModelIdForEndpoint, migrateLegacyCompatEndpoint, isKnownModelId |
+| `src/modules/ai/lib/modelPrefs.ts` | toggleFavoriteModel, pushRecentModel |
+| `src/modules/settings/preferences.ts` | mirrorBgFastPath, init |
+| `src/settings/sections/ThemesSection.tsx` | handleBgFiles, onRemoveBackground |
+| `src/settings/SettingsApp.tsx` | apply, unlistenPromise |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`setCustomInstructions`** (Function) — `src/modules/settings/store.ts:382`
+- **`setAutocompleteProvider`** (Function) — `src/modules/settings/store.ts:398`
+- **`setAutocompleteModelId`** (Function) — `src/modules/settings/store.ts:404`
+- **`setLmstudioBaseURL`** (Function) — `src/modules/settings/store.ts:408`
+- **`setLmstudioModelId`** (Function) — `src/modules/settings/store.ts:412`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `setCustomInstructions` | Function | `src/modules/settings/store.ts` | 382 |
+| `setAutocompleteProvider` | Function | `src/modules/settings/store.ts` | 398 |
+| `setAutocompleteModelId` | Function | `src/modules/settings/store.ts` | 404 |
+| `setLmstudioBaseURL` | Function | `src/modules/settings/store.ts` | 408 |
+| `setLmstudioModelId` | Function | `src/modules/settings/store.ts` | 412 |
+| `setMlxBaseURL` | Function | `src/modules/settings/store.ts` | 416 |
+| `setMlxModelId` | Function | `src/modules/settings/store.ts` | 420 |
+| `setOllamaBaseURL` | Function | `src/modules/settings/store.ts` | 424 |
+| `setOllamaModelId` | Function | `src/modules/settings/store.ts` | 428 |
+| `setOpenaiCompatibleBaseURL` | Function | `src/modules/settings/store.ts` | 432 |
+| `setOpenaiCompatibleModelId` | Function | `src/modules/settings/store.ts` | 436 |
+| `setOpenaiCompatibleContextLimit` | Function | `src/modules/settings/store.ts` | 440 |
+| `setVimMode` | Function | `src/modules/settings/store.ts` | 467 |
+| `setLastWslDistro` | Function | `src/modules/settings/store.ts` | 510 |
+| `resetShortcuts` | Function | `src/modules/settings/store.ts` | 541 |
+| `setEnv` | Function | `src/modules/workspace/env.ts` | 30 |
+| `setAutostart` | Function | `src/modules/settings/store.ts` | 386 |
+| `setRestoreWindowState` | Function | `src/modules/settings/store.ts` | 390 |
+| `setShowHidden` | Function | `src/modules/settings/store.ts` | 471 |
+| `setTerminalWebglEnabled` | Function | `src/modules/settings/store.ts` | 475 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 11 calls |
+| Sections | 4 calls |
+| Theme | 3 calls |
+| Updater | 1 calls |
+| Components | 1 calls |
+| Ai | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "setCustomInstructions"})` — see callers and callees
+2. `gitnexus_query({query: "settings"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/shell/SKILL.md
+++ b/.claude/skills/generated/shell/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: shell
+description: "Skill for the Shell area of terax-ai. 39 symbols across 9 files."
+---
+
+# Shell
+
+39 symbols | 9 files | Cohesion: 81%
+
+## When to Use
+
+- Working with code in `src-tauri/`
+- Understanding how new, decorations, visible work
+- Modifying shell-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src-tauri/src/modules/shell/mod.rs` | shell_run_command, run_blocking_inner, run_blocking, drain, run (+8) |
+| `src-tauri/src/modules/shell/session.rs` | new, wrap_posix_with_sentinel, wrap_with_sentinel, strip_cwd_sentinel, sentinels_are_unique_per_session (+3) |
+| `src-tauri/src/modules/shell/ringbuffer.rs` | new, read_from, read_from_returns_all_when_within_cap, read_from_skips_consumed_prefix, read_from_handles_wraparound (+2) |
+| `src-tauri/src/modules/shell/background.rs` | spawn, read_logs, info |
+| `src-tauri/tests/shell_background.rs` | spawn_captures_stdout_and_exits_zero, read_logs_advances_offset, info_reflects_command_and_exit |
+| `src-tauri/src/modules/pty/shell_init.rs` | windows_shell_path, which_in_path |
+| `src-tauri/src/lib.rs` | open_settings_window |
+| `src/modules/editor/lib/colorSwatches.ts` | decorations |
+| `src/modules/ai/components/LocalAgentNotificationsBridge.tsx` | visible |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`new`** (Function) — `src-tauri/src/modules/shell/session.rs:47`
+- **`decorations`** (Function) — `src/modules/editor/lib/colorSwatches.ts:118`
+- **`visible`** (Function) — `src/modules/ai/components/LocalAgentNotificationsBridge.tsx:29`
+- **`shell_run_command`** (Function) — `src-tauri/src/modules/shell/mod.rs:41`
+- **`run_blocking_inner`** (Function) — `src-tauri/src/modules/shell/mod.rs:77`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `new` | Function | `src-tauri/src/modules/shell/session.rs` | 47 |
+| `decorations` | Function | `src/modules/editor/lib/colorSwatches.ts` | 118 |
+| `visible` | Function | `src/modules/ai/components/LocalAgentNotificationsBridge.tsx` | 29 |
+| `shell_run_command` | Function | `src-tauri/src/modules/shell/mod.rs` | 41 |
+| `run_blocking_inner` | Function | `src-tauri/src/modules/shell/mod.rs` | 77 |
+| `new` | Function | `src-tauri/src/modules/shell/ringbuffer.rs` | 19 |
+| `read_from` | Function | `src-tauri/src/modules/shell/ringbuffer.rs` | 50 |
+| `windows_shell_path` | Function | `src-tauri/src/modules/pty/shell_init.rs` | 727 |
+| `spawn` | Function | `src-tauri/src/modules/shell/background.rs` | 91 |
+| `build_oneshot_command` | Function | `src-tauri/src/modules/shell/mod.rs` | 283 |
+| `read_logs` | Function | `src-tauri/src/modules/shell/background.rs` | 46 |
+| `shell_bg_logs` | Function | `src-tauri/src/modules/shell/mod.rs` | 249 |
+| `info` | Function | `src-tauri/src/modules/shell/background.rs` | 67 |
+| `shell_bg_list` | Function | `src-tauri/src/modules/shell/mod.rs` | 273 |
+| `open_settings_window` | Function | `src-tauri/src/lib.rs` | 35 |
+| `wrap_posix_with_sentinel` | Function | `src-tauri/src/modules/shell/session.rs` | 122 |
+| `wrap_with_sentinel` | Function | `src-tauri/src/modules/shell/session.rs` | 128 |
+| `strip_cwd_sentinel` | Function | `src-tauri/src/modules/shell/session.rs` | 144 |
+| `sentinels_are_unique_per_session` | Function | `src-tauri/src/modules/shell/session.rs` | 160 |
+| `strip_uses_session_sentinel_only` | Function | `src-tauri/src/modules/shell/session.rs` | 170 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Spawn → Is_safe_distro_name` | cross_community | 5 |
+| `Shell_run_command → Is_safe_distro_name` | cross_community | 5 |
+| `Shell_run_command → Which_in_path` | cross_community | 5 |
+| `Spawn → Wsl_drvfs_to_windows` | cross_community | 4 |
+| `Spawn → Which_in_path` | intra_community | 4 |
+| `Shell_run_command → CurrentWorkspaceEnv` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Modules | 3 calls |
+| Fs | 2 calls |
+| Pty | 2 calls |
+| Git | 2 calls |
+| Tests | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "new"})` — see callers and callees
+2. `gitnexus_query({query: "shell"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/source-control/SKILL.md
+++ b/.claude/skills/generated/source-control/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: source-control
+description: "Skill for the Source-control area of terax-ai. 58 symbols across 5 files."
+---
+
+# Source-control
+
+58 symbols | 5 files | Cohesion: 87%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how invalidateDiff, useSourceControlPanel, cancelReconcile work
+- Modifying source-control-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/source-control/useSourceControlPanel.ts` | optimisticStage, optimisticUnstage, optimisticDiscard, useSourceControlPanel, cancelReconcile (+29) |
+| `src/modules/source-control/SourceControlPanel.tsx` | basename, dirname, entryPathLabel, statusAccent, checkboxValue (+8) |
+| `src/modules/source-control/useSourceControl.ts` | normalizeError, getContextualAction, touchAutoFetch, doRefresh, refresh (+3) |
+| `src/modules/editor/lib/diffCache.ts` | invalidateDiff, invalidateRepoDiffs |
+| `src/components/ui/checkbox.tsx` | Checkbox |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`invalidateDiff`** (Function) — `src/modules/editor/lib/diffCache.ts:29`
+- **`useSourceControlPanel`** (Function) — `src/modules/source-control/useSourceControlPanel.ts:355`
+- **`cancelReconcile`** (Function) — `src/modules/source-control/useSourceControlPanel.ts:527`
+- **`scheduleReconcile`** (Function) — `src/modules/source-control/useSourceControlPanel.ts:534`
+- **`runMutation`** (Function) — `src/modules/source-control/useSourceControlPanel.ts:660`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `invalidateDiff` | Function | `src/modules/editor/lib/diffCache.ts` | 29 |
+| `useSourceControlPanel` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 355 |
+| `cancelReconcile` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 527 |
+| `scheduleReconcile` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 534 |
+| `runMutation` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 660 |
+| `stageEntry` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 690 |
+| `unstageEntry` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 704 |
+| `confirmPendingDiscard` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 735 |
+| `stageAllEntries` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 757 |
+| `unstageAllEntries` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 768 |
+| `toggleStageFile` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 800 |
+| `toggleAll` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 823 |
+| `doRefresh` | Function | `src/modules/source-control/useSourceControl.ts` | 204 |
+| `refresh` | Function | `src/modules/source-control/useSourceControl.ts` | 343 |
+| `run` | Function | `src/modules/source-control/useSourceControl.ts` | 355 |
+| `runRemoteAction` | Function | `src/modules/source-control/useSourceControl.ts` | 367 |
+| `onFocus` | Function | `src/modules/source-control/useSourceControl.ts` | 450 |
+| `generateCommitMessage` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 849 |
+| `stagedEntries` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 408 |
+| `unstagedEntries` | Function | `src/modules/source-control/useSourceControlPanel.ts` | 416 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `SourceControlPanel → IsCompatModelId` | cross_community | 6 |
+| `EntryRow → ToIconifySlug` | cross_community | 5 |
+| `RunRemoteAction → TouchAutoFetch` | intra_community | 4 |
+| `RunRemoteAction → NormalizeError` | intra_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Ui | 7 calls |
+| Explorer | 5 calls |
+| Editor | 2 calls |
+| Components | 1 calls |
+| Theme | 1 calls |
+| Ai | 1 calls |
+| Cluster_142 | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "invalidateDiff"})` — see callers and callees
+2. `gitnexus_query({query: "source-control"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/store/SKILL.md
+++ b/.claude/skills/generated/store/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: store
+description: "Skill for the Store area of terax-ai. 53 symbols across 13 files."
+---
+
+# Store
+
+53 symbols | 13 files | Cohesion: 89%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how loadAll, saveSessionsList, saveActiveId work
+- Modifying store-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/ai/store/chatStore.ts` | hydrateSessions, newSession, flip, deleteSession, renameSession (+14) |
+| `src/modules/ai/lib/sessions.ts` | loadAll, saveSessionsList, saveActiveId, newSessionId, deriveTitle (+4) |
+| `src/modules/ai/lib/todos.ts` | todosKey, loadTodos, saveTodos, deleteTodos |
+| `src/modules/ai/store/agentsStore.ts` | setActiveId, upsert, remove, hydrate |
+| `src/modules/ai/store/todoStore.ts` | hydrate, setTodos, clearSession |
+| `src/modules/ai/lib/agents.ts` | saveCustomAgents, saveActiveAgentId, loadAgents |
+| `src/modules/ai/store/snippetsStore.ts` | upsert, remove, hydrate |
+| `src/modules/ai/lib/snippets.ts` | saveSnippets, loadSnippets |
+| `src/modules/agents/store/managedAgentsStore.ts` | get, getBySessionId |
+| `src/modules/ai/lib/transport.ts` | createContextAwareTransport |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`loadAll`** (Function) — `src/modules/ai/lib/sessions.ts:22`
+- **`saveSessionsList`** (Function) — `src/modules/ai/lib/sessions.ts:40`
+- **`saveActiveId`** (Function) — `src/modules/ai/lib/sessions.ts:44`
+- **`newSessionId`** (Function) — `src/modules/ai/lib/sessions.ts:59`
+- **`deriveTitle`** (Function) — `src/modules/ai/lib/sessions.ts:63`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `loadAll` | Function | `src/modules/ai/lib/sessions.ts` | 22 |
+| `saveSessionsList` | Function | `src/modules/ai/lib/sessions.ts` | 40 |
+| `saveActiveId` | Function | `src/modules/ai/lib/sessions.ts` | 44 |
+| `newSessionId` | Function | `src/modules/ai/lib/sessions.ts` | 59 |
+| `deriveTitle` | Function | `src/modules/ai/lib/sessions.ts` | 63 |
+| `hydrateSessions` | Function | `src/modules/ai/store/chatStore.ts` | 399 |
+| `newSession` | Function | `src/modules/ai/store/chatStore.ts` | 432 |
+| `flip` | Function | `src/modules/ai/store/chatStore.ts` | 453 |
+| `deleteSession` | Function | `src/modules/ai/store/chatStore.ts` | 467 |
+| `renameSession` | Function | `src/modules/ai/store/chatStore.ts` | 500 |
+| `persistMessages` | Function | `src/modules/ai/store/chatStore.ts` | 508 |
+| `stop` | Function | `src/modules/ai/store/chatStore.ts` | 587 |
+| `loadTodos` | Function | `src/modules/ai/lib/todos.ts` | 16 |
+| `saveTodos` | Function | `src/modules/ai/lib/todos.ts` | 20 |
+| `deleteTodos` | Function | `src/modules/ai/lib/todos.ts` | 27 |
+| `createContextAwareTransport` | Function | `src/modules/ai/lib/transport.ts` | 73 |
+| `getOrCreateChat` | Function | `src/modules/ai/store/chatStore.ts` | 560 |
+| `stop` | Function | `src/modules/ai/lib/composer.tsx` | 321 |
+| `saveCustomAgents` | Function | `src/modules/ai/lib/agents.ts` | 104 |
+| `saveActiveAgentId` | Function | `src/modules/ai/lib/agents.ts` | 109 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Bridge → MessagesKey` | cross_community | 5 |
+
+## How to Explore
+
+1. `gitnexus_context({name: "loadAll"})` — see callers and callees
+2. `gitnexus_query({query: "store"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/tests/SKILL.md
+++ b/.claude/skills/generated/tests/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: tests
+description: "Skill for the Tests area of terax-ai. 62 symbols across 9 files."
+---
+
+# Tests
+
+62 symbols | 9 files | Cohesion: 78%
+
+## When to Use
+
+- Working with code in `src-tauri/`
+- Understanding how log, remote_url, repo_str work
+- Modifying tests-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src-tauri/tests/git_operations.rs` | skip_if_no_git, resolve_repo_returns_branch_for_real_repo, resolve_repo_returns_branch_for_unborn_head, status_on_empty_repo_has_no_files, status_lists_untracked_file (+18) |
+| `src-tauri/tests/fs_search.rs` | grep_finds_matches_and_returns_relative_paths, grep_case_insensitive_finds_mixed_case, grep_glob_filter_restricts_files, grep_max_results_truncates, grep_empty_pattern_errors (+16) |
+| `src-tauri/tests/common/mod.rs` | repo_str, run_git, write_file, git_available, root_str (+1) |
+| `src-tauri/src/modules/git/operations.rs` | log, parse_shortstat, remote_url |
+| `src-tauri/src/modules/fs/grep.rs` | build_globset, fs_grep, fs_glob |
+| `src-tauri/src/modules/fs/search.rs` | fs_list_files, fs_search |
+| `src-tauri/src/modules/fs/tree.rs` | fs_read_dir, list_subdirs |
+| `src-tauri/src/modules/shell/mod.rs` | shell_session_run |
+| `src/modules/ai/lib/miniWindowGeometry.ts` | clamp |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`log`** (Function) — `src-tauri/src/modules/git/operations.rs:473`
+- **`remote_url`** (Function) — `src-tauri/src/modules/git/operations.rs:791`
+- **`repo_str`** (Function) — `src-tauri/tests/common/mod.rs:38`
+- **`run_git`** (Function) — `src-tauri/tests/common/mod.rs:42`
+- **`write_file`** (Function) — `src-tauri/tests/common/mod.rs:46`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `log` | Function | `src-tauri/src/modules/git/operations.rs` | 473 |
+| `remote_url` | Function | `src-tauri/src/modules/git/operations.rs` | 791 |
+| `repo_str` | Function | `src-tauri/tests/common/mod.rs` | 38 |
+| `run_git` | Function | `src-tauri/tests/common/mod.rs` | 42 |
+| `write_file` | Function | `src-tauri/tests/common/mod.rs` | 46 |
+| `git_available` | Function | `src-tauri/tests/common/mod.rs` | 68 |
+| `fs_grep` | Function | `src-tauri/src/modules/fs/grep.rs` | 46 |
+| `fs_glob` | Function | `src-tauri/src/modules/fs/grep.rs` | 182 |
+| `fs_list_files` | Function | `src-tauri/src/modules/fs/search.rs` | 146 |
+| `fs_read_dir` | Function | `src-tauri/src/modules/fs/tree.rs` | 27 |
+| `list_subdirs` | Function | `src-tauri/src/modules/fs/tree.rs` | 102 |
+| `shell_session_run` | Function | `src-tauri/src/modules/shell/mod.rs` | 196 |
+| `root_str` | Function | `src-tauri/tests/common/mod.rs` | 88 |
+| `mkdir` | Function | `src-tauri/tests/common/mod.rs` | 100 |
+| `clamp` | Function | `src/modules/ai/lib/miniWindowGeometry.ts` | 11 |
+| `fs_search` | Function | `src-tauri/src/modules/fs/search.rs` | 45 |
+| `parse_shortstat` | Function | `src-tauri/src/modules/git/operations.rs` | 615 |
+| `skip_if_no_git` | Function | `src-tauri/tests/git_operations.rs` | 10 |
+| `resolve_repo_returns_branch_for_real_repo` | Function | `src-tauri/tests/git_operations.rs` | 34 |
+| `resolve_repo_returns_branch_for_unborn_head` | Function | `src-tauri/tests/git_operations.rs` | 52 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Git_panel_snapshot → Clamp` | cross_community | 6 |
+| `Git_log → Clamp` | cross_community | 6 |
+| `Git_show_commit → Clamp` | cross_community | 6 |
+| `Git_commit_files → Clamp` | cross_community | 6 |
+| `Git_commit_file_diff → Clamp` | cross_community | 6 |
+| `Git_remote_url → Clamp` | cross_community | 6 |
+| `Git_remote_url → Env` | cross_community | 6 |
+| `Git_remote_url → Hide_console` | cross_community | 6 |
+| `AiMiniWindow → Clamp` | cross_community | 5 |
+| `Diff_content → Clamp` | cross_community | 5 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Git | 27 calls |
+| Fs | 13 calls |
+| Pty | 1 calls |
+| Modules | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "log"})` — see callers and callees
+2. `gitnexus_query({query: "tests"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/theme/SKILL.md
+++ b/.claude/skills/generated/theme/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: theme
+description: "Skill for the Theme area of terax-ai. 52 symbols across 13 files."
+---
+
+# Theme
+
+52 symbols | 13 files | Cohesion: 65%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how setEditorTheme, onCustomThemesChange, getBuiltinTheme work
+- Modifying theme-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/theme/ThemeProvider.tsx` | readFastMode, readFastThemeId, resolveTheme, ThemeProvider, writeFastMode (+5) |
+| `src/modules/theme/bgImageStore.ts` | openDb, putBgImage, getBgImage, formatBytes, isAnimated (+2) |
+| `src/modules/theme/validateTheme.ts` | isObj, isStr, parseColors, parseTerminal, parseVariant (+1) |
+| `src/modules/theme/themeFiles.ts` | isThemeFilePath, parseThemeFile, themesDir, themeFilePath, writeThemeFile (+1) |
+| `src/modules/theme/customThemes.ts` | onCustomThemesChange, saveCustomTheme, listCustomThemes, deleteCustomTheme |
+| `src/modules/theme/SurfaceLayer.tsx` | SurfaceLayer, BackgroundImage, useWindowResizing, useDocumentHidden |
+| `src/modules/theme/applyTheme.ts` | applyTheme, clearTheme, writeColors, writeTerminal |
+| `src/modules/settings/store.ts` | setEditorTheme, setTheme, setThemeId |
+| `src/modules/theme/themes/index.ts` | getBuiltinTheme, getDefaultTheme |
+| `src/lib/useZoom.ts` | applyToDom, useZoom |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`setEditorTheme`** (Function) — `src/modules/settings/store.ts:378`
+- **`onCustomThemesChange`** (Function) — `src/modules/theme/customThemes.ts:32`
+- **`getBuiltinTheme`** (Function) — `src/modules/theme/themes/index.ts:31`
+- **`getDefaultTheme`** (Function) — `src/modules/theme/themes/index.ts:35`
+- **`ThemeProvider`** (Function) — `src/modules/theme/ThemeProvider.tsx:74`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `setEditorTheme` | Function | `src/modules/settings/store.ts` | 378 |
+| `onCustomThemesChange` | Function | `src/modules/theme/customThemes.ts` | 32 |
+| `getBuiltinTheme` | Function | `src/modules/theme/themes/index.ts` | 31 |
+| `getDefaultTheme` | Function | `src/modules/theme/themes/index.ts` | 35 |
+| `ThemeProvider` | Function | `src/modules/theme/ThemeProvider.tsx` | 74 |
+| `useZoom` | Function | `src/lib/useZoom.ts` | 18 |
+| `usePreferencesStore` | Function | `src/modules/settings/preferences.ts` | 47 |
+| `SurfaceLayer` | Function | `src/modules/theme/SurfaceLayer.tsx` | 12 |
+| `setTheme` | Function | `src/modules/settings/store.ts` | 335 |
+| `setThemeId` | Function | `src/modules/settings/store.ts` | 339 |
+| `unlistenP` | Function | `src/modules/theme/ThemeProvider.tsx` | 93 |
+| `setMode` | Function | `src/modules/theme/ThemeProvider.tsx` | 156 |
+| `setThemeId` | Function | `src/modules/theme/ThemeProvider.tsx` | 162 |
+| `putBgImage` | Function | `src/modules/theme/bgImageStore.ts` | 30 |
+| `getBgImage` | Function | `src/modules/theme/bgImageStore.ts` | 50 |
+| `importBgImageFromFile` | Function | `src/modules/theme/bgImageStore.ts` | 102 |
+| `validateTheme` | Function | `src/modules/theme/validateTheme.ts` | 93 |
+| `saveCustomTheme` | Function | `src/modules/theme/customThemes.ts` | 15 |
+| `isThemeFilePath` | Function | `src/modules/theme/themeFiles.ts` | 14 |
+| `parseThemeFile` | Function | `src/modules/theme/themeFiles.ts` | 54 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `UnlistenPromise → IsObj` | cross_community | 6 |
+| `UnlistenPromise → IsStr` | cross_community | 6 |
+| `EditorStack → UsePreferencesStore` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Settings | 5 calls |
+| Workspace | 3 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "setEditorTheme"})` — see callers and callees
+2. `gitnexus_query({query: "theme"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/tools/SKILL.md
+++ b/.claude/skills/generated/tools/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: tools
+description: "Skill for the Tools area of terax-ai. 41 symbols across 17 files."
+---
+
+# Tools
+
+41 symbols | 17 files | Cohesion: 85%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how checkReadableCanonical, checkWritableCanonical, newQueuedEditId work
+- Modifying tools-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/ai/tools/edit.ts` | djb2, applyEdits, execute, buildEditTools |
+| `src/modules/ai/tools/search.ts` | resolveRoot, clipLine, execute, buildSearchTools |
+| `src/modules/ai/tools/agent.ts` | hasControlChars, tailLines, execute, buildManagedAgentTools |
+| `src/modules/ai/tools/shell.ts` | buildShellTools, getSessionShell, workspaceSessionKey, execute |
+| `src/modules/ai/lib/security.ts` | checkReadableCanonical, checkWritableCanonical, checkShellCommand |
+| `src/modules/ai/tools/fs.ts` | djb2, execute, buildFsTools |
+| `src/app/App.tsx` | waitForClaudeTuiReady, spawnManagedAgent, readBuf |
+| `src/modules/ai/tools/todo.ts` | buildTodoTools, normalized, execute |
+| `src/modules/terminal/lib/useTerminalSession.ts` | whenSessionReady, writeToSession |
+| `src/modules/ai/tools/subagent.ts` | buildSubagentTools, execute |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`checkReadableCanonical`** (Function) — `src/modules/ai/lib/security.ts:264`
+- **`checkWritableCanonical`** (Function) — `src/modules/ai/lib/security.ts:290`
+- **`newQueuedEditId`** (Function) — `src/modules/ai/store/planStore.ts:32`
+- **`resolvePath`** (Function) — `src/modules/ai/tools/context.ts:24`
+- **`execute`** (Function) — `src/modules/ai/tools/edit.ts:133`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `checkReadableCanonical` | Function | `src/modules/ai/lib/security.ts` | 264 |
+| `checkWritableCanonical` | Function | `src/modules/ai/lib/security.ts` | 290 |
+| `newQueuedEditId` | Function | `src/modules/ai/store/planStore.ts` | 32 |
+| `resolvePath` | Function | `src/modules/ai/tools/context.ts` | 24 |
+| `execute` | Function | `src/modules/ai/tools/edit.ts` | 133 |
+| `execute` | Function | `src/modules/ai/tools/fs.ts` | 42 |
+| `execute` | Function | `src/modules/ai/tools/search.ts` | 60 |
+| `execute` | Function | `src/modules/ai/tools/agent.ts` | 38 |
+| `whenSessionReady` | Function | `src/modules/terminal/lib/useTerminalSession.ts` | 79 |
+| `writeToSession` | Function | `src/modules/terminal/lib/useTerminalSession.ts` | 94 |
+| `spawnManagedAgent` | Function | `src/app/App.tsx` | 1381 |
+| `readBuf` | Function | `src/app/App.tsx` | 1398 |
+| `buildManagedAgentTools` | Function | `src/modules/ai/tools/agent.ts` | 24 |
+| `buildEditTools` | Function | `src/modules/ai/tools/edit.ts` | 119 |
+| `buildShellTools` | Function | `src/modules/ai/tools/shell.ts` | 29 |
+| `buildSubagentTools` | Function | `src/modules/ai/tools/subagent.ts` | 9 |
+| `buildTerminalTools` | Function | `src/modules/ai/tools/terminal.ts` | 5 |
+| `buildTodoTools` | Function | `src/modules/ai/tools/todo.ts` | 8 |
+| `buildTools` | Function | `src/modules/ai/tools/tools.ts` | 30 |
+| `checkShellCommand` | Function | `src/modules/ai/lib/security.ts` | 323 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `GitDiffPane → WorkspaceScopeKey` | cross_community | 6 |
+| `Execute → Basename` | cross_community | 5 |
+| `Execute → ComparisonForm` | cross_community | 5 |
+| `Execute → IsUnderProtected` | cross_community | 5 |
+| `Execute → DescribeProtected` | cross_community | 5 |
+| `Execute → Basename` | cross_community | 5 |
+| `Execute → ComparisonForm` | cross_community | 5 |
+| `Execute → IsUnderProtected` | cross_community | 5 |
+| `Execute → DescribeProtected` | cross_community | 5 |
+| `SpawnManagedAgent → IsLeaf` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Components | 2 calls |
+| App | 1 calls |
+| Workspace | 1 calls |
+| Autocomplete | 1 calls |
+| Ai | 1 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "checkReadableCanonical"})` — see callers and callees
+2. `gitnexus_query({query: "tools"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/ui/SKILL.md
+++ b/.claude/skills/generated/ui/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: ui
+description: "Skill for the Ui area of terax-ai. 203 symbols across 66 files."
+---
+
+# Ui
+
+203 symbols | 66 files | Cohesion: 57%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how cn, useTodosStore, ContextContent work
+- Modifying ui-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/components/ui/menubar.tsx` | Menubar, MenubarPortal, MenubarTrigger, MenubarContent, MenubarItem (+7) |
+| `src/components/ui/alert-dialog.tsx` | AlertDialogMedia, AlertDialog, AlertDialogPortal, AlertDialogOverlay, AlertDialogContent (+6) |
+| `src/components/ui/item.tsx` | ItemGroup, ItemSeparator, Item, ItemMedia, ItemContent (+5) |
+| `src/components/ui/context-menu.tsx` | ContextMenuSubTrigger, ContextMenuSubContent, ContextMenuCheckboxItem, ContextMenuRadioItem, ContextMenuLabel (+4) |
+| `src/components/ui/dialog.tsx` | Dialog, DialogPortal, DialogOverlay, DialogContent, DialogHeader (+3) |
+| `src/components/ui/card.tsx` | Card, CardHeader, CardTitle, CardDescription, CardAction (+2) |
+| `src/components/ui/sheet.tsx` | SheetPortal, SheetOverlay, SheetContent, SheetHeader, SheetFooter (+2) |
+| `src/components/ai-elements/message.tsx` | MessageActions, MessageBranch, MessageBranchSelector, MessageBranchPage, MessageToolbar (+1) |
+| `src/components/ui/empty.tsx` | Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription (+1) |
+| `src/components/ui/input-group.tsx` | InputGroup, InputGroupAddon, InputGroupText, InputGroupInput, InputGroupButton (+1) |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`cn`** (Function) — `src/lib/utils.ts:3`
+- **`useTodosStore`** (Function) — `src/modules/ai/store/todoStore.ts:18`
+- **`ContextContent`** (Function) — `src/components/ai-elements/context.tsx:130`
+- **`ContextContentHeader`** (Function) — `src/components/ai-elements/context.tsx:142`
+- **`MessageActions`** (Function) — `src/components/ai-elements/message.tsx:67`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `cn` | Function | `src/lib/utils.ts` | 3 |
+| `useTodosStore` | Function | `src/modules/ai/store/todoStore.ts` | 18 |
+| `ContextContent` | Function | `src/components/ai-elements/context.tsx` | 130 |
+| `ContextContentHeader` | Function | `src/components/ai-elements/context.tsx` | 142 |
+| `MessageActions` | Function | `src/components/ai-elements/message.tsx` | 67 |
+| `MessageBranch` | Function | `src/components/ai-elements/message.tsx` | 143 |
+| `MessageBranchSelector` | Function | `src/components/ai-elements/message.tsx` | 229 |
+| `MessageBranchPage` | Function | `src/components/ai-elements/message.tsx` | 300 |
+| `MessageToolbar` | Function | `src/components/ai-elements/message.tsx` | 348 |
+| `Snippet` | Function | `src/components/ai-elements/snippet.tsx` | 35 |
+| `SnippetAddon` | Function | `src/components/ai-elements/snippet.tsx` | 54 |
+| `SnippetText` | Function | `src/components/ai-elements/snippet.tsx` | 60 |
+| `SnippetInput` | Function | `src/components/ai-elements/snippet.tsx` | 72 |
+| `AgentStatusPill` | Function | `src/modules/ai/components/AgentStatusPill.tsx` | 11 |
+| `AiMiniWindow` | Function | `src/modules/ai/components/AiMiniWindow.tsx` | 65 |
+| `FilePickerContent` | Function | `src/modules/ai/components/FilePicker.tsx` | 16 |
+| `SnippetPickerContent` | Function | `src/modules/ai/components/SnippetPicker.tsx` | 17 |
+| `TodoStrip` | Function | `src/modules/ai/components/TodoStrip.tsx` | 20 |
+| `hydrate` | Function | `src/modules/ai/components/TodoStrip.tsx` | 21 |
+| `MarkdownPreviewPane` | Function | `src/modules/markdown/MarkdownPreviewPane.tsx` | 26 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `SourceControlPanel → IsCompatModelId` | cross_community | 6 |
+| `UpdaterDialog → ParseVersion` | cross_community | 6 |
+| `AiMiniWindow → Clamp` | cross_community | 5 |
+| `EntryRowImpl → ToIconifySlug` | cross_community | 5 |
+| `SourceControlPanel → Cn` | cross_community | 4 |
+| `CommandPalette → Cn` | cross_community | 4 |
+| `AiStatusBarControls → Cn` | cross_community | 4 |
+| `ExplorerSearch → Cn` | cross_community | 4 |
+| `AiTools → Cn` | cross_community | 4 |
+| `UpdaterDialog → Cn` | cross_community | 4 |
+
+## Connected Areas
+
+| Area | Connections |
+|------|-------------|
+| Components | 15 calls |
+| Explorer | 8 calls |
+| Sections | 5 calls |
+| Ai-elements | 5 calls |
+| Updater | 2 calls |
+| Source-control | 2 calls |
+| Theme | 2 calls |
+| Workspace | 2 calls |
+
+## How to Explore
+
+1. `gitnexus_context({name: "cn"})` — see callers and callees
+2. `gitnexus_query({query: "ui"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/generated/workspace/SKILL.md
+++ b/.claude/skills/generated/workspace/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: workspace
+description: "Skill for the Workspace area of terax-ai. 34 symbols across 5 files."
+---
+
+# Workspace
+
+34 symbols | 5 files | Cohesion: 78%
+
+## When to Use
+
+- Working with code in `src/`
+- Understanding how workspaceAuthorize, readFile, writeFile work
+- Modifying workspace-related functionality
+
+## Key Files
+
+| File | Symbols |
+|------|---------|
+| `src/modules/ai/lib/native.ts` | workspaceAuthorize, readFile, writeFile, createFile, createDir (+24) |
+| `src/modules/ai/lib/composer.tsx` | onAttach, attachFileByPath |
+| `src/modules/editor/lib/useDocument.ts` | reload |
+| `src/modules/workspace/env.ts` | currentWorkspaceEnv |
+| `src/modules/explorer/ExplorerSearch.tsx` | handle |
+
+## Entry Points
+
+Start here when exploring this area:
+
+- **`workspaceAuthorize`** (Function) — `src/modules/ai/lib/native.ts:127`
+- **`readFile`** (Function) — `src/modules/ai/lib/native.ts:132`
+- **`writeFile`** (Function) — `src/modules/ai/lib/native.ts:137`
+- **`createFile`** (Function) — `src/modules/ai/lib/native.ts:148`
+- **`createDir`** (Function) — `src/modules/ai/lib/native.ts:150`
+
+## Key Symbols
+
+| Symbol | Type | File | Line |
+|--------|------|------|------|
+| `workspaceAuthorize` | Function | `src/modules/ai/lib/native.ts` | 127 |
+| `readFile` | Function | `src/modules/ai/lib/native.ts` | 132 |
+| `writeFile` | Function | `src/modules/ai/lib/native.ts` | 137 |
+| `createFile` | Function | `src/modules/ai/lib/native.ts` | 148 |
+| `createDir` | Function | `src/modules/ai/lib/native.ts` | 150 |
+| `readDir` | Function | `src/modules/ai/lib/native.ts` | 154 |
+| `grep` | Function | `src/modules/ai/lib/native.ts` | 160 |
+| `glob` | Function | `src/modules/ai/lib/native.ts` | 175 |
+| `runCommand` | Function | `src/modules/ai/lib/native.ts` | 182 |
+| `shellSessionOpen` | Function | `src/modules/ai/lib/native.ts` | 194 |
+| `shellSessionRun` | Function | `src/modules/ai/lib/native.ts` | 199 |
+| `shellBgSpawn` | Function | `src/modules/ai/lib/native.ts` | 221 |
+| `gitResolveRepo` | Function | `src/modules/ai/lib/native.ts` | 247 |
+| `gitPanelSnapshot` | Function | `src/modules/ai/lib/native.ts` | 252 |
+| `gitStatus` | Function | `src/modules/ai/lib/native.ts` | 257 |
+| `gitDiff` | Function | `src/modules/ai/lib/native.ts` | 262 |
+| `gitDiffContent` | Function | `src/modules/ai/lib/native.ts` | 269 |
+| `gitStage` | Function | `src/modules/ai/lib/native.ts` | 282 |
+| `gitUnstage` | Function | `src/modules/ai/lib/native.ts` | 288 |
+| `gitDiscard` | Function | `src/modules/ai/lib/native.ts` | 294 |
+
+## Execution Flows
+
+| Flow | Type | Steps |
+|------|------|-------|
+| `Run → CurrentWorkspaceEnv` | cross_community | 7 |
+| `GitDiffPane → CurrentWorkspaceEnv` | cross_community | 6 |
+| `UseTerminalSession → CurrentWorkspaceEnv` | cross_community | 5 |
+| `HandleLeafExit → CurrentWorkspaceEnv` | cross_community | 5 |
+| `Git_diff_content → CurrentWorkspaceEnv` | cross_community | 5 |
+| `AiInputBar → CurrentWorkspaceEnv` | cross_community | 4 |
+| `FileExplorer → CurrentWorkspaceEnv` | cross_community | 4 |
+| `Shell_session_open → CurrentWorkspaceEnv` | cross_community | 4 |
+| `EditorStack → CurrentWorkspaceEnv` | cross_community | 4 |
+| `Fs_watch_add → CurrentWorkspaceEnv` | cross_community | 4 |
+
+## How to Explore
+
+1. `gitnexus_context({name: "workspaceAuthorize"})` — see callers and callees
+2. `gitnexus_query({query: "workspace"})` — find related execution flows
+3. Read key files listed above for implementation details

--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gitnexus-cli
+description: "Use when the user needs to run GitNexus CLI commands like analyze/index a repo, check status, clean the index, generate a wiki, or list indexed repos. Examples: \"Index this repo\", \"Reanalyze the codebase\", \"Generate a wiki\""
+---
+
+# GitNexus CLI Commands
+
+All commands work via `npx` — no global install required.
+
+## Commands
+
+### analyze — Build or refresh the index
+
+```bash
+npx gitnexus analyze
+```
+
+Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
+
+| Flag           | Effect                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| `--force`      | Force full re-index even if up to date                           |
+| `--embeddings` | Enable embedding generation for semantic search (off by default) |
+| `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+
+### status — Check index freshness
+
+```bash
+npx gitnexus status
+```
+
+Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
+
+### clean — Delete the index
+
+```bash
+npx gitnexus clean
+```
+
+Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
+
+| Flag      | Effect                                            |
+| --------- | ------------------------------------------------- |
+| `--force` | Skip confirmation prompt                          |
+| `--all`   | Clean all indexed repos, not just the current one |
+
+### wiki — Generate documentation from the graph
+
+```bash
+npx gitnexus wiki
+```
+
+Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
+
+| Flag                | Effect                                    |
+| ------------------- | ----------------------------------------- |
+| `--force`           | Force full regeneration                   |
+| `--model <model>`   | LLM model (default: minimax/minimax-m2.5) |
+| `--base-url <url>`  | LLM API base URL                          |
+| `--api-key <key>`   | LLM API key                               |
+| `--concurrency <n>` | Parallel LLM calls (default: 3)           |
+| `--gist`            | Publish wiki as a public GitHub Gist      |
+
+### list — Show all indexed repos
+
+```bash
+npx gitnexus list
+```
+
+Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.
+
+## After Indexing
+
+1. **Read `gitnexus://repo/{name}/context`** to verify the index loaded
+2. Use the other GitNexus skills (`exploring`, `debugging`, `impact-analysis`, `refactoring`) for your task
+
+## Troubleshooting
+
+- **"Not inside a git repository"**: Run from a directory inside a git repo
+- **Index is stale after re-analyzing**: Restart Claude Code to reload the MCP server
+- **Embeddings slow**: Omit `--embeddings` (it's off by default) or set `OPENAI_API_KEY` for faster API-based embedding

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: gitnexus-debugging
+description: "Use when the user is debugging a bug, tracing an error, or asking why something fails. Examples: \"Why is X failing?\", \"Where does this error come from?\", \"Trace this bug\""
+---
+
+# Debugging with GitNexus
+
+## When to Use
+
+- "Why is this function failing?"
+- "Trace where this error comes from"
+- "Who calls this method?"
+- "This endpoint returns 500"
+- Investigating bugs, errors, or unexpected behavior
+
+## Workflow
+
+```
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] Understand the symptom (error message, unexpected behavior)
+- [ ] gitnexus_query for error text or related code
+- [ ] Identify the suspect function from returned processes
+- [ ] gitnexus_context to see callers and callees
+- [ ] Trace execution flow via process resource if applicable
+- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] Read source files to confirm root cause
+```
+
+## Debugging Patterns
+
+| Symptom              | GitNexus Approach                                          |
+| -------------------- | ---------------------------------------------------------- |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Wrong return value   | `context` on the function → trace callees for data flow    |
+| Intermittent failure | `context` → look for external calls, async deps            |
+| Performance issue    | `context` → find symbols with many callers (hot paths)     |
+| Recent regression    | `detect_changes` to see what your changes affect           |
+
+## Tools
+
+**gitnexus_query** — find code related to error:
+
+```
+gitnexus_query({query: "payment validation error"})
+→ Processes: CheckoutFlow, ErrorHandling
+→ Symbols: validatePayment, handlePaymentError, PaymentException
+```
+
+**gitnexus_context** — full context for a suspect:
+
+```
+gitnexus_context({name: "validatePayment"})
+→ Incoming calls: processCheckout, webhookHandler
+→ Outgoing calls: verifyCard, fetchRates (external API!)
+→ Processes: CheckoutFlow (step 3/7)
+```
+
+**gitnexus_cypher** — custom call chain traces:
+
+```cypher
+MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
+RETURN [n IN nodes(path) | n.name] AS chain
+```
+
+## Example: "Payment endpoint returns 500 intermittently"
+
+```
+1. gitnexus_query({query: "payment error handling"})
+   → Processes: CheckoutFlow, ErrorHandling
+   → Symbols: validatePayment, handlePaymentError
+
+2. gitnexus_context({name: "validatePayment"})
+   → Outgoing calls: verifyCard, fetchRates (external API!)
+
+3. READ gitnexus://repo/my-app/process/CheckoutFlow
+   → Step 3: validatePayment → calls fetchRates (external)
+
+4. Root cause: fetchRates calls external API without proper timeout
+```

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: gitnexus-exploring
+description: "Use when the user asks how code works, wants to understand architecture, trace execution flows, or explore unfamiliar parts of the codebase. Examples: \"How does X work?\", \"What calls this function?\", \"Show me the auth flow\""
+---
+
+# Exploring Codebases with GitNexus
+
+## When to Use
+
+- "How does authentication work?"
+- "What's the project structure?"
+- "Show me the main components"
+- "Where is the database logic?"
+- Understanding code you haven't seen before
+
+## Workflow
+
+```
+1. READ gitnexus://repos                          → Discover indexed repos
+2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
+```
+
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] READ gitnexus://repo/{name}/context
+- [ ] gitnexus_query for the concept you want to understand
+- [ ] Review returned processes (execution flows)
+- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] READ process resource for full execution traces
+- [ ] Read source files for implementation details
+```
+
+## Resources
+
+| Resource                                | What you get                                            |
+| --------------------------------------- | ------------------------------------------------------- |
+| `gitnexus://repo/{name}/context`        | Stats, staleness warning (~150 tokens)                  |
+| `gitnexus://repo/{name}/clusters`       | All functional areas with cohesion scores (~300 tokens) |
+| `gitnexus://repo/{name}/cluster/{name}` | Area members with file paths (~500 tokens)              |
+| `gitnexus://repo/{name}/process/{name}` | Step-by-step execution trace (~200 tokens)              |
+
+## Tools
+
+**gitnexus_query** — find execution flows related to a concept:
+
+```
+gitnexus_query({query: "payment processing"})
+→ Processes: CheckoutFlow, RefundFlow, WebhookHandler
+→ Symbols grouped by flow with file locations
+```
+
+**gitnexus_context** — 360-degree view of a symbol:
+
+```
+gitnexus_context({name: "validateUser"})
+→ Incoming calls: loginHandler, apiMiddleware
+→ Outgoing calls: checkToken, getUserById
+→ Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
+```
+
+## Example: "How does payment processing work?"
+
+```
+1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
+2. gitnexus_query({query: "payment processing"})
+   → CheckoutFlow: processPayment → validateCard → chargeStripe
+   → RefundFlow: initiateRefund → calculateRefund → processRefund
+3. gitnexus_context({name: "processPayment"})
+   → Incoming: checkoutHandler, webhookHandler
+   → Outgoing: validateCard, chargeStripe, saveTransaction
+4. Read src/payments/processor.ts for implementation details
+```

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: gitnexus-guide
+description: "Use when the user asks about GitNexus itself — available tools, how to query the knowledge graph, MCP resources, graph schema, or workflow reference. Examples: \"What GitNexus tools are available?\", \"How do I use GitNexus?\""
+---
+
+# GitNexus Guide
+
+Quick reference for all GitNexus MCP tools, resources, and the knowledge graph schema.
+
+## Always Start Here
+
+For any task involving code understanding, debugging, impact analysis, or refactoring:
+
+1. **Read `gitnexus://repo/{name}/context`** — codebase overview + check index freshness
+2. **Match your task to a skill below** and **read that skill file**
+3. **Follow the skill's workflow and checklist**
+
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+
+## Skills
+
+| Task                                         | Skill to read       |
+| -------------------------------------------- | ------------------- |
+| Understand architecture / "How does X work?" | `gitnexus-exploring`         |
+| Blast radius / "What breaks if I change X?"  | `gitnexus-impact-analysis`   |
+| Trace bugs / "Why is X failing?"             | `gitnexus-debugging`         |
+| Rename / extract / split / refactor          | `gitnexus-refactoring`       |
+| Tools, resources, schema reference           | `gitnexus-guide` (this file) |
+| Index, status, clean, wiki CLI commands      | `gitnexus-cli`               |
+
+## Tools Reference
+
+| Tool             | What it gives you                                                        |
+| ---------------- | ------------------------------------------------------------------------ |
+| `query`          | Process-grouped code intelligence — execution flows related to a concept |
+| `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
+| `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `detect_changes` | Git-diff impact — what do your current changes affect                    |
+| `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
+| `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
+| `list_repos`     | Discover indexed repos                                                   |
+
+## Resources Reference
+
+Lightweight reads (~100-500 tokens) for navigation:
+
+| Resource                                       | Content                                   |
+| ---------------------------------------------- | ----------------------------------------- |
+| `gitnexus://repo/{name}/context`               | Stats, staleness check                    |
+| `gitnexus://repo/{name}/clusters`              | All functional areas with cohesion scores |
+| `gitnexus://repo/{name}/cluster/{clusterName}` | Area members                              |
+| `gitnexus://repo/{name}/processes`             | All execution flows                       |
+| `gitnexus://repo/{name}/process/{processName}` | Step-by-step trace                        |
+| `gitnexus://repo/{name}/schema`                | Graph schema for Cypher                   |
+
+## Graph Schema
+
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})
+RETURN caller.name, caller.filePath
+```

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gitnexus-impact-analysis
+description: "Use when the user wants to know what will break if they change something, or needs safety analysis before editing code. Examples: \"Is it safe to change X?\", \"What depends on this?\", \"What will break?\""
+---
+
+# Impact Analysis with GitNexus
+
+## When to Use
+
+- "Is it safe to change this function?"
+- "What will break if I modify X?"
+- "Show me the blast radius"
+- "Who uses this code?"
+- Before making non-trivial code changes
+- Before committing — to understand what your changes affect
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+4. Assess risk and report to user
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklist
+
+```
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] Review d=1 items first (these WILL BREAK)
+- [ ] Check high-confidence (>0.8) dependencies
+- [ ] READ processes to check affected execution flows
+- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] Assess risk level and report to user
+```
+
+## Understanding Output
+
+| Depth | Risk Level       | Meaning                  |
+| ----- | ---------------- | ------------------------ |
+| d=1   | **WILL BREAK**   | Direct callers/importers |
+| d=2   | LIKELY AFFECTED  | Indirect dependencies    |
+| d=3   | MAY NEED TESTING | Transitive effects       |
+
+## Risk Assessment
+
+| Affected                       | Risk     |
+| ------------------------------ | -------- |
+| <5 symbols, few processes      | LOW      |
+| 5-15 symbols, 2-5 processes    | MEDIUM   |
+| >15 symbols or many processes  | HIGH     |
+| Critical path (auth, payments) | CRITICAL |
+
+## Tools
+
+**gitnexus_impact** — the primary tool for symbol blast radius:
+
+```
+gitnexus_impact({
+  target: "validateUser",
+  direction: "upstream",
+  minConfidence: 0.8,
+  maxDepth: 3
+})
+
+→ d=1 (WILL BREAK):
+  - loginHandler (src/auth/login.ts:42) [CALLS, 100%]
+  - apiMiddleware (src/api/middleware.ts:15) [CALLS, 100%]
+
+→ d=2 (LIKELY AFFECTED):
+  - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
+```
+
+**gitnexus_detect_changes** — git-diff based impact analysis:
+
+```
+gitnexus_detect_changes({scope: "staged"})
+
+→ Changed: 5 symbols in 3 files
+→ Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
+→ Risk: MEDIUM
+```
+
+## Example: "What breaks if I change validateUser?"
+
+```
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+   → d=1: loginHandler, apiMiddleware (WILL BREAK)
+   → d=2: authRouter, sessionManager (LIKELY AFFECTED)
+
+2. READ gitnexus://repo/my-app/processes
+   → LoginFlow and TokenRefresh touch validateUser
+
+3. Risk: 2 direct callers, 2 processes = MEDIUM
+```

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: gitnexus-refactoring
+description: "Use when the user wants to rename, extract, split, move, or restructure code safely. Examples: \"Rename this function\", \"Extract this into a module\", \"Refactor this class\", \"Move this to a separate file\""
+---
+
+# Refactoring with GitNexus
+
+## When to Use
+
+- "Rename this function safely"
+- "Extract this into a module"
+- "Split this service"
+- "Move this to a new file"
+- Any task involving renaming, extracting, splitting, or restructuring code
+
+## Workflow
+
+```
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+4. Plan update order: interfaces → implementations → callers → tests
+```
+
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+
+## Checklists
+
+### Rename Symbol
+
+```
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] Run tests for affected processes
+```
+
+### Extract Module
+
+```
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] Define new module interface
+- [ ] Extract code, update imports
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+### Split Function/Service
+
+```
+- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] Group callees by responsibility
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] Create new functions/services
+- [ ] Update callers
+- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] Run tests for affected processes
+```
+
+## Tools
+
+**gitnexus_rename** — automated multi-file rename:
+
+```
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+→ 12 edits across 8 files
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
+```
+
+**gitnexus_impact** — map all dependents first:
+
+```
+gitnexus_impact({target: "validateUser", direction: "upstream"})
+→ d=1: loginHandler, apiMiddleware, testUtils
+→ Affected Processes: LoginFlow, TokenRefresh
+```
+
+**gitnexus_detect_changes** — verify your changes after refactoring:
+
+```
+gitnexus_detect_changes({scope: "all"})
+→ Changed: 8 files, 12 symbols
+→ Affected processes: LoginFlow, TokenRefresh
+→ Risk: MEDIUM
+```
+
+**gitnexus_cypher** — custom reference queries:
+
+```cypher
+MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
+RETURN caller.name, caller.filePath ORDER BY caller.filePath
+```
+
+## Risk Rules
+
+| Risk Factor         | Mitigation                                |
+| ------------------- | ----------------------------------------- |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Cross-area refs     | Use detect_changes after to verify scope  |
+| String/dynamic refs | gitnexus_query to find them               |
+| External/public API | Version and deprecate properly            |
+
+## Example: Rename `validateUser` to `authenticateUser`
+
+```
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
+   → Files: validator.ts, login.ts, middleware.ts, config.json...
+
+2. Review ast_search edits (config.json: dynamic reference!)
+
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+   → Applied 12 edits across 8 files
+
+4. gitnexus_detect_changes({scope: "all"})
+   → Affected: LoginFlow, TokenRefresh
+   → Risk: MEDIUM — run tests for these flows
+```

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, net, pty, secrets, shell, workspace};
+use modules::{agent, agents, fs, git, net, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -225,6 +225,8 @@ pub fn run() {
             open_settings_window,
             agent::agent_enable_claude_hooks,
             agent::agent_claude_hooks_status,
+            agents::antigravity::agent_enable_antigravity_hooks,
+            agents::antigravity::agent_antigravity_hooks_status,
             secrets::secrets_get,
             secrets::secrets_set,
             secrets::secrets_delete,

--- a/src-tauri/src/modules/agents/antigravity.rs
+++ b/src-tauri/src/modules/agents/antigravity.rs
@@ -1,0 +1,143 @@
+use serde_json::{json, Value};
+
+const ANTIGRAVITY_EVENTS: [(&str, &str); 3] = [
+    ("BeforeAgent", "working"),
+    ("AfterAgent", "finished"),
+    ("Notification", "attention"),
+];
+
+fn settings_path() -> Result<std::path::PathBuf, String> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| "no home dir".to_string())?
+        .join(".gemini")
+        .join("antigravity-cli")
+        .join("settings.json"))
+}
+
+fn hook_cmd(event: &str) -> String {
+    format!(
+        r#"[ -n "$TERAX_TERMINAL" ] && printf '\033]777;notify;Terax;antigravity;{}\007' || true"#,
+        event
+    )
+}
+
+fn hook_name(event: &str) -> String {
+    format!("terax-ag-{}", event)
+}
+
+fn is_ours(group: &Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_some_and(|hs| {
+            hs.iter().any(|h| {
+                h.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|n| n.starts_with("terax-ag-"))
+            })
+        })
+}
+
+fn hook_group(event: &str) -> Value {
+    json!({
+        "hooks": [{
+            "type": "command",
+            "command": hook_cmd(event),
+            "name": hook_name(event),
+            "timeout": 5000
+        }]
+    })
+}
+
+fn is_empty_group(group: &Value) -> bool {
+    group
+        .get("hooks")
+        .and_then(Value::as_array)
+        .is_none_or(|hs| hs.is_empty())
+}
+
+fn merge_hooks(mut root: Value) -> Value {
+    if !root.is_object() {
+        root = json!({});
+    }
+    let obj = root.as_object_mut().unwrap();
+    let hooks = obj.entry("hooks").or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let hooks_obj = hooks.as_object_mut().unwrap();
+
+    for (event, marker) in ANTIGRAVITY_EVENTS {
+        let arr = hooks_obj.entry(event).or_insert_with(|| json!([]));
+        let arr = arr.as_array_mut().unwrap();
+        arr.retain(|g| !is_ours(g) && !is_empty_group(g));
+        arr.push(hook_group(marker));
+    }
+    root
+}
+
+/// Enable Antigravity CLI hooks by writing to ~/.gemini/antigravity-cli/settings.json.
+#[tauri::command]
+pub fn agent_enable_antigravity_hooks() -> Result<(), String> {
+    let path = settings_path()?;
+    std::fs::create_dir_all(path.parent().unwrap())
+        .map_err(|e| format!("mkdir: {e}"))?;
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(s) if !s.trim().is_empty() => {
+            serde_json::from_str(&s).map_err(|e| format!("invalid JSON: {e}"))?
+        }
+        Ok(_) | Err(_) => json!({}),
+    };
+    let merged = merge_hooks(existing);
+    let out = serde_json::to_string_pretty(&merged).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("json.terax-tmp");
+    std::fs::write(&tmp, out).map_err(|e| format!("write: {e}"))?;
+    std::fs::rename(&tmp, &path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename: {e}")
+    })?;
+    Ok(())
+}
+
+/// Check if Antigravity CLI hooks are installed.
+#[tauri::command]
+pub fn agent_antigravity_hooks_status() -> bool {
+    settings_path()
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .is_some_and(|c| {
+            ANTIGRAVITY_EVENTS
+                .iter()
+                .all(|(_, m)| c.contains(&format!("notify;Terax;antigravity;{m}")))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_all_events_to_empty_config() {
+        let out = merge_hooks(json!({}));
+        for (event, marker) in ANTIGRAVITY_EVENTS {
+            let arr = out["hooks"][event].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "missing event: {event}");
+            let cmd = arr[0]["hooks"][0]["command"].as_str().unwrap();
+            assert!(cmd.contains(&format!("antigravity;{marker}")));
+        }
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let once = merge_hooks(json!({}));
+        let twice = merge_hooks(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn preserves_foreign_settings() {
+        let input = json!({"security": {"approvalMode": "yolo"}});
+        let out = merge_hooks(input);
+        assert_eq!(out["security"]["approvalMode"], "yolo");
+    }
+}

--- a/src-tauri/src/modules/agents/mod.rs
+++ b/src-tauri/src/modules/agents/mod.rs
@@ -1,0 +1,1 @@
+pub mod antigravity;

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod agents;
 pub mod fs;
 pub mod git;
 pub mod net;

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -5,7 +5,7 @@ const ST_FINAL: u8 = b'\\';
 
 const OSC_MAX: usize = 2048;
 
-const DEFAULT_AGENTS: &[&str] = &["claude", "codex"];
+const DEFAULT_AGENTS: &[&str] = &["claude", "codex", "gemini", "agy"];
 
 // OSC 777 marker our Claude Code hooks emit via `terminalSequence`.
 const TERAX_MARKER: &[u8] = b"notify;Terax;";
@@ -160,21 +160,37 @@ impl AgentDetector {
     }
 
     fn handle_osc777<F: FnMut(Transition)>(&mut self, pt: &[u8], emit: &mut F) {
-        if let Some(event) = pt.strip_prefix(TERAX_MARKER) {
-            // Self-arms so notifications work even when no shell preexec fired
-            // (bash, Windows, tmux, wrappers).
+        // Parse: notify;Terax;[<agent_id>;]<event>
+        // Legacy: notify;Terax;working  → agent=claude, event=working
+        // New:    notify;Terax;antigravity;finished → agent=antigravity, event=finished
+        if let Some(body) = pt.strip_prefix(TERAX_MARKER) {
+            let (agent_id, event) = if let Some(semi) = body.iter().position(|&c| c == b';') {
+                let id = std::str::from_utf8(&body[..semi]).unwrap_or("claude");
+                let ev = std::str::from_utf8(&body[semi + 1..]).unwrap_or("");
+                (id, ev)
+            } else {
+                let ev = std::str::from_utf8(body).unwrap_or("");
+                ("claude", ev)
+            };
+            let agent_name = match agent_id {
+                "claude" => "Claude Code",
+                "codex" => "Codex CLI",
+                "gemini" => "Gemini CLI",
+                "antigravity" => "Antigravity CLI",
+                other => other,
+            };
             match event {
-                b"working" => {
-                    self.ensure_armed(emit);
+                "working" => {
+                    self.ensure_armed(emit, agent_name);
                     self.set_working(emit);
                 }
-                b"attention" => {
-                    self.ensure_armed(emit);
+                "attention" => {
+                    self.ensure_armed(emit, agent_name);
                     self.status = Status::Waiting;
                     emit(Transition::Attention);
                 }
-                b"finished" => {
-                    self.ensure_armed(emit);
+                "finished" => {
+                    self.ensure_armed(emit, agent_name);
                     self.status = Status::Waiting;
                     emit(Transition::Finished);
                 }
@@ -206,11 +222,11 @@ impl AgentDetector {
         }
     }
 
-    fn ensure_armed<F: FnMut(Transition)>(&mut self, emit: &mut F) {
+    fn ensure_armed<F: FnMut(Transition)>(&mut self, emit: &mut F, agent_name: &str) {
         if !self.armed {
             self.armed = true;
             self.status = Status::Working;
-            emit(Transition::Started { agent: "claude".into() });
+            emit(Transition::Started { agent: agent_name.to_string() });
         }
     }
 
@@ -321,7 +337,7 @@ mod tests {
         let mut d = AgentDetector::new();
         assert_eq!(
             run(&mut d, &osc("777;notify;Terax;attention")),
-            vec![started("claude"), Transition::Attention]
+            vec![started("Claude Code"), Transition::Attention]
         );
     }
 


### PR DESCRIPTION
Adds native hook support for Antigravity CLI (binary: `agy`) via `~/.gemini/antigravity-cli/settings.json`.

Antigravity shares the Google Gemini hook architecture -- same event schema, same nested JSON format.

**Three events:** BeforeAgent -> working, AfterAgent -> finished, Notification -> attention.

## Changes

| Area | What |
|------|------|
| `src-tauri/src/modules/agents/antigravity.rs` | Isolated hook installer, 3 tests (empty config, idempotent, preserves foreign settings) |
| `src-tauri/src/modules/pty/agent_detect.rs` | Added `agy` to DEFAULT_AGENTS, `antigravity` -> `Antigravity CLI` in generic OSC 777 parser |
| `src-tauri/src/lib.rs` + `mod.rs` | Registered new Tauri commands |

## Testing

```
cargo check -> 0 errors
```

Follows same pattern as #703 (Gemini CLI hooks). No `agent.rs` changes.