### PR TITLE
refactor(ui): replace motion with native CSS animations

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -6,8 +6,7 @@
       "dist/assets/react-*.js",
       "dist/assets/radix-*.js",
       "dist/assets/alert-dialog-*.js",
-      "dist/assets/xterm-*.js",
-      "dist/assets/motion-*.js"
+      "dist/assets/xterm-*.js"
     ],
     "limit": "540 KB",
     "gzip": true

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "motion": "^12.38.0",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,9 +203,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      motion:
-        specifier: ^12.38.0
-        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2477,8 +2474,8 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@react-grab/cli@0.1.40':
-    resolution: {integrity: sha512-4y8kRfXizJ2Klr+ztIKUmejoJoJqazgHhCSIY63DfvjI17eZh1dDioH7n07nxh5D4tLyONUv/ftUETIbAI4wBw==}
+  '@react-grab/cli@0.1.43':
+    resolution: {integrity: sha512-S+UBB0Mwu1g0Cjhff5YzsA33YFYu91DmazPL9uVvF1wDjsO2Lu9hKN/OzBCHYjWlxdBT7TLy2A6pNTS3Sx8o9w==}
     hasBin: true
 
   '@replit/codemirror-vim@6.3.0':
@@ -4049,20 +4046,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.38.0:
-    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -4773,26 +4756,6 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  motion-dom@12.38.0:
-    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
-
-  motion-utils@12.36.0:
-    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
-
-  motion@12.38.0:
-    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -5125,8 +5088,8 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
-  react-grab@0.1.40:
-    resolution: {integrity: sha512-oIK2Q7UrhU/DjtxOEgsBmE7rmzjvCdlS2MrooJ9YXaFuvBUuRFyVk0AJ37KwcpE2fLQ2403RBZ3qU4IuS8OL+w==}
+  react-grab@0.1.43:
+    resolution: {integrity: sha512-3wplt0CobZE5k1Vf3PBqBm3vlNQnVWEpSGBMHRnnFcj/khYYwGXSMSTedW1s8MI5FqkdhU/CFoJ7hQqGwzqFIA==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -8041,7 +8004,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-grab/cli@0.1.40':
+  '@react-grab/cli@0.1.43':
     dependencies:
       agent-install: 0.0.5
       commander: 14.0.3
@@ -9703,15 +9666,6 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      motion-dom: 12.38.0
-      motion-utils: 12.36.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   fresh@2.0.0: {}
 
   fs-extra@11.3.4:
@@ -10592,20 +10546,6 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  motion-dom@12.38.0:
-    dependencies:
-      motion-utils: 12.36.0
-
-  motion-utils@12.36.0: {}
-
-  motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      framer-motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -11105,9 +11045,9 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
-  react-grab@0.1.40(react@19.2.5):
+  react-grab@0.1.43(react@19.2.5):
     dependencies:
-      '@react-grab/cli': 0.1.40
+      '@react-grab/cli': 0.1.43
       bippy: 0.5.41(react@19.2.5)
     optionalDependencies:
       react: 19.2.5
@@ -11152,7 +11092,7 @@ snapshots:
       react: 19.2.5
       react-doctor: 0.2.14(eslint@10.4.1(jiti@2.7.0))
       react-dom: 19.2.5(react@19.2.5)
-      react-grab: 0.1.40(react@19.2.5)
+      react-grab: 0.1.43(react@19.2.5)
     optionalDependencies:
       esbuild: 0.27.7
       unplugin: 3.0.0

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import {
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getLaunchDir } from "@/lib/launchDir";
+import { usePresence } from "@/lib/usePresence";
 import { quoteShellArg } from "@/lib/shellQuote";
 import { useZoom } from "@/lib/useZoom";
 import { AgentNotificationsBridge } from "@/modules/agents";
@@ -78,7 +79,6 @@ import { ThemeProvider, useThemeFileEditing } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import { useWorkspaceEnvStore } from "@/modules/workspace";
 import type { SearchAddon } from "@xterm/addon-search";
-import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CloseDialogs } from "./components/CloseDialogs";
 import { WorkspaceSurface } from "./components/WorkspaceSurface";
