### PR TITLE
fix(editor): correct cursor positioning on macOS when zoom is not 100%

### DIFF
--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -384,7 +384,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     }
 
     return (
-      <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-full min-h-0 flex-col zoom-exempt">
         <CodeMirror
           ref={cmRef}
           value={doc.content}

--- a/src/modules/editor/lib/extensions.ts
+++ b/src/modules/editor/lib/extensions.ts
@@ -30,7 +30,7 @@ export function buildSharedExtensions(): Extension[] {
       },
       ".cm-scroller": {
         fontFamily: detectMonoFontFamily(),
-        fontSize: "13px",
+        fontSize: "calc(13px * var(--app-zoom, 1))",
         lineHeight: "1.55",
         backgroundColor: "transparent !important",
       },


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Fixed cursor offset when clicking in the editor on macOS

## Why
Closes #763 

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] ~(If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean~
- [x] ~(If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep~
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOs
- [x] Shells tested (if relevant): zsh


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
