### PR TITLE
perf(terminal): static cursor default, WebGL/slot reaping, TUI keep-alive

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -80,6 +80,7 @@ export type Preferences = {
   vimMode: boolean;
   showHidden: boolean;
   terminalWebglEnabled: boolean;
+  terminalCursorBlink: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -124,6 +125,7 @@ const KEY_VIM_MODE = "vimMode";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
+const KEY_TERMINAL_CURSOR_BLINK = "terminalCursorBlink";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -181,6 +183,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   vimMode: false,
   showHidden: false,
   terminalWebglEnabled: true,
+  terminalCursorBlink: false,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -300,6 +303,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
+    terminalCursorBlink:
+      get<boolean>(KEY_TERMINAL_CURSOR_BLINK) ??
+      DEFAULT_PREFERENCES.terminalCursorBlink,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -477,6 +483,10 @@ export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
 }
 
+export async function setTerminalCursorBlink(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_CURSOR_BLINK, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
@@ -580,6 +590,7 @@ export async function onPreferencesChange(
     [KEY_VIM_MODE]: "vimMode",
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
+    [KEY_TERMINAL_CURSOR_BLINK]: "terminalCursorBlink",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/lib/cursorBlink.test.ts
+++ b/src/modules/terminal/lib/cursorBlink.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldCursorBlink } from "./cursorBlink";
+
+describe("shouldCursorBlink", () => {
+  it("blinks only when enabled, the window is active and the slot is focused", () => {
+    expect(shouldCursorBlink(true, true, true)).toBe(true);
+  });
+
+  it("never blinks when disabled, regardless of focus", () => {
+    expect(shouldCursorBlink(false, true, true)).toBe(false);
+  });
+
+  it("never blinks while the window is inactive", () => {
+    expect(shouldCursorBlink(true, false, true)).toBe(false);
+  });
+
+  it("does not blink an unfocused slot", () => {
+    expect(shouldCursorBlink(true, true, false)).toBe(false);
+  });
+});

--- a/src/modules/terminal/lib/cursorBlink.ts
+++ b/src/modules/terminal/lib/cursorBlink.ts
@@ -1,0 +1,7 @@
+export function shouldCursorBlink(
+  blinkEnabled: boolean,
+  windowActive: boolean,
+  slotFocused: boolean,
+): boolean {
+  return blinkEnabled && windowActive && slotFocused;
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -8,6 +8,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
+import { shouldCursorBlink } from "./cursorBlink";
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
@@ -49,6 +50,8 @@ export type Slot = {
   observer: ResizeObserver | null;
   fitTimer: ReturnType<typeof setTimeout> | null;
   ptyTimer: ReturnType<typeof setTimeout> | null;
+  webglReapTimer: ReturnType<typeof setTimeout> | null;
+  slotReapTimer: ReturnType<typeof setTimeout> | null;
   unhideRaf: number | null;
   lastCols: number;
   lastRows: number;
@@ -61,8 +64,36 @@ const slots: Slot[] = [];
 let recyclerEl: HTMLDivElement | null = null;
 let adapter: SlotAdapter | null = null;
 
+let windowActive =
+  typeof document === "undefined" ||
+  (!document.hidden && document.hasFocus());
+let windowActivityBound = false;
+let cursorBlinkEnabled = false;
+
+function bindWindowActivityListeners(): void {
+  if (windowActivityBound || typeof window === "undefined") return;
+  windowActivityBound = true;
+  const sync = () => setWindowActive(!document.hidden && document.hasFocus());
+  window.addEventListener("focus", sync);
+  window.addEventListener("blur", sync);
+  document.addEventListener("visibilitychange", sync);
+}
+
+function setWindowActive(active: boolean): void {
+  if (windowActive === active) return;
+  windowActive = active;
+  for (const slot of slots) {
+    if (slot.currentLeafId === null) continue;
+    applyCursorBlinkOnSlot(
+      slot,
+      adapter?.isLeafFocused(slot.currentLeafId) ?? false,
+    );
+  }
+}
+
 export function configureRendererPool(a: SlotAdapter): void {
   adapter = a;
+  bindWindowActivityListeners();
 }
 
 export function forEachSlot(fn: (slot: Slot) => void): void {
@@ -71,6 +102,28 @@ export function forEachSlot(fn: (slot: Slot) => void): void {
 
 export function poolSize(): number {
   return slots.length;
+}
+
+export type PoolSlotStat = {
+  id: number;
+  leafId: number | null;
+  cols: number;
+  rows: number;
+  bufferLines: number;
+  webgl: boolean;
+  canvases: number;
+};
+
+export function poolSlotStats(): PoolSlotStat[] {
+  return slots.map((s) => ({
+    id: s.id,
+    leafId: s.currentLeafId,
+    cols: s.term.cols,
+    rows: s.term.rows,
+    bufferLines: s.term.buffer.active.length,
+    webgl: !!s.webglAddon,
+    canvases: s.webglCanvases.length,
+  }));
 }
 
 // Bracketed paste via xterm, so an app that enabled it (Claude Code) treats a
@@ -158,6 +211,8 @@ function createSlot(): Slot {
     observer: null,
     fitTimer: null,
     ptyTimer: null,
+    webglReapTimer: null,
+    slotReapTimer: null,
     unhideRaf: null,
     lastCols: term.cols,
     lastRows: term.rows,
@@ -165,8 +220,6 @@ function createSlot(): Slot {
     lastH: 0,
     lastUsedAt: 0,
   };
-
-  attachWebgl(slot);
 
   term.attachCustomKeyEventHandler((event) => {
     // During IME composition the browser is assembling a multi-keystroke
@@ -319,6 +372,8 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
   slot.lastUsedAt = performance.now();
 
   cancelPendingUnhide(slot);
+  cancelWebglReap(slot);
+  cancelSlotReap(slot);
   slot.host.style.visibility = "hidden";
 
   if (slot.host.parentNode !== p.container) {
@@ -528,12 +583,84 @@ function detachSlotFromLeaf(slot: Slot): void {
 
   slot.currentLeafId = null;
   slot.lastUsedAt = performance.now();
+  scheduleWebglReap(slot);
+  scheduleSlotReap(slot);
+}
+
+function scheduleWebglReap(slot: Slot): void {
+  cancelWebglReap(slot);
+  if (!slot.webglAddon) return;
+  slot.webglReapTimer = setTimeout(() => {
+    slot.webglReapTimer = null;
+    if (slot.currentLeafId === null) disposeSlotWebgl(slot);
+  }, WEBGL_REAP_GRACE_MS);
+}
+
+function cancelWebglReap(slot: Slot): void {
+  if (slot.webglReapTimer !== null) {
+    clearTimeout(slot.webglReapTimer);
+    slot.webglReapTimer = null;
+  }
+}
+
+function scheduleSlotReap(slot: Slot): void {
+  cancelSlotReap(slot);
+  slot.slotReapTimer = setTimeout(() => {
+    slot.slotReapTimer = null;
+    reapIdleSlot(slot);
+  }, SLOT_REAP_GRACE_MS);
+}
+
+function cancelSlotReap(slot: Slot): void {
+  if (slot.slotReapTimer !== null) {
+    clearTimeout(slot.slotReapTimer);
+    slot.slotReapTimer = null;
+  }
+}
+
+function reapIdleSlot(slot: Slot): void {
+  if (slot.currentLeafId !== null) return;
+  const idle = slots.filter((s) => s.currentLeafId === null);
+  if (idle.length <= IDLE_SLOTS_KEEP_WARM) return;
+  idle.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+  const surplus = idle.slice(0, idle.length - IDLE_SLOTS_KEEP_WARM);
+  if (surplus.includes(slot)) disposeSlot(slot);
+}
+
+function disposeSlot(slot: Slot): void {
+  cancelSlotReap(slot);
+  cancelWebglReap(slot);
+  cancelPendingUnhide(slot);
+  if (slot.fitTimer) clearTimeout(slot.fitTimer);
+  if (slot.ptyTimer) clearTimeout(slot.ptyTimer);
+  slot.fitTimer = null;
+  slot.ptyTimer = null;
+  slot.observer?.disconnect();
+  slot.observer = null;
+  for (const d of slot.oscDisposers) {
+    try {
+      d();
+    } catch {}
+  }
+  slot.oscDisposers = [];
+  disposeSlotWebgl(slot);
+  try {
+    slot.term.dispose();
+  } catch (e) {
+    console.warn("[terax] slot dispose failed:", e);
+  }
+  slot.host.remove();
+  const i = slots.indexOf(slot);
+  if (i >= 0) slots.splice(i, 1);
 }
 
 const WEBGL_RECOVERY_DELAY_MS = 250;
 // Below this a re-shown slot is fresh enough to trust; above it, repaint on
 // unhide to defeat silent GPU/context staleness.
 const SLOT_STALE_MS = 10_000;
+const WEBGL_REAP_GRACE_MS = 30_000;
+const SLOT_REAP_GRACE_MS = 45_000;
+const IDLE_SLOTS_KEEP_WARM = 1;
 
 function attachWebgl(slot: Slot): void {
   if (slot.webglAddon || !slot.term.element) return;
@@ -557,7 +684,7 @@ function attachWebgl(slot: Slot): void {
       // reset; without re-attach the slot would silently fall back to DOM
       // forever. Defer past WebKit's reset window before retrying.
       setTimeout(() => {
-        if (slot.webglAddon) return;
+        if (slot.webglAddon || slot.currentLeafId === null) return;
         if (!usePreferencesStore.getState().terminalWebglEnabled) return;
         attachWebgl(slot);
         if (slot.webglAddon) {
@@ -632,8 +759,19 @@ function releaseCanvasContext(canvas: HTMLCanvasElement): void {
 
 export function applyWebglPreference(enabled: boolean): void {
   for (const slot of slots) {
-    if (enabled && !slot.webglAddon) attachWebgl(slot);
-    else if (!enabled && slot.webglAddon) disposeSlotWebgl(slot);
+    if (enabled) {
+      if (slot.currentLeafId !== null && !slot.webglAddon) {
+        attachWebgl(slot);
+        if (slot.webglAddon) {
+          try {
+            slot.term.refresh(0, slot.term.rows - 1);
+          } catch {}
+        }
+      }
+    } else if (slot.webglAddon) {
+      cancelWebglReap(slot);
+      disposeSlotWebgl(slot);
+    }
   }
 }
 
@@ -699,14 +837,51 @@ export function setSlotFocused(leafId: number, focused: boolean): void {
   applyCursorBlinkOnSlot(slot, focused);
 }
 
+export function applyCursorBlink(enabled: boolean): void {
+  cursorBlinkEnabled = enabled;
+  for (const slot of slots) {
+    if (slot.currentLeafId === null) continue;
+    applyCursorBlinkOnSlot(
+      slot,
+      adapter?.isLeafFocused(slot.currentLeafId) ?? false,
+    );
+  }
+}
+
 function applyCursorBlinkOnSlot(slot: Slot, focused: boolean): void {
-  const desired = focused;
+  const desired = shouldCursorBlink(cursorBlinkEnabled, windowActive, focused);
   if (slot.term.options.cursorBlink === desired) return;
   slot.term.options.cursorBlink = desired;
 }
 
 export function getSlotForLeaf(leafId: number): Slot | null {
   return slots.find((s) => s.currentLeafId === leafId) ?? null;
+}
+
+export function isLeafAltScreen(leafId: number): boolean {
+  const slot = slots.find((s) => s.currentLeafId === leafId);
+  return slot ? isAltScreen(slot) : false;
+}
+
+export function parkLeafSlot(leafId: number): void {
+  const slot = slots.find((s) => s.currentLeafId === leafId);
+  if (slot) disposeSlotWebgl(slot);
+}
+
+export function refreshLeafSlot(leafId: number): void {
+  const slot = slots.find((s) => s.currentLeafId === leafId);
+  if (!slot) return;
+  if (usePreferencesStore.getState().terminalWebglEnabled && !slot.webglAddon) {
+    attachWebgl(slot);
+  }
+  try {
+    slot.term.refresh(0, slot.term.rows - 1);
+  } catch {}
+}
+
+export function disposeLeafSlot(leafId: number): void {
+  const slot = slots.find((s) => s.currentLeafId === leafId);
+  if (slot) disposeSlot(slot);
 }
 
 const IS_MAC =

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -13,6 +13,7 @@ import { openPty, type PtySession } from "./pty-bridge";
 import {
   acquireSlot,
   applyBackgroundActive,
+  applyCursorBlink,
   applyFontFamily,
   applyFontSize,
   applyLetterSpacing,
@@ -20,8 +21,14 @@ import {
   applyScrollback,
   applyWebglPreference,
   configureRendererPool,
+  disposeLeafSlot,
   focusSlot,
   getSlotForLeaf,
+  isLeafAltScreen,
+  parkLeafSlot,
+  poolSize,
+  poolSlotStats,
+  refreshLeafSlot,
   releaseSlot,
   setSlotFocused,
 } from "./rendererPool";
@@ -378,7 +385,8 @@ export function disposeSession(leafId: number): void {
   const s = sessions.get(leafId);
   if (!s) return;
   s.disposed = true;
-  unbindLeafFromSlot(leafId, s);
+  disposeLeafSlot(leafId);
+  s.hasSlot = false;
   s.snapshot = null;
   s.pty?.close();
   s.pty = null;
@@ -464,6 +472,11 @@ export function useTerminalSession({
     applyWebglPreference(webglPref);
   }, [webglPref]);
 
+  const cursorBlink = usePreferencesStore((p) => p.terminalCursorBlink);
+  useEffect(() => {
+    applyCursorBlink(cursorBlink);
+  }, [cursorBlink]);
+
   const bgActive = usePreferencesStore(
     (p) => p.backgroundKind === "image" && !!p.backgroundImageId,
   );
@@ -478,10 +491,12 @@ export function useTerminalSession({
     s.focusedNow = focused;
     if (visible) {
       if (s.container && !s.hasSlot) bindLeafToSlot(leafId, s);
+      else if (s.hasSlot) refreshLeafSlot(leafId);
       setSlotFocused(leafId, focused);
       if (focused) focusSlot(leafId);
     } else if (s.hasSlot) {
-      unbindLeafFromSlot(leafId, s);
+      if (isLeafAltScreen(leafId)) parkLeafSlot(leafId);
+      else unbindLeafFromSlot(leafId, s);
     }
   }, [leafId, visible, focused]);
 
@@ -539,4 +554,41 @@ const ANSI_RE =
 
 function stripAnsi(s: string): string {
   return s.replace(ANSI_RE, "");
+}
+
+export function terminalDebugStats() {
+  const liveSessions = [...sessions.entries()].map(([leafId, s]) => ({
+    leafId,
+    pty: !!s.pty,
+    visible: s.visibleNow,
+    focused: s.focusedNow,
+    hasSlot: s.hasSlot,
+    ringBytes: s.dormantRing.byteLength(),
+    snapshotLen: s.snapshot?.length ?? 0,
+    shellExited: s.shellExited,
+  }));
+  const ringTotal = liveSessions.reduce((n, s) => n + s.ringBytes, 0);
+  const snapshotTotal = liveSessions.reduce((n, s) => n + s.snapshotLen, 0);
+  const slots = poolSlotStats();
+  return {
+    poolSize: poolSize(),
+    webglContexts: slots.filter((s) => s.webgl).length,
+    idleSlots: slots.filter((s) => s.leafId === null).length,
+    slots,
+    sessionCount: liveSessions.length,
+    sessions: liveSessions,
+    ringBytesTotal: ringTotal,
+    snapshotCharsTotal: snapshotTotal,
+    domCanvases: document.querySelectorAll("canvas").length,
+    domScreens: document.querySelectorAll(".xterm-screen").length,
+    domRows: document.querySelectorAll(".xterm-rows > div").length,
+    jsHeapBytes:
+      (performance as unknown as { memory?: { usedJSHeapSize: number } })
+        .memory?.usedJSHeapSize ?? null,
+  };
+}
+
+if (import.meta.env?.DEV && typeof window !== "undefined") {
+  (window as unknown as { __teraxTerm?: unknown }).__teraxTerm =
+    terminalDebugStats;
 }

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -29,6 +29,7 @@ import {
   setTerminalFontFamily,
   setTerminalLetterSpacing,
   setTerminalFontSize,
+  setTerminalCursorBlink,
   setTerminalScrollback,
   setTerminalWebglEnabled,
   setVimMode,
@@ -75,6 +76,9 @@ export function GeneralSection() {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
+  );
+  const terminalCursorBlink = usePreferencesStore(
+    (s) => s.terminalCursorBlink,
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
@@ -240,6 +244,15 @@ export function GeneralSection() {
           <Switch
             checked={terminalWebglEnabled}
             onCheckedChange={(v) => void setTerminalWebglEnabled(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Cursor blinking"
+          description="Blink the terminal cursor. Off by default for lower idle CPU, matching VS Code and the macOS terminal."
+        >
+          <Switch
+            checked={terminalCursorBlink}
+            onCheckedChange={(v) => void setTerminalCursorBlink(v)}
           />
         </SettingRow>
         <SettingRow


### PR DESCRIPTION
Terminal renderer pass on top of the renderer pool. No new dependencies, frontend only.

- Cursor blink off by default (new `terminalCursorBlink` setting), gated on window focus when enabled. Removes the idle repaint loop that drives Page memory; matches VS Code and the macOS terminal.
- WebGL attached only to visible slots and reaped from idle hidden slots after a grace period: one live context in steady state instead of up to five.
- Idle pool slots beyond one warm slot are disposed (xterm + DOM freed), so closing splits actually shrinks the pool.
- Slots and WebGL are torn down immediately on tab close instead of waiting on a timer.
- Alt-screen TUIs (Claude Code, vim, btop) keep their grid live while hidden and repaint from the buffer on return, instead of serialize + SIGWINCH which corrupted the screen and needed a manual resize.
- Dev-only `__teraxTerm()` stats hook, stripped from prod builds.

Verified locally: pnpm check-types, pnpm test (108), pnpm build, lint (no new warnings).