### PR TITLE
fix(terminal): suppress context menu during mouse tracking

### DIFF
--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -63,6 +63,16 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
       return () => cancelAnimationFrame(id);
     }, [resolvedMode, themeId, customThemes, session]);
 
+    useEffect(() => {
+      const node = containerRef.current;
+      if (!node) return;
+      const handleContextMenu = (event: MouseEvent) => {
+        if (session.shouldSuppressContextMenu()) event.preventDefault();
+      };
+      node.addEventListener("contextmenu", handleContextMenu);
+      return () => node.removeEventListener("contextmenu", handleContextMenu);
+    }, [session]);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -112,7 +122,11 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, Props>(
     }
 
     return (
-      <div ref={containerRef} className="zoom-exempt h-full w-full" style={hideStyle} />
+      <div
+        ref={containerRef}
+        className="zoom-exempt h-full w-full"
+        style={hideStyle}
+      />
     );
   },
 );

--- a/src/modules/terminal/lib/mouseTracking.test.ts
+++ b/src/modules/terminal/lib/mouseTracking.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSuppressTerminalContextMenu } from "./mouseTracking";
+
+describe("shouldSuppressTerminalContextMenu", () => {
+  it("suppresses the native menu while terminal mouse reporting is active", () => {
+    expect(shouldSuppressTerminalContextMenu("x10")).toBe(true);
+    expect(shouldSuppressTerminalContextMenu("vt200")).toBe(true);
+    expect(shouldSuppressTerminalContextMenu("drag")).toBe(true);
+    expect(shouldSuppressTerminalContextMenu("any")).toBe(true);
+  });
+
+  it("keeps the native menu available outside terminal mouse reporting", () => {
+    expect(shouldSuppressTerminalContextMenu("none")).toBe(false);
+    expect(shouldSuppressTerminalContextMenu(null)).toBe(false);
+    expect(shouldSuppressTerminalContextMenu(undefined)).toBe(false);
+  });
+});

--- a/src/modules/terminal/lib/mouseTracking.ts
+++ b/src/modules/terminal/lib/mouseTracking.ts
@@ -1,0 +1,9 @@
+import type { Terminal } from "@xterm/xterm";
+
+type MouseTrackingMode = Terminal["modes"]["mouseTrackingMode"];
+
+export function shouldSuppressTerminalContextMenu(
+  mode: MouseTrackingMode | null | undefined,
+): boolean {
+  return mode != null && mode !== "none";
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -10,6 +10,7 @@ import {
   registerCwdHandler,
   registerPromptTracker,
 } from "./osc-handlers";
+import { shouldSuppressTerminalContextMenu } from "./mouseTracking";
 import { openPty, type PtySession } from "./pty-bridge";
 import { BlockDecorations } from "../block/lib/blockDecorations";
 import "../block/block.css";
@@ -621,6 +622,13 @@ export function useTerminalSession({
     [leafId],
   );
 
+  const shouldSuppressContextMenu = useCallback((): boolean => {
+    const slot = getSlotForLeaf(leafId);
+    return shouldSuppressTerminalContextMenu(
+      slot?.term.modes.mouseTrackingMode,
+    );
+  }, [leafId]);
+
   return useMemo(
     () => ({
       write,
@@ -632,6 +640,7 @@ export function useTerminalSession({
       submitCommand,
       interrupt,
       selectBlockAt,
+      shouldSuppressContextMenu,
     }),
     [
       write,
@@ -643,6 +652,7 @@ export function useTerminalSession({
       submitCommand,
       interrupt,
       selectBlockAt,
+      shouldSuppressContextMenu,
     ],
   );
 }


### PR DESCRIPTION
## What

Suppress the terminal pane's native browser/WebKit context menu while xterm.js reports that terminal mouse tracking is active.

Closes #721.

## Why

TUI apps that enable mouse reporting can receive right-clicks and render their own context menus, but the native Terax/WebKit context menu was still opening on top and blocking the app menu.

## How

- Read xterm.js `Terminal.modes.mouseTrackingMode` and treat every non-`none` mode as terminal-owned mouse input.
- Install a native `contextmenu` listener on the terminal container and call `preventDefault()` only while mouse tracking is active.
- Keep the native context menu available when no terminal app has mouse reporting enabled.

## Testing

- [x] `pnpm exec tsc --noEmit` clean via `pnpm check-types`
- [x] `pnpm test src/modules/terminal/lib/mouseTracking.test.ts`
- [x] `pnpm lint` ran; it reports existing repository warnings outside this change, with no new terminal-file errors from this PR
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: Linux checks only; macOS/WebKit runtime not available in this environment
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A. This suppresses a native context menu during terminal mouse tracking; no local macOS/WebKit runtime was available for before/after capture.

## Notes for reviewer

The change is intentionally scoped to xterm's documented mouse tracking modes (`x10`, `vt200`, `drag`, `any`). Native context menus still work when `mouseTrackingMode` is `none`.
