### PR TITLE
feat(source-control): add commit action menu

### DIFF
--- a/src/modules/sidebar/SidebarRail.tsx
+++ b/src/modules/sidebar/SidebarRail.tsx
@@ -37,6 +37,7 @@ export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
       {items.map((item) => {
         const isActive = item.id === activeView;
         const showBadge = !!item.badge && item.badge > 0;
+        const badgeLabel = item.badge && item.badge > 99 ? "99+" : item.badge;
         return (
           <button
             key={item.id}
@@ -45,7 +46,7 @@ export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
             aria-pressed={isActive}
             onClick={() => onSelectView(item.id)}
             className={cn(
-              "group relative flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md text-[11px] font-medium outline-none transition-colors duration-150",
+              "group relative flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-1.5 overflow-hidden rounded-md px-1.5 text-[11px] font-medium outline-none transition-colors duration-150",
               "focus-visible:ring-2 focus-visible:ring-primary/40",
               isActive
                 ? "bg-foreground/[0.07] text-foreground dark:bg-foreground/[0.09]"
@@ -58,10 +59,12 @@ export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
               strokeWidth={isActive ? 2 : 1.75}
               className="shrink-0 transition-[stroke-width] duration-150"
             />
-            <span>{item.label}</span>
+            <span className="min-w-0 truncate whitespace-nowrap">
+              {item.label}
+            </span>
             {showBadge ? (
-              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-border/60 bg-card px-1 text-[9px] font-semibold leading-none tabular-nums text-muted-foreground/95">
-                {item.badge! > 99 ? "99+" : item.badge}
+              <span className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full border border-border/60 bg-card px-1 text-[9px] font-semibold leading-none tabular-nums text-muted-foreground/95">
+                {badgeLabel}
               </span>
             ) : null}
           </button>

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -9,7 +9,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -17,6 +16,13 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -48,6 +54,8 @@ import {
   FolderCloudIcon,
   FolderGitTwoIcon,
   GitBranchIcon,
+  MinusSignIcon,
+  PlusSignIcon,
   Refresh01Icon,
   RemoveSquareIcon,
 } from "@hugeicons/core-free-icons";
@@ -64,10 +72,11 @@ import {
   type ReactNode,
 } from "react";
 import type { SourceControlSummary } from "./useSourceControl";
+import { commitPrimaryLabel } from "./sourceControlCommitAction";
 import {
   useSourceControlPanel,
-  type CheckState,
-  type SourceControlFileEntry,
+  type DiffSelection,
+  type SourceControlEntry,
 } from "./useSourceControlPanel";
 
 type Props = {
@@ -95,8 +104,19 @@ const ROW_HEIGHTS = {
 
 type RowDescriptor =
   | { kind: "banner-diverged"; key: string }
-  | { kind: "list-header"; key: string; count: number }
-  | { kind: "entry"; key: string; entry: SourceControlFileEntry };
+  | {
+      kind: "list-header";
+      key: string;
+      count: number;
+      section: "staged" | "unstaged";
+      title: string;
+    }
+  | {
+      kind: "entry";
+      key: string;
+      entry: SourceControlEntry;
+      section: "staged" | "unstaged";
+    };
 
 function basename(path: string): string {
   const parts = path.split(/[\\/]/).filter(Boolean);
@@ -110,7 +130,7 @@ function dirname(path: string): string {
   return normalized.slice(0, index);
 }
 
-function entryPathLabel(entry: SourceControlFileEntry): string {
+function entryPathLabel(entry: SourceControlEntry): string {
   if (entry.originalPath) return `${entry.originalPath} → ${entry.path}`;
   return dirname(entry.path);
 }
@@ -135,12 +155,6 @@ function statusAccent(code: string): string {
     default:
       return "bg-muted-foreground/40";
   }
-}
-
-function checkboxValue(state: CheckState): boolean | "indeterminate" {
-  if (state === "checked") return true;
-  if (state === "indeterminate") return "indeterminate";
-  return false;
 }
 
 export const SourceControlPanel = memo(function SourceControlPanel({
@@ -187,12 +201,13 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   const commitHint = canCommit
     ? `Commit with ${commitShortcut}.`
     : (commitDisabledReason ?? `Commit with ${commitShortcut}.`);
-  const pushHint = scm.pushHint ?? "Push is unavailable right now.";
-  const pushDisabledReason = scm.actionBusy
-    ? "Wait for the current Git action to finish."
-    : pushHint;
+  const commitPrimaryText = commitPrimaryLabel({
+    committed: scm.commitSucceeded,
+    message: scm.commitMessage,
+    actionBusy: scm.actionBusy,
+  });
   const stagedCount = scm.stagedEntries.length;
-  const changedCount = scm.fileEntries.length;
+  const changedCount = scm.stagedEntries.length + scm.unstagedEntries.length;
   const pushStatusLabel = upstreamBadgeLabel(scm.status?.upstream);
   const hasUpstream = !!scm.status?.upstream;
   const isDiverged =
@@ -264,21 +279,66 @@ export const SourceControlPanel = memo(function SourceControlPanel({
       result.push({ kind: "banner-diverged", key: "banner-diverged" });
     }
     if (changedCount > 0) {
-      result.push({
-        kind: "list-header",
-        key: "list-header",
-        count: changedCount,
-      });
-      for (const entry of scm.fileEntries) {
-        result.push({ kind: "entry", key: entry.key, entry });
+      if (scm.stagedEntries.length > 0) {
+        result.push({
+          kind: "list-header",
+          key: "list-header:staged",
+          count: scm.stagedEntries.length,
+          section: "staged",
+          title: "Staged Changes",
+        });
+        for (const entry of scm.stagedEntries) {
+          result.push({
+            kind: "entry",
+            key: entry.key,
+            entry,
+            section: "staged",
+          });
+        }
+      }
+      if (scm.unstagedEntries.length > 0) {
+        result.push({
+          kind: "list-header",
+          key: "list-header:unstaged",
+          count: scm.unstagedEntries.length,
+          section: "unstaged",
+          title: "Changes",
+        });
+        for (const entry of scm.unstagedEntries) {
+          result.push({
+            kind: "entry",
+            key: entry.key,
+            entry,
+            section: "unstaged",
+          });
+        }
       }
     }
     return result;
-  }, [changedCount, isDiverged, scm.fileEntries]);
+  }, [changedCount, isDiverged, scm.stagedEntries, scm.unstagedEntries]);
+
+  const markedEntryKeys = useMemo(
+    () => new Set(scm.markedEntryKeys),
+    [scm.markedEntryKeys],
+  );
+
+  const markedCounts = useMemo(
+    () => ({
+      staged: scm.stagedEntries.filter((entry) =>
+        markedEntryKeys.has(entry.key),
+      ).length,
+      unstaged: scm.unstagedEntries.filter((entry) =>
+        markedEntryKeys.has(entry.key),
+      ).length,
+    }),
+    [markedEntryKeys, scm.stagedEntries, scm.unstagedEntries],
+  );
 
   const rowKeyToIndex = useMemo(() => {
     const map = new Map<string, number>();
-    rows.forEach((row, index) => map.set(row.key, index));
+    rows.forEach((row, index) => {
+      map.set(row.key, index);
+    });
     return map;
   }, [rows]);
 
@@ -326,7 +386,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
       if (focusableIndices.length === 0) return;
       const currentIndex =
         focusedRowKey === null ? -1 : (rowKeyToIndex.get(focusedRowKey) ?? -1);
-      let pos = focusableIndices.findIndex((i) => i === currentIndex);
+      let pos = focusableIndices.indexOf(currentIndex);
       if (pos === -1) pos = direction > 0 ? -1 : focusableIndices.length;
       let nextPos = pos + direction;
       if (nextPos < 0) nextPos = 0;
@@ -341,7 +401,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
     [focusableIndices, focusedRowKey, rowKeyToIndex, rows, virtualizer],
   );
 
-  const focusedEntry = useCallback((): SourceControlFileEntry | null => {
+  const focusedEntry = useCallback((): SourceControlEntry | null => {
     if (!focusedRowKey) return null;
     const index = rowKeyToIndex.get(focusedRowKey);
     if (index === undefined) return null;
@@ -379,7 +439,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
           const entry = focusedEntry();
           if (entry) {
             event.preventDefault();
-            void scm.selectFile(entry);
+            void scm.selectEntry(entry);
           }
           break;
         }
@@ -390,7 +450,9 @@ export const SourceControlPanel = memo(function SourceControlPanel({
           const entry = focusedEntry();
           if (entry) {
             event.preventDefault();
-            void scm.toggleStageFile(entry);
+            void (entry.mode === "+"
+              ? scm.unstageEntry(entry)
+              : scm.stageEntry(entry));
           }
           break;
         }
@@ -398,9 +460,9 @@ export const SourceControlPanel = memo(function SourceControlPanel({
         case "D": {
           if (meta) break;
           const entry = focusedEntry();
-          if (entry && entry.unstaged) {
+          if (entry && entry.mode === "-") {
             event.preventDefault();
-            scm.requestDiscardFile(entry);
+            scm.requestDiscardEntry(entry);
           }
           break;
         }
@@ -575,7 +637,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                   scm.commitMessage.length > 0
                     ? "border-border/70"
                     : "border-border/45",
-                  "focus-within:border-primary/45 focus-within:shadow-md focus-within:shadow-primary/5",
+                  "focus-within:border-border/70 focus-within:shadow-none focus-within:ring-0",
                 )}
               >
                 <Textarea
@@ -585,7 +647,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                   placeholder="Commit message"
                   rows={3}
                   className={cn(
-                    "min-h-[72px] border-border resize-none rounded-lg bg-transparent px-3 pb-7 pt-2.5 text-[12.5px] leading-snug shadow-none placeholder:text-muted-foreground/65 focus-visible:ring-0 focus:border-0",
+                    "min-h-[72px] resize-none rounded-lg border-0 bg-transparent px-3 pb-7 pt-2.5 text-[12.5px] leading-snug shadow-none outline-none placeholder:text-muted-foreground/65 focus:border-0 focus:shadow-none focus-visible:border-transparent focus-visible:ring-0 focus-visible:ring-transparent",
                   )}
                 />
                 <div className="pointer-events-none absolute inset-x-3 bottom-1.5 flex items-center justify-between p-1 gap-2 text-[10px] tabular-nums text-muted-foreground/55">
@@ -656,50 +718,106 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 </span>
               </div>
 
-              <div className="grid w-full grid-cols-2 gap-1.5">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="xs"
-                      className="h-7 cursor-pointer text-[11.5px] font-semibold tracking-tight shadow-sm disabled:cursor-not-allowed disabled:shadow-none"
-                      disabled={!canCommit}
-                      onClick={() => void scm.commit()}
+              <div className="w-full">
+                <div
+                  className={cn(
+                    "flex h-7 w-full overflow-hidden rounded-md border shadow-sm transition-colors",
+                    canCommit
+                      ? "border-primary/35 bg-primary text-primary-foreground"
+                      : "border-border/55 bg-secondary/70 text-secondary-foreground/75",
+                  )}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className={cn(
+                          "min-w-0 flex-1 cursor-pointer px-2.5 text-center text-[11.5px] font-semibold tracking-tight transition-colors",
+                          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35",
+                          canCommit
+                            ? "hover:bg-primary-foreground/10"
+                            : "cursor-not-allowed opacity-60",
+                        )}
+                        disabled={!canCommit}
+                        onClick={() => void scm.commit()}
+                      >
+                        {commitPrimaryText}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="bottom"
+                      className={cn(
+                        SOURCE_CONTROL_TOOLTIP_CLASS,
+                        "text-[10.5px]",
+                      )}
                     >
-                      {scm.actionBusy === "commit" ? "Committing…" : "Commit"}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="bottom"
-                    className={cn(
-                      SOURCE_CONTROL_TOOLTIP_CLASS,
-                      "text-[10.5px]",
-                    )}
-                  >
-                    {commitHint}
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="xs"
-                      variant="secondary"
-                      className="h-7 cursor-pointer text-[11.5px] font-medium disabled:cursor-not-allowed"
-                      disabled={!scm.canPush || !!scm.actionBusy}
-                      onClick={() => void scm.push()}
+                      {commitHint}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <DropdownMenu>
+                      <TooltipTrigger asChild>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className={cn(
+                              "flex h-7 w-8 shrink-0 cursor-pointer items-center justify-center border-l transition-colors",
+                              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/35",
+                              canCommit
+                                ? "border-primary-foreground/20 text-primary-foreground hover:bg-primary-foreground/10"
+                                : "border-border/55 text-secondary-foreground/65 hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-60",
+                            )}
+                            disabled={!!scm.actionBusy}
+                            aria-label="More actions..."
+                          >
+                            <HugeiconsIcon
+                              icon={ArrowDown01Icon}
+                              size={13}
+                              strokeWidth={2.35}
+                              className="block"
+                            />
+                          </button>
+                        </DropdownMenuTrigger>
+                      </TooltipTrigger>
+                      <DropdownMenuContent
+                        align="end"
+                        className="min-w-44 rounded-lg border border-border/70 bg-popover p-1 text-[12px] shadow-xl shadow-black/25"
+                      >
+                        <DropdownMenuItem
+                          className="rounded-md px-2 py-1.5 text-[12px]"
+                          disabled={!canCommit}
+                          onSelect={() => void scm.commit()}
+                        >
+                          Commit
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator className="my-1" />
+                        <DropdownMenuItem
+                          className="rounded-md px-2 py-1.5 text-[12px]"
+                          disabled={!canCommit || !scm.canPush}
+                          onSelect={() => void scm.commitAndPush()}
+                        >
+                          Commit & Push
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="rounded-md px-2 py-1.5 text-[12px]"
+                          disabled={!canCommit || !scm.canPush}
+                          onSelect={() => void scm.commitAndSync()}
+                        >
+                          Commit & Sync
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                    <TooltipContent
+                      side="bottom"
+                      className={cn(
+                        SOURCE_CONTROL_TOOLTIP_CLASS,
+                        "text-[10.5px]",
+                      )}
                     >
-                      {scm.actionBusy === "push" ? "Pushing…" : "Push"}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="bottom"
-                    className={cn(
-                      SOURCE_CONTROL_TOOLTIP_CLASS,
-                      "max-w-64 text-[10.5px]",
-                    )}
-                  >
-                    {pushDisabledReason}
-                  </TooltipContent>
-                </Tooltip>
+                      More actions...
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
               </div>
 
               <CommitFeedback feedback={footerFeedback} />
@@ -748,15 +866,21 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                           <RowRenderer
                             row={row}
                             focused={focusedRowKey === row.key}
-                            selectedPath={scm.selected?.path ?? null}
+                            selected={scm.selected}
+                            markedEntryKeys={markedEntryKeys}
+                            markedCounts={markedCounts}
                             actionBusy={scm.actionBusy}
-                            headerCheckState={scm.headerCheckState}
                             repoRoot={scm.repo?.repoRoot ?? null}
                             onFocusRow={setFocusedRowKey}
-                            onToggleAll={scm.toggleAll}
-                            onSelectFile={scm.selectFile}
-                            onToggleStageFile={scm.toggleStageFile}
-                            onDiscardFile={scm.requestDiscardFile}
+                            onStageSectionEntries={scm.stageSectionEntries}
+                            onUnstageSectionEntries={scm.unstageSectionEntries}
+                            onToggleMarkedEntry={scm.toggleMarkedEntry}
+                            onClearMarkedEntries={scm.clearMarkedEntries}
+                            onSelectEntry={scm.selectEntry}
+                            onStageEntry={scm.stageEntry}
+                            onUnstageEntry={scm.unstageEntry}
+                            onDiscardEntry={scm.requestDiscardEntry}
+                            onDiscardAll={scm.requestDiscardAll}
                             onOpenFile={onOpenFile}
                           />
                         </div>
@@ -846,15 +970,21 @@ function CleanTreeHint({ repoLabel }: { repoLabel: string }) {
 type RowRendererProps = {
   row: RowDescriptor;
   focused: boolean;
-  selectedPath: string | null;
+  selected: DiffSelection | null;
+  markedEntryKeys: Set<string>;
+  markedCounts: { staged: number; unstaged: number };
   actionBusy: string | null;
-  headerCheckState: CheckState;
   repoRoot: string | null;
   onFocusRow: (key: string | null) => void;
-  onToggleAll: () => Promise<void> | void;
-  onSelectFile: (entry: SourceControlFileEntry) => Promise<void>;
-  onToggleStageFile: (entry: SourceControlFileEntry) => Promise<void>;
-  onDiscardFile: (entry: SourceControlFileEntry) => void;
+  onStageSectionEntries: (section: "staged" | "unstaged") => Promise<void>;
+  onUnstageSectionEntries: (section: "staged" | "unstaged") => Promise<void>;
+  onToggleMarkedEntry: (entry: SourceControlEntry) => void;
+  onClearMarkedEntries: () => void;
+  onSelectEntry: (entry: SourceControlEntry) => Promise<void>;
+  onStageEntry: (entry: SourceControlEntry) => Promise<void>;
+  onUnstageEntry: (entry: SourceControlEntry) => Promise<void>;
+  onDiscardEntry: (entry: SourceControlEntry) => void;
+  onDiscardAll: () => void;
   onOpenFile?: (absolutePath: string) => void;
 };
 
@@ -892,29 +1022,64 @@ function DivergedBanner() {
 function ListHeader({
   row,
   actionBusy,
-  headerCheckState,
-  onToggleAll,
+  markedCounts,
+  onStageSectionEntries,
+  onUnstageSectionEntries,
+  onDiscardAll,
 }: RowRendererProps & {
   row: Extract<RowDescriptor, { kind: "list-header" }>;
 }) {
+  const isStaged = row.section === "staged";
+  const markedCount = isStaged ? markedCounts.staged : markedCounts.unstaged;
+  const scopeLabel =
+    markedCount > 0
+      ? `${markedCount} marked ${markedCount === 1 ? "file" : "files"}`
+      : "all";
+  const primaryLabel = isStaged
+    ? `Unstage ${scopeLabel}`
+    : `Stage ${scopeLabel}`;
+  const discardLabel =
+    markedCount > 0 ? `Discard ${scopeLabel}` : "Discard all changes";
   return (
-    <div className="flex h-7 items-center gap-2 px-3">
-      <span className="text-[10.5px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/85">
-        Changes
+    <div className="group/header flex h-7 items-center gap-2 px-3">
+      <span className="min-w-0 flex-1 truncate text-[10.5px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/85">
+        {row.title}
       </span>
-      <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-border/60 px-1 text-[9.5px] font-semibold tabular-nums text-muted-foreground">
+      <div className="flex shrink-0 select-none items-center gap-0.5 opacity-0 transition-opacity group-hover/header:opacity-100 group-focus-within/header:opacity-100">
+        <IconActionButton
+          label={primaryLabel}
+          disabled={actionBusy !== null}
+          side="top"
+          onClick={() =>
+            void (isStaged
+              ? onUnstageSectionEntries("staged")
+              : onStageSectionEntries("unstaged"))
+          }
+        >
+          <HugeiconsIcon
+            icon={isStaged ? MinusSignIcon : PlusSignIcon}
+            size={11}
+            strokeWidth={2.1}
+          />
+        </IconActionButton>
+        {!isStaged ? (
+          <IconActionButton
+            label={discardLabel}
+            disabled={actionBusy !== null}
+            side="top"
+            onClick={onDiscardAll}
+          >
+            <HugeiconsIcon
+              icon={RemoveSquareIcon}
+              size={11}
+              strokeWidth={1.9}
+            />
+          </IconActionButton>
+        ) : null}
+      </div>
+      <span className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-full border border-border/60 px-1 text-[9.5px] font-semibold tabular-nums text-muted-foreground">
         {row.count}
       </span>
-      <label className="ml-auto flex shrink-0 cursor-pointer select-none items-center gap-1.5 text-[10.5px] font-medium text-muted-foreground hover:text-foreground">
-        <span>All</span>
-        <Checkbox
-          aria-label="Stage all changes"
-          checked={checkboxValue(headerCheckState)}
-          disabled={actionBusy !== null}
-          onCheckedChange={() => void onToggleAll()}
-          className="size-3.5"
-        />
-      </label>
     </div>
   );
 }
@@ -922,27 +1087,43 @@ function ListHeader({
 const EntryRow = memo(function EntryRow({
   row,
   focused,
-  selectedPath,
+  selected,
+  markedEntryKeys,
+  markedCounts,
   actionBusy,
   repoRoot,
   onFocusRow,
-  onSelectFile,
-  onToggleStageFile,
-  onDiscardFile,
+  onToggleMarkedEntry,
+  onClearMarkedEntries,
+  onSelectEntry,
+  onStageEntry,
+  onUnstageEntry,
+  onStageSectionEntries,
+  onUnstageSectionEntries,
+  onDiscardEntry,
+  onDiscardAll,
   onOpenFile,
 }: RowRendererProps & {
   row: Extract<RowDescriptor, { kind: "entry" }>;
 }) {
   const entry = row.entry;
-  const isSelected = selectedPath === entry.path;
+  const isSelected =
+    selected?.path === entry.path && selected.mode === entry.mode;
+  const isMarked = markedEntryKeys.has(entry.key);
   const fileName = basename(entry.path);
   const iconUrl = fileIconUrl(fileName);
   const pathLabel = entryPathLabel(entry);
-  const showDiscard = entry.unstaged;
+  const isStaged = entry.mode === "+";
+  const showDiscard = !isStaged;
+  const markedCount = isStaged ? markedCounts.staged : markedCounts.unstaged;
   const isStageBusy =
     actionBusy === `stage:${entry.path}` ||
-    actionBusy === `unstage:${entry.path}`;
-  const isDiscardBusy = actionBusy === `discard:${entry.path}`;
+    actionBusy === `unstage:${entry.path}` ||
+    (!isStaged && actionBusy === "stage:unstaged") ||
+    (isStaged && actionBusy === "unstage:staged");
+  const isDiscardBusy =
+    actionBusy === `discard:${entry.path}` ||
+    (!isStaged && actionBusy === "discard:all");
   const disabled = actionBusy !== null;
 
   const absolutePath = repoRoot
@@ -958,8 +1139,10 @@ const EntryRow = memo(function EntryRow({
           id={`scm-row-${row.key}`}
           data-focused={focused || undefined}
           data-selected={isSelected || undefined}
+          data-marked={isMarked || undefined}
           role="option"
-          aria-selected={isSelected}
+          tabIndex={-1}
+          aria-selected={isSelected || isMarked}
           onMouseDown={() => onFocusRow(row.key)}
           className={cn(
             "group relative flex h-[30px] items-center gap-2 rounded-md pl-2 pr-2 transition-all duration-100",
@@ -967,6 +1150,8 @@ const EntryRow = memo(function EntryRow({
               ? "bg-accent/60"
               : isSelected
                 ? "bg-accent/55 text-foreground"
+                : isMarked
+                  ? "bg-primary/10 text-foreground ring-1 ring-primary/25"
                 : "hover:bg-accent/30",
           )}
         >
@@ -980,46 +1165,90 @@ const EntryRow = memo(function EntryRow({
             )}
             aria-hidden
           />
-          <button
-            type="button"
-            onClick={() => {
-              onFocusRow(row.key);
-              void onSelectFile(entry);
-            }}
-            className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
-          >
-            {iconUrl ? (
-              <img src={iconUrl} alt="" className="size-4 shrink-0" />
-            ) : (
-              <span className="size-4 shrink-0" />
-            )}
-            <div className="flex min-w-0 flex-1 items-baseline gap-1.5 leading-none">
-              <span
-                className={cn(
-                  "truncate text-[12px] leading-tight",
-                  isSelected || focused
-                    ? "font-semibold text-foreground"
-                    : "font-medium text-foreground/95",
-                  pathLabel ? "max-w-[58%] shrink-0" : "min-w-0 flex-1",
-                )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(event) => {
+                  onFocusRow(row.key);
+                  if (event.altKey) {
+                    event.preventDefault();
+                    onToggleMarkedEntry(entry);
+                    return;
+                  }
+                  void onSelectEntry(entry);
+                }}
+                className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
               >
-                {fileName}
-              </span>
-              {pathLabel ? (
-                <span className="min-w-0 flex-1 truncate text-[10.5px] leading-tight text-muted-foreground/75">
-                  {pathLabel}
-                </span>
-              ) : null}
-            </div>
-          </button>
+                {iconUrl ? (
+                  <img src={iconUrl} alt="" className="size-3.5 shrink-0" />
+                ) : (
+                  <span className="size-3.5 shrink-0" />
+                )}
+                <div className="flex min-w-0 flex-1 items-baseline gap-1.5 leading-none">
+                  <span
+                    className={cn(
+                      "truncate text-[12px] leading-tight",
+                      isSelected || focused
+                        ? "font-semibold text-foreground"
+                        : "font-medium text-foreground/95",
+                      pathLabel ? "max-w-[58%] shrink-0" : "min-w-0 flex-1",
+                    )}
+                  >
+                    {fileName}
+                  </span>
+                  {pathLabel ? (
+                    <span className="min-w-0 flex-1 truncate text-[10.5px] leading-tight text-muted-foreground/75">
+                      {pathLabel}
+                    </span>
+                  ) : null}
+                </div>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent
+              side="top"
+              className={cn(
+                SOURCE_CONTROL_TOOLTIP_CLASS,
+                "max-w-72 rounded-md text-[10.5px]",
+              )}
+            >
+              {entry.path}
+            </TooltipContent>
+          </Tooltip>
 
-          {showDiscard ? (
-            <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 data-[focused=true]:opacity-100 data-[selected=true]:opacity-100">
+          <div
+            className={cn(
+              "absolute right-1 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md bg-card/95 opacity-0 shadow-sm transition-opacity",
+              "group-hover:opacity-100 group-focus-within:opacity-100",
+              (isStageBusy || isDiscardBusy) && "opacity-100",
+            )}
+          >
+            {isStageBusy ? (
+              <span className="flex size-6 items-center justify-center">
+                <Spinner className="size-3" />
+              </span>
+            ) : (
               <IconActionButton
-                label={`Discard ${entry.path}`}
+                label={isStaged ? "Unstage changes" : "Stage changes"}
                 disabled={disabled}
                 side="top"
-                onClick={() => onDiscardFile(entry)}
+                onClick={() =>
+                  void (isStaged ? onUnstageEntry(entry) : onStageEntry(entry))
+                }
+              >
+                <HugeiconsIcon
+                  icon={isStaged ? MinusSignIcon : PlusSignIcon}
+                  size={11}
+                  strokeWidth={2.1}
+                />
+              </IconActionButton>
+            )}
+            {showDiscard ? (
+              <IconActionButton
+                label="Discard changes"
+                disabled={disabled}
+                side="top"
+                onClick={() => onDiscardEntry(entry)}
               >
                 {isDiscardBusy ? (
                   <Spinner className="size-3" />
@@ -1031,22 +1260,8 @@ const EntryRow = memo(function EntryRow({
                   />
                 )}
               </IconActionButton>
-            </div>
-          ) : null}
-
-          <span className="flex size-5 shrink-0 items-center justify-center">
-            {isStageBusy ? (
-              <Spinner className="size-3" />
-            ) : (
-              <Checkbox
-                aria-label={`Stage ${entry.path}`}
-                checked={checkboxValue(entry.checkState)}
-                disabled={disabled}
-                onCheckedChange={() => void onToggleStageFile(entry)}
-                className="size-3.5"
-              />
-            )}
-          </span>
+            ) : null}
+          </div>
         </div>
       </ContextMenuTrigger>
 
@@ -1056,7 +1271,7 @@ const EntryRow = memo(function EntryRow({
           className={COMPACT_ITEM}
           onSelect={() => {
             onFocusRow(row.key);
-            void onSelectFile(entry);
+            void onSelectEntry(entry);
           }}
         >
           Open Diff
@@ -1073,19 +1288,55 @@ const EntryRow = memo(function EntryRow({
         <ContextMenuSeparator />
 
         {/* Stage / Unstage */}
+        {markedCount > 0 ? (
+          <>
+            <ContextMenuItem
+              className={COMPACT_ITEM}
+              disabled={disabled}
+              onSelect={() =>
+                void (isStaged
+                  ? onUnstageSectionEntries("staged")
+                  : onStageSectionEntries("unstaged"))
+              }
+            >
+              {isStaged
+                ? `Unstage marked (${markedCount})`
+                : `Stage marked (${markedCount})`}
+            </ContextMenuItem>
+            {!isStaged ? (
+              <ContextMenuItem
+                className={COMPACT_ITEM}
+                variant="destructive"
+                disabled={disabled}
+                onSelect={() => onDiscardAll()}
+              >
+                Discard marked ({markedCount})
+              </ContextMenuItem>
+            ) : null}
+            <ContextMenuItem
+              className={COMPACT_ITEM}
+              onSelect={() => onClearMarkedEntries()}
+            >
+              Clear marks
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        ) : null}
         <ContextMenuItem
           className={COMPACT_ITEM}
           disabled={disabled}
-          onSelect={() => void onToggleStageFile(entry)}
+          onSelect={() =>
+            void (isStaged ? onUnstageEntry(entry) : onStageEntry(entry))
+          }
         >
-          {entry.checkState === "checked" ? "Unstage" : "Stage"}
+          {isStaged ? "Unstage" : "Stage"}
         </ContextMenuItem>
-        {entry.unstaged ? (
+        {!isStaged ? (
           <ContextMenuItem
             className={COMPACT_ITEM}
             variant="destructive"
             disabled={disabled}
-            onSelect={() => onDiscardFile(entry)}
+            onSelect={() => onDiscardEntry(entry)}
           >
             Discard Changes
           </ContextMenuItem>

--- a/src/modules/source-control/sourceControlCommitAction.test.ts
+++ b/src/modules/source-control/sourceControlCommitAction.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  commitPrimaryLabel,
+  shouldResetCommitSuccess,
+} from "./sourceControlCommitAction";
+
+describe("source control commit action", () => {
+  it("shows committed only after a successful commit with an empty message", () => {
+    expect(
+      commitPrimaryLabel({
+        committed: true,
+        message: "",
+        actionBusy: null,
+      }),
+    ).toBe("Committed");
+
+    expect(
+      commitPrimaryLabel({
+        committed: true,
+        message: "feat: next commit",
+        actionBusy: null,
+      }),
+    ).toBe("Commit");
+  });
+
+  it("shows a busy label while commit and sync is running", () => {
+    expect(
+      commitPrimaryLabel({
+        committed: false,
+        message: "feat: sync changes",
+        actionBusy: "commit-sync",
+      }),
+    ).toBe("Committing...");
+  });
+
+  it("resets the committed state when the user starts a new message", () => {
+    expect(shouldResetCommitSuccess("", "feat: next commit")).toBe(true);
+    expect(shouldResetCommitSuccess("feat: old", "feat: next")).toBe(false);
+    expect(shouldResetCommitSuccess("", "   ")).toBe(false);
+  });
+});

--- a/src/modules/source-control/sourceControlCommitAction.ts
+++ b/src/modules/source-control/sourceControlCommitAction.ts
@@ -1,0 +1,24 @@
+export type SourceControlCommitActionState = {
+  committed: boolean;
+  message: string;
+  actionBusy: string | null;
+};
+
+export function commitPrimaryLabel({
+  committed,
+  message,
+  actionBusy,
+}: SourceControlCommitActionState): string {
+  if (actionBusy === "commit") return "Committing...";
+  if (actionBusy === "commit-push") return "Committing...";
+  if (actionBusy === "commit-sync") return "Committing...";
+  if (committed && message.trim().length === 0) return "Committed";
+  return "Commit";
+}
+
+export function shouldResetCommitSuccess(
+  previousMessage: string,
+  nextMessage: string,
+): boolean {
+  return previousMessage.trim().length === 0 && nextMessage.trim().length > 0;
+}

--- a/src/modules/source-control/sourceControlEntries.test.ts
+++ b/src/modules/source-control/sourceControlEntries.test.ts
@@ -1,0 +1,87 @@
+import type { GitChangedFile } from "@/modules/ai/lib/native";
+import { describe, expect, it } from "vitest";
+import {
+  buildSourceControlEntryModel,
+  entrySelectionKey,
+  resolveSectionBatchEntries,
+} from "./sourceControlEntries";
+
+describe("buildSourceControlEntryModel", () => {
+  it("keeps staged and unstaged entries separate for the same file", () => {
+    const file: GitChangedFile = {
+      path: "src/example.ts",
+      originalPath: null,
+      indexStatus: "M",
+      worktreeStatus: "M",
+      staged: true,
+      unstaged: true,
+      untracked: false,
+      statusLabel: "Modified",
+    };
+
+    const model = buildSourceControlEntryModel([file]);
+
+    expect(model.stagedEntries).toEqual([
+      expect.objectContaining({
+        key: "+:src/example.ts",
+        path: "src/example.ts",
+        mode: "+",
+        statusCode: "M",
+      }),
+    ]);
+    expect(model.unstagedEntries).toEqual([
+      expect.objectContaining({
+        key: "-:src/example.ts",
+        path: "src/example.ts",
+        mode: "-",
+        statusCode: "M",
+      }),
+    ]);
+    expect(model.fileEntries).toEqual([
+      expect.objectContaining({
+        key: "src/example.ts",
+        checkState: "indeterminate",
+        staged: true,
+        unstaged: true,
+      }),
+    ]);
+    expect(model.headerCheckState).toBe("indeterminate");
+  });
+
+  it("uses marked entries for section batch actions when present", () => {
+    const files: GitChangedFile[] = [
+      {
+        path: "src/one.ts",
+        originalPath: null,
+        indexStatus: " ",
+        worktreeStatus: "M",
+        staged: false,
+        unstaged: true,
+        untracked: false,
+        statusLabel: "Modified",
+      },
+      {
+        path: "src/two.ts",
+        originalPath: null,
+        indexStatus: " ",
+        worktreeStatus: "M",
+        staged: false,
+        unstaged: true,
+        untracked: false,
+        statusLabel: "Modified",
+      },
+    ];
+    const model = buildSourceControlEntryModel(files);
+    expect(model.unstagedEntries).toHaveLength(2);
+    const second = model.unstagedEntries[1];
+    if (!second) throw new Error("Expected second unstaged entry");
+    const marked = new Set([entrySelectionKey(second)]);
+
+    expect(resolveSectionBatchEntries(model.unstagedEntries, marked)).toEqual([
+      second,
+    ]);
+    expect(resolveSectionBatchEntries(model.unstagedEntries, new Set())).toEqual(
+      model.unstagedEntries,
+    );
+  });
+});

--- a/src/modules/source-control/sourceControlEntries.ts
+++ b/src/modules/source-control/sourceControlEntries.ts
@@ -1,0 +1,157 @@
+import type { GitChangedFile } from "@/modules/ai/lib/native";
+
+export type DiffMode = "+" | "-";
+
+export type SourceControlEntry = {
+  key: string;
+  path: string;
+  mode: DiffMode;
+  indexStatus: string;
+  worktreeStatus: string;
+  statusLabel: string;
+  statusCode: string;
+  originalPath: string | null;
+  untracked: boolean;
+};
+
+export type CheckState = "checked" | "indeterminate" | "unchecked";
+export type SourceControlSection = "staged" | "unstaged";
+
+/** One row per changed file (flat list) for bulk checkbox state. */
+export type SourceControlFileEntry = {
+  key: string;
+  path: string;
+  originalPath: string | null;
+  statusCode: string;
+  statusLabel: string;
+  checkState: CheckState;
+  staged: boolean;
+  unstaged: boolean;
+  untracked: boolean;
+};
+
+export type SourceControlEntryModel = {
+  stagedEntries: SourceControlEntry[];
+  unstagedEntries: SourceControlEntry[];
+  fileEntries: SourceControlFileEntry[];
+  headerCheckState: CheckState;
+};
+
+export function entrySelectionKey(
+  entry: Pick<SourceControlEntry, "mode" | "path">,
+): string {
+  return `${entry.mode}:${entry.path}`;
+}
+
+function normalizeStatusCode(status: string): string {
+  const code = status.trim().toUpperCase();
+  switch (code) {
+    case "?":
+      return "U";
+    case "A":
+      return "A";
+    case "M":
+      return "M";
+    case "D":
+      return "D";
+    case "R":
+    case "C":
+      return "R";
+    case "U":
+      return "U";
+    default:
+      return code || "M";
+  }
+}
+
+export function statusCodeForMode(
+  mode: DiffMode,
+  file: GitChangedFile,
+): string {
+  if (mode === "-" && file.untracked) return "U";
+  const primary = mode === "+" ? file.indexStatus : file.worktreeStatus;
+  const fallback = mode === "+" ? file.worktreeStatus : file.indexStatus;
+  return normalizeStatusCode(primary !== " " ? primary : fallback);
+}
+
+export function makeSourceControlEntry(
+  path: string,
+  mode: DiffMode,
+  file: GitChangedFile,
+): SourceControlEntry {
+  return {
+    key: `${mode}:${path}`,
+    path,
+    mode,
+    indexStatus: file.indexStatus,
+    worktreeStatus: file.worktreeStatus,
+    statusLabel: file.statusLabel,
+    statusCode: statusCodeForMode(mode, file),
+    originalPath: file.originalPath,
+    untracked: file.untracked,
+  };
+}
+
+function buildFileEntries(files: GitChangedFile[]): SourceControlFileEntry[] {
+  const seen = new Set<string>();
+  const out: SourceControlFileEntry[] = [];
+  for (const file of files) {
+    if (seen.has(file.path)) continue;
+    seen.add(file.path);
+    const checkState: CheckState =
+      file.staged && file.unstaged
+        ? "indeterminate"
+        : file.staged
+          ? "checked"
+          : "unchecked";
+    const statusCode = file.unstaged
+      ? statusCodeForMode("-", file)
+      : statusCodeForMode("+", file);
+    out.push({
+      key: file.path,
+      path: file.path,
+      originalPath: file.originalPath,
+      statusCode,
+      statusLabel: file.statusLabel,
+      checkState,
+      staged: file.staged,
+      unstaged: file.unstaged,
+      untracked: file.untracked,
+    });
+  }
+  return out;
+}
+
+export function getHeaderCheckState(
+  fileEntries: SourceControlFileEntry[],
+): CheckState {
+  if (fileEntries.length === 0) return "unchecked";
+  const allChecked = fileEntries.every((e) => e.checkState === "checked");
+  if (allChecked) return "checked";
+  const anyStaged = fileEntries.some((e) => e.staged);
+  return anyStaged ? "indeterminate" : "unchecked";
+}
+
+export function buildSourceControlEntryModel(
+  files: GitChangedFile[],
+): SourceControlEntryModel {
+  const stagedEntries = files
+    .filter((file) => file.staged)
+    .map((file) => makeSourceControlEntry(file.path, "+", file));
+  const unstagedEntries = files
+    .filter((file) => file.unstaged)
+    .map((file) => makeSourceControlEntry(file.path, "-", file));
+  const fileEntries = buildFileEntries(files);
+  const headerCheckState = getHeaderCheckState(fileEntries);
+  return { stagedEntries, unstagedEntries, fileEntries, headerCheckState };
+}
+
+export function resolveSectionBatchEntries(
+  entries: SourceControlEntry[],
+  markedKeys: Set<string>,
+): SourceControlEntry[] {
+  const marked = entries.filter((entry) =>
+    markedKeys.has(entrySelectionKey(entry)),
+  );
+  return marked.length > 0 ? marked : entries;
+}

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -14,10 +14,19 @@ import {
 } from "@/modules/editor/lib/diffCache";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildSourceControlEntryModel,
+  type CheckState,
+  type DiffMode,
+  type SourceControlEntry,
+  type SourceControlFileEntry,
+  type SourceControlSection,
+  entrySelectionKey,
+  resolveSectionBatchEntries,
+} from "./sourceControlEntries";
 import type { SourceControlSummary } from "./useSourceControl";
 
 type PanelState = "closed" | "loading" | "no-repo" | "ready" | "error";
-type DiffMode = "+" | "-";
 type SelectionTransition = "none" | "moved-group" | "reset";
 
 const COMMIT_DIFF_CHAR_LIMIT = 60_000;
@@ -33,31 +42,11 @@ export type DiffSelection = {
   mode: DiffMode;
 };
 
-export type SourceControlEntry = {
-  key: string;
-  path: string;
-  mode: DiffMode;
-  indexStatus: string;
-  worktreeStatus: string;
-  statusLabel: string;
-  statusCode: string;
-  originalPath: string | null;
-  untracked: boolean;
-};
-
-export type CheckState = "checked" | "indeterminate" | "unchecked";
-
-/** One row per changed file (flat list) — merges the staged/unstaged split. */
-export type SourceControlFileEntry = {
-  key: string;
-  path: string;
-  originalPath: string | null;
-  statusCode: string;
-  statusLabel: string;
-  checkState: CheckState;
-  staged: boolean;
-  unstaged: boolean;
-  untracked: boolean;
+export type {
+  CheckState,
+  DiffMode,
+  SourceControlEntry,
+  SourceControlFileEntry,
 };
 
 export type PendingDiscard = {
@@ -72,6 +61,7 @@ type SourceControlPanelState = {
   status: GitStatusSnapshot | null;
   selected: DiffSelection | null;
   commitMessage: string;
+  commitSucceeded: boolean;
   actionBusy: string | null;
   statusError: string | null;
   actionError: string | null;
@@ -81,6 +71,7 @@ type SourceControlPanelState = {
   unstagedEntries: SourceControlEntry[];
   fileEntries: SourceControlFileEntry[];
   headerCheckState: CheckState;
+  markedEntryKeys: string[];
   allClean: boolean;
   canPush: boolean;
   pushHint: string | null;
@@ -96,8 +87,10 @@ type SourceControlPanelState = {
   selectFile: (entry: SourceControlFileEntry) => Promise<void>;
   stageEntry: (entry: SourceControlEntry) => Promise<void>;
   unstageEntry: (entry: SourceControlEntry) => Promise<void>;
-  toggleStageFile: (entry: SourceControlFileEntry) => Promise<void>;
-  toggleAll: () => Promise<void>;
+  toggleMarkedEntry: (entry: SourceControlEntry) => void;
+  clearMarkedEntries: () => void;
+  stageSectionEntries: (section: SourceControlSection) => Promise<void>;
+  unstageSectionEntries: (section: SourceControlSection) => Promise<void>;
   requestDiscardEntry: (entry: SourceControlEntry) => void;
   requestDiscardFile: (entry: SourceControlFileEntry) => void;
   requestDiscardAll: () => void;
@@ -107,6 +100,8 @@ type SourceControlPanelState = {
   unstageAllEntries: () => Promise<void>;
   generateCommitMessage: () => Promise<void>;
   commit: () => Promise<void>;
+  commitAndPush: () => Promise<void>;
+  commitAndSync: () => Promise<void>;
   push: () => Promise<void>;
 };
 
@@ -117,52 +112,6 @@ function normalizeError(error: unknown): string {
     if (typeof message === "string") return message;
   }
   return "Unknown source control error";
-}
-
-function normalizeStatusCode(status: string): string {
-  const code = status.trim().toUpperCase();
-  switch (code) {
-    case "?":
-      return "U";
-    case "A":
-      return "A";
-    case "M":
-      return "M";
-    case "D":
-      return "D";
-    case "R":
-    case "C":
-      return "R";
-    case "U":
-      return "U";
-    default:
-      return code || "M";
-  }
-}
-
-function statusCodeForMode(mode: DiffMode, file: GitChangedFile): string {
-  if (mode === "-" && file.untracked) return "U";
-  const primary = mode === "+" ? file.indexStatus : file.worktreeStatus;
-  const fallback = mode === "+" ? file.worktreeStatus : file.indexStatus;
-  return normalizeStatusCode(primary !== " " ? primary : fallback);
-}
-
-function makeEntry(
-  path: string,
-  mode: DiffMode,
-  file: GitChangedFile,
-): SourceControlEntry {
-  return {
-    key: `${mode}:${path}`,
-    path,
-    mode,
-    indexStatus: file.indexStatus,
-    worktreeStatus: file.worktreeStatus,
-    statusLabel: file.statusLabel,
-    statusCode: statusCodeForMode(mode, file),
-    originalPath: file.originalPath,
-    untracked: file.untracked,
-  };
 }
 
 function sameSelection(
@@ -258,7 +207,8 @@ function optimisticStage(
     if (!paths.has(file.path)) return file;
     if (file.staged && !file.unstaged) return file;
     changed = true;
-    const wt = file.worktreeStatus !== " " ? file.worktreeStatus : file.indexStatus;
+    const wt =
+      file.worktreeStatus !== " " ? file.worktreeStatus : file.indexStatus;
     return {
       ...file,
       indexStatus: wt,
@@ -288,7 +238,8 @@ function optimisticUnstage(
       continue;
     }
     changed = true;
-    const idx = file.indexStatus !== " " ? file.indexStatus : file.worktreeStatus;
+    const idx =
+      file.indexStatus !== " " ? file.indexStatus : file.worktreeStatus;
     if (idx === "R" && file.originalPath) {
       next.push({
         path: file.originalPath,
@@ -389,9 +340,13 @@ export function useSourceControlPanel(
   const [status, setStatus] = useState<GitStatusSnapshot | null>(null);
   const [selected, setSelected] = useState<DiffSelection | null>(null);
   const [commitMessage, setCommitMessage] = useState("");
+  const [commitSucceeded, setCommitSucceeded] = useState(false);
   const [localActionBusy, setLocalActionBusy] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [markedEntryKeys, setMarkedEntryKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [selectionTransition, setSelectionTransition] =
     useState<SelectionTransition>("none");
   const [pendingDiscard, setPendingDiscard] = useState<
@@ -400,65 +355,50 @@ export function useSourceControlPanel(
     | null
   >(null);
   const selectedRef = useRef<DiffSelection | null>(null);
+  const repoRootRef = useRef<string | null>(null);
   const reconcileTimerRef = useRef(0);
 
   useEffect(() => {
     selectedRef.current = selected;
   }, [selected]);
 
-  const stagedEntries = useMemo(
-    () =>
-      (status?.changedFiles ?? [])
-        .filter((file) => file.staged)
-        .map((file) => makeEntry(file.path, "+", file)),
+  useEffect(() => {
+    const nextRoot = repo?.repoRoot ?? null;
+    if (repoRootRef.current === nextRoot) return;
+    repoRootRef.current = nextRoot;
+    setMarkedEntryKeys(new Set());
+  });
+
+  const entryModel = useMemo(
+    () => buildSourceControlEntryModel(status?.changedFiles ?? []),
     [status],
   );
-
-  const unstagedEntries = useMemo(
-    () =>
-      (status?.changedFiles ?? [])
-        .filter((file) => file.unstaged)
-        .map((file) => makeEntry(file.path, "-", file)),
-    [status],
+  const { stagedEntries, unstagedEntries, fileEntries, headerCheckState } =
+    entryModel;
+  const markedKeyList = useMemo(
+    () => Array.from(markedEntryKeys),
+    [markedEntryKeys],
   );
 
-  const fileEntries = useMemo<SourceControlFileEntry[]>(() => {
-    const seen = new Set<string>();
-    const out: SourceControlFileEntry[] = [];
-    for (const file of status?.changedFiles ?? []) {
-      if (seen.has(file.path)) continue;
-      seen.add(file.path);
-      const checkState: CheckState =
-        file.staged && file.unstaged
-          ? "indeterminate"
-          : file.staged
-            ? "checked"
-            : "unchecked";
-      const statusCode = file.unstaged
-        ? statusCodeForMode("-", file)
-        : statusCodeForMode("+", file);
-      out.push({
-        key: file.path,
-        path: file.path,
-        originalPath: file.originalPath,
-        statusCode,
-        statusLabel: file.statusLabel,
-        checkState,
-        staged: file.staged,
-        unstaged: file.unstaged,
-        untracked: file.untracked,
-      });
-    }
-    return out;
-  }, [status]);
-
-  const headerCheckState = useMemo<CheckState>(() => {
-    if (fileEntries.length === 0) return "unchecked";
-    const allChecked = fileEntries.every((e) => e.checkState === "checked");
-    if (allChecked) return "checked";
-    const anyStaged = fileEntries.some((e) => e.staged);
-    return anyStaged ? "indeterminate" : "unchecked";
-  }, [fileEntries]);
+  useEffect(() => {
+    const validKeys = new Set([
+      ...stagedEntries.map(entrySelectionKey),
+      ...unstagedEntries.map(entrySelectionKey),
+    ]);
+    setMarkedEntryKeys((current) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const key of current) {
+        if (validKeys.has(key)) {
+          next.add(key);
+        } else {
+          changed = true;
+        }
+      }
+      if (!changed && next.size === current.size) return current;
+      return next;
+    });
+  }, [stagedEntries, unstagedEntries]);
 
   const allClean = stagedEntries.length === 0 && unstagedEntries.length === 0;
   const canPush = !!status?.upstream && status.behind === 0;
@@ -525,6 +465,11 @@ export function useSourceControlPanel(
   const stagedEmptyText = "No staged changes";
   const unstagedEmptyText = "No unstaged changes";
 
+  const updateCommitMessage = useCallback((value: string) => {
+    setCommitMessage(value);
+    setCommitSucceeded(false);
+  }, []);
+
   const cancelReconcile = useCallback(() => {
     if (reconcileTimerRef.current) {
       window.clearTimeout(reconcileTimerRef.current);
@@ -543,7 +488,11 @@ export function useSourceControlPanel(
   useEffect(() => () => cancelReconcile(), [cancelReconcile]);
 
   const openSelection = useCallback(
-    (sel: DiffSelection, repoRoot: string, file: GitChangedFile | undefined) => {
+    (
+      sel: DiffSelection,
+      repoRoot: string,
+      file: GitChangedFile | undefined,
+    ) => {
       onOpenDiff?.({
         path: sel.path,
         repoRoot,
@@ -621,6 +570,7 @@ export function useSourceControlPanel(
           mode: current.mode === "+" ? "-" : "+",
         };
         setSelected(moved);
+        openSelection(moved, summary.repo.repoRoot, samePathOtherMode);
         setSelectionTransition("moved-group");
       } else {
         setSelected(null);
@@ -636,12 +586,16 @@ export function useSourceControlPanel(
     summary.localError,
     summary.repo,
     summary.status,
+    openSelection,
   ]);
 
   const selectEntry = useCallback(
     async (entry: SourceControlEntry) => {
       if (!repo) return;
-      const nextSelection: DiffSelection = { path: entry.path, mode: entry.mode };
+      const nextSelection: DiffSelection = {
+        path: entry.path,
+        mode: entry.mode,
+      };
       if (sameSelection(selected, nextSelection)) {
         setActionError(null);
         setActionMessage(null);
@@ -664,6 +618,7 @@ export function useSourceControlPanel(
       optimistic: ((status: GitStatusSnapshot) => GitStatusSnapshot) | null,
       ipc: () => Promise<void>,
       affected: string[],
+      afterSuccess?: () => void,
     ) => {
       if (!repo || summary.busyAction) return;
       setLocalActionBusy(busyKey);
@@ -676,6 +631,7 @@ export function useSourceControlPanel(
       }
       try {
         await ipc();
+        afterSuccess?.();
         scheduleReconcile();
       } catch (error) {
         setActionError(normalizeError(error));
@@ -697,6 +653,14 @@ export function useSourceControlPanel(
         (s) => optimisticStage(s, paths),
         () => native.gitStage(repo.repoRoot, [entry.path]),
         [entry.path],
+        () =>
+          setMarkedEntryKeys((current) => {
+            const key = entrySelectionKey(entry);
+            if (!current.has(key)) return current;
+            const next = new Set(current);
+            next.delete(key);
+            return next;
+          }),
       );
     },
     [repo, runMutation],
@@ -711,9 +675,80 @@ export function useSourceControlPanel(
         (s) => optimisticUnstage(s, paths),
         () => native.gitUnstage(repo.repoRoot, [entry.path]),
         [entry.path],
+        () =>
+          setMarkedEntryKeys((current) => {
+            const key = entrySelectionKey(entry);
+            if (!current.has(key)) return current;
+            const next = new Set(current);
+            next.delete(key);
+            return next;
+          }),
       );
     },
     [repo, runMutation],
+  );
+
+  const toggleMarkedEntry = useCallback((entry: SourceControlEntry) => {
+    const key = entrySelectionKey(entry);
+    setMarkedEntryKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const clearMarkedEntries = useCallback(() => {
+    setMarkedEntryKeys((current) => (current.size === 0 ? current : new Set()));
+  }, []);
+
+  const runSectionMutation = useCallback(
+    async (section: SourceControlSection, action: "stage" | "unstage") => {
+      if (!repo) return;
+      const sourceEntries =
+        section === "unstaged" ? unstagedEntries : stagedEntries;
+      const entries = resolveSectionBatchEntries(sourceEntries, markedEntryKeys);
+      if (entries.length === 0) return;
+      const paths = new Set(entries.map((entry) => entry.path));
+      const keys = entries.map(entrySelectionKey);
+      await runMutation(
+        `${action}:${section}`,
+        action === "stage"
+          ? (s) => optimisticStage(s, paths)
+          : (s) => optimisticUnstage(s, paths),
+        () =>
+          action === "stage"
+            ? native.gitStage(repo.repoRoot, [...paths])
+            : native.gitUnstage(repo.repoRoot, [...paths]),
+        [...paths],
+        () =>
+          setMarkedEntryKeys((current) => {
+            let changed = false;
+            const next = new Set(current);
+            for (const key of keys) {
+              if (next.delete(key)) changed = true;
+            }
+            return changed ? next : current;
+          }),
+      );
+    },
+    [markedEntryKeys, repo, runMutation, stagedEntries, unstagedEntries],
+  );
+
+  const stageSectionEntries = useCallback(
+    async (section: SourceControlSection) => {
+      if (section !== "unstaged") return;
+      await runSectionMutation("unstaged", "stage");
+    },
+    [runSectionMutation],
+  );
+
+  const unstageSectionEntries = useCallback(
+    async (section: SourceControlSection) => {
+      if (section !== "staged") return;
+      await runSectionMutation("staged", "unstage");
+    },
+    [runSectionMutation],
   );
 
   const requestDiscardEntry = useCallback(
@@ -726,8 +761,10 @@ export function useSourceControlPanel(
 
   const requestDiscardAll = useCallback(() => {
     if (!repo || summary.busyAction || unstagedEntries.length === 0) return;
-    setPendingDiscard({ scope: "all", entries: unstagedEntries });
-  }, [repo, summary.busyAction, unstagedEntries]);
+    const entries = resolveSectionBatchEntries(unstagedEntries, markedEntryKeys);
+    if (entries.length === 0) return;
+    setPendingDiscard({ scope: "all", entries });
+  }, [markedEntryKeys, repo, summary.busyAction, unstagedEntries]);
 
   const cancelPendingDiscard = useCallback(() => {
     setPendingDiscard(null);
@@ -745,6 +782,7 @@ export function useSourceControlPanel(
       untracked: entry.untracked,
     }));
     const paths = new Set(list.map((entry) => entry.path));
+    const keys = list.map(entrySelectionKey);
     await runMutation(
       pendingDiscard.scope === "single"
         ? `discard:${list[0].path}`
@@ -752,6 +790,15 @@ export function useSourceControlPanel(
       (s) => optimisticDiscard(s, paths),
       () => native.gitDiscard(repo.repoRoot, entries),
       [...paths],
+      () =>
+        setMarkedEntryKeys((current) => {
+          let changed = false;
+          const next = new Set(current);
+          for (const key of keys) {
+            if (next.delete(key)) changed = true;
+          }
+          return changed ? next : current;
+        }),
     );
   }, [pendingDiscard, repo, runMutation]);
 
@@ -797,34 +844,6 @@ export function useSourceControlPanel(
     },
     [openSelection, repo, selected, status],
   );
-
-  const toggleStageFile = useCallback(
-    async (entry: SourceControlFileEntry) => {
-      if (!repo) return;
-      const paths = new Set([entry.path]);
-      if (entry.checkState === "checked") {
-        await runMutation(
-          `unstage:${entry.path}`,
-          (s) => optimisticUnstage(s, paths),
-          () => native.gitUnstage(repo.repoRoot, [entry.path]),
-          [entry.path],
-        );
-      } else {
-        await runMutation(
-          `stage:${entry.path}`,
-          (s) => optimisticStage(s, paths),
-          () => native.gitStage(repo.repoRoot, [entry.path]),
-          [entry.path],
-        );
-      }
-    },
-    [repo, runMutation],
-  );
-
-  const toggleAll = useCallback(async () => {
-    if (headerCheckState === "checked") await unstageAllEntries();
-    else await stageAllEntries();
-  }, [headerCheckState, stageAllEntries, unstageAllEntries]);
 
   const requestDiscardFile = useCallback(
     (entry: SourceControlFileEntry) => {
@@ -908,7 +927,7 @@ export function useSourceControlPanel(
           "AI returned an invalid commit message. Try again or switch models.",
         );
       }
-      setCommitMessage(message);
+      updateCommitMessage(message);
       setActionMessage(null);
     } catch (error) {
       setActionError(normalizeError(error));
@@ -927,27 +946,58 @@ export function useSourceControlPanel(
     repo,
     selectedModelId,
     stagedEntries,
+    updateCommitMessage,
   ]);
 
-  const commit = useCallback(async () => {
+  const runCommitAction = useCallback(async (
+    mode: "commit" | "commit-push" | "commit-sync",
+  ) => {
     if (!repo || summary.busyAction) return;
-    setLocalActionBusy("commit");
+    setLocalActionBusy(mode);
     setActionMessage(null);
     setActionError(null);
+    let didCommit = false;
     try {
       const result = await native.gitCommit(repo.repoRoot, commitMessage);
+      didCommit = true;
       setCommitMessage("");
+      setCommitSucceeded(true);
       setActionMessage(
         `Committed ${result.commitSha.slice(0, 7)} ${result.summary}`,
       );
       invalidateRepoDiffs(repo.repoRoot);
+      if (mode === "commit-sync") {
+        await native.gitFetch(repo.repoRoot);
+      }
+      if (mode === "commit-push" || mode === "commit-sync") {
+        await native.gitPush(repo.repoRoot);
+        setActionMessage(
+          status?.upstream
+            ? `Committed and pushed to ${status.upstream}`
+            : "Committed and pushed",
+        );
+      }
       await summary.refresh({ remote: "never" });
     } catch (error) {
       setActionError(normalizeError(error));
+      setCommitSucceeded(didCommit);
+      await summary.refresh({ remote: "never" }).catch(() => {});
     } finally {
       setLocalActionBusy(null);
     }
-  }, [commitMessage, repo, summary]);
+  }, [commitMessage, repo, status?.upstream, summary]);
+
+  const commit = useCallback(async () => {
+    await runCommitAction("commit");
+  }, [runCommitAction]);
+
+  const commitAndPush = useCallback(async () => {
+    await runCommitAction("commit-push");
+  }, [runCommitAction]);
+
+  const commitAndSync = useCallback(async () => {
+    await runCommitAction("commit-sync");
+  }, [runCommitAction]);
 
   const push = useCallback(async () => {
     if (!repo) return;
@@ -989,6 +1039,7 @@ export function useSourceControlPanel(
     status,
     selected,
     commitMessage,
+    commitSucceeded,
     actionBusy: localActionBusy ?? summary.busyAction,
     statusError: summary.localError,
     actionError,
@@ -998,6 +1049,7 @@ export function useSourceControlPanel(
     unstagedEntries,
     fileEntries,
     headerCheckState,
+    markedEntryKeys: markedKeyList,
     allClean,
     canPush,
     pushHint,
@@ -1007,14 +1059,16 @@ export function useSourceControlPanel(
     stagedEmptyText,
     unstagedEmptyText,
     pendingDiscard: pendingDiscardView,
-    setCommitMessage,
+    setCommitMessage: updateCommitMessage,
     refresh,
     selectEntry,
     selectFile,
     stageEntry,
     unstageEntry,
-    toggleStageFile,
-    toggleAll,
+    toggleMarkedEntry,
+    clearMarkedEntries,
+    stageSectionEntries,
+    unstageSectionEntries,
     requestDiscardEntry,
     requestDiscardFile,
     requestDiscardAll,
@@ -1024,6 +1078,8 @@ export function useSourceControlPanel(
     unstageAllEntries,
     generateCommitMessage,
     commit,
+    commitAndPush,
+    commitAndSync,
     push,
   };
 }


### PR DESCRIPTION
## What
Adds a split staged and unstaged source-control panel with focused batch actions, marked entries, and a primary commit action menu for Commit, Commit & Push, and Commit & Sync.

## Why
The source-control workflow needs clearer separation between staged and unstaged changes and faster commit follow-up actions without leaving the panel.

## How
Moved entry construction and commit label logic into tested helpers, updated the panel hook to track marked entries and section actions, and adjusted the sidebar badge to stay compact for large counts.

## Testing

- [x] `pnpm exec tsc --noEmit` clean via `pnpm check-types`
- [x] `pnpm exec vitest run src/modules/source-control/sourceControlCommitAction.test.ts src/modules/source-control/sourceControlEntries.test.ts` clean
- [ ] `pnpm test` full suite. It currently fails in pre-existing `src/app/eager-budget.test.ts` with `SyntaxError: Invalid or unexpected token`; that file is not part of this staged diff.
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows CLI checks
- [ ] Shells tested (if relevant): Not relevant


## Screenshots / GIFs
Not captured in this workflow.

## Notes for reviewer
Full-suite Vitest is blocked by the existing eager-budget import failure noted above. The untracked `docs/superpowers/` directory was intentionally left out because this PR only includes staged changes.