### PR TITLE
feat(terminal): $PATH support for homebrew on macOS 

### DIFF
--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -61,4 +61,12 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
 
   _terax_precmd
 fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ -x /opt/homebrew/bin/brew ]] && [[ ":$PATH:" != *":/opt/homebrew/bin:"* ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]] && [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
 :

--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -49,3 +49,11 @@ function __terax_preexec --on-event fish_preexec
     set -l cmd (string replace -ra '[\x00-\x1f\x7f]' ' ' -- "$argv")
     printf '\e]133;C;%s\e\\' (string sub -l 256 -- "$cmd")
 end
+
+if test (uname) = Darwin
+    if test -x /opt/homebrew/bin/brew; and not contains /opt/homebrew/bin $PATH
+        eval (/opt/homebrew/bin/brew shellenv)
+    else if test -x /usr/local/bin/brew; and not contains /usr/local/bin $PATH
+        eval (/usr/local/bin/brew shellenv)
+    end
+end

--- a/src-tauri/src/modules/pty/scripts/zprofile.zsh
+++ b/src-tauri/src/modules/pty/scripts/zprofile.zsh
@@ -6,4 +6,12 @@
   [ -f "$_terax_user_zdotdir/.zprofile" ] && source "$_terax_user_zdotdir/.zprofile"
   unset _terax_user_zdotdir
 }
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ -x /opt/homebrew/bin/brew ]] && [[ ":$PATH:" != *":/opt/homebrew/bin:"* ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]] && [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
 :


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
add homebrew paths to $PATH on macOS.

## Why
Closes [Issue 702](https://github.com/crynta/terax-ai/issues/702)

## How
Simple script 

## Testing
Compiled the project and checked fish, bash, zsh $PATH variables. And ran homebrew binaries.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS
- [x] Shells tested (if relevant): bash / zsh / fish