### PR TITLE
Add image attachments to AI workflow

### DIFF
--- a/.github/workflows/unsigned-installers.yml
+++ b/.github/workflows/unsigned-installers.yml
@@ -1,0 +1,161 @@
+name: Build unsigned installers
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Git tag to create/update for the GitHub release"
+        required: true
+        default: "vision-image-attachments-unsigned"
+      release_name:
+        description: "GitHub release name"
+        required: true
+        default: "Vision image attachments unsigned build"
+      draft:
+        description: "Create release as draft"
+        required: true
+        type: boolean
+        default: true
+  push:
+    branches:
+      - "feature/vision-image-attachments"
+    tags:
+      - "v*"
+      - "*-unsigned"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: unsigned-installers-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS DMG
+            os: macos-14
+            bundle: dmg
+            artifact_name: terax-macos-dmg
+            artifact_path: src-tauri/target/release/bundle/dmg/*.dmg
+          - label: Windows NSIS EXE
+            os: windows-latest
+            bundle: nsis
+            artifact_name: terax-windows-exe
+            artifact_path: src-tauri/target/release/bundle/nsis/*.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable pnpm via Corepack
+        shell: bash
+        run: |
+          corepack enable
+          corepack prepare --activate
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Disable updater artifacts for unsigned CI builds
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("src-tauri/tauri.conf.json")
+          config = json.loads(path.read_text())
+          config.setdefault("bundle", {})["createUpdaterArtifacts"] = False
+          path.write_text(json.dumps(config, indent=2) + "\n")
+          PY
+
+      - name: Typecheck
+        run: pnpm check-types
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build unsigned Tauri bundle
+        run: pnpm tauri build --bundles ${{ matrix.bundle }}
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/feature/vision-image-attachments' || startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download installers
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "tag=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+            echo "name=${{ inputs.release_name }}" >> "$GITHUB_OUTPUT"
+            echo "draft=${{ inputs.draft }}" >> "$GITHUB_OUTPUT"
+          else
+            if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              tag="${GITHUB_REF_NAME}"
+              name="${tag}"
+              draft="false"
+            else
+              safe_ref="${GITHUB_REF_NAME//\//-}"
+              short_sha="${GITHUB_SHA::7}"
+              tag="${safe_ref}-${short_sha}-unsigned"
+              name="Unsigned build ${short_sha} from ${GITHUB_REF_NAME}"
+              draft="true"
+            fi
+            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+            echo "name=${name}" >> "$GITHUB_OUTPUT"
+            echo "draft=${draft}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.name }}
+          draft: ${{ steps.meta.outputs.draft }}
+          prerelease: true
+          make_latest: false
+          fail_on_unmatched_files: true
+          files: |
+            release-assets/*.dmg
+            release-assets/*.exe
+          body: |
+            Unsigned Terax installers built from `${{ github.sha }}`.
+
+            Artifacts:
+            - macOS DMG: unsigned, may require Gatekeeper override on first launch.
+            - Windows NSIS EXE: unsigned, Windows SmartScreen may warn.

--- a/docs/plans/2026-06-08-vision-image-context.md
+++ b/docs/plans/2026-06-08-vision-image-context.md
@@ -1,0 +1,74 @@
+# Vision Image Context Implementation Plan
+
+> For Terax fork: implement in small patches, preserve existing text workflow, keep provider calls on the current AI SDK v6 path.
+
+Goal: Add image attachments from paste, drag and drop, and file picker so vision-capable OpenAI, Anthropic, Gemini, OpenRouter, and OpenAI-compatible models can receive images as context.
+
+Architecture: Keep the current composer-owned attachment model and Chat transport. Image files stay in memory as data URLs and are stripped before session persistence, so no permanent image storage is introduced. Provider-specific handling is isolated behind a small TypeScript adapter module that validates model vision capability and normalizes message parts before `convertToModelMessages`.
+
+Tech stack: Tauri 2, Rust IPC command for reading dropped image paths, React 19, TypeScript, AI SDK v6 file parts.
+
+## Existing code map
+
+- AI model/provider registry: `src/modules/ai/config.ts`
+- Model construction and stream call: `src/modules/ai/lib/agent.ts`
+- Context-aware transport: `src/modules/ai/lib/transport.ts`
+- Composer state and submit path: `src/modules/ai/lib/composer.tsx`
+- Composer textarea: `src/modules/ai/components/AiComposerInput.tsx`
+- Attachment chips: `src/modules/ai/components/ChipsRow.tsx`
+- Status bar file input: `src/modules/ai/components/AiStatusBarControls.tsx`
+- Chat persistence bridge: `src/modules/ai/components/AgentRunBridge.tsx`
+- Session persistence store: `src/modules/ai/store/chatStore.ts`
+- Rust file IPC commands: `src-tauri/src/modules/fs/file.rs`
+- Command registration: `src-tauri/src/lib.rs`
+
+## File tree to change
+
+- Create: `src/modules/ai/lib/imageAttachments.ts`
+- Create: `src/modules/ai/lib/visionAdapters.ts`
+- Create: `src/modules/ai/components/AttachedImages.tsx`
+- Modify: `src/modules/ai/lib/composer.tsx`
+- Modify: `src/modules/ai/components/AiComposerInput.tsx`
+- Modify: `src/modules/ai/components/AiStatusBarControls.tsx`
+- Modify: `src/modules/ai/components/AiChat.tsx`
+- Modify: `src/modules/ai/store/chatStore.ts`
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/src/modules/fs/file.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+## New components
+
+- `AttachedImages`: preview-before-send section with thumbnail, filename, formatted size, and remove button.
+- Drag overlay inside `AiComposerInput`: shown only when supported image files are dragged over composer.
+
+## New TypeScript types
+
+- `ImageAttachmentLimits`
+- `ImageAttachmentInput`
+- `ImageAttachmentErrorCode`
+- `ImageAttachmentResult`
+- `ImageDropPathPayload`
+- `VisionProviderAdapter`
+
+## Rust changes
+
+- Add lightweight `base64` dependency.
+- Add `fs_read_image_attachment(path, workspace)` command.
+- Validate regular file, size limit, and MIME from magic bytes plus extension fallback for png, jpg, jpeg, webp.
+- Return `{ name, media_type, size, data_url }`.
+
+## Safe limits
+
+- Accepted MIME: `image/png`, `image/jpeg`, `image/webp`.
+- Max images per message: 5.
+- Max single image: 10 MB.
+- Max total image bytes: 20 MB.
+
+## Implementation steps
+
+1. Add pure image validation/helpers and vision provider adapter tests by typecheck.
+2. Harden composer attachment ingestion: paste, browser drop, Tauri path drop, count and size limits.
+3. Add UI previews: Attached Images section, paste hint, drag overlay, image-only file picker label.
+4. Add Rust IPC for OS-dropped image paths with MIME sniffing.
+5. Strip image file parts from persisted sessions while keeping them in the active in-memory run.
+6. Run `pnpm check-types`, targeted Rust tests, then full frontend tests if dependencies are present.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 	"stream",
 ] }
 bytes = "1"
+base64 = "0.22"
 futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,6 +181,7 @@ pub fn run() {
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,
+            fs::file::fs_read_image_attachment,
             fs::file::fs_write_file,
             fs::file::fs_stat,
             fs::file::fs_canonicalize,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::time::UNIX_EPOCH;
 use std::{fs, io::Write};
 
+use base64::Engine;
 use serde::Serialize;
 use tauri::Emitter;
 use tempfile::NamedTempFile;
@@ -9,6 +10,7 @@ use tempfile::NamedTempFile;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
 const MAX_READ_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+const MAX_IMAGE_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 const BINARY_SNIFF_BYTES: usize = 8 * 1024;
 
 #[derive(Serialize)]
@@ -75,6 +77,75 @@ pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<Rea
     match String::from_utf8(bytes) {
         Ok(content) => Ok(ReadResult::Text { content, size }),
         Err(_) => Ok(ReadResult::Binary { size }),
+    }
+}
+
+#[derive(Serialize)]
+pub struct ImageAttachmentRead {
+    pub name: String,
+    #[serde(rename = "mediaType")]
+    pub media_type: String,
+    pub size: u64,
+    #[serde(rename = "dataUrl")]
+    pub data_url: String,
+}
+
+#[tauri::command]
+pub fn fs_read_image_attachment(
+    path: String,
+    workspace: Option<WorkspaceEnv>,
+) -> Result<ImageAttachmentRead, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    let p = resolve_path(&path, &workspace);
+    let meta = std::fs::metadata(&p).map_err(|e| {
+        log::debug!("fs_read_image_attachment stat({}) failed: {e}", p.display());
+        e.to_string()
+    })?;
+    let size = meta.len();
+    if size > MAX_IMAGE_ATTACHMENT_BYTES {
+        return Err(format!("Image is larger than {MAX_IMAGE_ATTACHMENT_BYTES} bytes"));
+    }
+    let bytes = std::fs::read(&p).map_err(|e| {
+        log::debug!("fs_read_image_attachment read({}) failed: {e}", p.display());
+        e.to_string()
+    })?;
+    let media_type = sniff_image_media_type(&bytes)
+        .or_else(|| media_type_from_path(&p))
+        .ok_or_else(|| "Only PNG, JPG, JPEG, and WebP images are supported".to_string())?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    let name = p
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("image")
+        .to_string();
+    Ok(ImageAttachmentRead {
+        name,
+        media_type: media_type.to_string(),
+        size,
+        data_url: format!("data:{media_type};base64,{encoded}"),
+    })
+}
+
+fn sniff_image_media_type(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Some("image/png");
+    }
+    if bytes.starts_with(b"\xff\xd8\xff") {
+        return Some("image/jpeg");
+    }
+    if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    None
+}
+
+fn media_type_from_path(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        _ => None,
     }
 }
 

--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -42,6 +42,7 @@ import type {
 } from "ai";
 import { memo, useCallback, useMemo } from "react";
 import { AiToolApproval } from "./AiToolApproval";
+import { formatBytes } from "../lib/imageAttachments";
 
 function CommandSnippet({ name }: { name: string }) {
   const meta = SLASH_COMMANDS[name];
@@ -89,6 +90,53 @@ function countLines(s: string): number {
   if (!trimmed) return 0;
   return trimmed.split("\n").length;
 }
+
+type UserImagePart = {
+  type: "file";
+  mediaType: string;
+  url: string;
+  filename?: string;
+  size?: number;
+};
+
+function userImageParts(message: UIMessage): UserImagePart[] {
+  return message.parts
+    .filter((p) => {
+      const part = p as Partial<UserImagePart>;
+      return (
+        part.type === "file" &&
+        typeof part.mediaType === "string" &&
+        part.mediaType.startsWith("image/") &&
+        typeof part.url === "string"
+      );
+    })
+    .map((p) => p as unknown as UserImagePart);
+}
+
+const UserImageStrip = memo(function UserImageStrip({ images }: { images: UserImagePart[] }) {
+  if (images.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-wrap gap-2">
+      {images.map((image) => (
+        <div
+          key={`${image.url}-${image.filename ?? "image"}`}
+          className="overflow-hidden rounded-md border border-border/50 bg-card/70"
+          title={image.filename ?? "Attached image"}
+        >
+          <img
+            src={image.url}
+            alt={image.filename ?? "Attached image"}
+            className="h-24 w-24 object-cover"
+            draggable={false}
+          />
+          <div className="max-w-24 truncate px-1.5 py-1 text-[10px] text-muted-foreground">
+            {image.size ? formatBytes(image.size) : image.mediaType?.replace("image/", "image ")}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+});
 
 function stripUserContextBlocks(text: string): {
   text: string;
@@ -345,6 +393,7 @@ const RenderedMessage = memo(function RenderedMessage({
     const commandName = cmdMatch?.[1] ?? null;
     const withoutCmd = cmdMatch ? rawText.slice(cmdMatch[0].length) : rawText;
     const stripped = stripUserContextBlocks(withoutCmd);
+    const images = userImageParts(message);
 
     return (
       <Message from="user">
@@ -358,14 +407,13 @@ const RenderedMessage = memo(function RenderedMessage({
               {stripped.text}
             </p>
           ) : null}
+          <UserImageStrip images={images} />
         </MessageContent>
       </Message>
     );
   }
 
-  const groups = useMemo(() => buildPartGroups(message.parts as AnyPart[]), [
-    message.parts,
-  ]);
+  const groups = buildPartGroups(message.parts as AnyPart[]);
 
   return (
     <Message from={message.role}>
@@ -433,15 +481,16 @@ function buildPartGroups(parts: AnyPart[]): Group[] {
   let run: { parts: AnyPart[]; startIdx: number } | null = null;
   const flushRun = () => {
     if (!run) return;
-    if (run.parts.length >= 2) {
+    const currentRun = run;
+    if (currentRun.parts.length >= 2) {
       out.push({
         kind: "reads",
-        parts: run.parts,
-        key: `reads-${partKey(run.parts[0], run.startIdx)}`,
+        parts: currentRun.parts,
+        key: `reads-${partKey(currentRun.parts[0], currentRun.startIdx)}`,
       });
     } else {
-      run.parts.forEach((p, k) => {
-        const idx = run!.startIdx + k;
+      currentRun.parts.forEach((p, k) => {
+        const idx = currentRun.startIdx + k;
         out.push({ kind: "single", part: p, idx, key: partKey(p, idx) });
       });
     }

--- a/src/modules/ai/components/AiComposerInput.tsx
+++ b/src/modules/ai/components/AiComposerInput.tsx
@@ -2,6 +2,7 @@ import { Popover, PopoverAnchor } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { usePresence } from "@/lib/usePresence";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceFiles } from "../hooks/useWorkspaceFiles";
 import { useComposer } from "../lib/composer";
@@ -10,6 +11,7 @@ import { useChatStore } from "../store/chatStore";
 import { useSnippetsStore } from "../store/snippetsStore";
 import { AgentSwitcher } from "./AgentSwitcher";
 import { FilePickerContent } from "./FilePicker";
+import { AttachedImages } from "./AttachedImages";
 import { SnippetPickerContent, type PickerItem } from "./SnippetPicker";
 
 type SnippetTrigger = {
@@ -69,6 +71,9 @@ export function AiComposerInput() {
   const workspaceFiles = useWorkspaceFiles(workspaceRoot, fileTrigger !== null);
 
   const [fileQuery, setFileQuery] = useState("");
+  const [draggingImage, setDraggingImage] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (!fileTrigger) {
       setFileQuery("");
@@ -196,6 +201,38 @@ export function AiComposerInput() {
     if (it) onPickItem(it);
   };
 
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void getCurrentWebview()
+      .onDragDropEvent((e) => {
+        const p = e.payload;
+        if (p.type === "enter" || p.type === "over") {
+          setDraggingImage(pointInRoot(rootRef.current, p.position.x, p.position.y));
+          return;
+        }
+        if (p.type === "leave") {
+          setDraggingImage(false);
+          return;
+        }
+        if (p.type === "drop") {
+          const inside = pointInRoot(rootRef.current, p.position.x, p.position.y);
+          setDraggingImage(false);
+          if (inside && p.paths.length) void c.addImagePaths(p.paths);
+        }
+      })
+      .then((fn) => {
+        if (disposed) fn();
+        else unlisten = fn;
+      })
+      .catch((err) => console.error("[terax] image drag-drop listen failed:", err));
+    return () => {
+      disposed = true;
+      setDraggingImage(false);
+      unlisten?.();
+    };
+  }, [c.addImagePaths]);
+
   const voiceLabel = c.voice.recording
     ? "Listening…"
     : c.voice.transcribing
@@ -206,7 +243,54 @@ export function AiComposerInput() {
   if (voiceLabel) lastVoiceLabel.current = voiceLabel;
 
   return (
-    <>
+    <div
+      ref={rootRef}
+      role="presentation"
+      className="relative space-y-2"
+      onPaste={(e) => {
+        const images = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));
+        if (images.length === 0) return;
+        e.preventDefault();
+        void c.addFiles(e.clipboardData.files);
+      }}
+      onDragEnter={(e) => {
+        if (hasImageDataTransfer(e.dataTransfer)) setDraggingImage(true);
+      }}
+      onDragOver={(e) => {
+        if (!hasImageDataTransfer(e.dataTransfer)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "copy";
+        setDraggingImage(true);
+      }}
+      onDragLeave={(e) => {
+        if (!rootRef.current?.contains(e.relatedTarget as Node | null)) {
+          setDraggingImage(false);
+        }
+      }}
+      onDrop={(e) => {
+        if (!hasImageDataTransfer(e.dataTransfer)) return;
+        e.preventDefault();
+        setDraggingImage(false);
+        void c.addFiles(e.dataTransfer.files);
+      }}
+    >
+      {draggingImage && (
+        <div className="pointer-events-none absolute inset-0 z-20 grid place-items-center rounded-xl border border-primary/45 bg-background/75 text-xs font-medium text-foreground shadow-lg backdrop-blur-sm">
+          Drop images to attach
+        </div>
+      )}
+      <AttachedImages files={c.files} onRemove={c.removeFile} />
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          void c.addFiles(e.currentTarget.files);
+          e.currentTarget.value = "";
+        }}
+      />
       <Popover open={pickerOpen}>
         <PopoverAnchor asChild>
           <div className="flex items-start gap-2">
@@ -257,13 +341,21 @@ export function AiComposerInput() {
                   c.submit();
                 }
               }}
-              placeholder="Ask Terax anything   -   # for snippets and commands, @ for files"
+              placeholder="Ask Terax anything   -   paste or drop images, # snippets, @ files"
               rows={1}
               className={cn(
                 "max-h-40 flex-1 resize-none bg-transparent text-[13px] leading-relaxed outline-none",
                 "placeholder:text-muted-foreground/60",
               )}
             />
+            <button
+              type="button"
+              onClick={() => imageInputRef.current?.click()}
+              className="shrink-0 rounded-md border border-border/50 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              title="Attach Image"
+            >
+              Attach Image
+            </button>
             <AgentSwitcher />
           </div>
         </PopoverAnchor>
@@ -301,8 +393,26 @@ export function AiComposerInput() {
           </div>
         </div>
       )}
-    </>
+    </div>
   );
+}
+
+function pointInRoot(root: HTMLElement | null, x: number, y: number): boolean {
+  if (!root) return false;
+  let lx = x;
+  let ly = y;
+  if (x > window.innerWidth || y > window.innerHeight) {
+    const dpr = window.devicePixelRatio || 1;
+    lx = x / dpr;
+    ly = y / dpr;
+  }
+  const el = document.elementFromPoint(lx, ly);
+  return Boolean(el && root.contains(el));
+}
+
+function hasImageDataTransfer(data: DataTransfer): boolean {
+  if (Array.from(data.files).some((f) => f.type.startsWith("image/"))) return true;
+  return Array.from(data.items).some((item) => item.kind === "file" && item.type.startsWith("image/"));
 }
 
 function autoresize(el: HTMLTextAreaElement | null) {

--- a/src/modules/ai/components/AttachedImages.tsx
+++ b/src/modules/ai/components/AttachedImages.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { formatBytes } from "../lib/imageAttachments";
+import type { FileAttachment } from "../lib/composer";
+
+type Props = {
+  files: FileAttachment[];
+  onRemove: (id: string) => void;
+};
+
+export function AttachedImages({ files, onRemove }: Props) {
+  const images = files.filter((f) => f.kind === "image" && f.url);
+  if (images.length === 0) return null;
+  return (
+    <section className="rounded-xl border border-border/50 bg-muted/20 p-2">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="text-[11px] font-medium text-foreground">Attached Images</div>
+        <div className="text-[10px] text-muted-foreground">Preview before send</div>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {images.map((image) => (
+          <div
+            key={image.id}
+            className={cn(
+              "group flex min-w-0 items-center gap-2 rounded-lg border border-border/45 bg-card/70 p-1.5",
+              "shadow-sm shadow-black/5",
+            )}
+          >
+            <img
+              src={image.url}
+              alt=""
+              className="size-12 shrink-0 rounded-md object-cover ring-1 ring-border/60"
+              draggable={false}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[11px] font-medium text-foreground" title={image.name}>
+                {image.name}
+              </div>
+              <div className="mt-0.5 text-[10px] text-muted-foreground">
+                {formatBytes(image.size)} · {image.mediaType.replace("image/", "")}
+              </div>
+            </div>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="size-6 shrink-0 opacity-80 hover:opacity-100"
+              onClick={() => onRemove(image.id)}
+              aria-label={`Remove ${image.name}`}
+              title="Remove image"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={1.75} />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -12,6 +12,14 @@ import { tryRunSlashCommand, type SlashCommandMeta } from "./slashCommands";
 import { getChat, useChatStore } from "../store/chatStore";
 import { useSnippetsStore } from "../store/snippetsStore";
 import { currentWorkspaceEnv } from "@/modules/workspace";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  imageAttachmentFromFile,
+  imageAttachmentFromPath,
+  isAcceptedImageName,
+  isAcceptedImageType,
+} from "./imageAttachments";
+import { modelSupportsImages } from "./visionAdapters";
 
 export type FileAttachment = {
   id: string;
@@ -41,6 +49,7 @@ type ComposerCtx = {
   setValue: React.Dispatch<React.SetStateAction<string>>;
   files: FileAttachment[];
   addFiles: (list: FileList | null) => Promise<void>;
+  addImagePaths: (paths: readonly string[]) => Promise<void>;
   /** Attach a file by absolute path — used by the file explorer's "Attach to Agent". */
   attachFileByPath: (path: string) => Promise<void>;
   removeFile: (id: string) => void;
