### PR TITLE
fix(editor): reconfigure language compartment when document becomes ready

### DIFF
--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -245,7 +245,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
       return () => {
         cancelled = true;
       };
-    }, [path]);
+    }, [path, doc.status]);
 
     useImperativeHandle(
       ref,


### PR DESCRIPTION

<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Fixed syntax highlighting loss when switching between preview tabs

## Why
Closes #752 

## How
Added doc.status to the effect dependency array

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] ~(If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean~
- [x] ~(If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep~
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOs
- [x] Shells tested (if relevant): zsh


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
