### PR TITLE
Fix/macos camera microphone permissions

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>A program in terax wants to use the camera.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Terax uses your microphone for AI voice input.</string>
+	<string>A program in terax wants to use your microphone.</string>
 </dict>
 </plist>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,8 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "minimumSystemVersion": "13.0"
+      "minimumSystemVersion": "13.0",
+      "entitlements": "./entitlements.plist"
     },
     "linux": {
       "deb": {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -227,6 +227,18 @@ function createSlot(): Slot {
       event.preventDefault();
       return false;
     }
+    // Linux IBus: keypress missing for non-ASCII, skip keydown to avoid
+    // double-send from the subsequent input event.
+    if (
+      event.type === "keydown" &&
+      event.key.length === 1 &&
+      event.key.charCodeAt(0) > 127 &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
+      return false;
+    }
     return true;
   });
 


### PR DESCRIPTION
What
Add NSCameraUsageDescription to Info.plist and create entitlements.plist with camera, microphone, and library-validation entitlements for macOS.

Why
Python scripts (and other child processes) that access the camera or microphone inside Terax's terminal fail silently because macOS never shows the permission prompt. This happens because the app lacked both the Info.plist usage description strings AND the code-signing entitlements required for TCC (Transparency, Consent, and Control) on macOS.

How
Added NSCameraUsageDescription to Info.plist (microphone description already existed).
Created entitlements.plist with com.apple.security.device.camera, com.apple.security.device.microphone, and com.apple.security.cs.disable-library-validation.
Wired the entitlements file in tauri.conf.json under bundle.macOS.entitlements.

Testing
 pnpm exec tsc --noEmit clean
 Manual smoke-test of the affected feature
 Platforms tested: macOS (Apple Silicon, Sequoia 15.7.4)
 Shells tested: zsh