@@ -154,12 +163,42 @@ export function AiComposerProvider({ children }: ProviderProps) {
 
   const addFiles = async (list: FileList | null) => {
     if (!list) return;
-    const next: FileAttachment[] = [];
+    const textAttachments: FileAttachment[] = [];
+    const imageFiles: File[] = [];
     for (const f of Array.from(list)) {
+      if (isAcceptedImageType(f.type) || isAcceptedImageName(f.name)) {
+        imageFiles.push(f);
+        continue;
+      }
       const att = await readAttachment(f);
-      if (att) next.push(att);
+      if (att) textAttachments.push(att);
+    }
+    if (textAttachments.length) setFiles((prev) => [...prev, ...textAttachments]);
+    if (imageFiles.length) await addImageFiles(imageFiles);
+  };
+
+  const addImageFiles = async (list: readonly File[]) => {
+    const working = files;
+    const next: FileAttachment[] = [];
+    for (const f of list) {
+      const result = await imageAttachmentFromFile(f, [...working, ...next]);
+      if (result.ok) next.push(result.attachment);
+      else console.warn("image attachment skipped:", result.message);
     }
     if (next.length) setFiles((prev) => [...prev, ...next]);
+  };
+
+  const addImagePaths = async (paths: readonly string[]) => {
+    const working = files;
+    const next: FileAttachment[] = [];
+    for (const path of paths) {
+      if (!isAcceptedImageName(path)) continue;
+      const result = await imageAttachmentFromPath(path, [...working, ...next]);
+      if (result.ok) next.push(result.attachment);
+      else console.warn("image attachment skipped:", result.message);
+    }
+    if (next.length) setFiles((prev) => [...prev, ...next]);
+    if (next.length) useChatStore.getState().focusInput();
   };
 
   const removeFile = (id: string) =>
@@ -246,6 +285,20 @@ export function AiComposerProvider({ children }: ProviderProps) {
         if (outcome.commandName) {
           commandMarker = `<terax-command name="${outcome.commandName}" />`;
         }
+      }
+    }
+
+    const images = files.filter((f) => f.kind === "image");
+    if (images.length > 0) {
+      const store = useChatStore.getState();
+      if (
+        !modelSupportsImages(
+          store.selectedModelId,
+          usePreferencesStore.getState().customEndpoints,
+        )
+      ) {
+        window.alert("Selected model does not support image context. Pick a vision-capable model before sending.");
+        return;
       }
     }
 
