### PR TITLE
feat(terminal): add renderer hibernation toggle

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -80,6 +80,7 @@ export type Preferences = {
   vimMode: boolean;
   showHidden: boolean;
   terminalWebglEnabled: boolean;
+  terminalRendererHibernationEnabled: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -124,6 +125,8 @@ const KEY_VIM_MODE = "vimMode";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
+const KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED =
+  "terminalRendererHibernationEnabled";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -181,6 +184,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   vimMode: false,
   showHidden: false,
   terminalWebglEnabled: true,
+  terminalRendererHibernationEnabled: false,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -300,6 +304,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
+    terminalRendererHibernationEnabled:
+      get<boolean>(KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED) ??
+      DEFAULT_PREFERENCES.terminalRendererHibernationEnabled,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -477,6 +484,12 @@ export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
 }
 
+export async function setTerminalRendererHibernationEnabled(
+  value: boolean,
+): Promise<void> {
+  await writePref(KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
@@ -580,6 +593,8 @@ export async function onPreferencesChange(
     [KEY_VIM_MODE]: "vimMode",
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
+    [KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED]:
+      "terminalRendererHibernationEnabled",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/lib/hibernationPolicy.test.ts
+++ b/src/modules/terminal/lib/hibernationPolicy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldReleaseHiddenRenderer } from "./hibernationPolicy";
+
+describe("shouldReleaseHiddenRenderer", () => {
+  it("keeps a hidden renderer when hibernation is disabled and a slot exists", () => {
+    expect(
+      shouldReleaseHiddenRenderer({
+        visible: false,
+        hasSlot: true,
+        hibernationEnabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("releases a hidden renderer when hibernation is enabled and a slot exists", () => {
+    expect(
+      shouldReleaseHiddenRenderer({
+        visible: false,
+        hasSlot: true,
+        hibernationEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not release without a bound slot", () => {
+    expect(
+      shouldReleaseHiddenRenderer({
+        visible: false,
+        hasSlot: false,
+        hibernationEnabled: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/modules/terminal/lib/hibernationPolicy.ts
+++ b/src/modules/terminal/lib/hibernationPolicy.ts
@@ -1,0 +1,13 @@
+export type HibernationPolicyInput = {
+  visible: boolean;
+  hasSlot: boolean;
+  hibernationEnabled: boolean;
+};
+
+export function shouldReleaseHiddenRenderer({
+  visible,
+  hasSlot,
+  hibernationEnabled,
+}: HibernationPolicyInput): boolean {
+  return !visible && hasSlot && hibernationEnabled;
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -10,6 +10,7 @@ import {
   registerPromptTracker,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
+import { shouldReleaseHiddenRenderer } from "./hibernationPolicy";
 import {
   acquireSlot,
   applyBackgroundActive,
@@ -471,6 +472,9 @@ export function useTerminalSession({
     applyBackgroundActive(bgActive);
   }, [bgActive]);
 
+  const hibernationEnabled = usePreferencesStore(
+    (p) => p.terminalRendererHibernationEnabled,
+  );
   useEffect(() => {
     const s = sessions.get(leafId);
     if (!s) return;
@@ -480,10 +484,19 @@ export function useTerminalSession({
       if (s.container && !s.hasSlot) bindLeafToSlot(leafId, s);
       setSlotFocused(leafId, focused);
       if (focused) focusSlot(leafId);
-    } else if (s.hasSlot) {
+    } else if (
+      shouldReleaseHiddenRenderer({
+        visible,
+        hasSlot: s.hasSlot,
+        hibernationEnabled,
+      })
+    ) {
       unbindLeafFromSlot(leafId, s);
+    } else {
+      setSlotFocused(leafId, false);
+      getSlotForLeaf(leafId)?.term.blur();
     }
-  }, [leafId, visible, focused]);
+  }, [leafId, visible, focused, hibernationEnabled]);
 
   const write = useCallback(
     (data: string) => sessions.get(leafId)?.pty?.write(data),

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -29,6 +29,7 @@ import {
   setTerminalFontFamily,
   setTerminalLetterSpacing,
   setTerminalFontSize,
+  setTerminalRendererHibernationEnabled,
   setTerminalScrollback,
   setTerminalWebglEnabled,
   setVimMode,
@@ -75,6 +76,9 @@ export function GeneralSection() {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
+  );
+  const terminalRendererHibernationEnabled = usePreferencesStore(
+    (s) => s.terminalRendererHibernationEnabled,
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
@@ -240,6 +244,17 @@ export function GeneralSection() {
           <Switch
             checked={terminalWebglEnabled}
             onCheckedChange={(v) => void setTerminalWebglEnabled(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Hibernate inactive renderers"
+          description="Release hidden terminal renderers immediately. When off, hidden terminals keep their renderer until the shared pool reaches its limit."
+        >
+          <Switch
+            checked={terminalRendererHibernationEnabled}
+            onCheckedChange={(v) =>
+              void setTerminalRendererHibernationEnabled(v)
+            }
           />
         </SettingRow>
         <SettingRow
@@ -418,4 +433,3 @@ function AutoSaveDelayInput({
     </SettingRow>
   );
 }
-


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: <!-- macOS / Linux / Windows -->
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
