### PR TITLE
feat(terminal): add renderer hibernation toggle

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -80,6 +80,7 @@ export type Preferences = {
   vimMode: boolean;
   showHidden: boolean;
   terminalWebglEnabled: boolean;
+  terminalRendererHibernationEnabled: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -124,6 +125,8 @@ const KEY_VIM_MODE = "vimMode";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
+const KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED =
+  "terminalRendererHibernationEnabled";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -181,6 +184,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   vimMode: false,
   showHidden: false,
   terminalWebglEnabled: true,
+  terminalRendererHibernationEnabled: false,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -300,6 +304,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
+    terminalRendererHibernationEnabled:
+      get<boolean>(KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED) ??
+      DEFAULT_PREFERENCES.terminalRendererHibernationEnabled,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -477,6 +484,12 @@ export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
 }
 
+export async function setTerminalRendererHibernationEnabled(
+  value: boolean,
+): Promise<void> {
+  await writePref(KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
@@ -580,6 +593,8 @@ export async function onPreferencesChange(
     [KEY_VIM_MODE]: "vimMode",
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
+    [KEY_TERMINAL_RENDERER_HIBERNATION_ENABLED]:
+      "terminalRendererHibernationEnabled",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/lib/hibernationPolicy.test.ts
+++ b/src/modules/terminal/lib/hibernationPolicy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldReleaseHiddenRenderer } from "./hibernationPolicy";
+
+describe("shouldReleaseHiddenRenderer", () => {
+  it("keeps a hidden renderer when hibernation is disabled and a slot exists", () => {
+    expect(
+      shouldReleaseHiddenRenderer({
+        visible: false,
+        hasSlot: true,
+        hibernationEnabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("releases a hidden renderer when hibernation is enabled and a slot exists", () => {
+    expect(
+      shouldReleaseHiddenRenderer({
+        visible: false,
+        hasSlot: true,
+        hibernationEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not release without a bound slot", () => {
+    expect(
+      shouldReleaseHiddenRenderer({
+        visible: false,
+        hasSlot: false,
+        hibernationEnabled: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/modules/terminal/lib/hibernationPolicy.ts
+++ b/src/modules/terminal/lib/hibernationPolicy.ts
@@ -1,0 +1,13 @@
+export type HibernationPolicyInput = {
+  visible: boolean;
+  hasSlot: boolean;
+  hibernationEnabled: boolean;
+};
+
+export function shouldReleaseHiddenRenderer({
+  visible,
+  hasSlot,
+  hibernationEnabled,
+}: HibernationPolicyInput): boolean {
+  return !visible && hasSlot && hibernationEnabled;
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -10,6 +10,7 @@ import {
   registerPromptTracker,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
+import { shouldReleaseHiddenRenderer } from "./hibernationPolicy";
 import {
   acquireSlot,
   applyBackgroundActive,
@@ -471,6 +472,9 @@ export function useTerminalSession({
     applyBackgroundActive(bgActive);
   }, [bgActive]);
 
+  const hibernationEnabled = usePreferencesStore(
+    (p) => p.terminalRendererHibernationEnabled,
+  );
   useEffect(() => {
     const s = sessions.get(leafId);
     if (!s) return;
@@ -480,10 +484,19 @@ export function useTerminalSession({
       if (s.container && !s.hasSlot) bindLeafToSlot(leafId, s);
       setSlotFocused(leafId, focused);
       if (focused) focusSlot(leafId);
-    } else if (s.hasSlot) {
+    } else if (
+      shouldReleaseHiddenRenderer({
+        visible,
+        hasSlot: s.hasSlot,
+        hibernationEnabled,
+      })
+    ) {
       unbindLeafFromSlot(leafId, s);
+    } else {
+      setSlotFocused(leafId, false);
+      getSlotForLeaf(leafId)?.term.blur();
     }
-  }, [leafId, visible, focused]);
+  }, [leafId, visible, focused, hibernationEnabled]);
 
   const write = useCallback(
     (data: string) => sessions.get(leafId)?.pty?.write(data),

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -29,6 +29,7 @@ import {
   setTerminalFontFamily,
   setTerminalLetterSpacing,
   setTerminalFontSize,
+  setTerminalRendererHibernationEnabled,
   setTerminalScrollback,
   setTerminalWebglEnabled,
   setVimMode,
@@ -75,6 +76,9 @@ export function GeneralSection() {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
+  );
+  const terminalRendererHibernationEnabled = usePreferencesStore(
+    (s) => s.terminalRendererHibernationEnabled,
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
@@ -240,6 +244,17 @@ export function GeneralSection() {
           <Switch
             checked={terminalWebglEnabled}
             onCheckedChange={(v) => void setTerminalWebglEnabled(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Hibernate inactive renderers"
+          description="Release hidden terminal renderers immediately. When off, hidden terminals keep their renderer until the shared pool reaches its limit."
+        >
+          <Switch
+            checked={terminalRendererHibernationEnabled}
+            onCheckedChange={(v) =>
+              void setTerminalRendererHibernationEnabled(v)
+            }
           />
         </SettingRow>
         <SettingRow
@@ -418,4 +433,3 @@ function AutoSaveDelayInput({
     </SettingRow>
   );
 }
-


### PR DESCRIPTION
## What
Adds a General > Terminal setting for terminal renderer hibernation. The new toggle defaults off, so hidden terminal tabs keep their renderer when possible, while users can opt back into immediate renderer release.

## Why
Switching away from a terminal currently releases its xterm renderer immediately. That keeps memory pressure down, but it can make returning to a long-running or output-heavy terminal feel like the view has been reconstructed instead of preserved.

## How
Adds a persisted `terminalRendererHibernationEnabled` preference, wires it into the terminal visibility path, and keeps the existing renderer pool cap unchanged. When the toggle is off, hidden terminals keep their renderer until the shared pool needs to evict one. When it is on, hidden terminals release their renderer immediately as before.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Linux
- [x] Shells tested (if relevant): N/A

Additional checks run:

- [x] `pnpm test`
- [x] `pnpm lint` exited 0 with existing warnings
- [x] `git diff --check`
- [x] `cargo clippy`
- [x] `cargo test --locked`

## Screenshots / GIFs

Not included. This is a single settings-row toggle in the existing General > Terminal section.

## Notes for reviewer

I read `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `ROADMAP.md`, and this PR template before opening. The branch is based directly on `crynta/terax-ai:main` and the diff is limited to the renderer-hibernation setting, policy helper, and focused test coverage.