@@ -180,6 +180,7 @@ export default function App() {
   const [newEditorOpen, setNewEditorOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const miniOpen = useChatStore((s) => s.mini.open);
+  const miniPresence = usePresence(miniOpen, 200);
   const openMini = useChatStore((s) => s.openMini);
   const focusInput = useChatStore((s) => s.focusInput);
   const openPanel = useChatStore((s) => s.openPanel);
@@ -345,6 +346,7 @@ export default function App() {
     captureActiveSelection,
     askFromSelection,
   });
+  const askPresence = usePresence(Boolean(askPopup), 120);
 
   const openNewTab = useCallback(() => {
     newTab(inheritedCwdForNewTab());
@@ -874,25 +876,22 @@ export default function App() {
                   </div>
 
                   {keysLoaded ? (
-                    <motion.div
+                    <div
                       data-ai-input-bar
-                      initial={false}
-                      animate={{
-                        height: panelOpen ? "auto" : 0,
-                        opacity: panelOpen ? 1 : 0,
-                      }}
-                      transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
-                      className="overflow-hidden"
+                      data-state={panelOpen ? "open" : "closed"}
+                      className="terax-reveal"
                       aria-hidden={!panelOpen}
                     >
-                      {hasComposer ? (
-                        <AiInputBar />
-                      ) : (
-                        <AiInputBarConnect
-                          onAdd={() => void openSettingsWindow("models")}
-                        />
-                      )}
-                    </motion.div>
+                      <div>
+                        {hasComposer ? (
+                          <AiInputBar />
+                        ) : (
+                          <AiInputBarConnect
+                            onAdd={() => void openSettingsWindow("models")}
+                          />
+                        )}
+                      </div>
+                    </div>
                   ) : null}
                 </div>
               </ResizablePanel>
@@ -931,18 +930,18 @@ export default function App() {
             </>
           ) : null}
 
-          <AnimatePresence>
-            {miniOpen && hasComposer ? <AiMiniWindow key="ai-mini" /> : null}
-            {askPopup ? (
-              <SelectionAskAi
-                key="ask-ai-popup"
-                x={askPopup.x}
-                y={askPopup.y}
-                onAsk={onAskFromSelection}
-                onDismiss={() => setAskPopup(null)}
-              />
-            ) : null}
-          </AnimatePresence>
+          {hasComposer && miniPresence.mounted ? (
+            <AiMiniWindow state={miniPresence.state} />
+          ) : null}
+          {askPresence.mounted ? (
+            <SelectionAskAi
+              state={askPresence.state}
+              x={askPopup?.x ?? 0}
+              y={askPopup?.y ?? 0}
+              onAsk={onAskFromSelection}
+              onDismiss={() => setAskPopup(null)}
+            />
+          ) : null}
 
           <CommandPalette
             open={commandPaletteOpen}

--- a/src/components/ai-elements/shimmer.tsx
+++ b/src/components/ai-elements/shimmer.tsx
@@ -1,27 +1,8 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import type { MotionProps } from "motion/react";
-import { motion } from "motion/react";
-import type { CSSProperties, ElementType, JSX } from "react";
-import { memo, useMemo } from "react";
-
-type MotionHTMLProps = MotionProps & Record<string, unknown>;
-
-// Cache motion components at module level to avoid creating during render
-const motionComponentCache = new Map<
-  keyof JSX.IntrinsicElements,
-  React.ComponentType<MotionHTMLProps>
->();
-
-const getMotionComponent = (element: keyof JSX.IntrinsicElements) => {
-  let component = motionComponentCache.get(element);
-  if (!component) {
-    component = motion.create(element);
-    motionComponentCache.set(element, component);
-  }
-  return component;
-};
+import type { CSSProperties, ElementType } from "react";
+import { createElement, memo, useMemo } from "react";
 
 export interface TextShimmerProps {
   children: string;
@@ -38,39 +19,24 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
-  const MotionComponent = getMotionComponent(
-    Component as keyof JSX.IntrinsicElements
-  );
-
   const dynamicSpread = useMemo(
     () => (children?.length ?? 0) * spread,
     [children, spread]
   );
 
-  return (
-    <MotionComponent
-      animate={{ backgroundPosition: "0% center" }}
-      className={cn(
-        "relative inline-block bg-[length:250%_100%,auto] bg-clip-text text-transparent",
-        "[--bg:linear-gradient(90deg,#0000_calc(50%-var(--spread)),var(--color-background),#0000_calc(50%+var(--spread)))] [background-repeat:no-repeat,padding-box]",
+  return createElement(
+    Component,
+    {
+      className: cn(
+        "terax-shimmer relative inline-block bg-clip-text text-transparent",
         className
-      )}
-      initial={{ backgroundPosition: "100% center" }}
-      style={
-        {
-          "--spread": `${dynamicSpread}px`,
-          backgroundImage:
-            "var(--bg), linear-gradient(var(--color-muted-foreground), var(--color-muted-foreground))",
-        } as CSSProperties
-      }
-      transition={{
-        duration,
-        ease: "linear",
-        repeat: Number.POSITIVE_INFINITY,
-      }}
-    >
-      {children}
-    </MotionComponent>
+      ),
+      style: {
+        "--shimmer-spread": `${dynamicSpread}px`,
+        "--shimmer-duration": `${duration}s`,
+      } as CSSProperties,
+    },
+    children
   );
 };
 

--- a/src/lib/usePresence.ts
+++ b/src/lib/usePresence.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState } from "react";
+
+export type PresenceState = "open" | "closed";
+
+/**
+ * Keeps a node mounted for one exit-animation duration after `open` flips to
+ * false, so CSS keyframes keyed on `data-state` can animate it out before it
+ * unmounts. Replaces motion's `AnimatePresence` for single-node transitions.
+ * `exitMs` must match the closed-state animation duration.
+ */
+export function usePresence(open: boolean, exitMs = 150) {
+  const [mounted, setMounted] = useState(open);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    if (open) {
+      setMounted(true);
+    } else if (mounted) {
+      timer.current = setTimeout(() => setMounted(false), exitMs);
+    }
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [open, exitMs, mounted]);
+
+  return { mounted, state: (open ? "open" : "closed") as PresenceState };
+}

--- a/src/modules/ai/components/AgentStatusPill.tsx
+++ b/src/modules/ai/components/AgentStatusPill.tsx
@@ -2,7 +2,6 @@ import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { AlertCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { AnimatePresence, motion } from "motion/react";
 import { useChatStore, type AgentMeta } from "../store/chatStore";
 
 type Props = {
@@ -19,25 +18,20 @@ export function AgentStatusPill({ onClick }: Props) {
   const { tone, icon, label } = describe(meta);
 
   return (
-    <AnimatePresence mode="wait">
-      <motion.button
-        key={`${meta.status}:${label}`}
-        type="button"
-        onClick={onClick}
-        initial={{ opacity: 0, y: 2 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -2 }}
-        transition={{ duration: 0.12, ease: "easeOut" }}
-        className={cn(
-          "flex h-6 items-center gap-1.5 rounded-md border px-1.5 text-[11px] transition-colors",
-          tone,
-        )}
-        title="Open AI log"
-      >
-        {icon}
-        <span className="max-w-[180px] truncate">{label}</span>
-      </motion.button>
-    </AnimatePresence>
+    <button
+      key={`${meta.status}:${label}`}
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex h-6 items-center gap-1.5 rounded-md border px-1.5 text-[11px] transition-colors",
+        "animate-in fade-in-0 slide-in-from-top-1 duration-150 ease-out",
+        tone,
+      )}
+      title="Open AI log"
+    >
+      {icon}
+      <span className="max-w-[180px] truncate">{label}</span>
+    </button>
   );
 }
 

--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -21,7 +21,6 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
-import { motion } from "motion/react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   ArrowRight01Icon,
@@ -553,14 +552,9 @@ const PartAppear = memo(function PartAppear({
   children: React.ReactNode;
 }) {
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 6 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-      style={{ willChange: "transform, opacity" }}
-    >
+    <div className="animate-in fade-in-0 slide-in-from-bottom-1 duration-200 ease-out">
       {children}
-    </motion.div>
+    </div>
   );
 });
 

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -10,8 +10,8 @@ import {
   TerminalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePresence } from "@/lib/usePresence";
 import { useWorkspaceFiles } from "../hooks/useWorkspaceFiles";
 import { useComposer, type FileAttachment } from "../lib/composer";
 import { SLASH_COMMANDS } from "../lib/slashCommands";
@@ -211,6 +211,9 @@ export function AiInputBar() {
     : c.voice.transcribing
       ? "Transcribing…"
       : null;
+  const voiceRow = usePresence(Boolean(voiceLabel), 180);
+  const lastVoiceLabel = useRef("");
+  if (voiceLabel) lastVoiceLabel.current = voiceLabel;
 
   return (
     <div className="shrink-0 border-t border-border/60 bg-card/40 px-3 py-2">
@@ -315,25 +318,18 @@ export function AiInputBar() {
           )}
         </Popover>
 
-        <AnimatePresence initial={false}>
-          {voiceLabel && (
-            <motion.div
-              key={voiceLabel}
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.12 }}
-              className="flex items-center gap-1.5 px-1 text-[11px] text-muted-foreground"
-            >
+        {voiceRow.mounted && (
+          <div data-state={voiceRow.state} className="terax-reveal">
+            <div className="flex items-center gap-1.5 px-1 text-[11px] text-muted-foreground">
               {c.voice.recording ? (
                 <span className="size-1.5 animate-pulse rounded-full bg-destructive" />
               ) : (
                 <Spinner className="size-3" />
               )}
-              <span className="truncate">{voiceLabel}</span>
-            </motion.div>
-          )}
-        </AnimatePresence>
+              <span className="truncate">{voiceLabel || lastVoiceLabel.current}</span>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -358,16 +354,10 @@ function ChipsRow({
     return null;
   return (
     <div className="flex flex-wrap gap-1">
-      <AnimatePresence initial={false}>
         {commands.map((cmd) => (
-          <motion.div
+          <div
             key={`cmd-${cmd.name}`}
-            layout
-            initial={{ opacity: 0, scale: 0.92 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.92 }}
-            transition={{ duration: 0.12 }}
-            className="group flex items-center gap-1 rounded-md border border-border/60 bg-card px-1.5 py-0.5 text-[11px]"
+            className="group flex items-center gap-1 rounded-md border border-border/60 bg-card px-1.5 py-0.5 text-[11px] animate-in fade-in-0 zoom-in-95 duration-150"
             title={cmd.label}
           >
             <HugeiconsIcon
@@ -385,17 +375,12 @@ function ChipsRow({
             >
               <HugeiconsIcon icon={Cancel01Icon} size={10} strokeWidth={2} />
             </button>
-          </motion.div>
+          </div>
         ))}
         {snippets.map((s) => (
-          <motion.div
+          <div
             key={`snip-${s.id}`}
-            layout
-            initial={{ opacity: 0, scale: 0.92 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.92 }}
-            transition={{ duration: 0.12 }}
-            className="group flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[11px] text-primary"
+            className="group flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[11px] text-primary animate-in fade-in-0 zoom-in-95 duration-150"
             title={s.description || s.name}
           >
             <HugeiconsIcon
@@ -413,17 +398,12 @@ function ChipsRow({
             >
               <HugeiconsIcon icon={Cancel01Icon} size={10} strokeWidth={2} />
             </button>
-          </motion.div>
+          </div>
         ))}
         {files.map((f) => (
-          <motion.div
+          <div
             key={f.id}
-            layout
-            initial={{ opacity: 0, scale: 0.92 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.92 }}
-            transition={{ duration: 0.12 }}
-            className="group flex items-center gap-1 rounded-md border border-border/60 bg-card px-1.5 py-0.5 text-[11px]"
+            className="group flex items-center gap-1 rounded-md border border-border/60 bg-card px-1.5 py-0.5 text-[11px] animate-in fade-in-0 zoom-in-95 duration-150"
           >
             {f.kind === "image" && f.url ? (
               <img src={f.url} alt="" className="size-4 rounded object-cover" />
@@ -455,9 +435,8 @@ function ChipsRow({
             >
               <HugeiconsIcon icon={Cancel01Icon} size={10} strokeWidth={2} />
             </button>
-          </motion.div>
+          </div>
         ))}
-      </AnimatePresence>
     </div>
   );
 }

--- a/src/modules/ai/components/AiMiniWindow.tsx
+++ b/src/modules/ai/components/AiMiniWindow.tsx
@@ -27,7 +27,7 @@ import {
   TerminalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { motion } from "motion/react";
+import type { PresenceState } from "@/lib/usePresence";
 import { useEffect, useMemo } from "react";
 import { estimateCost, getModel, getModelContextLimit, type ModelId } from "../config";
 import type { ResizeDir } from "../lib/miniWindowGeometry";
@@ -64,7 +64,7 @@ const SUGGESTIONS = [
   },
 ];
 
-export function AiMiniWindow() {
+export function AiMiniWindow({ state }: { state: PresenceState }) {
   const closeMini = useChatStore((s) => s.closeMini);
   const sessionId = useChatStore((s) => s.activeSessionId);
   const openPanel = useChatStore((s) => s.openPanel);
@@ -89,18 +89,18 @@ export function AiMiniWindow() {
   }, [closeMini]);
 
   return (
-    <motion.div
+    <div
       ref={ref}
-      initial={{ opacity: 0, y: 12, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, y: 12, scale: 0.98 }}
-      transition={{ type: "spring", stiffness: 320, damping: 32 }}
+      data-state={state}
       data-ai-mini-window
       className={cn(
         "no-scrollbar-deep fixed z-40 flex flex-col overflow-hidden",
         "rounded-2xl border border-border/60 bg-card text-[12px]",
         "shadow-[0_1px_0_0_rgba(255,255,255,0.04)_inset,0_24px_48px_-12px_rgba(0,0,0,0.45),0_8px_16px_-8px_rgba(0,0,0,0.3)]",
         "ring-1 ring-black/5 dark:ring-white/5",
+        "duration-200 ease-out",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-bottom-2",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-bottom-2",
       )}
     >
       <div
@@ -125,7 +125,7 @@ export function AiMiniWindow() {
         />
       )}
       <PlanDiffReview />
-    </motion.div>
+    </div>
   );
 }
 

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -41,7 +41,6 @@ import {
   Tick01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { motion } from "motion/react";
 import { useMemo, useRef, useState } from "react";
 import {
   compatModelIdForEndpoint,
@@ -79,20 +78,19 @@ const PROVIDER_ICON = {
 
 export function AiOpenButton({ onOpen }: { onOpen: () => void }) {
   return (
-    <motion.button
-      initial={{ y: -15 }}
-      animate={{ y: 0 }}
+    <button
       type="button"
       onClick={onOpen}
       className={cn(
         "flex h-6 items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 text-xs",
         "text-muted-foreground transition-colors hover:border-border hover:bg-accent hover:text-foreground",
+        "animate-in slide-in-from-top-2 duration-200 ease-out",
       )}
       title="Open AI agent"
     >
       <span>Open AI agent</span>
       <Kbd className="h-4 min-w-4 px-1">{fmtShortcut(MOD_KEY, "I")}</Kbd>
-    </motion.button>
+    </button>
   );
 }
 

--- a/src/modules/ai/components/SelectionAskAi.tsx
+++ b/src/modules/ai/components/SelectionAskAi.tsx
@@ -1,9 +1,10 @@
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { fmtShortcut, MOD_KEY } from "@/lib/platform";
-import { motion } from "motion/react";
-import { useEffect } from "react";
+import type { PresenceState } from "@/lib/usePresence";
+import { useEffect, useRef } from "react";
 
 export type SelectionAskAiProps = {
+  state: PresenceState;
   x: number;
   y: number;
   onAsk: () => void;
@@ -13,27 +14,38 @@ export type SelectionAskAiProps = {
 const W = 110;
 const OFFSET = 32;
 
-export function SelectionAskAi({ x, y, onAsk, onDismiss }: SelectionAskAiProps) {
+export function SelectionAskAi({
+  state,
+  x,
+  y,
+  onAsk,
+  onDismiss,
+}: SelectionAskAiProps) {
+  const pos = useRef({ top: 0, left: 0 });
+  const open = state === "open";
+
   useEffect(() => {
+    if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onDismiss();
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [onDismiss]);
+  }, [open, onDismiss]);
 
-  const top = Math.max(8, y - OFFSET);
-  const left = Math.max(8, Math.min(x - W / 2, window.innerWidth - W - 8));
+  if (open) {
+    pos.current = {
+      top: Math.max(8, y - OFFSET),
+      left: Math.max(8, Math.min(x - W / 2, window.innerWidth - W - 8)),
+    };
+  }
 
   return (
-    <motion.div
+    <div
       data-selection-ask-ai
-      initial={{ opacity: 0, y: 4, scale: 0.95 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, y: 4, scale: 0.95 }}
-      transition={{ duration: 0.12, ease: "easeOut" }}
-      style={{ top, left, width: W }}
-      className="fixed z-50"
+      data-state={state}
+      style={{ top: pos.current.top, left: pos.current.left, width: W }}
+      className="fixed z-50 duration-150 ease-out data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-bottom-1 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-bottom-1"
     >
       <button
         type="button"
@@ -45,9 +57,11 @@ export function SelectionAskAi({ x, y, onAsk, onDismiss }: SelectionAskAiProps) 
       >
         <span>Ask Terax</span>
         <KbdGroup>
-          <Kbd className="h-4 min-w-4 px-1 text-[10px]">{fmtShortcut(MOD_KEY, "L")}</Kbd>
+          <Kbd className="h-4 min-w-4 px-1 text-[10px]">
+            {fmtShortcut(MOD_KEY, "L")}
+          </Kbd>
         </KbdGroup>
       </button>
-    </motion.div>
+    </div>
   );
 }

--- a/src/modules/ai/components/lazy.tsx
+++ b/src/modules/ai/components/lazy.tsx
@@ -1,3 +1,4 @@
+import type { PresenceState } from "@/lib/usePresence";
 import { lazy, Suspense } from "react";
 import type { AgentRunBridgeProps } from "./AgentRunBridge";
 import type { SelectionAskAiProps } from "./SelectionAskAi";
@@ -32,10 +33,10 @@ export function AgentRunBridge(props: AgentRunBridgeProps) {
   );
 }
 
-export function AiMiniWindow() {
+export function AiMiniWindow({ state }: { state: PresenceState }) {
   return (
     <Suspense fallback={null}>
-      <AiMiniWindowInner />
+      <AiMiniWindowInner state={state} />
     </Suspense>
   );
 }

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -15,7 +15,6 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { currentWorkspaceEnv } from "@/modules/workspace";
-import { motion } from "motion/react";
 import {
   forwardRef,
   useEffect,
@@ -170,11 +169,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   return (
     <div className="flex flex-col">
       {open ? (
-        <motion.div
-          className="relative shrink-0 px-2 py-1.5"
-          initial={{ opacity: 0, transform: "translateY(-15px)" }}
-          animate={{ opacity: 1, transform: "translateY(0px)" }}
-        >
+        <div className="relative shrink-0 px-2 py-1.5 animate-in fade-in-0 slide-in-from-top-3 duration-200 ease-out">
           <HugeiconsIcon
             icon={Search01Icon}
             size={13}
@@ -222,7 +217,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
               <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
             </button>
           ) : null}
-        </motion.div>
+        </div>
       ) : null}
 
       {active ? (

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -7,7 +7,6 @@ import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
 import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
-import { AnimatePresence, motion } from "motion/react";
 import {
   forwardRef,
   useCallback,
@@ -134,102 +133,75 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     };
 
     return (
-      <motion.div
-        layout
-        initial={false}
-        animate={{ width: expanded ? 192 : 28 }}
-        transition={{ type: "spring", stiffness: 380, damping: 34 }}
-        className="relative h-7 shrink-0"
+      <div
+        className="relative h-7 shrink-0 transition-[width] duration-200 ease-out"
+        style={{ width: expanded ? 192 : 28 }}
       >
-        <AnimatePresence initial={false} mode="wait">
-          {expanded ? (
-            <motion.div
-              key="input"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.12 }}
-              className="absolute inset-0"
-            >
-              <HugeiconsIcon
-                icon={Search01Icon}
-                size={13}
-                strokeWidth={1.75}
-                className="pointer-events-none absolute top-1/2 left-2 -translate-y-1/2 text-muted-foreground"
-              />
-              <Input
-                ref={setInputRef}
-                value={q}
-                placeholder={placeholder}
-                className="h-7 w-full bg-muted/80 pr-7 pl-7 text-[13px]! placeholder:text-muted-foreground/70 focus-visible:ring-0"
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setQ(next);
-                  applyIncremental(next);
-                }}
-                onBlur={() => {
-                  if (compact && !q) setOpenInCompact(false);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    findDirection(!e.shiftKey);
-                  } else if (e.key === "Escape") {
-                    e.preventDefault();
-                    clearTarget();
-                    setQ("");
-                    if (compact) {
-                      setOpenInCompact(false);
-                    }
-                    restoreTargetFocus();
+        {expanded ? (
+          <div className="absolute inset-0 animate-in fade-in-0 duration-150">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              size={13}
+              strokeWidth={1.75}
+              className="pointer-events-none absolute top-1/2 left-2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              ref={setInputRef}
+              value={q}
+              placeholder={placeholder}
+              className="h-7 w-full bg-muted/80 pr-7 pl-7 text-[13px]! placeholder:text-muted-foreground/70 focus-visible:ring-0"
+              onChange={(e) => {
+                const next = e.target.value;
+                setQ(next);
+                applyIncremental(next);
+              }}
+              onBlur={() => {
+                if (compact && !q) setOpenInCompact(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  findDirection(!e.shiftKey);
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  clearTarget();
+                  setQ("");
+                  if (compact) {
+                    setOpenInCompact(false);
                   }
+                  restoreTargetFocus();
+                }
+              }}
+            />
+            {q && (
+              <button
+                type="button"
+                onClick={() => {
+                  setQ("");
+                  clearTarget();
+                  inputRef.current?.focus();
                 }}
-              />
-              {q && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setQ("");
-                    clearTarget();
-                    inputRef.current?.focus();
-                  }}
-                  className="absolute top-1/2 right-1.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-                  aria-label="Clear search"
-                >
-                  <HugeiconsIcon
-                    icon={Cancel01Icon}
-                    size={11}
-                    strokeWidth={2}
-                  />
-                </button>
-              )}
-            </motion.div>
-          ) : (
-            <motion.div
-              key="icon"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.12 }}
-              className="absolute inset-0 flex items-center justify-end"
-            >
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-                onClick={focus}
-                title={tooltipTitle}
+                className="absolute top-1/2 right-1.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                aria-label="Clear search"
               >
-                <HugeiconsIcon
-                  icon={Search01Icon}
-                  size={15}
-                  strokeWidth={1.75}
-                />
-              </Button>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </motion.div>
+                <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-end animate-in fade-in-0 duration-150">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={focus}
+              title={tooltipTitle}
+            >
+              <HugeiconsIcon icon={Search01Icon} size={15} strokeWidth={1.75} />
+            </Button>
+          </div>
+        )}
+      </div>
     );
   },
 );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -347,3 +347,62 @@ html *::-webkit-scrollbar {
 .terax-collapsible-content[data-state="closed"] {
   animation: terax-collapsible-up 160ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+/* Height auto<->0 reveal without JS measuring: animate the grid track from 0fr
+ * to 1fr. The inner child must be the sole grid row with min-height:0. Used by
+ * the docked AI input bar and the composer voice-status row. */
+.terax-reveal {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition:
+    grid-template-rows 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 180ms cubic-bezier(0.16, 1, 0.3, 1);
+  opacity: 0;
+}
+.terax-reveal[data-state="open"] {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+.terax-reveal > * {
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Text shimmer loop (replaces motion background-position animation). Driven by
+ * --shimmer-duration / --shimmer-spread set inline per instance. */
+@keyframes terax-shimmer {
+  from {
+    background-position: 100% center;
+  }
+  to {
+    background-position: 0% center;
+  }
+}
+.terax-shimmer {
+  background-repeat: no-repeat, padding-box;
+  background-size:
+    250% 100%,
+    auto;
+  background-image:
+    linear-gradient(
+      90deg,
+      transparent calc(50% - var(--shimmer-spread)),
+      var(--color-background),
+      transparent calc(50% + var(--shimmer-spread))
+    ),
+    linear-gradient(
+      var(--color-muted-foreground),
+      var(--color-muted-foreground)
+    );
+  animation: terax-shimmer var(--shimmer-duration, 2s) linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terax-reveal {
+    transition: none;
+  }
+  .terax-shimmer {
+    animation: none;
+    background-position: 0% center;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -110,8 +110,6 @@ export default defineConfig(async ({ mode }) => ({
             return "codemirror";
           if (id.includes("/streamdown/") || id.includes("@streamdown/"))
             return "streamdown";
-          if (id.includes("/motion/") || id.includes("framer-motion"))
-            return "motion";
           if (
             id.includes("/react-dom/") ||
             id.includes("/react/") ||


### PR DESCRIPTION
Drops the `motion` dependency (~40 KB gzip) in favor of native CSS animations + tw-animate-css, removing the largest pure-decoration dep.

## What changed
- New `usePresence` hook (~30 LOC) replaces `AnimatePresence` for exit animations, keyed on `data-state` (mirrors the existing collapsible pattern).
- Enter-only animations → `tw-animate-css` utility classes (AiChat parts, status pill, explorer search, open button, chips).
- Height auto↔0 → grid `0fr→1fr` reveal (AI input bar, voice row). Shimmer → CSS keyframe loop. SearchInline → width transition + enter fade.
- Exit animations (mini window, ask-AI popup) gated at the App lazy boundary so chunks still load on demand.
- Removed `motion` from package.json, vite manualChunks, and the size-limit motion chunk.

## Deliberate UX changes
- Chip removal snaps (user click, instant); chip add still scales in. Dropped the FLIP sibling-reflow.
- Added `prefers-reduced-motion` guard (stops the shimmer loop).

## Verification
- check-types clean, lint exit 0, 104 tests pass, build OK (no motion chunk), startup JS 479 KB (under 540 KB gate).
- Lazy boundaries preserved (AiMiniWindow stays a separate chunk; eager-budget test passes).