### PR TITLE
fix: prevent Cyrillic/IME character duplication on Linux IBus

### DIFF
--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -227,6 +227,18 @@ function createSlot(): Slot {
       event.preventDefault();
       return false;
     }
+    // Linux IBus: keypress missing for non-ASCII, skip keydown to avoid
+    // double-send from the subsequent input event.
+    if (
+      event.type === "keydown" &&
+      event.key.length === 1 &&
+      event.key.charCodeAt(0) > 127 &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
+      return false;
+    }
     return true;
   });
 


### PR DESCRIPTION
What
Filter out keydown events for non-ASCII printable characters in the terminal's custom key event handler to prevent double-send on Linux/IBus.

Why
On Linux with IBus (Ubuntu 24.04, etc.), typing Cyrillic/non-Latin characters triggers both keydown and input events, but keypress does not fire. xterm.js relies on _keyPressHandled (set by keypress) to deduplicate the input event. When keypress is missing, each character is sent to the PTY twice, producing garbled output like соозозжожаожжайозжай instead of создай.

How
Added a guard in attachCustomKeyEventHandler that returns false for keydown events where the key is a single non-ASCII printable character (charCode > 127) with no modifiers. This prevents xterm.js's _keyDown from sending the character, leaving only the input event to deliver it — exactly once.

Testing
pnpm exec tsc --noEmit clean
pnpm lint clean
Manual smoke-test of the affected feature
Platforms tested: Linux (the fix is Linux-specific; macOS/Windows are unaffected since keypress fires there)
Shells tested: