### PR TITLE
fix(window): keep app shortcuts vs native menu, fix focus & zen chrome

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,44 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     Ok(())
 }
 
+/// The default app menu binds several `Cmd/Ctrl` accelerators ("Close Window",
+/// "Undo", "Redo") whose native key-equivalents fire before the webview sees the
+/// keydown, shadowing the app's own shortcuts (tab.close, editor undo/redo, zen
+/// mode on Cmd+Shift+Z, ...). Drop those items so the keys reach the frontend.
+/// Copy/Paste/Cut/Select-All/Quit/Hide stay (they aren't app shortcuts, and the
+/// webview still handles text-field undo from the keydown itself).
+fn strip_conflicting_menu_items<R: tauri::Runtime>(menu: &tauri::menu::Menu<R>) {
+    use tauri::menu::MenuItemKind;
+    // Normalized predefined-item labels whose accelerators collide with app
+    // shortcuts. muda text is e.g. "Close"/"Undo"/"Redo" (macOS) or carries a
+    // "&" mnemonic on Windows ("C&lose Window"), so strip "&" and lowercase.
+    const CONFLICTING: [&str; 4] = ["close", "close window", "undo", "redo"];
+    let Ok(items) = menu.items() else {
+        return;
+    };
+    for item in items {
+        let Some(submenu) = item.as_submenu() else {
+            continue;
+        };
+        let Ok(children) = submenu.items() else {
+            continue;
+        };
+        for child in &children {
+            if let MenuItemKind::Predefined(predefined) = child {
+                let text = predefined
+                    .text()
+                    .unwrap_or_default()
+                    .replace('&', "")
+                    .trim()
+                    .to_lowercase();
+                if CONFLICTING.contains(&text.as_str()) {
+                    let _ = submenu.remove(predefined);
+                }
+            }
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let cli_dir = parse_launch_dir();
@@ -136,6 +174,11 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .menu(|app| {
+            let menu = tauri::menu::Menu::default(app)?;
+            strip_conflicting_menu_items(&menu);
+            Ok(menu)
+        })
         .setup(|_app| {
             // macOS skips parent() for the settings window, so tie its lifecycle
             // to the main window here instead. Other platforms keep parent().

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import { getLaunchDir } from "@/lib/launchDir";
 import { usePresence } from "@/lib/usePresence";
 import { quoteShellArg } from "@/lib/shellQuote";
 import { useZoom } from "@/lib/useZoom";
+import { IS_MAC } from "@/lib/platform";
 import { AgentNotificationsBridge } from "@/modules/agents";
 import {
   AgentRunBridge,
@@ -142,6 +143,16 @@ export default function App() {
   useTerminalFileDrop();
   const explorerRef = useRef<FileExplorerHandle>(null);
 
+  // Focus the active terminal/editor pane. Used to hand keyboard control back
+  // when the sidebar is collapsed while one of its panels held focus.
+  const focusActivePane = useCallback(() => {
+    if (activeLeafId !== null) {
+      terminalRefs.current.get(activeLeafId)?.focus();
+      return;
+    }
+    activeEditorHandle?.focus();
+  }, [activeLeafId, activeEditorHandle]);
+
   // Drives session disposal off the pane tree, not React lifecycles —
   // split/unsplit re-mount components but the leaf is still live.
   const liveLeavesRef = useRef<Set<number>>(new Set());
@@ -176,7 +187,7 @@ export default function App() {
     cycleSidebarView,
     persistSidebarWidth,
     toggleExplorerFocus,
-  } = useSidebarPanel(explorerRef);
+  } = useSidebarPanel(explorerRef, focusActivePane);
 
   const [newEditorOpen, setNewEditorOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -590,17 +601,16 @@ export default function App() {
         return !(activeTab?.kind === "terminal" && activeTab.blocks === true);
       }
       if (id === "sidebar.toggle") {
-        // Ctrl+B is also Claude Code's "run in background" key. While a terminal
-        // is focused, let Ctrl+B reach the shell/Claude instead of toggling the
-        // sidebar. Ctrl+Shift+B (second binding) still toggles it from anywhere.
+        // Ctrl+B is Claude Code's "run in background" key. Only defer a literal
+        // Ctrl+B (no Cmd) while a terminal is focused so it reaches the shell;
+        // the Cmd+B binding (macOS) and the Ctrl/⌘+Shift+B variant always
+        // toggle the sidebar.
         const target =
           (e.target as HTMLElement | null) ?? document.activeElement;
         const inTerminal = !!(target as HTMLElement | null)?.closest?.(
           ".xterm",
         );
-        // Only defer the plain (no-shift) Ctrl/⌘+B binding; the Shift variant
-        // is the always-on toggle and is never claimed by the terminal.
-        return inTerminal && !e.shiftKey;
+        return inTerminal && !e.shiftKey && e.ctrlKey && !e.metaKey;
       }
       return false;
     },
@@ -852,6 +862,13 @@ export default function App() {
             />
           )}
 
+          {/* Zen mode hides the Header, but macOS keeps the native traffic
+              lights from the overlay titlebar. Reserve a draggable top strip so
+              they don't sit on top of the terminal (e.g. tmux's status row). */}
+          {zenMode && IS_MAC && (
+            <div data-tauri-drag-region className="h-7 shrink-0" />
+          )}
+
           <main className="zoom-content flex min-h-0 flex-1 flex-col">
             <ResizablePanelGroup
               orientation="horizontal"
@@ -869,7 +886,10 @@ export default function App() {
                   if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
                 }}
               >
-                <div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">
+                <div
+                  data-sidebar-root
+                  className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card"
+                >
                   <div className="min-h-0 flex-1">
                     {sidebarView === "explorer" ? (
                       <FileExplorer

--- a/src/modules/sidebar/useSidebarPanel.ts
+++ b/src/modules/sidebar/useSidebarPanel.ts
@@ -48,13 +48,27 @@ type FocusableExplorer = {
   isFocused: () => boolean;
 };
 
+/** True when keyboard focus is currently inside the sidebar panel. */
+function sidebarHasFocus(): boolean {
+  const active = document.activeElement;
+  return (
+    active instanceof HTMLElement && !!active.closest("[data-sidebar-root]")
+  );
+}
+
 export function useSidebarPanel(
   explorerRef: RefObject<FocusableExplorer | null>,
+  focusActivePane?: () => void,
 ) {
   const sidebarRef = useRef<PanelImperativeHandle | null>(null);
   const sidebarWidthRef = useRef(readSidebarWidth());
   const sidebarWidthWriteTimerRef = useRef(0);
   const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
+  // Latest "focus the active pane" callback; called when the sidebar collapses
+  // while focused so keyboard control returns to the terminal/editor instead of
+  // being stranded on the now-hidden (0-width but still mounted) panel.
+  const focusActivePaneRef = useRef(focusActivePane);
+  focusActivePaneRef.current = focusActivePane;
   const [sidebarView, setSidebarViewState] =
     useState<SidebarViewId>(readSidebarView);
 
@@ -70,8 +84,13 @@ export function useSidebarPanel(
   const toggleSidebar = useCallback(() => {
     const p = sidebarRef.current;
     if (!p) return;
-    if (p.getSize().asPercentage <= 0) p.expand();
-    else p.collapse();
+    if (p.getSize().asPercentage <= 0) {
+      p.expand();
+      return;
+    }
+    const refocus = sidebarHasFocus();
+    p.collapse();
+    if (refocus) focusActivePaneRef.current?.();
   }, []);
 
   const cycleSidebarView = useCallback(
@@ -84,7 +103,9 @@ export function useSidebarPanel(
         return;
       }
       if (view === sidebarView) {
+        const refocus = sidebarHasFocus();
         panel?.collapse();
+        if (refocus) focusActivePaneRef.current?.();
         return;
       }
       persistSidebarView(view);


### PR DESCRIPTION
## Summary
Fixes a cluster of macOS window/keyboard/focus issues where the native menu and panel focus stole keys from the app.

## What's fixed
- **⌘W closed the whole app** — the default native menu binds ⌘W to "Close Window", whose key-equivalent fires before the webview, so the app's `tab.close` never ran. Strips "Close Window" (plus "Undo" / "Redo", which shadowed ⌘Z / ⌘⇧Z = editor undo/redo and **zen mode**) from the default menu so those keys reach the app. The window is still closable via its traffic lights / window controls.
- **Zen mode (⌘⇧Z) didn't toggle** — same native-menu collision (Redo); fixed by the menu strip above.
- **⌘B didn't toggle the sidebar in the terminal** — the defer-to-shell rule keyed off ⌘B on macOS, but Claude Code's "run in background" key is Ctrl+B (a different key). Now only a literal Ctrl+B is deferred; ⌘B toggles the sidebar.
- **Collapsing the sidebar stranded keyboard focus** — collapsing the explorer/source-control panel while focused there left focus on the now 0-width but still-mounted panel, so the terminal stopped receiving input. Focus now returns to the active terminal/editor.
- **Zen mode traffic lights overlapped the terminal** — with the header hidden, the macOS overlay traffic lights sat on top of the content (e.g. tmux's status row). Added a draggable top inset in zen mode so content clears them.

## Files
`src-tauri/src/lib.rs` (menu), `src/app/App.tsx`, `src/modules/sidebar/useSidebarPanel.ts`.

## How to test
`pnpm tauri dev`:
- ⌘W closes a tab/pane (not the app); the red traffic light still closes the window.
- ⌘⇧Z toggles zen mode; ⌘B toggles the sidebar.
- Focus the File Explorer / Source Control, collapse the sidebar → the terminal regains keyboard focus.

Checks: `pnpm check-types`, `pnpm test`, `cargo check`, `cargo clippy`.

## Notes
- Touches `src/app/App.tsx` and `src-tauri/src/lib.rs` (small hunks) — overlaps with the web-preview PR, so whichever merges second may need a trivial rebase.
- Related (different scenarios in the same macOS traffic-light area): #671, #669.