### PR TITLE
feat(net): add HTTP_PROXY support for reqwest

### DIFF
--- a/src-tauri/src/modules/net.rs
+++ b/src-tauri/src/modules/net.rs
@@ -9,6 +9,20 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
 
+fn env_proxy() -> reqwest::Proxy {
+    reqwest::Proxy::custom(|url| {
+        if url.scheme() == "https" {
+            std::env::var("HTTPS_PROXY")
+                .or_else(|_| std::env::var("https_proxy"))
+                .ok()
+        } else {
+            std::env::var("HTTP_PROXY")
+                .or_else(|_| std::env::var("http_proxy"))
+                .ok()
+        }
+    })
+}
+
 const HEADER_BLOCKLIST: &[&str] = &[
     "host",
     "content-length",
@@ -203,6 +217,7 @@ pub async fn lm_ping(base_url: String) -> Result<u16, String> {
     let safe_ips = classify_and_collect_safe_ips(&host, true).await?;
 
     let mut builder = reqwest::Client::builder()
+        .proxy(env_proxy())
         .timeout(Duration::from_secs(5))
         .redirect(reqwest::redirect::Policy::none());
     let addrs: Vec<SocketAddr> = safe_ips.iter().map(|ip| SocketAddr::new(*ip, 0)).collect();
@@ -247,6 +262,7 @@ fn build_safe_client(
     pinned: &[(String, Vec<IpAddr>)],
 ) -> Result<reqwest::Client, String> {
     let mut builder = reqwest::Client::builder()
+        .proxy(env_proxy())
         .connect_timeout(Duration::from_secs(10));
     // Pin reqwest's resolver to the IPs we just classified. Without this,
     // reqwest's own DNS lookup could return a different (private/metadata) IP


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Add HTTP_PROXY support for reqwest via environment variables.

## Why
Users behind proxies need to access AI providers through their corporate network proxy.

## How
- Added env_proxy() helper in net.rs using reqwest::Proxy::custom() to read HTTP_PROXY/HTTPS_PROXY env vars
- Applied proxy to both client builders (lm_ping and build_safe_client)

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macos
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
