### PR TITLE
/fix: handle file drop issue #733 (terminal) 

### DIFF
--- a/src/modules/terminal/lib/useTerminalFileDrop.test.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { dragPointCandidates } from "./useTerminalFileDrop";
+
+describe("dragPointCandidates", () => {
+  it("keeps logical coordinates unchanged", () => {
+    expect(
+      dragPointCandidates(120, 80, { devicePixelRatio: 1 }),
+    ).toStrictEqual([{ x: 120, y: 80 }]);
+  });
+
+  it("also tries physical coordinates normalized by device pixel ratio", () => {
+    expect(
+      dragPointCandidates(800, 400, { devicePixelRatio: 2 }),
+    ).toStrictEqual([
+      { x: 800, y: 400 },
+      { x: 400, y: 200 },
+    ]);
+  });
+});

--- a/src/modules/terminal/lib/useTerminalFileDrop.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.ts
@@ -4,21 +4,52 @@ import { useTerminalDropStore } from "./dropStore";
 import { formatDroppedPaths } from "./quoteShellPath";
 import { pasteIntoLeaf } from "./rendererPool";
 
-// Tauri reports the drop point in physical pixels on some platforms and logical
-// on others; only scale down when it overflows the logical viewport.
-function leafIdAt(x: number, y: number): number | null {
-  let lx = x;
-  let ly = y;
-  if (x > window.innerWidth || y > window.innerHeight) {
-    const dpr = window.devicePixelRatio || 1;
-    lx = x / dpr;
-    ly = y / dpr;
-  }
-  const el = document.elementFromPoint(lx, ly);
+type Point = { x: number; y: number };
+type ViewportLike = { devicePixelRatio?: number };
+
+export function dragPointCandidates(
+  x: number,
+  y: number,
+  viewport: ViewportLike = window,
+): Point[] {
+  const points: Point[] = [{ x, y }];
+  const dpr = viewport.devicePixelRatio || 1;
+  if (dpr !== 1) points.push({ x: x / dpr, y: y / dpr });
+  return points;
+}
+
+function leafIdFromElement(el: Element | null): number | null {
   const leafEl = el?.closest<HTMLElement>("[data-pane-leaf]");
   if (!leafEl) return null;
   const id = Number(leafEl.dataset.paneLeaf);
   return Number.isFinite(id) ? id : null;
+}
+
+function leafIdFromRects(points: Point[]): number | null {
+  for (const leaf of document.querySelectorAll<HTMLElement>("[data-pane-leaf]")) {
+    const rect = leaf.getBoundingClientRect();
+    for (const p of points) {
+      if (
+        p.x >= rect.left &&
+        p.x <= rect.right &&
+        p.y >= rect.top &&
+        p.y <= rect.bottom
+      ) {
+        const id = Number(leaf.dataset.paneLeaf);
+        return Number.isFinite(id) ? id : null;
+      }
+    }
+  }
+  return null;
+}
+
+function leafIdAt(x: number, y: number): number | null {
+  const points = dragPointCandidates(x, y);
+  for (const p of points) {
+    const id = leafIdFromElement(document.elementFromPoint(p.x, p.y));
+    if (id !== null) return id;
+  }
+  return leafIdFromRects(points);
 }
 
 /** Wires native OS file drops into the terminal pane under the cursor: shows a


### PR DESCRIPTION
## What

  Fix terminal file/folder drag-and-drop so dropped Finder paths are resolved against the correct terminal pane and pasted
  into the shell.

  ## Why (fixes #733 )

  In release builds, dragging a file or folder from Finder into the terminal could do nothing because the drop coordinates
  did not always map back to the terminal pane. Tauri may report drag positions in physical pixels, while DOM hit testing
  expects logical CSS pixels.

  ## How

  The terminal drop handler now tries both raw drag coordinates and `devicePixelRatio`-normalized coordinates. If direct DOM hit testing still misses, it falls back to checking terminal pane bounding boxes before deciding the drop is outside a
terminal.

  ## Testing

  - [x] `pnpm exec tsc --noEmit` clean
  - [x] Manual smoke-test of the affected feature
  - [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
  - [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
  - [x] (If UI) tested in `pnpm tauri dev`
  - [x] Platforms tested: macOS
  - [x] Shells tested (if relevant): zsh

  Also ran:
  - `pnpm test`
  - `pnpm build`
  - `pnpm exec biome lint src/modules/terminal/lib/useTerminalFileDrop.ts src/modules/terminal/lib/
  useTerminalFileDrop.test.ts`

  ## Screenshots / GIFs

  N/A. This is a drag-and-drop terminal paste behavior change, not a visual UI change.

  ## Notes for reviewer

  `pnpm lint` exits successfully but reports existing unrelated warnings elsewhere in the repo. The touched files lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal file drop-target detection to be more reliable across different screen pixel densities (device pixel ratios).
* **Tests**
  * Added unit tests covering coordinate candidate generation behavior for both standard and high-DPI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->