### PR TITLE
feat(preview): native embedded web preview (Tauri child webview)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = ["devtools", "unstable", "protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod modules;
 
-use modules::{agent, fs, git, history, net, pty, secrets, shell, workspace};
+use modules::{agent, fs, git, history, net, preview, pty, secrets, shell, workspace};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
@@ -59,7 +59,9 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         .visible(false)
         // Keep settings above the main app window so it doesn't get hidden
         // when the user clicks back into the editor or terminal (#33).
-        .always_on_top(true);
+        .always_on_top(true)
+        // App UI isn't inspectable; only the web preview gets devtools.
+        .devtools(false);
 
     // Tie lifecycle to the main window so settings minimizes/closes with it.
     // macOS: skip parent() — child + always_on_top leaves the settings webview
@@ -240,6 +242,13 @@ pub fn run() {
             history::history_commands,
             history::history_record,
             history::history_list,
+            preview::preview_open,
+            preview::preview_set_bounds,
+            preview::preview_navigate,
+            preview::preview_show,
+            preview::preview_hide,
+            preview::preview_reload,
+            preview::preview_close,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -3,6 +3,7 @@ pub mod fs;
 pub mod git;
 pub mod history;
 pub mod net;
+pub mod preview;
 pub mod proc;
 pub mod pty;
 pub mod secrets;

--- a/src-tauri/src/modules/preview.rs
+++ b/src-tauri/src/modules/preview.rs
@@ -1,0 +1,269 @@
+//! Embedded web preview backed by a native child webview.
+//!
+//! The preview used to be an HTML `<iframe>`, but framed pages that set
+//! `X-Frame-Options`/CSP `frame-ancestors` (auth/login redirects, security
+//! middleware) refuse to render cross-origin and show blank. A native child
+//! webview loads the URL as a *top-level* navigation — exactly like a browser
+//! tab — so those framing rules never apply.
+//!
+//! Every webview is created and driven from Rust via the commands below. The
+//! preview webview is deliberately given no Tauri capability, so the embedded
+//! page has zero access to the IPC / `window.__TAURI__` surface.
+
+use serde::Serialize;
+use tauri::webview::WebviewBuilder;
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, WebviewUrl};
+
+/// Label of the host window the preview webviews are attached to.
+const MAIN_WINDOW: &str = "main";
+/// Event carrying the live URL of a preview webview (initial load + redirects +
+/// in-page navigations) so the address bar can stay in sync.
+const NAV_EVENT: &str = "preview://navigated";
+
+#[derive(Clone, Serialize)]
+struct PreviewNav {
+    label: String,
+    url: String,
+}
+
+/// Custom scheme used by the injected key-forwarding script as a one-way
+/// channel to the host (the preview has no IPC). Navigations to it are
+/// intercepted and cancelled in `on_navigation`.
+const SHORTCUT_SCHEME: &str = "terax-shortcut";
+/// Event carrying an app-shell keystroke (Ctrl+Tab, etc.) pressed while the
+/// preview webview had focus, so the host can act on it.
+const KEY_EVENT: &str = "preview://shortcut-key";
+
+#[derive(Clone, Serialize)]
+struct PreviewKey {
+    key: String,
+    code: String,
+    #[serde(rename = "ctrlKey")]
+    ctrl: bool,
+    #[serde(rename = "metaKey")]
+    meta: bool,
+    #[serde(rename = "shiftKey")]
+    shift: bool,
+    #[serde(rename = "altKey")]
+    alt: bool,
+}
+
+/// Injected into the preview page: forwards a curated allow-list of app-shell
+/// shortcuts (tab cycling/management, palette, settings) to the host via the
+/// sentinel scheme. A focused webview otherwise swallows these keys. Keys the
+/// web content needs (copy/paste/find/...) are intentionally left alone.
+const SHORTCUT_SCRIPT: &str = r#"(function () {
+  var IS_MAC = __IS_MAC__;
+  function mod(e) { return IS_MAC ? e.metaKey : e.ctrlKey; }
+  function other(e) { return IS_MAC ? e.ctrlKey : e.metaKey; }
+  function isShell(e) {
+    if (e.key === "Tab" && e.ctrlKey && !e.metaKey && !e.altKey) return true;
+    if (!mod(e) || e.altKey || other(e)) return false;
+    if (/^[1-9]$/.test(e.key)) return true;
+    var k = e.key.toLowerCase();
+    if (k === "t" || k === "w" || k === ",") return true;
+    if (k === "p" && e.shiftKey) return true;
+    return false;
+  }
+  window.addEventListener("keydown", function (e) {
+    if (!isShell(e)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    var p = new URLSearchParams();
+    p.set("key", e.key);
+    p.set("code", e.code);
+    p.set("ctrl", e.ctrlKey ? "1" : "0");
+    p.set("meta", e.metaKey ? "1" : "0");
+    p.set("shift", e.shiftKey ? "1" : "0");
+    p.set("alt", e.altKey ? "1" : "0");
+    try { window.location.href = "terax-shortcut://k?" + p.toString(); } catch (err) {}
+  }, true);
+})();"#;
+
+fn shortcut_script() -> String {
+    SHORTCUT_SCRIPT.replace(
+        "__IS_MAC__",
+        if cfg!(target_os = "macos") {
+            "true"
+        } else {
+            "false"
+        },
+    )
+}
+
+fn emit_shortcut_key(app: &AppHandle, url: &tauri::Url) {
+    let mut key = String::new();
+    let mut code = String::new();
+    let mut ctrl = false;
+    let mut meta = false;
+    let mut shift = false;
+    let mut alt = false;
+    for (k, v) in url.query_pairs() {
+        match k.as_ref() {
+            "key" => key = v.into_owned(),
+            "code" => code = v.into_owned(),
+            "ctrl" => ctrl = v == "1",
+            "meta" => meta = v == "1",
+            "shift" => shift = v == "1",
+            "alt" => alt = v == "1",
+            _ => {}
+        }
+    }
+    if key.is_empty() {
+        return;
+    }
+    let _ = app.emit(
+        KEY_EVENT,
+        PreviewKey {
+            key,
+            code,
+            ctrl,
+            meta,
+            shift,
+            alt,
+        },
+    );
+}
+
+fn parse_url(url: &str) -> Result<tauri::Url, String> {
+    url.parse::<tauri::Url>()
+        .map_err(|e| format!("invalid preview url '{url}': {e}"))
+}
+
+fn logical_pos(x: f64, y: f64) -> LogicalPosition<f64> {
+    LogicalPosition::new(x, y)
+}
+
+fn logical_size(width: f64, height: f64) -> LogicalSize<f64> {
+    // A zero/negative size makes the platform webview misbehave; clamp to >= 1.
+    LogicalSize::new(width.max(1.0), height.max(1.0))
+}
+
+/// Create the preview webview if missing (navigating to `url`), otherwise just
+/// reposition + show the existing one.
+#[tauri::command]
+pub fn preview_open(
+    app: AppHandle,
+    label: String,
+    url: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        let _ = webview.set_position(logical_pos(x, y));
+        let _ = webview.set_size(logical_size(width, height));
+        let _ = webview.show();
+        return Ok(());
+    }
+
+    let parent = app
+        .get_webview(MAIN_WINDOW)
+        .ok_or_else(|| "main webview not found".to_string())?;
+    let window = parent.window();
+
+    let parsed = parse_url(&url)?;
+    let handle = app.clone();
+    let nav_label = label.clone();
+    let builder = WebviewBuilder::new(&label, WebviewUrl::External(parsed))
+        .on_navigation(move |next| {
+            if next.scheme() == SHORTCUT_SCHEME {
+                // Sentinel from the injected key-forwarding script — not a real
+                // navigation. Forward the keystroke and cancel the navigation.
+                emit_shortcut_key(&handle, next);
+                return false;
+            }
+            let _ = handle.emit(
+                NAV_EVENT,
+                PreviewNav {
+                    label: nav_label.clone(),
+                    url: next.to_string(),
+                },
+            );
+            true
+        })
+        .initialization_script(shortcut_script())
+        // Devtools/Web Inspector is allowed only on the preview (it's a browser-
+        // like surface); the app's own webviews disable it.
+        .devtools(true);
+
+    window
+        .add_child(builder, logical_pos(x, y), logical_size(width, height))
+        .map(|_| ())
+        .map_err(|e| format!("failed to create preview webview: {e}"))
+}
+
+/// Move/resize an existing preview webview to track its host element. No-op when
+/// the webview hasn't been created yet (avoids races during mount/teardown).
+#[tauri::command]
+pub fn preview_set_bounds(
+    app: AppHandle,
+    label: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        let _ = webview.set_position(logical_pos(x, y));
+        let _ = webview.set_size(logical_size(width, height));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn preview_navigate(app: AppHandle, label: String, url: String) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        let parsed = parse_url(&url)?;
+        webview.navigate(parsed).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn preview_show(app: AppHandle, label: String) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        let _ = webview.show();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn preview_hide(app: AppHandle, label: String) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        // The Web Inspector docks to the window and would otherwise stay open
+        // over the app after leaving the preview tab; close it with the view.
+        webview.close_devtools();
+        let _ = webview.hide();
+        // Hiding the WKWebView drops it from the responder chain without moving
+        // keyboard focus back, so keys would fall through to the native window
+        // (Cmd+W => close app) and the app's global shortcuts would go dead.
+        // Hand focus back to the main webview.
+        if let Some(main) = app.get_webview(MAIN_WINDOW) {
+            let _ = main.set_focus();
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn preview_reload(app: AppHandle, label: String) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        let _ = webview.reload();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn preview_close(app: AppHandle, label: String) -> Result<(), String> {
+    if let Some(webview) = app.get_webview(&label) {
+        let _ = webview.close();
+        // Closing drops keyboard focus to the native window; hand it back to the
+        // main webview so shortcuts keep working and Cmd+W doesn't close the app.
+        if let Some(main) = app.get_webview(MAIN_WINDOW) {
+            let _ = main.set_focus();
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
         "minHeight": 280,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "devtools": false,
         "visible": false
       }
     ],

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -38,7 +38,7 @@ import {
   type SearchInlineHandle,
   type SearchTarget,
 } from "@/modules/header";
-import type { PreviewPaneHandle } from "@/modules/preview";
+import { usePreviewShortcuts, type PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import {
   useGlobalShortcuts,
@@ -608,6 +608,7 @@ export default function App() {
   );
 
   useGlobalShortcuts(shortcutHandlers, { isDisabled: shortcutsDisabled });
+  usePreviewShortcuts();
 
   const registerTerminalHandle = useCallback(
     (leafId: number, h: TerminalPaneHandle | null) => {
@@ -824,6 +825,15 @@ export default function App() {
     terminalRefs,
   });
 
+  // The native preview webview renders above all HTML, so hide it whenever a
+  // centered modal is open that it would otherwise cover.
+  const previewSuppressed =
+    commandPaletteOpen ||
+    newEditorOpen ||
+    pendingCloseTab !== null ||
+    pendingTerminalCloseTab !== null ||
+    pendingDeleteTabs !== null;
+
   const shell = (
     <ThemeProvider>
       <TooltipProvider>
@@ -918,6 +928,7 @@ export default function App() {
                       onEditorCloseTab={disposeTab}
                       registerPreviewHandle={registerPreviewHandle}
                       onPreviewUrlChange={handlePreviewUrl}
+                      previewSuppressed={previewSuppressed}
                       onAiDiffAccept={(id) => respondToApproval(id, true)}
                       onAiDiffReject={(id) => respondToApproval(id, false)}
                       onOpenCommitFile={openCommitFileDiffTab}

--- a/src/app/components/WorkspaceSurface.tsx
+++ b/src/app/components/WorkspaceSurface.tsx
@@ -27,6 +27,7 @@ type Props = {
   onEditorCloseTab: EditorStackProps["onCloseTab"];
   registerPreviewHandle: PreviewStackProps["registerHandle"];
   onPreviewUrlChange: PreviewStackProps["onUrlChange"];
+  previewSuppressed: boolean;
   onAiDiffAccept: AiDiffStackProps["onAccept"];
   onAiDiffReject: AiDiffStackProps["onReject"];
   onOpenCommitFile: GitHistoryStackProps["onOpenCommitFile"];
@@ -52,6 +53,7 @@ export function WorkspaceSurface({
   onEditorCloseTab,
   registerPreviewHandle,
   onPreviewUrlChange,
+  previewSuppressed,
   onAiDiffAccept,
   onAiDiffReject,
   onOpenCommitFile,
@@ -110,6 +112,7 @@ export function WorkspaceSurface({
         <PreviewStack
           tabs={tabs}
           activeId={activeId}
+          suppressed={previewSuppressed}
           registerHandle={registerPreviewHandle}
           onUrlChange={onPreviewUrlChange}
         />

--- a/src/modules/preview/PreviewAddressBar.tsx
+++ b/src/modules/preview/PreviewAddressBar.tsx
@@ -55,10 +55,13 @@ type Props = {
   url: string;
   onSubmit: (url: string) => void;
   onReload: () => void;
+  /** Fired when the ports dropdown opens/closes, so the host can hide the
+   *  native preview webview that would otherwise cover the menu. */
+  onMenuOpenChange?: (open: boolean) => void;
 };
 
 export const PreviewAddressBar = forwardRef<PreviewAddressBarHandle, Props>(
-  function PreviewAddressBar({ url, onSubmit, onReload }, ref) {
+  function PreviewAddressBar({ url, onSubmit, onReload, onMenuOpenChange }, ref) {
     const [draft, setDraft] = useState(url);
     const inputRef = useRef<HTMLInputElement>(null);
 
@@ -126,7 +129,7 @@ export const PreviewAddressBar = forwardRef<PreviewAddressBarHandle, Props>(
             strokeWidth={1.75}
           />
         </Button>
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={onMenuOpenChange}>
           <DropdownMenuTrigger asChild>
             <Button
               type="button"

--- a/src/modules/preview/PreviewPane.test.ts
+++ b/src/modules/preview/PreviewPane.test.ts
@@ -1,59 +1,64 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { previewLabel } from "./previewBridge";
 
 /**
- * Source-level regression test for the preview iframe's security attributes.
- * Rendering this component for real requires jsdom + a working
- * useImperativeHandle stub; for a focused security check we just verify the
- * static JSX still carries the sandbox/referrerPolicy attributes — if a
- * future change silently removes them, this test fails.
+ * The web preview renders in a native child webview (see
+ * src-tauri/src/modules/preview.rs). Its security model is: the webview is
+ * given NO Tauri capability, so the embedded page can't reach the IPC /
+ * `window.__TAURI__` surface. Capabilities target webviews by label (with glob
+ * support), so if a capability ever lists `*` or a `preview-*` pattern, the
+ * embedded page would gain IPC access. This test locks that invariant.
  */
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const src = readFileSync(path.join(here, "PreviewPane.tsx"), "utf8");
-const iframeMatch = src.match(/<iframe[\s\S]*?\/>/);
-// Strip JSX comments (`// …` inside `{…}` and `{/* … */}` blocks) so the
-// assertions only see actual attribute syntax — the source explains in a
-// comment why `allow-top-navigation` is intentionally omitted, which we
-// don't want to match.
-const iframeJsx = (iframeMatch?.[0] ?? "")
-  .replace(/\/\*[\s\S]*?\*\//g, "")
-  .replace(/\/\/[^\n]*/g, "");
+const capsDir = path.join(here, "../../../src-tauri/capabilities");
 
-describe("PreviewPane iframe sandbox", () => {
-  it("declares an iframe in the source", () => {
-    expect(iframeJsx).not.toBe("");
+/** Minimal glob match for Tauri window-label patterns (only `*` is used). */
+function labelMatches(pattern: string, label: string): boolean {
+  const re = new RegExp(
+    `^${pattern.split("*").map(escapeRegExp).join(".*")}$`,
+  );
+  return re.test(label);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function capabilityWindowPatterns(): string[] {
+  const files = readdirSync(capsDir).filter((f) => f.endsWith(".json"));
+  const patterns: string[] = [];
+  for (const f of files) {
+    const json = JSON.parse(readFileSync(path.join(capsDir, f), "utf8"));
+    if (Array.isArray(json.windows)) patterns.push(...json.windows);
+  }
+  return patterns;
+}
+
+describe("previewLabel", () => {
+  it("is a stable, per-id label", () => {
+    expect(previewLabel(0)).toBe("preview-0");
+    expect(previewLabel(42)).toBe("preview-42");
   });
+});
 
-  it("includes a sandbox attribute", () => {
-    expect(iframeJsx).toMatch(/sandbox="[^"]*"/);
-  });
+describe("preview webview capabilities", () => {
+  it("no capability grants the preview webview Tauri/IPC access", () => {
+    const patterns = capabilityWindowPatterns();
+    // Sanity: we actually parsed real capability files.
+    expect(patterns.length).toBeGreaterThan(0);
 
-  it("grants allow-scripts and allow-same-origin", () => {
-    // These two are what makes a dev preview useful — strip either and dev
-    // servers stop working.
-    expect(iframeJsx).toMatch(/sandbox="[^"]*allow-scripts/);
-    expect(iframeJsx).toMatch(/sandbox="[^"]*allow-same-origin/);
-  });
-
-  it("does NOT include allow-top-navigation* tokens", () => {
-    // The whole point of sandboxing here: forbid the iframe from navigating
-    // the parent Tauri webview to an attacker origin (which would expose
-    // window.__TAURI__). Top-nav permissions must never be added.
-    expect(iframeJsx).not.toMatch(/allow-top-navigation/);
-  });
-
-  it("does NOT include allow-popups-without-allow-popups-to-escape-sandbox combo", () => {
-    // If popups are allowed, they MUST escape the sandbox cleanly — otherwise
-    // a popup window inherits sandbox flags and we get hard-to-debug behavior.
-    if (/allow-popups\b/.test(iframeJsx)) {
-      expect(iframeJsx).toMatch(/allow-popups-to-escape-sandbox/);
+    const sampleLabels = [previewLabel(0), previewLabel(7), previewLabel(123)];
+    for (const pattern of patterns) {
+      for (const label of sampleLabels) {
+        expect(
+          labelMatches(pattern, label),
+          `capability window pattern "${pattern}" must not match preview label "${label}"`,
+        ).toBe(false);
+      }
     }
-  });
-
-  it("sets referrerPolicy to no-referrer", () => {
-    expect(iframeJsx).toMatch(/referrerPolicy="no-referrer"/);
   });
 });

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -1,7 +1,9 @@
-import { Alert02Icon, Globe02Icon } from "@hugeicons/core-free-icons";
+import { Globe02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -11,6 +13,13 @@ import {
   PreviewAddressBar,
   type PreviewAddressBarHandle,
 } from "./PreviewAddressBar";
+import {
+  PREVIEW_NAV_EVENT,
+  type PreviewBounds,
+  type PreviewNavPayload,
+  previewBridge,
+  previewLabel,
+} from "./previewBridge";
 
 export type PreviewPaneHandle = {
   reload: () => void;
@@ -19,178 +28,168 @@ export type PreviewPaneHandle = {
 };
 
 type Props = {
+  id: number;
   url: string;
   visible: boolean;
+  /** A modal/dropdown that overlaps the pane is open; the native webview
+   *  renders above all HTML, so it must be hidden to not cover the overlay. */
+  suppressed: boolean;
   onUrlChange: (url: string) => void;
 };
 
-// Tear the iframe down after this much invisibility — a background dev
-// server page can hold hundreds of MB inside the WebView.
-const SUSPEND_AFTER_MS = 30_000;
-
+/**
+ * Hosts a native Tauri child webview (created/driven from Rust) over the pane's
+ * content area. The webview is a separate native layer positioned to match
+ * `hostRef`; it renders above the HTML, so it is shown only when this preview
+ * is the active tab and nothing overlaps it.
+ */
 export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
-  function PreviewPane({ url, visible, onUrlChange }, ref) {
-    // `nonce` is part of the iframe `key`. Bumping it remounts the iframe,
-    // which is the only reliable cross-origin reload (calling
-    // contentWindow.location.reload() throws on cross-origin frames).
-    const [nonce, setNonce] = useState(0);
-    const [loaded, setLoaded] = useState(visible);
+  function PreviewPane({ id, url, visible, suppressed, onUrlChange }, ref) {
+    const label = previewLabel(id);
+    const hostRef = useRef<HTMLDivElement>(null);
     const addressRef = useRef<PreviewAddressBarHandle>(null);
+    const [portsOpen, setPortsOpen] = useState(false);
 
-    useEffect(() => {
-      if (visible) {
-        setLoaded(true);
+    // getUrl()/nav handler need the latest values without re-creating effects.
+    const urlRef = useRef(url);
+    urlRef.current = url;
+    const onUrlChangeRef = useRef(onUrlChange);
+    onUrlChangeRef.current = onUrlChange;
+
+    const createdRef = useRef(false);
+    const shownRef = useRef(false);
+    // URL the webview is currently at (updated by nav events). Used to avoid
+    // re-navigating in response to a URL change that the webview itself caused.
+    const lastUrlRef = useRef(url);
+
+    const measure = useCallback((): PreviewBounds | null => {
+      const el = hostRef.current;
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      if (r.width <= 0 || r.height <= 0) return null;
+      return { x: r.left, y: r.top, width: r.width, height: r.height };
+    }, []);
+
+    const sync = useCallback(async () => {
+      const wantShow = visible && !suppressed && !portsOpen && !!url;
+
+      if (!wantShow) {
+        if (createdRef.current && shownRef.current) {
+          shownRef.current = false;
+          await previewBridge.hide(label);
+        }
         return;
       }
-      const t = setTimeout(() => setLoaded(false), SUSPEND_AFTER_MS);
-      return () => clearTimeout(t);
-    }, [visible]);
+
+      const bounds = measure();
+      if (!bounds) return; // not laid out yet; ResizeObserver re-runs this
+
+      if (!createdRef.current) {
+        createdRef.current = true;
+        shownRef.current = true;
+        lastUrlRef.current = url;
+        await previewBridge.open(label, url, bounds);
+        return;
+      }
+
+      if (url !== lastUrlRef.current) {
+        lastUrlRef.current = url;
+        await previewBridge.navigate(label, url);
+      }
+      shownRef.current = true;
+      // open() on an existing webview just repositions + shows it.
+      await previewBridge.open(label, url, bounds);
+    }, [visible, suppressed, portsOpen, url, label, measure]);
+
+    // rAF-coalesce the burst of ResizeObserver/resize callbacks during drags.
+    const rafRef = useRef(0);
+    const scheduleSync = useCallback(() => {
+      if (rafRef.current) return;
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = 0;
+        void sync();
+      });
+    }, [sync]);
+
+    // Re-runs whenever any input to `sync` changes (visibility, url, ...).
+    useEffect(() => {
+      void sync();
+    }, [sync]);
+
+    // Track the host element's box (sidebar/pane resize, window resize, zen).
+    useEffect(() => {
+      const el = hostRef.current;
+      if (!el) return;
+      const ro = new ResizeObserver(scheduleSync);
+      ro.observe(el);
+      window.addEventListener("resize", scheduleSync);
+      return () => {
+        ro.disconnect();
+        window.removeEventListener("resize", scheduleSync);
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      };
+    }, [scheduleSync]);
+
+    // Keep the address bar in sync with the webview's real URL (initial load,
+    // auth redirects, in-page navigation).
+    useEffect(() => {
+      let alive = true;
+      let unlisten: UnlistenFn | undefined;
+      void listen<PreviewNavPayload>(PREVIEW_NAV_EVENT, (e) => {
+        if (e.payload.label !== label) return;
+        lastUrlRef.current = e.payload.url;
+        onUrlChangeRef.current(e.payload.url);
+      }).then((un) => {
+        if (alive) unlisten = un;
+        else un();
+      });
+      return () => {
+        alive = false;
+        unlisten?.();
+      };
+    }, [label]);
+
+    // Destroy the webview when the preview tab is closed.
+    useEffect(() => {
+      return () => {
+        void previewBridge.close(label);
+        createdRef.current = false;
+        shownRef.current = false;
+      };
+    }, [label]);
 
     useImperativeHandle(
       ref,
       () => ({
-        reload: () => {
-          setLoaded(true);
-          setNonce((n) => n + 1);
-        },
+        reload: () => void previewBridge.reload(label),
         focusAddressBar: () => addressRef.current?.focus(),
-        getUrl: () => url,
+        getUrl: () => urlRef.current,
       }),
-      [url],
+      [label],
     );
 
-    const showXfoHint = url ? !isLocalUrl(url) : false;
-
     return (
-      <div
-        className="flex h-full w-full flex-col overflow-hidden rounded-md border border-border/60 bg-background"
-        style={{
-          visibility: visible ? "visible" : "hidden",
-          pointerEvents: visible ? "auto" : "none",
-        }}
-      >
+      <div className="flex h-full w-full flex-col overflow-hidden rounded-md border border-border/60 bg-background">
         <PreviewAddressBar
           ref={addressRef}
           url={url}
           onSubmit={onUrlChange}
-          onReload={() => setNonce((n) => n + 1)}
+          onReload={() => void previewBridge.reload(label)}
+          onMenuOpenChange={setPortsOpen}
         />
-        {showXfoHint ? (
-          <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border/60 bg-amber-500/8 px-3 text-[11px] text-amber-600 dark:text-amber-400">
-            <HugeiconsIcon
-              icon={Alert02Icon}
-              size={12}
-              strokeWidth={1.75}
-              className="shrink-0"
-            />
-            <span className="truncate">
-              Many public sites refuse to embed (X-Frame-Options). If the page
-              is blank, open it externally.
-            </span>
-          </div>
-        ) : null}
-        <div
-          className={
-            url
-              ? "relative min-h-0 flex-1 bg-white"
-              : "relative min-h-0 flex-1 bg-background"
-          }
-        >
-          {url ? (
-            loaded ? (
-              <iframe
-                key={`${url}#${nonce}`}
-                src={url}
-                title="Preview"
-                className="h-full w-full border-0"
-                // sandbox grants the bare minimum for a dev preview: scripts,
-                // same-origin (cookies/storage for the previewed app), forms,
-                // popups for "open in new tab". Critically OMITS
-                // `allow-top-navigation*` — without it the iframe cannot
-                // navigate the parent Tauri webview to an attacker origin,
-                // which would otherwise expose `window.__TAURI__` IPC.
-                sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads"
-                referrerPolicy="no-referrer"
-                allow="clipboard-read; clipboard-write; fullscreen"
-              />
-            ) : (
-              <SuspendedState
-                onReload={() => {
-                  setLoaded(true);
-                  setNonce((n) => n + 1);
-                }}
-              />
-            )
-          ) : (
-            <EmptyState />
-          )}
+        <div ref={hostRef} className="relative min-h-0 flex-1 bg-background">
+          {url ? null : <EmptyState />}
         </div>
       </div>
     );
   },
 );
 
-function SuspendedState({ onReload }: { onReload: () => void }) {
-  return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
-      <div className="flex size-10 items-center justify-center rounded-2xl border border-border/60 bg-card text-muted-foreground">
-        <HugeiconsIcon icon={Globe02Icon} size={18} strokeWidth={1.5} />
-      </div>
-      <div className="space-y-1">
-        <p className="text-[12.5px] font-medium text-foreground">
-          Preview suspended
-        </p>
-        <p className="max-w-xs text-[11px] leading-relaxed text-muted-foreground">
-          Released to free memory after sitting in the background.
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={onReload}
-        className="rounded-md border border-border/60 bg-card px-3 py-1 text-[11px] hover:bg-accent/50"
-      >
-        Reload
-      </button>
-    </div>
-  );
-}
-
 function EmptyState() {
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center">
-      <div className="flex size-12 items-center justify-center rounded-2xl border border-border/60 bg-card text-muted-foreground">
-        <HugeiconsIcon icon={Globe02Icon} size={20} strokeWidth={1.5} />
-      </div>
-      <div className="space-y-1.5">
-        <p className="text-sm font-medium text-foreground">
-          Nothing to preview yet
-        </p>
-        <p className="max-w-sm text-xs leading-relaxed text-muted-foreground">
-          Type a URL above, or open the{" "}
-          <span className="rounded bg-muted px-1 py-0.5 font-mono text-[10.5px]">
-            Ports
-          </span>{" "}
-          dropdown to jump straight to your running dev server. Public sites
-          often block embedding — open them in your browser via the link icon
-          if you see a blank page.
-        </p>
-      </div>
+    <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-muted-foreground">
+      <HugeiconsIcon icon={Globe02Icon} size={28} strokeWidth={1.5} />
+      <p className="text-[12px]">Enter a URL or pick a dev-server port.</p>
     </div>
   );
-}
-
-function isLocalUrl(url: string): boolean {
-  try {
-    const u = new URL(url);
-    const h = u.hostname;
-    return (
-      h === "localhost" ||
-      h === "127.0.0.1" ||
-      h === "0.0.0.0" ||
-      h === "[::1]" ||
-      h.endsWith(".localhost")
-    );
-  } catch {
-    return false;
-  }
 }

--- a/src/modules/preview/PreviewStack.tsx
+++ b/src/modules/preview/PreviewStack.tsx
@@ -6,6 +6,7 @@ import { PreviewPane, type PreviewPaneHandle } from "./PreviewPane";
 type Props = {
   tabs: Tab[];
   activeId: number;
+  suppressed: boolean;
   onUrlChange: (id: number, url: string) => void;
   registerHandle: (id: number, handle: PreviewPaneHandle | null) => void;
 };
@@ -13,6 +14,7 @@ type Props = {
 export function PreviewStack({
   tabs,
   activeId,
+  suppressed,
   onUrlChange,
   registerHandle,
 }: Props) {
@@ -75,8 +77,10 @@ export function PreviewStack({
           >
             <PreviewPane
               ref={getRefCallback(t.id)}
+              id={t.id}
               url={t.url}
               visible={visible}
+              suppressed={suppressed}
               onUrlChange={getUrlCallback(t.id)}
             />
           </div>

--- a/src/modules/preview/index.ts
+++ b/src/modules/preview/index.ts
@@ -1,2 +1,3 @@
 export { PreviewStack } from "./PreviewStack";
 export type { PreviewPaneHandle } from "./PreviewPane";
+export { usePreviewShortcuts } from "./usePreviewShortcuts";

--- a/src/modules/preview/previewBridge.ts
+++ b/src/modules/preview/previewBridge.ts
@@ -1,0 +1,52 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Thin typed wrapper over the Rust `preview_*` commands that drive a native
+ * child webview (see src-tauri/src/modules/preview.rs). The webview renders the
+ * URL as a top-level navigation, so framing rules (X-Frame-Options /
+ * frame-ancestors) never apply — unlike the old `<iframe>` approach.
+ */
+
+export type PreviewBounds = {
+  /** Logical px, relative to the window content top-left. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** Event emitted by Rust on every preview navigation (initial, redirect, SPA). */
+export const PREVIEW_NAV_EVENT = "preview://navigated";
+
+export type PreviewNavPayload = { label: string; url: string };
+
+/** Stable per-tab webview label. */
+export function previewLabel(id: number): string {
+  return `preview-${id}`;
+}
+
+export const previewBridge = {
+  open: (label: string, url: string, b: PreviewBounds): Promise<void> =>
+    invoke("preview_open", {
+      label,
+      url,
+      x: b.x,
+      y: b.y,
+      width: b.width,
+      height: b.height,
+    }),
+  setBounds: (label: string, b: PreviewBounds): Promise<void> =>
+    invoke("preview_set_bounds", {
+      label,
+      x: b.x,
+      y: b.y,
+      width: b.width,
+      height: b.height,
+    }),
+  navigate: (label: string, url: string): Promise<void> =>
+    invoke("preview_navigate", { label, url }),
+  show: (label: string): Promise<void> => invoke("preview_show", { label }),
+  hide: (label: string): Promise<void> => invoke("preview_hide", { label }),
+  reload: (label: string): Promise<void> => invoke("preview_reload", { label }),
+  close: (label: string): Promise<void> => invoke("preview_close", { label }),
+};

--- a/src/modules/preview/usePreviewShortcuts.ts
+++ b/src/modules/preview/usePreviewShortcuts.ts
@@ -1,0 +1,49 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+
+type PreviewKeyPayload = {
+  key: string;
+  code: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+};
+
+/**
+ * A focused native preview webview swallows the keyboard, so the host window's
+ * global shortcuts (Ctrl+Tab, ...) never fire while the preview has focus. The
+ * preview forwards an allow-list of app-shell keystrokes via the
+ * `preview://shortcut-key` event (see src-tauri/src/modules/preview.rs); we
+ * replay them as a synthetic keydown on the host window so `useGlobalShortcuts`
+ * handles them exactly like a real press — reusing the live keymap and any user
+ * rebindings, with no duplicated shortcut table.
+ */
+export function usePreviewShortcuts(): void {
+  useEffect(() => {
+    let alive = true;
+    let unlisten: (() => void) | undefined;
+    void listen<PreviewKeyPayload>("preview://shortcut-key", (e) => {
+      const p = e.payload;
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: p.key,
+          code: p.code,
+          ctrlKey: p.ctrlKey,
+          metaKey: p.metaKey,
+          shiftKey: p.shiftKey,
+          altKey: p.altKey,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    }).then((un) => {
+      if (alive) unlisten = un;
+      else un();
+    });
+    return () => {
+      alive = false;
+      unlisten?.();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
Replaces the iframe-based web preview with a **native Tauri child webview**, so previewing local dev servers works like a real browser tab.

## Why
The `<iframe>` preview rendered **blank** for any dev server that sends `X-Frame-Options` / CSP `frame-ancestors` (e.g. a Next.js app that redirects to `/login`) — cross-origin framing is refused by the embedded site. A native child webview loads the URL as a **top-level navigation**, so framing rules never apply; auth flows and redirects work.

## What's included
- Native preview webview driven entirely from Rust (`src-tauri/src/modules/preview.rs`).
- **Security:** the preview webview gets **no Tauri capability**, so the embedded page has zero IPC / `window.__TAURI__` access (locked by a test in `PreviewPane.test.ts`).
- Address bar tracks live navigations/redirects; each preview tab has its own webview shown only when active; bounds track the pane (resize / sidebar / zen); hidden under modals.
- Forwards app-shell shortcuts (Ctrl+Tab, ⌘1–9, ⌘T/⌘W, ⌘⇧P, ⌘,) from the focused preview to the host via a sentinel-navigation channel (no IPC), and returns focus to the app when the preview hides.
- DevTools/Web Inspector enabled **only** on the preview webview (main + settings windows disabled); closes when leaving the preview tab.
- Uses Tauri's `unstable` feature for the multi-webview (`add_child`) API.

## How to test
`pnpm tauri dev` → open a preview tab pointed at a dev server that sets `X-Frame-Options` (e.g. a Next.js app with auth) → it renders. Address bar follows redirects; right-click → Inspect works on the preview only.

Checks: `pnpm check-types`, `pnpm test`, `cargo check`, `cargo clippy`.

## Notes
- Touches `src/app/App.tsx` and `src-tauri/src/lib.rs` (small hunks) — overlaps with the window/menu PR, so whichever merges second may need a trivial rebase.

## Evidence
<!-- paste screenshots/recordings -->
- Before (blank Next.js preview) / After (renders):

<img width="1902" height="1032" alt="image" src="https://github.com/user-attachments/assets/ecee653e-a262-486e-83f1-2150f1a71c7b" />

<img width="1907" height="1025" alt="image" src="https://github.com/user-attachments/assets/b96ad5cd-e7d2-47a6-903c-935ac167c065" />


- DevTools on the preview:

<img width="1896" height="1032" alt="image" src="https://github.com/user-attachments/assets/a82a42fb-a618-41d1-b0a3-8de8b07218a6" />
