### PR TITLE
fix(terminal): font input spaces, custom font loading, and bold text

### DIFF
--- a/src/lib/fonts.test.ts
+++ b/src/lib/fonts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { detectMonoFontFamily, loadFontFamily, resolveFontFamily } from "./fonts";
+
+describe("resolveFontFamily", () => {
+  it("quotes a bare multi-word family and appends a fallback chain", () => {
+    const out = resolveFontFamily("CaskaydiaCove Nerd Font Mono");
+    expect(out.startsWith('"CaskaydiaCove Nerd Font Mono"')).toBe(true);
+    // A fallback chain follows the primary family.
+    expect(out.includes(",")).toBe(true);
+    expect(out.length).toBeGreaterThan('"CaskaydiaCove Nerd Font Mono"'.length);
+  });
+
+  it("trims surrounding whitespace before quoting", () => {
+    expect(resolveFontFamily("  Hack Nerd Font  ")).toBe(
+      resolveFontFamily("Hack Nerd Font"),
+    );
+    expect(resolveFontFamily("  Hack Nerd Font  ").startsWith('"Hack Nerd Font"')).toBe(
+      true,
+    );
+  });
+
+  it("falls back to auto-detect for blank or whitespace-only input", () => {
+    expect(resolveFontFamily("")).toBe(detectMonoFontFamily());
+    expect(resolveFontFamily("   ")).toBe(detectMonoFontFamily());
+  });
+
+  it("does not double-quote an already-quoted family", () => {
+    const out = resolveFontFamily('"Iosevka Nerd Font"');
+    expect(out.startsWith('""')).toBe(false);
+    expect(out.startsWith('"Iosevka Nerd Font"')).toBe(true);
+  });
+
+  it("passes through a user-supplied font stack untouched", () => {
+    const stack = '"My Font", monospace';
+    expect(resolveFontFamily(stack)).toBe(stack);
+  });
+});
+
+describe("loadFontFamily", () => {
+  it("resolves without throwing when there is no document (node)", async () => {
+    await expect(loadFontFamily("CaskaydiaCove Nerd Font Mono")).resolves.toBeUndefined();
+    await expect(loadFontFamily("")).resolves.toBeUndefined();
+    await expect(loadFontFamily('"My Font", monospace')).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -53,3 +53,39 @@ export function detectMonoFontFamily(): string {
   detected = FALLBACK_CHAIN;
   return detected;
 }
+
+/** Build the xterm/CSS `font-family` value for a user-entered custom font name.
+ *  Quotes a bare family name (so multi-word names like "CaskaydiaCove Nerd Font
+ *  Mono" resolve as one family) and appends the mono fallback chain so an
+ *  unrecognized name still renders. Mirrors {@link detectMonoFontFamily}. */
+export function resolveFontFamily(custom: string): string {
+  const name = custom.trim();
+  if (!name) return detectMonoFontFamily();
+  if (name.includes(",")) return name;
+  const quoted = name.startsWith('"') ? name : `"${name}"`;
+  return `${quoted}, ${FALLBACK_CHAIN}`;
+}
+
+/** Force WebKit to load a custom (system-installed) family before xterm measures
+ *  cell metrics. Without this, the first measurement uses fallback metrics: the
+ *  glyph advance then mismatches the cell width and text renders mis-spaced. */
+export function loadFontFamily(custom: string): Promise<void> {
+  const name = custom.trim();
+  if (
+    !name ||
+    name.includes(",") ||
+    typeof document === "undefined" ||
+    !document.fonts?.load
+  ) {
+    return Promise.resolve();
+  }
+  const family = name.startsWith('"') ? name : `"${name}"`;
+  try {
+    return Promise.allSettled([
+      document.fonts.load(`400 14px ${family}`),
+      document.fonts.load(`700 14px ${family}`),
+    ]).then(() => undefined);
+  } catch {
+    return Promise.resolve();
+  }
+}

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -81,6 +81,7 @@ export type Preferences = {
   showHidden: boolean;
   terminalWebglEnabled: boolean;
   terminalCursorBlink: boolean;
+  terminalBoldText: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -126,6 +127,7 @@ const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_CURSOR_BLINK = "terminalCursorBlink";
+const KEY_TERMINAL_BOLD_TEXT = "terminalBoldText";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -184,6 +186,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   showHidden: false,
   terminalWebglEnabled: true,
   terminalCursorBlink: false,
+  terminalBoldText: true,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -306,6 +309,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalCursorBlink:
       get<boolean>(KEY_TERMINAL_CURSOR_BLINK) ??
       DEFAULT_PREFERENCES.terminalCursorBlink,
+    terminalBoldText:
+      get<boolean>(KEY_TERMINAL_BOLD_TEXT) ??
+      DEFAULT_PREFERENCES.terminalBoldText,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -487,6 +493,10 @@ export async function setTerminalCursorBlink(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_CURSOR_BLINK, value);
 }
 
+export async function setTerminalBoldText(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_BOLD_TEXT, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
@@ -591,6 +601,7 @@ export async function onPreferencesChange(
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_CURSOR_BLINK]: "terminalCursorBlink",
+    [KEY_TERMINAL_BOLD_TEXT]: "terminalBoldText",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/block/ShellInput.tsx
+++ b/src/modules/terminal/block/ShellInput.tsx
@@ -1,4 +1,4 @@
-import { detectMonoFontFamily } from "@/lib/fonts";
+import { resolveFontFamily } from "@/lib/fonts";
 import { MOD_KEY, fmtShortcut } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -58,7 +58,7 @@ export default function ShellInput({
 
   const fontFamilyPref = usePreferencesStore((p) => p.terminalFontFamily);
   const fontSize = usePreferencesStore((p) => p.terminalFontSize);
-  const fontFamily = fontFamilyPref || detectMonoFontFamily();
+  const fontFamily = resolveFontFamily(fontFamilyPref);
   const fontRef = useRef({ fontFamily, fontSize });
   fontRef.current = { fontFamily, fontSize };
 

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,4 +1,4 @@
-import { detectMonoFontFamily } from "@/lib/fonts";
+import { loadFontFamily, resolveFontFamily } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -159,9 +159,10 @@ function bgActive(
 function termOptions() {
   const prefs = usePreferencesStore.getState();
   return {
-    fontFamily: prefs.terminalFontFamily || detectMonoFontFamily(),
+    fontFamily: resolveFontFamily(prefs.terminalFontFamily),
     letterSpacing: prefs.terminalLetterSpacing,
     fontSize: Math.max(4, Math.round(prefs.terminalFontSize * prefs.zoomLevel)),
+    fontWeightBold: prefs.terminalBoldText ? ("bold" as const) : ("normal" as const),
     theme: buildTerminalTheme(),
     cursorBlink: false,
     cursorStyle: "bar" as const,
@@ -778,6 +779,12 @@ export function applyWebglPreference(enabled: boolean): void {
     } else if (slot.webglAddon) {
       cancelWebglReap(slot);
       disposeSlotWebgl(slot);
+      // Disposing the addon restores xterm's DOM renderer; force a repaint so
+      // the switch is visible immediately instead of after the next output.
+      try {
+        slot.fitAddon.fit();
+        slot.term.refresh(0, slot.term.rows - 1);
+      } catch {}
     }
   }
 }
@@ -796,6 +803,15 @@ export function applyFontSize(size: number): void {
   }
 }
 
+export function applyBoldText(enabled: boolean): void {
+  const weight = enabled ? "bold" : "normal";
+  for (const slot of slots) {
+    if (slot.term.options.fontWeightBold === weight) continue;
+    slot.term.options.fontWeightBold = weight;
+    slot.fitAddon.fit();
+  }
+}
+
 export function applyLetterSpacing(spacing: number): void {
   for (const slot of slots) {
     if (slot.term.options.letterSpacing === spacing) continue;
@@ -805,18 +821,22 @@ export function applyLetterSpacing(spacing: number): void {
 }
 
 export function applyFontFamily(family: string): void {
-  const resolved = family || detectMonoFontFamily();
-  for (const slot of slots) {
-    if (slot.term.options.fontFamily === resolved) continue;
-    slot.term.options.fontFamily = resolved;
-    slot.fitAddon.fit();
-    if (slot.currentLeafId !== null) {
-      slot.lastCols = slot.term.cols;
-      slot.lastRows = slot.term.rows;
-      const bridge = adapter?.resolveLeaf(slot.currentLeafId);
-      bridge?.resizePty(slot.term.cols, slot.term.rows);
+  const resolved = resolveFontFamily(family);
+  // Apply only after the (possibly system-installed) font is loaded, so xterm
+  // re-measures cell metrics against real glyph advances instead of fallback.
+  void loadFontFamily(family).then(() => {
+    for (const slot of slots) {
+      if (slot.term.options.fontFamily === resolved) continue;
+      slot.term.options.fontFamily = resolved;
+      slot.fitAddon.fit();
+      if (slot.currentLeafId !== null) {
+        slot.lastCols = slot.term.cols;
+        slot.lastRows = slot.term.rows;
+        const bridge = adapter?.resolveLeaf(slot.currentLeafId);
+        bridge?.resizePty(slot.term.cols, slot.term.rows);
+      }
     }
-  }
+  });
 }
 
 export function applyScrollback(value: number): void {

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { ensureMonoFontsLoaded } from "@/lib/fonts";
+import { ensureMonoFontsLoaded, loadFontFamily } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -20,6 +20,7 @@ import "../block/block.css";
 import {
   acquireSlot,
   applyBackgroundActive,
+  applyBoldText,
   applyCursorBlink,
   applyFontFamily,
   applyFontSize,
@@ -281,6 +282,7 @@ function ensureSession(
 
   session.ready = (async () => {
     await ensureMonoFontsLoaded();
+    await loadFontFamily(usePreferencesStore.getState().terminalFontFamily);
     await document.fonts.ready;
   })();
 
@@ -628,6 +630,11 @@ export function useTerminalSession({
   useEffect(() => {
     applyCursorBlink(cursorBlink);
   }, [cursorBlink]);
+
+  const boldText = usePreferencesStore((p) => p.terminalBoldText);
+  useEffect(() => {
+    applyBoldText(boldText);
+  }, [boldText]);
 
   const bgActive = usePreferencesStore(
     (p) => p.backgroundKind === "image" && !!p.backgroundImageId,

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -30,6 +30,7 @@ import {
   setTerminalLetterSpacing,
   setTerminalFontSize,
   setTerminalCursorBlink,
+  setTerminalBoldText,
   setTerminalScrollback,
   setTerminalWebglEnabled,
   setVimMode,
@@ -80,6 +81,7 @@ export function GeneralSection() {
   const terminalCursorBlink = usePreferencesStore(
     (s) => s.terminalCursorBlink,
   );
+  const terminalBoldText = usePreferencesStore((s) => s.terminalBoldText);
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
     (s) => s.terminalLetterSpacing,
@@ -256,15 +258,21 @@ export function GeneralSection() {
           />
         </SettingRow>
         <SettingRow
+          title="Bold text"
+          description="Render bold text with a heavier font weight. Turn off if a single-weight font (e.g. a Nerd Font with one style) renders too thick."
+        >
+          <Switch
+            checked={terminalBoldText}
+            onCheckedChange={(v) => void setTerminalBoldText(v)}
+          />
+        </SettingRow>
+        <SettingRow
           title="Font family"
           description='Nerd Font name for icons (e.g. "CaskaydiaCove Nerd Font Mono"). Leave blank to auto-detect.'
         >
-          <input
-            type="text"
+          <FontFamilyInput
             value={terminalFontFamily}
-            placeholder="Auto-detect"
-            onChange={(e) => void setTerminalFontFamily(e.target.value)}
-            className="h-8 w-48 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+            onChange={(v) => void setTerminalFontFamily(v)}
           />
         </SettingRow>
         <SettingRow
@@ -375,6 +383,40 @@ function Label({ children }: { children: React.ReactNode }) {
     <span className="text-[11px] font-medium tracking-tight text-muted-foreground">
       {children}
     </span>
+  );
+}
+
+function FontFamilyInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    setDraft(trimmed);
+    if (trimmed !== value) onChange(trimmed);
+  };
+
+  return (
+    <input
+      type="text"
+      value={draft}
+      placeholder="Auto-detect"
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") e.currentTarget.blur();
+      }}
+      className="h-8 w-48 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"
+    />
   );
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -241,6 +241,10 @@ html[data-chrome="borderless"] #settings-root {
 body {
   -webkit-user-select: none;
   user-select: none;
+  /* macOS WebKit defaults to heavy font smoothing; grayscale AA matches the
+   * weight native apps (and ghostty) render, instead of bolded glyphs. */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 input,
 textarea,


### PR DESCRIPTION
## Summary
Fixes terminal font handling: typing multi-word Nerd Font names, actually applying a custom font, and over-heavy bold text.

## What's fixed
- **Font-family input couldn't type spaces** — the value was `.trim()`-ed on every keystroke of a controlled input, so trailing spaces vanished and multi-word names (e.g. `CaskaydiaCove Nerd Font Mono`) were impossible. It now edits in a local draft and commits on blur.
- **Custom font not applied / mis-spaced glyphs** — the family is quoted + given a mono fallback chain and preloaded via `document.fonts.load()` before xterm measures, so cell metrics are correct and the font actually takes effect.
- **New "Bold text" setting** (Settings → General → Terminal) — single-weight Nerd Fonts produced heavy synthetic faux-bold; turn it off to render bold cells at normal weight. Works with the WebGL renderer on or off.
- Grayscale font smoothing (`-webkit-font-smoothing: antialiased`) for native-weight text.
- Repaint the terminal when the WebGL renderer is toggled off.

## Files
`src/lib/fonts.ts` (+ test), `src/modules/terminal/lib/{rendererPool,useTerminalSession}.ts`, `src/modules/terminal/block/ShellInput.tsx`, `src/modules/settings/store.ts`, `src/settings/sections/GeneralSection.tsx`, `src/styles/globals.css`.

## How to test
`pnpm tauri dev` → Settings → General → Font family: type `CaskaydiaCove Nerd Font Mono` (spaces work, the font applies) → toggle **Bold text**.

Checks: `pnpm check-types`, `pnpm test` (incl. new `fonts.test.ts`).

## Evidence
<!-- paste screenshots/recordings -->
- Typing a multi-word font name (spaces):

<img width="680" height="102" alt="image" src="https://github.com/user-attachments/assets/0e229c20-3008-405e-8af6-287a5a58436c" />

