### PR TITLE
Enhance security tests for shell command checks

### DIFF
--- a/src/modules/ai/lib/security.test.ts
+++ b/src/modules/ai/lib/security.test.ts
@@ -19,16 +19,11 @@ describe("checkReadable — secret basenames", () => {
   });
 
   it("blocks .env with trailing Windows-stripped characters", () => {
-    // Windows strips trailing dot/space at open time — so `.env.` and `.env `
-    // open the same file as `.env`. The pre-canonicalize deny-list must
-    // refuse these on its first pass.
     expect(checkReadable("C:\\Users\\me\\.env.")).toMatchObject({ ok: false });
     expect(checkReadable("C:\\Users\\me\\.env ")).toMatchObject({ ok: false });
   });
 
   it("blocks NTFS alternate-data-stream notation for .env", () => {
-    // `.env:hidden` and `.env::$DATA` access the same underlying file's
-    // default data stream — must not bypass the deny-list.
     expect(checkReadable("C:\\Users\\me\\.env::$DATA")).toMatchObject({
       ok: false,
     });
@@ -56,8 +51,6 @@ describe("checkReadable — secret basenames", () => {
   });
 
   it("does not block names that merely start with id_rsa- prefix-prefix", () => {
-    // `id_rsax` is not a real key file — make sure the regex doesn't
-    // over-match identifiers that happen to share the prefix.
     expect(checkReadable("/home/me/Documents/id_rsaxyz.txt")).toMatchObject({
       ok: true,
     });
@@ -89,9 +82,6 @@ describe("checkReadable — protected directories", () => {
   });
 
   it("blocks reads under /etc, /proc, /sys (newly added)", () => {
-    // These directories are not WRITE_DENY-only any more — reading them is
-    // also blocked because they hold global config/credentials/process state
-    // with basenames the regex doesn't catch (passwd, shadow, environ, …).
     expect(checkReadable("/etc/shadow")).toMatchObject({ ok: false });
     expect(checkReadable("/etc/nginx/nginx.conf")).toMatchObject({ ok: false });
     expect(checkReadable("/proc/self/environ")).toMatchObject({ ok: false });
@@ -104,7 +94,6 @@ describe("checkReadable — protected directories", () => {
   });
 
   it("rejects path-segment look-alikes (.sshx is not .ssh)", () => {
-    // The comparator must use segment-boundary matching, not raw substring.
     expect(checkReadable("/home/me/.sshx/file")).toMatchObject({ ok: true });
     expect(checkReadable("/home/me/.gitignore-stuff/config")).toMatchObject({
       ok: true,
@@ -147,9 +136,6 @@ describe("checkReadable — path normalization", () => {
 
 describe("checkReadableCanonical — symlink defense + always-recheck", () => {
   it("rechecks even when canonical equals input", async () => {
-    // Regression: previously the recheck was skipped when canonicalize
-    // returned the same string, allowing some OS-specific bypasses to slip
-    // through. Now the recheck always runs.
     const identity = async (p: string) => p;
     const r = await checkReadableCanonical("/etc/nginx/nginx.conf", identity);
     expect(r.ok).toBe(false);
@@ -229,5 +215,22 @@ describe("checkShellCommand — control-character / newline injection", () => {
     expect(checkShellCommand("echo safe\nprintenv")).toMatchObject({
       ok: false,
     });
+  });
+});
+
+describe("checkShellCommand — home directory rm guard", () => {
+  it("blocks rm -rf with ${HOME} (braces variant)", () => {
+    expect(checkShellCommand("rm -rf ${HOME}")).toMatchObject({ ok: false });
+    expect(checkShellCommand('rm -rf "${HOME}"')).toMatchObject({ ok: false });
+    expect(checkShellCommand("rm -rf ${HOME}/")).toMatchObject({ ok: false });
+  });
+
+  it("blocks rm -rf on home subdirectories", () => {
+    expect(checkShellCommand("rm -rf ~/subdir")).toMatchObject({ ok: false });
+    expect(checkShellCommand("rm -rf ~/subdir && ls")).toMatchObject({ ok: false });
+  });
+
+  it("does not block rm -rf on explicit absolute paths", () => {
+    expect(checkShellCommand("rm -rf /home/me/safe")).toMatchObject({ ok: true });
   });
 });


### PR DESCRIPTION
Added tests for checkShellCommand to block dangerous rm -rf commands involving home directory.

<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: <!-- macOS / Linux / Windows -->
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
