### PR TITLE
fix: resolve a11y and complexity lint issues

### DIFF
--- a/src/settings/sections/ThemesSection.tsx
+++ b/src/settings/sections/ThemesSection.tsx
@@ -124,6 +124,7 @@ export function ThemesSection() {
       />
 
       <div
+        role="presentation"
         className="flex flex-col gap-2"
         onDragOver={(e) => {
           e.preventDefault();
@@ -254,6 +255,7 @@ export function ThemesSection() {
       </div>
 
       <div
+        role="presentation"
         className="flex flex-col gap-2"
         onDragOver={(e) => {
           e.preventDefault();

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -51,7 +51,7 @@ const KEYS = Object.keys(VAR_BY_KEY) as (keyof TerminalTokens)[];
 let probe: HTMLDivElement | null = null;
 
 function getProbe(): HTMLDivElement {
-  if (probe && probe.isConnected) return probe;
+  if (probe?.isConnected) return probe;
   const el = document.createElement("div");
   el.setAttribute("aria-hidden", "true");
   el.style.cssText =


### PR DESCRIPTION
This PR fixes several linting issues across the application:\n- Simplified `probe && probe.isConnected` check using optional chaining in `src/styles/tokens.ts`.\n- Added `role="presentation"` to the drag-and-drop containers in `src/settings/sections/ThemesSection.tsx` to resolve `noStaticElementInteractions` rules.