@@ -340,6 +393,7 @@ export function AiComposerProvider({ children }: ProviderProps) {
     setValue,
     files,
     addFiles,
+    addImagePaths,
     attachFileByPath,
     removeFile,
     pickedSnippets,
@@ -360,17 +414,6 @@ export function AiComposerProvider({ children }: ProviderProps) {
 
 async function readAttachment(file: File): Promise<FileAttachment | null> {
   const id = `${file.name}-${file.size}-${file.lastModified}`;
-  if (file.type.startsWith("image/")) {
-    const url = await readAsDataURL(file);
-    return {
-      id,
-      name: file.name,
-      kind: "image",
-      mediaType: file.type || "image/png",
-      url,
-      size: file.size,
-    };
-  }
   if (file.size > MAX_TEXT_INLINE) return null;
   const text = await file.text();
   return {
@@ -381,13 +424,4 @@ async function readAttachment(file: File): Promise<FileAttachment | null> {
     text,
     size: file.size,
   };
-}
-
-function readAsDataURL(file: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result ?? ""));
-    reader.onerror = () => reject(reader.error);
-    reader.readAsDataURL(file);
-  });
 }

--- a/src/modules/ai/lib/imageAttachments.ts
+++ b/src/modules/ai/lib/imageAttachments.ts
@@ -1,0 +1,160 @@
+import { invoke } from "@tauri-apps/api/core";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { FileAttachment } from "./composer";
+
+export const IMAGE_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+] as const;
+
+export const IMAGE_ATTACHMENT_LIMITS = {
+  maxImages: 5,
+  maxSingleBytes: 10 * 1024 * 1024,
+  maxTotalBytes: 20 * 1024 * 1024,
+} as const;
+
+export type ImageAttachmentErrorCode =
+  | "unsupported-type"
+  | "too-large"
+  | "too-many"
+  | "total-too-large"
+  | "read-failed";
+
+export type ImageAttachmentResult =
+  | { ok: true; attachment: FileAttachment }
+  | { ok: false; code: ImageAttachmentErrorCode; message: string };
+
+type NativeImageAttachment = {
+  name: string;
+  mediaType: string;
+  size: number;
+  dataUrl: string;
+};
+
+export function isAcceptedImageType(type: string): boolean {
+  return IMAGE_MIME_TYPES.includes(type.toLowerCase() as (typeof IMAGE_MIME_TYPES)[number]);
+}
+
+export function isAcceptedImageName(name: string): boolean {
+  return /\.(png|jpe?g|webp)$/i.test(name);
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(kb >= 10 ? 0 : 1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(mb >= 10 ? 0 : 1)} MB`;
+}
+
+export function validateImageBudget(
+  existing: readonly FileAttachment[],
+  incoming: { size: number },
+): ImageAttachmentResult | null {
+  const images = existing.filter((f) => f.kind === "image");
+  if (images.length >= IMAGE_ATTACHMENT_LIMITS.maxImages) {
+    return {
+      ok: false,
+      code: "too-many",
+      message: `Attach up to ${IMAGE_ATTACHMENT_LIMITS.maxImages} images.`,
+    };
+  }
+  if (incoming.size > IMAGE_ATTACHMENT_LIMITS.maxSingleBytes) {
+    return {
+      ok: false,
+      code: "too-large",
+      message: `Image is larger than ${formatBytes(IMAGE_ATTACHMENT_LIMITS.maxSingleBytes)}.`,
+    };
+  }
+  const total = images.reduce((sum, f) => sum + f.size, 0) + incoming.size;
+  if (total > IMAGE_ATTACHMENT_LIMITS.maxTotalBytes) {
+    return {
+      ok: false,
+      code: "total-too-large",
+      message: `Attached images exceed ${formatBytes(IMAGE_ATTACHMENT_LIMITS.maxTotalBytes)} total.`,
+    };
+  }
+  return null;
+}
+
+export async function imageAttachmentFromFile(
+  file: File,
+  existing: readonly FileAttachment[],
+): Promise<ImageAttachmentResult> {
+  const mediaType = normalizeImageType(file.type, file.name);
+  if (!mediaType) {
+    return {
+      ok: false,
+      code: "unsupported-type",
+      message: "Only PNG, JPG, JPEG, and WebP images are supported.",
+    };
+  }
+  const budget = validateImageBudget(existing, file);
+  if (budget) return budget;
+  try {
+    const url = await readAsDataURL(file);
+    return {
+      ok: true,
+      attachment: {
+        id: `img-${file.name}-${file.size}-${file.lastModified}-${crypto.randomUUID()}`,
+        name: file.name,
+        kind: "image",
+        mediaType,
+        url,
+        size: file.size,
+      },
+    };
+  } catch {
+    return { ok: false, code: "read-failed", message: "Could not read image." };
+  }
+}
+
+export async function imageAttachmentFromPath(
+  path: string,
+  existing: readonly FileAttachment[],
+): Promise<ImageAttachmentResult> {
+  try {
+    const r = await invoke<NativeImageAttachment>("fs_read_image_attachment", {
+      path,
+      workspace: currentWorkspaceEnv(),
+    });
+    const budget = validateImageBudget(existing, r);
+    if (budget) return budget;
+    return {
+      ok: true,
+      attachment: {
+        id: `img-path-${path}-${r.size}-${crypto.randomUUID()}`,
+        name: r.name,
+        kind: "image",
+        mediaType: r.mediaType,
+        url: r.dataUrl,
+        size: r.size,
+      },
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      code: "read-failed",
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+function normalizeImageType(type: string, name: string): string | null {
+  const lower = type.toLowerCase();
+  if (isAcceptedImageType(lower)) return lower;
+  if (/\.png$/i.test(name)) return "image/png";
+  if (/\.jpe?g$/i.test(name)) return "image/jpeg";
+  if (/\.webp$/i.test(name)) return "image/webp";
+  return null;
+}
+
+function readAsDataURL(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/modules/ai/lib/visionAdapters.ts
+++ b/src/modules/ai/lib/visionAdapters.ts
@@ -1,0 +1,55 @@
+import type { UIMessage } from "@ai-sdk/react";
+import { isCompatModelId, resolveModel, type ModelInfo, type ProviderId } from "../config";
+
+type PartLike = { type?: string; mediaType?: unknown };
+
+export type VisionProviderAdapter = {
+  provider: ProviderId;
+  acceptsImages: (model: ModelInfo) => boolean;
+};
+
+const tagVision = (model: ModelInfo) => model.tags?.includes("vision") ?? false;
+
+export const VISION_PROVIDER_ADAPTERS: Partial<Record<ProviderId, VisionProviderAdapter>> = {
+  openai: { provider: "openai", acceptsImages: tagVision },
+  anthropic: { provider: "anthropic", acceptsImages: tagVision },
+  google: { provider: "google", acceptsImages: tagVision },
+  openrouter: { provider: "openrouter", acceptsImages: tagVision },
+  "openai-compatible": {
+    provider: "openai-compatible",
+    acceptsImages: () => true,
+  },
+  lmstudio: { provider: "lmstudio", acceptsImages: () => true },
+  mlx: { provider: "mlx", acceptsImages: () => true },
+  ollama: { provider: "ollama", acceptsImages: () => true },
+};
+
+export function modelSupportsImages(
+  modelId: string,
+  endpoints: Parameters<typeof resolveModel>[1] = [],
+): boolean {
+  if (isCompatModelId(modelId)) return true;
+  const model = resolveModel(modelId, endpoints);
+  return VISION_PROVIDER_ADAPTERS[model.provider]?.acceptsImages(model) ?? false;
+}
+
+export function messageHasImageParts(message: UIMessage): boolean {
+  return message.parts.some((p: PartLike) => {
+    return p.type === "file" && typeof p.mediaType === "string" && p.mediaType.startsWith("image/");
+  });
+}
+
+export function stripImagePartsForPersistence(messages: UIMessage[]): UIMessage[] {
+  let changed = false;
+  const next = messages.map((message) => {
+    if (!messageHasImageParts(message)) return message;
+    changed = true;
+    return {
+      ...message,
+      parts: message.parts.filter((p: PartLike) => {
+        return !(p.type === "file" && typeof p.mediaType === "string" && p.mediaType.startsWith("image/"));
+      }),
+    } as UIMessage;
+  });
+  return changed ? next : messages;
+}

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -24,6 +24,7 @@ import {
   type SessionMeta,
 } from "../lib/sessions";
 import { pushRecentModel } from "../lib/modelPrefs";
+import { stripImagePartsForPersistence } from "../lib/visionAdapters";
 
 export type Live = {
   getCwd: () => string | null;
@@ -394,6 +395,7 @@ export const useChatStore = create<StoreState>((set, get) => ({
   },
 
   persistMessages: (id, messages) => {
+    const persistableMessages = stripImagePartsForPersistence(messages);
     // Debounce the message-blob write so streaming doesn't pound the store.
     const existing = pendingPersist.get(id);
     if (existing) clearTimeout(existing.timer);
@@ -403,7 +405,7 @@ export const useChatStore = create<StoreState>((set, get) => ({
       pendingPersist.delete(id);
       void saveMessages(id, entry.latest);
     }, PERSIST_DEBOUNCE_MS);
-    pendingPersist.set(id, { latest: messages, timer });
+    pendingPersist.set(id, { latest: persistableMessages, timer });
 
     // Update zustand session list only when the derived title actually
     // changes — otherwise we'd rewrite the sessions array (and trigger
@@ -413,7 +415,7 @@ export const useChatStore = create<StoreState>((set, get) => ({
     if (!meta) return;
     const isUntitled = !meta.title || meta.title === "New chat";
     if (!isUntitled) return;
-    const nextTitle = deriveTitle(messages);
+    const nextTitle = deriveTitle(persistableMessages);
     if (nextTitle === meta.title) return;
     const next = sessions.map((s) =>
       s.id === id ? { ...s, title: nextTitle, updatedAt: Date.now() } : s,


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: <!-- macOS / Linux / Windows -->
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
