### PR TITLE
feat(terminal): block-mode terminal (Warp-style command blocks)

### DIFF
--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -43,17 +43,20 @@ pub async fn pty_open(
     rows: u16,
     cwd: Option<String>,
     workspace: Option<WorkspaceEnv>,
+    blocks: Option<bool>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    let blocks = blocks.unwrap_or(false);
     authorize_user_spawn_cwd(&registry, cwd.as_deref(), &workspace).map_err(|e| {
         log::warn!("pty_open: cwd rejected: {e}");
         e
     })?;
     let id = state.next_id.fetch_add(1, Ordering::Relaxed);
     let session = tauri::async_runtime::spawn_blocking(move || {
-        session::spawn(id, app, cols, rows, cwd, workspace, on_data, on_exit).map(|(s, _)| s)
+        session::spawn(id, app, cols, rows, cwd, workspace, blocks, on_data, on_exit)
+            .map(|(s, _)| s)
     })
     .await
     .map_err(|e| {

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -38,8 +38,14 @@ if [[ -z "$__TERAX_HOOKS_LOADED" ]]; then
     local _terax_ret=$?
     printf '\e]133;D;%s\e\\' "$_terax_ret"
     printf '\e]7;file://%s%s\e\\' "${HOST}" "$(_terax_urlencode "$PWD")"
-    # Re-inject prompt-end marker in case a framework rebuilt PS1 (p10k, starship).
-    if [[ "$PS1" != *$'\e]133;B\e\\'* ]]; then
+    # In block mode the host renders its own input bar, so suppress the shell
+    # prompt entirely (keep only the OSC 133 B marker) and add a leading blank
+    # line so frozen command blocks get vertical breathing room.
+    if [[ -n "$TERAX_BLOCKS" ]]; then
+      PS1=$'\n%{\e]133;B\e\\%}'
+      RPROMPT=''
+    elif [[ "$PS1" != *$'\e]133;B\e\\'* ]]; then
+      # Re-inject prompt-end marker in case a framework rebuilt PS1 (p10k, starship).
       PS1=$'%{\e]133;B\e\\%}'"$PS1"
     fi
     printf '\e]133;A\e\\'

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -103,6 +103,7 @@ pub fn spawn(
     rows: u16,
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    blocks: bool,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<(Arc<Session>, PtySize), String> {
@@ -118,7 +119,7 @@ pub fn spawn(
     };
     let pair = pty_system.openpty(size).map_err(|e| e.to_string())?;
 
-    let cmd = shell_init::build_command(cwd, workspace)?;
+    let cmd = shell_init::build_command(cwd, workspace, blocks)?;
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -50,15 +50,16 @@ fn fish_init_script() -> &'static str {
 pub fn build_command(
     cwd: Option<String>,
     workspace: WorkspaceEnv,
+    blocks: bool,
 ) -> Result<CommandBuilder, String> {
     #[cfg(unix)]
     {
         let _ = workspace;
-        unix::build(cwd)
+        unix::build(cwd, blocks)
     }
     #[cfg(windows)]
     {
-        windows::build(cwd, workspace)
+        windows::build(cwd, workspace, blocks)
     }
 }
 
@@ -82,10 +83,13 @@ fn ensure_utf8_locale(cmd: &mut CommandBuilder) {
     cmd.env("LANG", fallback);
 }
 
-fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>) {
+fn apply_common(cmd: &mut CommandBuilder, cwd: Option<String>, blocks: bool) {
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     cmd.env("TERAX_TERMINAL", "1");
+    if blocks {
+        cmd.env("TERAX_BLOCKS", "1");
+    }
     ensure_utf8_locale(cmd);
 
     let resolved_cwd = cwd
@@ -158,10 +162,10 @@ mod unix {
         }
     }
 
-    pub fn build(cwd: Option<String>) -> Result<CommandBuilder, String> {
+    pub fn build(cwd: Option<String>, blocks: bool) -> Result<CommandBuilder, String> {
         let (shell, shell_path) = Shell::detect();
         let mut cmd = CommandBuilder::new(&shell_path);
-        super::apply_common(&mut cmd, cwd);
+        super::apply_common(&mut cmd, cwd, blocks);
 
         match shell {
             Shell::Zsh => {
@@ -310,8 +314,13 @@ mod windows {
         args: Vec<String>,
     }
 
-    pub fn build(cwd: Option<String>, workspace: WorkspaceEnv) -> Result<CommandBuilder, String> {
+    pub fn build(
+        cwd: Option<String>,
+        workspace: WorkspaceEnv,
+        blocks: bool,
+    ) -> Result<CommandBuilder, String> {
         if let WorkspaceEnv::Wsl { distro } = workspace {
+            let _ = blocks;
             return build_wsl(cwd, distro);
         }
         let shell_path = super::windows_shell_path();
@@ -323,7 +332,7 @@ mod windows {
         let is_powershell = shell_name == "pwsh.exe" || shell_name == "powershell.exe";
 
         let mut cmd = CommandBuilder::new(&shell_path);
-        super::apply_common(&mut cmd, cwd);
+        super::apply_common(&mut cmd, cwd, blocks);
 
         if is_powershell {
             match prepare_ps_profile() {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -91,6 +91,7 @@ export default function App() {
     activeId,
     setActiveId,
     newTab,
+    newBlockTab,
     newAgentTab,
     newPrivateTab,
     openFileTab,
@@ -355,6 +356,10 @@ export default function App() {
   const openNewPrivateTab = useCallback(() => {
     newPrivateTab(inheritedCwdForNewTab());
   }, [newPrivateTab, inheritedCwdForNewTab]);
+
+  const openNewBlockTab = useCallback(() => {
+    newBlockTab(inheritedCwdForNewTab());
+  }, [newBlockTab, inheritedCwdForNewTab]);
 
   const sendCd = useCallback(
     (path: string) => {
@@ -781,6 +786,7 @@ export default function App() {
               activeId={activeId}
               onSelect={setActiveId}
               onNew={openNewTab}
+              onNewBlock={openNewBlockTab}
               onNewPrivate={openNewPrivateTab}
               onNewPreview={() => openPreviewTab("")}
               onNewEditor={() => setNewEditorOpen(true)}

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -36,6 +36,7 @@ type Props = {
   activeId: number;
   onSelect: (id: number) => void;
   onNew: () => void;
+  onNewBlock: () => void;
   onNewPrivate: () => void;
   onNewPreview: () => void;
   onNewEditor: () => void;
@@ -63,6 +64,7 @@ export function Header({
   activeId,
   onSelect,
   onNew,
+  onNewBlock,
   onNewPrivate,
   onNewPreview,
   onNewEditor,
@@ -197,6 +199,7 @@ export function Header({
           activeId={activeId}
           onSelect={onSelect}
           onNew={onNew}
+          onNewBlock={onNewBlock}
           onNewPrivate={onNewPrivate}
           onNewPreview={onNewPreview}
           onNewEditor={onNewEditor}

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -37,6 +37,7 @@ type Props = {
   activeId: number;
   onSelect: (id: number) => void;
   onNew: () => void;
+  onNewBlock: () => void;
   onNewPrivate: () => void;
   onNewPreview: () => void;
   onNewEditor: () => void;
@@ -54,6 +55,7 @@ export function TabBar({
   activeId,
   onSelect,
   onNew,
+  onNewBlock,
   onNewPrivate,
   onNewPreview,
   onNewEditor,
@@ -255,6 +257,15 @@ export function TabBar({
               <span className="text-xs text-muted-foreground">
                 {fmtShortcut(MOD_KEY, "T")}
               </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onNewBlock()}>
+              <HugeiconsIcon
+                icon={ComputerTerminal02Icon}
+                size={14}
+                strokeWidth={1.75}
+              />
+              <span className="flex-1">Block terminal</span>
+              <span className="text-xs text-muted-foreground">beta</span>
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => onNewPrivate()}>
               <HugeiconsIcon

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -23,6 +23,7 @@ export type TerminalTab = {
   cwd?: string;
   paneTree: PaneNode;
   activeLeafId: number;
+  blocks?: boolean;
   /** AI agent cannot read buffer / context of this terminal. */
   private?: boolean;
   /** User-set label that overrides the cwd-derived name. Survives cd. */
@@ -176,6 +177,32 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setActiveId(tabId);
     return tabId;
   }, []);
+
+  const newBlockTab = useCallback((cwd?: string) => {
+    const tabId = nextIdRef.current++;
+    const leafId = nextIdRef.current++;
+    setTabs((t) => [
+      ...t,
+      {
+        id: tabId,
+        kind: "terminal",
+        title: "blocks",
+        cwd,
+        paneTree: { kind: "leaf", id: leafId, cwd },
+        activeLeafId: leafId,
+        blocks: true,
+      },
+    ]);
+    setActiveId(tabId);
+    return tabId;
+  }, []);
+
+  useEffect(() => {
+    if (!import.meta.env?.DEV || typeof window === "undefined") return;
+    (
+      window as unknown as { __teraxNewBlockTab?: (cwd?: string) => number }
+    ).__teraxNewBlockTab = newBlockTab;
+  }, [newBlockTab]);
 
   const newAgentTab = useCallback(
     (cwd: string | undefined, title: string) => {
@@ -689,7 +716,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       let newLeafId: number | null = null;
       setTabs((curr) =>
         curr.map((t) => {
-          if (t.id !== tabId || t.kind !== "terminal") return t;
+          if (t.id !== tabId || t.kind !== "terminal" || t.blocks) return t;
           if (leafIds(t.paneTree).length >= MAX_PANES_PER_TAB) return t;
           const splitId = nextIdRef.current++;
           const leafId = nextIdRef.current++;
@@ -806,6 +833,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     activeId,
     setActiveId,
     newTab,
+    newBlockTab,
     newAgentTab,
     newPrivateTab,
     openFileTab,

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -20,6 +20,7 @@ type Props = {
   node: PaneNode;
   tabVisible: boolean;
   activeLeafId: number;
+  blocks: boolean;
   onFocusLeaf: (leafId: number) => void;
   getBundle: (leafId: number) => LeafBundle;
 };
@@ -28,6 +29,7 @@ export function PaneTreeView({
   node,
   tabVisible,
   activeLeafId,
+  blocks,
   onFocusLeaf,
   getBundle,
 }: Props) {
@@ -52,6 +54,7 @@ export function PaneTreeView({
           visible={tabVisible}
           focused={focused}
           initialCwd={node.cwd}
+          blocks={blocks}
           ref={b.setRef}
           onSearchReady={(_id, addon) => b.onSearch(addon)}
           onCwd={(_id, cwd) => b.onCwd(cwd)}
@@ -74,6 +77,7 @@ export function PaneTreeView({
               node={child}
               tabVisible={tabVisible}
               activeLeafId={activeLeafId}
+              blocks={blocks}
               onFocusLeaf={onFocusLeaf}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@/modules/theme";
 import type { SearchAddon } from "@xterm/addon-search";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { BlockInputBar, type BlockInputBarHandle } from "./block/BlockInputBar";
 import { useTerminalSession } from "./lib/useTerminalSession";
 
 export type TerminalPaneHandle = {
@@ -18,6 +19,8 @@ type Props = {
   /** This leaf is the active pane within its tab — receives auto-focus. */
   focused?: boolean;
   initialCwd?: string;
+  /** Enable command-block decorations (OSC 133) for this terminal. */
+  blocks?: boolean;
   onSearchReady?: (leafId: number, addon: SearchAddon) => void;
   onExit?: (leafId: number, code: number) => void;
   onCwd?: (leafId: number, cwd: string) => void;
@@ -30,6 +33,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       visible,
       focused = true,
       initialCwd,
+      blocks = false,
       onSearchReady,
       onExit,
       onCwd,
@@ -37,6 +41,8 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
     ref,
   ) {
     const containerRef = useRef<HTMLDivElement>(null);
+    const barRef = useRef<BlockInputBarHandle>(null);
+    const downYRef = useRef<number | null>(null);
     const { resolvedMode, themeId, customThemes } = useTheme();
 
     const session = useTerminalSession({
@@ -45,6 +51,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       visible,
       focused,
       initialCwd,
+      blocks,
       onSearchReady: (a) => onSearchReady?.(leafId, a),
       onExit: (c) => onExit?.(leafId, c),
       onCwd: (c) => onCwd?.(leafId, c),
@@ -67,15 +74,45 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       [session],
     );
 
+    const hideStyle = {
+      visibility: visible ? ("visible" as const) : ("hidden" as const),
+      pointerEvents: visible ? ("auto" as const) : ("none" as const),
+    };
+
+    if (blocks) {
+      return (
+        <div
+          className="zoom-exempt flex h-full w-full flex-col"
+          style={hideStyle}
+        >
+          <BlockInputBar
+            ref={barRef}
+            mode={session.blockMode}
+            onSubmit={session.submitCommand}
+            onInterrupt={session.interrupt}
+          />
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal surface; pointer selects command blocks */}
+          <div
+            ref={containerRef}
+            className="min-h-0 flex-1"
+            onMouseDown={(e) => {
+              downYRef.current = e.clientY;
+            }}
+            onMouseUp={(e) => {
+              const moved =
+                downYRef.current != null &&
+                Math.abs(e.clientY - downYRef.current) > 4;
+              downYRef.current = null;
+              if (!moved) session.selectBlockAt(e.clientY);
+              if (session.blockMode === "prompt") barRef.current?.focus();
+            }}
+          />
+        </div>
+      );
+    }
+
     return (
-      <div
-        ref={containerRef}
-        className="zoom-exempt h-full w-full"
-        style={{
-          visibility: visible ? "visible" : "hidden",
-          pointerEvents: visible ? "auto" : "none",
-        }}
-      />
+      <div ref={containerRef} className="zoom-exempt h-full w-full" style={hideStyle} />
     );
   },
 );

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -95,6 +95,7 @@ export function TerminalStack({
               node={t.paneTree}
               tabVisible={tabVisible}
               activeLeafId={t.activeLeafId}
+              blocks={t.blocks ?? false}
               onFocusLeaf={(leafId) => onFocusLeaf(t.id, leafId)}
               getBundle={getBundle}
             />

--- a/src/modules/terminal/block/BlockInputBar.tsx
+++ b/src/modules/terminal/block/BlockInputBar.tsx
@@ -1,0 +1,114 @@
+import { detectMonoFontFamily } from "@/lib/fonts";
+import { cn } from "@/lib/utils";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  forwardRef,
+  type KeyboardEvent,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
+import type { BlockMode } from "./lib/modeMachine";
+
+export type BlockInputBarHandle = { focus: () => void };
+
+type Props = {
+  mode: BlockMode;
+  onSubmit: (text: string) => void;
+  onInterrupt: () => void;
+};
+
+function autoSize(el: HTMLTextAreaElement): void {
+  el.style.height = "0px";
+  el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+}
+
+export const BlockInputBar = forwardRef<BlockInputBarHandle, Props>(
+  function BlockInputBar({ mode, onSubmit, onInterrupt }, ref) {
+    const taRef = useRef<HTMLTextAreaElement>(null);
+    const history = useRef<string[]>([]);
+    const histIdx = useRef(-1);
+    const atPrompt = mode === "prompt";
+
+    useImperativeHandle(ref, () => ({ focus: () => taRef.current?.focus() }), []);
+
+    const fontFamilyPref = usePreferencesStore((p) => p.terminalFontFamily);
+    const fontSize = usePreferencesStore((p) => p.terminalFontSize);
+    const fontFamily = fontFamilyPref || detectMonoFontFamily();
+
+    useEffect(() => {
+      if (atPrompt) taRef.current?.focus();
+    }, [atPrompt]);
+
+    const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      const ta = e.currentTarget;
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const value = ta.value;
+        if (value.trim()) history.current.push(value);
+        histIdx.current = -1;
+        ta.value = "";
+        autoSize(ta);
+        onSubmit(value);
+        return;
+      }
+      if (e.key === "c" && e.ctrlKey) {
+        e.preventDefault();
+        ta.value = "";
+        autoSize(ta);
+        onInterrupt();
+        return;
+      }
+      const h = history.current;
+      if (e.key === "ArrowUp" && ta.selectionStart === 0 && h.length > 0) {
+        e.preventDefault();
+        histIdx.current =
+          histIdx.current < 0 ? h.length - 1 : Math.max(0, histIdx.current - 1);
+        ta.value = h[histIdx.current] ?? "";
+        autoSize(ta);
+        return;
+      }
+      if (e.key === "ArrowDown" && histIdx.current >= 0) {
+        e.preventDefault();
+        histIdx.current += 1;
+        if (histIdx.current >= h.length) {
+          histIdx.current = -1;
+          ta.value = "";
+        } else {
+          ta.value = h[histIdx.current] ?? "";
+        }
+        autoSize(ta);
+      }
+    };
+
+    return (
+      <div
+        className={cn(
+          "flex items-start gap-2 border-b border-border/50 px-4 py-2.5",
+          !atPrompt && "opacity-45",
+        )}
+      >
+        <span
+          className="select-none pt-px text-primary/80"
+          style={{ fontFamily, fontSize: `${fontSize}px`, lineHeight: 1.5 }}
+        >
+          ❯
+        </span>
+        <textarea
+          ref={taRef}
+          rows={1}
+          disabled={!atPrompt}
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          placeholder={atPrompt ? "Run a command" : "running…"}
+          onKeyDown={onKeyDown}
+          onInput={(e) => autoSize(e.currentTarget)}
+          className="flex-1 resize-none bg-transparent text-foreground outline-none placeholder:text-muted-foreground/40"
+          style={{ fontFamily, fontSize: `${fontSize}px`, lineHeight: 1.5 }}
+        />
+      </div>
+    );
+  },
+);

--- a/src/modules/terminal/block/block.css
+++ b/src/modules/terminal/block/block.css
@@ -1,0 +1,21 @@
+.bt-deco {
+  box-sizing: border-box;
+  border-left: 2px solid transparent;
+  pointer-events: none;
+}
+
+.bt-deco.bt-ok {
+  border-left-color: rgba(95, 179, 179, 0.45);
+}
+
+.bt-deco.bt-fail {
+  border-left-color: rgba(229, 112, 107, 0.55);
+  background: rgba(229, 112, 107, 0.05);
+}
+
+.bt-gutter.bt-running {
+  background: #5fb3b3;
+  border-radius: 50%;
+  opacity: 0.8;
+  pointer-events: none;
+}

--- a/src/modules/terminal/block/lib/blockDecorations.ts
+++ b/src/modules/terminal/block/lib/blockDecorations.ts
@@ -1,0 +1,260 @@
+import {
+  createShellIntegrationState,
+  registerCwdHandler,
+} from "@/modules/terminal/lib/osc-handlers";
+import type { IDecoration, IMarker, Terminal } from "@xterm/xterm";
+import {
+  type BlockMode,
+  initialModeState,
+  type ModeState,
+  modeOf,
+  reduceMode,
+} from "./modeMachine";
+import { readRangeText } from "./readBlock";
+import type { BlockMeta } from "./types";
+
+const OK_BORDER = "rgba(95, 179, 179, 0.4)";
+const FAIL_BORDER = "rgba(229, 112, 107, 0.55)";
+const OK_RULER = "#5fb3b3";
+const FAIL_RULER = "#e5706b";
+const MAX_BLOCKS = 1000;
+
+type Entry = {
+  meta: BlockMeta;
+  marker: IMarker;
+  endMarker: IMarker | null;
+  deco: IDecoration | null;
+};
+
+type LiveBlock = {
+  id: string;
+  command: string;
+  cwd: string;
+  marker: IMarker;
+  usedAlt: boolean;
+};
+
+export type BlockContext = {
+  command: string;
+  cwd: string;
+  exitCode: number | null;
+  output: string;
+};
+
+export type BlockDecorationsOptions = {
+  onCwd?: (cwd: string) => void;
+  onMode?: (mode: BlockMode) => void;
+};
+
+export class BlockDecorations {
+  private readonly entries: Entry[] = [];
+  private live: LiveBlock | null = null;
+  private cwd = "";
+  private idSeq = 0;
+  private mode: ModeState = initialModeState();
+  private lastMode: BlockMode = modeOf(initialModeState());
+  private readonly shellState = createShellIntegrationState();
+  private readonly disposers: (() => void)[] = [];
+  private readonly onCwd?: (cwd: string) => void;
+  private readonly onMode?: (mode: BlockMode) => void;
+
+  constructor(
+    private readonly term: Terminal,
+    opts?: BlockDecorationsOptions,
+  ) {
+    this.onCwd = opts?.onCwd;
+    this.onMode = opts?.onMode;
+    this.term.options.cursorInactiveStyle = "none";
+    const osc133 = term.parser.registerOscHandler(133, (data) => {
+      this.onOsc133(data);
+      return true;
+    });
+    const cwd = registerCwdHandler(
+      term,
+      (c) => {
+        this.cwd = c;
+        this.onCwd?.(c);
+      },
+      this.shellState,
+    );
+    const parsed = term.onWriteParsed(() => this.syncAlt());
+    this.disposers.push(() => osc133.dispose(), cwd, () => parsed.dispose());
+  }
+
+  syncAlt(): void {
+    const alt = this.term.buffer.active.type === "alternate";
+    if (alt === this.mode.altScreen) return;
+    this.mode = reduceMode(this.mode, { type: "altScreen", active: alt });
+    if (alt && this.live) this.live.usedAlt = true;
+    this.emitMode();
+  }
+
+  getBlocks(): BlockMeta[] {
+    return this.entries.map((e) => e.meta);
+  }
+
+  blockAt(line: number): BlockMeta | null {
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      const m = this.entries[i].meta;
+      if (line >= m.startLine && line <= m.endLine) return m;
+    }
+    return null;
+  }
+
+  read(block: BlockMeta): BlockContext {
+    return {
+      command: block.command,
+      cwd: block.cwd,
+      exitCode: block.exitCode,
+      output: readRangeText(this.term, block.startLine, block.endLine),
+    };
+  }
+
+  commandLines(): number[] {
+    const lines: number[] = [];
+    for (const e of this.entries) {
+      if (!e.marker.isDisposed && e.marker.line >= 0) lines.push(e.marker.line);
+    }
+    return lines;
+  }
+
+  selectBlockAt(clientY: number): void {
+    const screen = this.term.element?.querySelector<HTMLElement>(".xterm-screen");
+    if (!screen || this.term.rows === 0) return;
+    const rect = screen.getBoundingClientRect();
+    const cellHeight = rect.height / this.term.rows;
+    if (cellHeight <= 0) return;
+    const row = Math.floor((clientY - rect.top) / cellHeight);
+    const bufferRow = this.term.buffer.active.viewportY + row;
+    const block = this.blockAt(bufferRow);
+    if (block) this.term.selectLines(block.startLine, block.endLine);
+    else this.term.clearSelection();
+  }
+
+  dispose(): void {
+    for (const e of this.entries) {
+      try {
+        e.deco?.dispose();
+      } catch {}
+      try {
+        e.marker.dispose();
+      } catch {}
+      try {
+        e.endMarker?.dispose();
+      } catch {}
+    }
+    this.entries.length = 0;
+    this.live?.marker.dispose();
+    this.live = null;
+    for (const d of this.disposers) {
+      try {
+        d();
+      } catch {}
+    }
+    this.disposers.length = 0;
+  }
+
+  private emitMode(): void {
+    const m = modeOf(this.mode);
+    if (m === this.lastMode) return;
+    this.lastMode = m;
+    this.onMode?.(m);
+  }
+
+  private onOsc133(data: string): void {
+    const marker = data[0];
+    const rest = data.length > 2 && data[1] === ";" ? data.slice(2) : "";
+    switch (marker) {
+      case "A":
+        this.shellState.inCommand = false;
+        this.mode = reduceMode(this.mode, { type: "osc133", marker: "A" });
+        break;
+      case "B":
+        this.shellState.inCommand = true;
+        this.mode = reduceMode(this.mode, { type: "osc133", marker: "B" });
+        break;
+      case "C":
+        this.shellState.inCommand = true;
+        this.mode = reduceMode(this.mode, { type: "osc133", marker: "C" });
+        this.startBlock(rest);
+        break;
+      case "D":
+        this.shellState.inCommand = false;
+        this.finishBlock(rest);
+        this.mode = reduceMode(this.mode, { type: "osc133", marker: "D" });
+        break;
+    }
+    this.emitMode();
+  }
+
+  private startBlock(commandFromMarker: string): void {
+    if (this.live) this.finishBlock("");
+    const marker = this.term.registerMarker(0);
+    if (!marker) return;
+    this.live = {
+      id: `b${++this.idSeq}`,
+      command: commandFromMarker,
+      cwd: this.cwd,
+      marker,
+      usedAlt: false,
+    };
+  }
+
+  private finishBlock(codeStr: string): void {
+    const lb = this.live;
+    if (!lb) return;
+    this.live = null;
+    const start = lb.marker.line;
+    const buf = this.term.buffer.active;
+    const end = buf.baseY + buf.cursorY;
+    const exit = parseExitCode(codeStr);
+    const ok = exit === 0 || exit === null;
+    const endMarker = this.term.registerMarker(0);
+    const deco = endMarker
+      ? (this.term.registerDecoration({
+          marker: endMarker,
+          x: 0,
+          width: this.term.cols,
+          overviewRulerOptions: { color: ok ? OK_RULER : FAIL_RULER },
+        }) ?? null)
+      : null;
+    if (deco) {
+      deco.onRender((el) => {
+        el.style.borderBottom = `1px solid ${ok ? OK_BORDER : FAIL_BORDER}`;
+        el.style.pointerEvents = "none";
+      });
+    }
+    this.entries.push({
+      meta: {
+        id: lb.id,
+        command: lb.command,
+        cwd: lb.cwd,
+        exitCode: exit,
+        startLine: start,
+        endLine: end,
+      },
+      marker: lb.marker,
+      endMarker,
+      deco,
+    });
+    while (this.entries.length > MAX_BLOCKS) {
+      const old = this.entries.shift();
+      if (!old) break;
+      try {
+        old.deco?.dispose();
+      } catch {}
+      try {
+        old.marker.dispose();
+      } catch {}
+      try {
+        old.endMarker?.dispose();
+      } catch {}
+    }
+  }
+}
+
+function parseExitCode(s: string): number | null {
+  if (!s) return null;
+  const n = Number.parseInt(s, 10);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/modules/terminal/block/lib/modeMachine.test.ts
+++ b/src/modules/terminal/block/lib/modeMachine.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  initialModeState,
+  type ModeEvent,
+  modeOf,
+  reduceMode,
+} from "./modeMachine";
+
+function run(events: ModeEvent[]) {
+  return events.reduce(reduceMode, initialModeState());
+}
+
+const osc = (marker: "A" | "B" | "C" | "D"): ModeEvent => ({
+  type: "osc133",
+  marker,
+});
+const alt = (active: boolean): ModeEvent => ({ type: "altScreen", active });
+
+describe("modeMachine", () => {
+  it("starts at the prompt", () => {
+    expect(modeOf(initialModeState())).toBe("prompt");
+  });
+
+  it("enters running on command exec (OSC 133 C)", () => {
+    expect(modeOf(run([osc("A"), osc("B"), osc("C")]))).toBe("running");
+  });
+
+  it("returns to the prompt when the command ends (OSC 133 D)", () => {
+    expect(modeOf(run([osc("C"), osc("D")]))).toBe("prompt");
+    expect(modeOf(run([osc("C"), osc("D"), osc("A")]))).toBe("prompt");
+  });
+
+  it("alt-screen takes visual precedence over the shell phase", () => {
+    expect(modeOf(run([osc("C"), alt(true)]))).toBe("alt");
+    expect(modeOf(run([alt(true), osc("A")]))).toBe("alt");
+  });
+
+  it("leaving alt-screen restores the underlying phase", () => {
+    // vim launched from a command: still running underneath until OSC 133 D.
+    expect(modeOf(run([osc("C"), alt(true), alt(false)]))).toBe("running");
+    expect(modeOf(run([osc("C"), alt(true), alt(false), osc("D")]))).toBe(
+      "prompt",
+    );
+  });
+
+  it("is idempotent for repeated markers and unchanged alt-screen", () => {
+    const a = run([osc("C"), osc("C")]);
+    const b = run([osc("C")]);
+    expect(a).toEqual(b);
+    const before = run([alt(true)]);
+    expect(reduceMode(before, alt(true))).toBe(before);
+  });
+});

--- a/src/modules/terminal/block/lib/modeMachine.ts
+++ b/src/modules/terminal/block/lib/modeMachine.ts
@@ -1,0 +1,36 @@
+export type ShellPhase = "prompt" | "running";
+
+export type BlockMode = "prompt" | "running" | "alt";
+
+export type Osc133Marker = "A" | "B" | "C" | "D";
+
+export type ModeEvent =
+  | { type: "osc133"; marker: Osc133Marker }
+  | { type: "altScreen"; active: boolean };
+
+export type ModeState = {
+  phase: ShellPhase;
+  altScreen: boolean;
+};
+
+export function initialModeState(): ModeState {
+  return { phase: "prompt", altScreen: false };
+}
+
+export function modeOf(state: ModeState): BlockMode {
+  return state.altScreen ? "alt" : state.phase;
+}
+
+export function reduceMode(state: ModeState, event: ModeEvent): ModeState {
+  if (event.type === "altScreen") {
+    if (state.altScreen === event.active) return state;
+    return { ...state, altScreen: event.active };
+  }
+  const phase = phaseForMarker(event.marker);
+  if (state.phase === phase) return state;
+  return { ...state, phase };
+}
+
+function phaseForMarker(marker: Osc133Marker): ShellPhase {
+  return marker === "C" ? "running" : "prompt";
+}

--- a/src/modules/terminal/block/lib/readBlock.ts
+++ b/src/modules/terminal/block/lib/readBlock.ts
@@ -1,0 +1,16 @@
+import type { Terminal } from "@xterm/xterm";
+
+export function readRangeText(
+  term: Terminal,
+  startLine: number,
+  endLine: number,
+): string {
+  const buf = term.buffer.active;
+  const last = Math.min(endLine, buf.length - 1);
+  const lines: string[] = [];
+  for (let i = Math.max(0, startLine); i <= last; i++) {
+    lines.push(buf.getLine(i)?.translateToString(true) ?? "");
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines.join("\n");
+}

--- a/src/modules/terminal/block/lib/types.ts
+++ b/src/modules/terminal/block/lib/types.ts
@@ -1,0 +1,8 @@
+export type BlockMeta = {
+  id: string;
+  command: string;
+  cwd: string;
+  exitCode: number | null;
+  startLine: number;
+  endLine: number;
+};

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -18,6 +18,7 @@ export async function openPty(
   rows: number,
   handlers: PtyHandlers,
   cwd?: string,
+  blocks?: boolean,
 ): Promise<PtySession> {
   // Raw bytes — no base64/JSON round-trip; messages arrive as ArrayBuffer.
   const onData = new Channel<ArrayBuffer>();
@@ -43,6 +44,7 @@ export async function openPty(
     rows,
     cwd: cwd ?? null,
     workspace: currentWorkspaceEnv(),
+    blocks: blocks ?? false,
     onData,
     onExit,
   });

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -2,14 +2,17 @@ import { invoke } from "@tauri-apps/api/core";
 import { ensureMonoFontsLoaded } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DormantRing } from "./dormantRing";
+import type { BlockMode } from "../block/lib/modeMachine";
 import {
   createShellIntegrationState,
   registerCwdHandler,
   registerPromptTracker,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
+import { BlockDecorations } from "../block/lib/blockDecorations";
+import "../block/block.css";
 import {
   acquireSlot,
   applyBackgroundActive,
@@ -58,6 +61,10 @@ type Session = {
   searchQuery: string | null;
   dormantRing: DormantRing;
   hasSlot: boolean;
+  blocks: boolean;
+  blockMode: BlockMode;
+  blockListeners: Set<() => void>;
+  blockDecorations: BlockDecorations | null;
   // True if the slot was in alt-screen mode (TUI like vim, htop, dofek)
   // at the most recent release. Read once on the next bind to trigger a
   // SIGWINCH-driven repaint instead of replaying dormant bytes.
@@ -166,7 +173,11 @@ configureRendererPool({
   },
 });
 
-function ensureSession(leafId: number, initialCwd?: string): Session {
+function ensureSession(
+  leafId: number,
+  initialCwd?: string,
+  blocks = false,
+): Session {
   const existing = sessions.get(leafId);
   if (existing) return existing;
 
@@ -189,6 +200,10 @@ function ensureSession(leafId: number, initialCwd?: string): Session {
     searchQuery: null,
     dormantRing: new DormantRing(),
     hasSlot: false,
+    blocks,
+    blockMode: "prompt",
+    blockListeners: new Set(),
+    blockDecorations: null,
     altScreenAtRelease: false,
   };
   sessions.set(leafId, session);
@@ -231,7 +246,20 @@ async function openPtyForSession(
       },
     },
     cwd,
+    s.blocks,
   );
+}
+
+function applyBlockMode(leafId: number, mode: BlockMode): void {
+  const s = sessions.get(leafId);
+  if (!s) return;
+  s.blockMode = mode;
+  const slot = getSlotForLeaf(leafId);
+  if (slot) {
+    slot.term.options.disableStdin = mode === "prompt";
+    if (mode !== "prompt") slot.term.focus();
+  }
+  for (const l of s.blockListeners) l();
 }
 
 function bindLeafToSlot(leafId: number, s: Session): void {
@@ -249,6 +277,24 @@ function bindLeafToSlot(leafId: number, s: Session): void {
     cols: s.cols,
     rows: s.rows,
     registerOsc: (term) => {
+      if (s.blocks) {
+        const deco = new BlockDecorations(term, {
+          onCwd: (next) => {
+            markSessionReady(leafId);
+            if (s.lastCwd === next) return;
+            s.lastCwd = next;
+            s.callbacks.onCwd?.(next);
+          },
+          onMode: (mode) => applyBlockMode(leafId, mode),
+        });
+        s.blockDecorations = deco;
+        return [
+          () => {
+            s.blockDecorations = null;
+            deco.dispose();
+          },
+        ];
+      }
       // Shared in-command flag — see osc-handlers.ts. The prompt tracker
       // flips it on OSC 133 B/C/D/A; the cwd handler reads it to ignore OSC
       // 7 emitted by untrusted command output (remote SSH, `cat` of an
@@ -271,6 +317,7 @@ function bindLeafToSlot(leafId: number, s: Session): void {
   });
   s.snapshot = null;
   s.hasSlot = true;
+  if (s.blocks) applyBlockMode(leafId, s.blockMode);
   if (s.lastCwd !== null) s.callbacks.onCwd?.(s.lastCwd);
   if (s.pendingExit !== null) {
     const code = s.pendingExit;
@@ -408,6 +455,7 @@ type Options = {
   visible: boolean;
   focused?: boolean;
   initialCwd?: string;
+  blocks?: boolean;
   onSearchReady?: (addon: SearchAddon) => void;
   onExit?: (code: number) => void;
   onCwd?: (cwd: string) => void;
@@ -419,6 +467,7 @@ export function useTerminalSession({
   visible,
   focused = true,
   initialCwd,
+  blocks = false,
   onSearchReady,
   onExit,
   onCwd,
@@ -428,7 +477,7 @@ export function useTerminalSession({
 
   useEffect(() => {
     let cancelled = false;
-    const s = ensureSession(leafId, initialCwd);
+    const s = ensureSession(leafId, initialCwd, blocks);
     s.ready.then(() => {
       if (cancelled || s.disposed) return;
       const node = container.current;
@@ -438,13 +487,25 @@ export function useTerminalSession({
         onExit: (c) => cbRef.current.onExit?.(c),
         onCwd: (c) => cbRef.current.onCwd?.(c),
       });
-      if (s.visibleNow && s.focusedNow) focusSlot(leafId);
+      if (s.visibleNow && s.focusedNow && !s.blocks) focusSlot(leafId);
     });
     return () => {
       cancelled = true;
       detachSession(leafId);
     };
-  }, [leafId, container, initialCwd]);
+  }, [leafId, container, initialCwd, blocks]);
+
+  const [blockMode, setBlockMode] = useState<BlockMode>("prompt");
+  useEffect(() => {
+    if (!blocks) return;
+    const s = ensureSession(leafId, initialCwd, blocks);
+    setBlockMode(s.blockMode);
+    const cb = () => setBlockMode(sessions.get(leafId)?.blockMode ?? "prompt");
+    s.blockListeners.add(cb);
+    return () => {
+      s.blockListeners.delete(cb);
+    };
+  }, [leafId, blocks, initialCwd]);
 
   const fontSize = usePreferencesStore((p) => p.terminalFontSize);
   const zoomLevel = usePreferencesStore((p) => p.zoomLevel);
@@ -493,12 +554,12 @@ export function useTerminalSession({
       if (s.container && !s.hasSlot) bindLeafToSlot(leafId, s);
       else if (s.hasSlot) refreshLeafSlot(leafId);
       setSlotFocused(leafId, focused);
-      if (focused) focusSlot(leafId);
+      if (focused && !blocks) focusSlot(leafId);
     } else if (s.hasSlot) {
-      if (isLeafAltScreen(leafId)) parkLeafSlot(leafId);
+      if (s.blocks || isLeafAltScreen(leafId)) parkLeafSlot(leafId);
       else unbindLeafFromSlot(leafId, s);
     }
-  }, [leafId, visible, focused]);
+  }, [leafId, visible, focused, blocks]);
 
   const write = useCallback(
     (data: string) => sessions.get(leafId)?.pty?.write(data),
@@ -543,9 +604,46 @@ export function useTerminalSession({
     applyPoolTheme();
   }, []);
 
+  const submitCommand = useCallback(
+    (text: string) => {
+      sessions.get(leafId)?.pty?.write(`${text}\r`);
+    },
+    [leafId],
+  );
+
+  const interrupt = useCallback(() => {
+    sessions.get(leafId)?.pty?.write("\x03");
+  }, [leafId]);
+
+  const selectBlockAt = useCallback(
+    (clientY: number) =>
+      sessions.get(leafId)?.blockDecorations?.selectBlockAt(clientY),
+    [leafId],
+  );
+
   return useMemo(
-    () => ({ write, focus, getBuffer, getSelection, applyTheme }),
-    [write, focus, getBuffer, getSelection, applyTheme],
+    () => ({
+      write,
+      focus,
+      getBuffer,
+      getSelection,
+      applyTheme,
+      blockMode,
+      submitCommand,
+      interrupt,
+      selectBlockAt,
+    }),
+    [
+      write,
+      focus,
+      getBuffer,
+      getSelection,
+      applyTheme,
+      blockMode,
+      submitCommand,
+      interrupt,
+      selectBlockAt,
+    ],
   );
 }
 


### PR DESCRIPTION
Opt-in "Block terminal" tab built as a layer on the existing renderer pool — not a second engine. xterm renders everything; OSC 133 markers drive per-command decorations and a custom input bar.

- New "Block terminal · beta" entry in the new-tab menu (a terminal tab with a `blocks` flag).
- Per-command bottom-border marks colored by exit code, plus overview-ruler ticks.
- Lightweight custom input bar (no CodeMirror): the prompt input lives in the bar; xterm stdin is gated by OSC 133, so raw passthrough during commands/TUIs keeps vim/htop/sudo working. Cursor hidden at the prompt.
- Click a block to select its output; up/down history; Ctrl-C.
- Block tabs are single-pane and keep their grid across tab switches (no hibernation wipe).
- PTY block-mode env flag (TERAX_BLOCKS) suppresses the shell prompt (zsh) so the bar is the only prompt.

Classic terminal is unchanged. Verified: pnpm check-types, test, build, lint; cargo check/clippy/test.