### PR TITLE
feat(motion): UI transition polish across tabs, panels, header and sidebar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1032,7 +1032,7 @@ export default function App() {
                 }}
               >
                 <div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">
-                  <div className="min-h-0 flex-1">
+                  <div key={sidebarView} className="min-h-0 flex-1 terax-panel-in">
                     {sidebarView === "explorer" ? (
                       <FileExplorer
                         ref={explorerRef}

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -122,14 +122,8 @@ export function Header({
           variant="ghost"
           onClick={onOpenCommandPalette}
           title="Command palette"
-          className="shrink-0 gap-1.5 rounded-md px-1.5 text-muted-foreground"
+          className="shrink-0 gap-1.5 rounded-md px-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
         >
-          {/* <span className="text-xs font-medium">Cmd</span>
-          {!compact && paletteTokens && (
-            <Kbd className="rounded bg-transparent px-1 py-px font-sans text-[10px]">
-            {paletteTokens}
-            </Kbd>
-          )} */}
           <HugeiconsIcon icon={CommandIcon} size={14} strokeWidth={1.75} />
         </Button>
 
@@ -141,16 +135,15 @@ export function Header({
         )}
       </div>
 
-      {!IS_MAC && <span className="mx-1 h-5 w-px shrink-0 bg-border" />}
+      {!IS_MAC && <span className="mx-1 h-full w-px shrink-0 bg-border/70" />}
 
-      {IS_MAC && <span className="mr-1 h-full w-px shrink-0 bg-border" />}
+      {IS_MAC && <span className="mr-1 h-full w-px shrink-0 bg-border/70" />}
 
       <div
         className="flex min-w-0 flex-1 items-center gap-2"
         data-tauri-drag-region
       >
         {spaceSwitcher}
-        <span className="h-5 w-px shrink-0 bg-border/70" />
         <TabBar
           tabs={tabs}
           activeId={activeId}
@@ -185,7 +178,7 @@ export function Header({
 
       {USE_CUSTOM_WINDOW_CONTROLS && (
         <>
-          <span className="ml-1 h-5 w-px shrink-0 bg-border" />
+          <span className="ml-1 h-5 w-px shrink-0 bg-border/60" />
           <WindowControls />
         </>
       )}

--- a/src/modules/sidebar/SidebarRail.tsx
+++ b/src/modules/sidebar/SidebarRail.tsx
@@ -45,7 +45,7 @@ export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
             aria-pressed={isActive}
             onClick={() => onSelectView(item.id)}
             className={cn(
-              "group relative flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md text-[11px] font-medium outline-none transition-colors duration-150",
+              "group relative flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md text-[11px] font-medium outline-none transition-colors duration-[var(--dur-base)]",
               "focus-visible:ring-2 focus-visible:ring-primary/40",
               isActive
                 ? "bg-foreground/[0.07] text-foreground dark:bg-foreground/[0.09]"
@@ -56,7 +56,7 @@ export function SidebarRail({ activeView, onSelectView, changedCount }: Props) {
               icon={item.icon}
               size={14}
               strokeWidth={isActive ? 2 : 1.75}
-              className="shrink-0 transition-[stroke-width] duration-150"
+              className="shrink-0 transition-[stroke-width] duration-[var(--dur-base)]"
             />
             <span>{item.label}</span>
             {showBadge ? (

--- a/src/modules/spaces/SpaceSwitcher.tsx
+++ b/src/modules/spaces/SpaceSwitcher.tsx
@@ -190,8 +190,11 @@ export function SpaceSwitcher({
         >
           <span
             aria-hidden
-            className="size-2 shrink-0 rounded-full"
-            style={{ backgroundColor: accentFor(current) }}
+            className="size-1.5 shrink-0 rounded-full"
+            style={{
+              backgroundColor: `color-mix(in oklch, ${accentFor(current)} 90%, transparent)`,
+              boxShadow: `0 0 0 2px color-mix(in oklch, ${accentFor(current)} 22%, transparent)`,
+            }}
           />
           <span className="max-w-36 truncate text-xs font-medium">
             {current.name}

--- a/src/modules/spaces/SpaceSwitcher.tsx
+++ b/src/modules/spaces/SpaceSwitcher.tsx
@@ -186,24 +186,16 @@ export function SpaceSwitcher({
         <button
           type="button"
           title={shortcut ? `Spaces · ${shortcut}` : "Spaces"}
-          className="flex h-7 shrink-0 items-center gap-2 rounded-md px-2 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+          className="flex h-7 shrink-0 items-center gap-2 rounded-md px-2 text-muted-foreground/90 outline-none transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
         >
-          <span
-            aria-hidden
-            className="size-1.5 shrink-0 rounded-full"
-            style={{
-              backgroundColor: `color-mix(in oklch, ${accentFor(current)} 90%, transparent)`,
-              boxShadow: `0 0 0 2px color-mix(in oklch, ${accentFor(current)} 22%, transparent)`,
-            }}
-          />
           <span className="max-w-36 truncate text-xs font-medium">
             {current.name}
           </span>
           <HugeiconsIcon
-            icon={ArrowDown01Icon}
-            size={13}
+            icon={ArrowRight01Icon}
+            size={14}
             strokeWidth={1.75}
-            className="shrink-0 opacity-60"
+            className="shrink-0 opacity-65"
           />
         </button>
       </PopoverTrigger>

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -28,7 +28,13 @@ import {
   PlusSignIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { labelFor } from "./lib/tabLabel";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
@@ -66,7 +72,42 @@ export function TabBar({
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
+
+  // Single shared pill slides to the active tab instead of each tab toggling
+  // its own background. Measured relative to the list (its offsetParent) so it
+  // scrolls with the strip for free; transform/width only, no layout on siblings.
+  const [pill, setPill] = useState<{ left: number; width: number } | null>(null);
+  const [pillReady, setPillReady] = useState(false);
+
+  const measurePill = useCallback(() => {
+    const el = listRef.current?.querySelector<HTMLElement>(
+      '[data-tab-active="true"]',
+    );
+    setPill(el ? { left: el.offsetLeft, width: el.offsetWidth } : null);
+  }, []);
+
+  useLayoutEffect(() => {
+    measurePill();
+  }, [measurePill, activeId, tabs]);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const ro = new ResizeObserver(measurePill);
+    ro.observe(list);
+    return () => ro.disconnect();
+  }, [measurePill]);
+
+  // Hold the transition off until the pill is first placed, so it never slides
+  // in from the origin on mount.
+  useEffect(() => {
+    if (pill && !pillReady) {
+      const id = requestAnimationFrame(() => setPillReady(true));
+      return () => cancelAnimationFrame(id);
+    }
+  }, [pill, pillReady]);
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -101,7 +142,25 @@ export function TabBar({
           value={String(activeId)}
           onValueChange={(v) => onSelect(Number(v))}
         >
-          <TabsList className="h-7 w-max gap-0.5 bg-transparent p-0">
+          <TabsList
+            ref={listRef}
+            className="relative h-7 w-max gap-0.5 bg-transparent p-0"
+          >
+            <span
+              aria-hidden
+              className="pointer-events-none absolute left-0 top-0 h-7 rounded-md bg-accent"
+              style={
+                pill
+                  ? {
+                      width: pill.width,
+                      transform: `translateX(${pill.left}px)`,
+                      transitionProperty: pillReady ? "transform, width" : "none",
+                      transitionDuration: "var(--dur-base)",
+                      transitionTimingFunction: "var(--ease-premium)",
+                    }
+                  : { opacity: 0 }
+              }
+            />
             {tabs.map((t) => {
               const isPreview = t.kind === "editor" && (t as EditorTab).preview;
               const isActive = t.id === activeId;
@@ -137,6 +196,7 @@ export function TabBar({
                   key={t.id}
                   value={String(t.id)}
                   data-tab-id={t.id}
+                  data-tab-active={isActive ? "true" : undefined}
                   onDoubleClick={() => isPreview && onPin(t.id)}
                   onAuxClick={(e) => {
                     if (e.button === 1 && tabs.length > 1) {
@@ -149,10 +209,8 @@ export function TabBar({
                     if (e.button === 1) e.preventDefault();
                   }}
                   className={cn(
-                    "group h-7 shrink-0 gap-1.5 rounded-md text-xs transition-colors hover:text-foreground/80 justify-between",
-                    isActive
-                      ? "bg-accent text-foreground"
-                      : "text-muted-foreground",
+                    "group relative z-[1] h-7 shrink-0 gap-1.5 rounded-md text-xs transition-colors hover:text-foreground/80 justify-between",
+                    isActive ? "text-foreground" : "text-muted-foreground",
                     compact
                       ? "px-1.5!"
                       : tabs.length === 1

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -75,10 +75,26 @@ export function TabBar({
   const listRef = useRef<HTMLDivElement>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
 
+  // Play the enter animation only for tabs opened after the first paint, never
+  // the restored set and never on switch/reorder (triggers are keyed, so they
+  // don't remount then). The ref is seeded with the initial ids on first render.
+  const seenRef = useRef<Set<number> | null>(null);
+  const firstRender = seenRef.current === null;
+  let seen = seenRef.current;
+  if (seen === null) {
+    seen = new Set(tabs.map((t) => t.id));
+    seenRef.current = seen;
+  }
+  useEffect(() => {
+    seenRef.current = new Set(tabs.map((t) => t.id));
+  }, [tabs]);
+
   // Single shared pill slides to the active tab instead of each tab toggling
   // its own background. Measured relative to the list (its offsetParent) so it
   // scrolls with the strip for free; transform/width only, no layout on siblings.
-  const [pill, setPill] = useState<{ left: number; width: number } | null>(null);
+  const [pill, setPill] = useState<{ left: number; width: number } | null>(
+    null,
+  );
   const [pillReady, setPillReady] = useState(false);
 
   const measurePill = useCallback(() => {
@@ -129,7 +145,7 @@ export function TabBar({
     if (!el) return;
     const active = el.querySelector<HTMLElement>(`[data-tab-id="${activeId}"]`);
     active?.scrollIntoView({ block: "nearest", inline: "nearest" });
-  }, [activeId, tabs.length]);
+  }, [activeId]);
 
   return (
     <div
@@ -148,13 +164,15 @@ export function TabBar({
           >
             <span
               aria-hidden
-              className="pointer-events-none absolute left-0 top-1/2 h-7 rounded-md bg-accent"
+              className="pointer-events-none absolute left-0 top-1/2 h-7 rounded-md bg-foreground/[0.07] shadow-sm ring-1 ring-inset ring-foreground/[0.05]"
               style={
                 pill
                   ? {
                       width: pill.width,
                       transform: `translate(${pill.left}px, -50%)`,
-                      transitionProperty: pillReady ? "transform, width" : "none",
+                      transitionProperty: pillReady
+                        ? "transform, width"
+                        : "none",
                       transitionDuration: "var(--dur-base)",
                       transitionTimingFunction: "var(--ease-premium)",
                     }
@@ -164,6 +182,7 @@ export function TabBar({
             {tabs.map((t) => {
               const isPreview = t.kind === "editor" && (t as EditorTab).preview;
               const isActive = t.id === activeId;
+              const isNew = !firstRender && !seen.has(t.id);
 
               // While renaming, render a non-button cell so the <input> is not
               // nested inside the trigger <button> (invalid HTML, and WebKit
@@ -210,6 +229,7 @@ export function TabBar({
                   }}
                   className={cn(
                     "group relative z-[1] h-7 shrink-0 justify-between gap-1.5 rounded-md bg-transparent text-xs transition-colors data-active:bg-transparent dark:data-active:bg-transparent",
+                    isNew && "terax-tab-in",
                     isActive
                       ? "text-foreground dark:text-foreground"
                       : "text-muted-foreground hover:text-foreground/80 dark:text-muted-foreground",
@@ -357,7 +377,11 @@ export function TabBar({
               </span>
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => onNewGitGraph()}>
-              <HugeiconsIcon icon={GitBranchIcon} size={14} strokeWidth={1.75} />
+              <HugeiconsIcon
+                icon={GitBranchIcon}
+                size={14}
+                strokeWidth={1.75}
+              />
               <span className="flex-1">Git Graph</span>
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -148,12 +148,12 @@ export function TabBar({
           >
             <span
               aria-hidden
-              className="pointer-events-none absolute left-0 top-0 h-7 rounded-md bg-accent"
+              className="pointer-events-none absolute left-0 top-1/2 h-7 rounded-md bg-accent"
               style={
                 pill
                   ? {
                       width: pill.width,
-                      transform: `translateX(${pill.left}px)`,
+                      transform: `translate(${pill.left}px, -50%)`,
                       transitionProperty: pillReady ? "transform, width" : "none",
                       transitionDuration: "var(--dur-base)",
                       transitionTimingFunction: "var(--ease-premium)",
@@ -209,8 +209,10 @@ export function TabBar({
                     if (e.button === 1) e.preventDefault();
                   }}
                   className={cn(
-                    "group relative z-[1] h-7 shrink-0 gap-1.5 rounded-md text-xs transition-colors hover:text-foreground/80 justify-between",
-                    isActive ? "text-foreground" : "text-muted-foreground",
+                    "group relative z-[1] h-7 shrink-0 justify-between gap-1.5 rounded-md bg-transparent text-xs transition-colors data-active:bg-transparent dark:data-active:bg-transparent",
+                    isActive
+                      ? "text-foreground dark:text-foreground"
+                      : "text-muted-foreground hover:text-foreground/80 dark:text-muted-foreground",
                     compact
                       ? "px-1.5!"
                       : tabs.length === 1

--- a/src/modules/terminal/block/block.css
+++ b/src/modules/terminal/block/block.css
@@ -131,7 +131,7 @@
   justify-content: space-between;
   height: 18px;
   opacity: 0.72;
-  transition: opacity 120ms ease;
+  transition: opacity var(--dur-fast) var(--ease-soft);
 }
 
 .bt-bar-active {
@@ -203,8 +203,8 @@
   border-radius: 5px;
   color: inherit;
   transition:
-    background 100ms ease,
-    color 100ms ease;
+    background var(--dur-fast) var(--ease-soft),
+    color var(--dur-fast) var(--ease-soft);
 }
 
 .bt-btn:hover {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -316,6 +316,15 @@ html *::-webkit-scrollbar {
   display: none;
 }
 
+/* Motion tokens. Reduced-motion zeroes the durations as a global snap. */
+:root {
+  --dur-fast: 120ms;
+  --dur-base: 180ms;
+  --dur-slow: 240ms;
+  --ease-premium: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-soft: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 @keyframes terax-collapsible-down {
   from {
     height: 0;
@@ -342,10 +351,10 @@ html *::-webkit-scrollbar {
   overflow: hidden;
 }
 .terax-collapsible-content[data-state="open"] {
-  animation: terax-collapsible-down 180ms cubic-bezier(0.4, 0, 0.2, 1);
+  animation: terax-collapsible-down var(--dur-base) var(--ease-soft);
 }
 .terax-collapsible-content[data-state="closed"] {
-  animation: terax-collapsible-up 160ms cubic-bezier(0.4, 0, 0.2, 1);
+  animation: terax-collapsible-up var(--dur-base) var(--ease-soft);
 }
 
 /* Height auto<->0 reveal without JS measuring: animate the grid track from 0fr
@@ -355,8 +364,8 @@ html *::-webkit-scrollbar {
   display: grid;
   grid-template-rows: 0fr;
   transition:
-    grid-template-rows 180ms cubic-bezier(0.16, 1, 0.3, 1),
-    opacity 180ms cubic-bezier(0.16, 1, 0.3, 1);
+    grid-template-rows var(--dur-base) var(--ease-premium),
+    opacity var(--dur-base) var(--ease-premium);
   opacity: 0;
 }
 .terax-reveal[data-state="open"] {
@@ -398,6 +407,11 @@ html *::-webkit-scrollbar {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  :root {
+    --dur-fast: 0.01ms;
+    --dur-base: 0.01ms;
+    --dur-slow: 0.01ms;
+  }
   .terax-reveal {
     transition: none;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -318,9 +318,9 @@ html *::-webkit-scrollbar {
 
 /* Motion tokens. Reduced-motion zeroes the durations as a global snap. */
 :root {
-  --dur-fast: 120ms;
-  --dur-base: 180ms;
-  --dur-slow: 240ms;
+  --dur-fast: 160ms;
+  --dur-base: 240ms;
+  --dur-slow: 320ms;
   --ease-premium: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-soft: cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -375,6 +375,34 @@ html *::-webkit-scrollbar {
 .terax-reveal > * {
   min-height: 0;
   overflow: hidden;
+}
+
+@keyframes terax-panel-in {
+  from {
+    opacity: 0;
+    transform: translateX(-40px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.terax-panel-in {
+  animation: terax-panel-in var(--dur-slow) var(--ease-premium);
+}
+
+@keyframes terax-tab-in {
+  from {
+    opacity: 0;
+    transform: scale(0.86);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+.terax-tab-in {
+  animation: terax-tab-in var(--dur-base) var(--ease-premium);
 }
 
 /* Text shimmer loop (replaces motion background-position animation). Driven by


### PR DESCRIPTION
Native CSS-only motion pass over the non-critical chrome. Critical surfaces stay instant: xterm/WebGL, editor, terminal blocks, and geometry resize never animate.

## What's in here
- Shared motion tokens (`--dur-fast/base/slow`, `--ease-premium/soft`) in `globals.css`; existing scattered durations/easings refactored onto them. `prefers-reduced-motion` zeroes the durations as a global snap.
- Tabs: single sliding active pill (measured, transform/width only) instead of per-tab background toggling; enter animation for newly opened tabs (restored/cold tabs never animate); raised active pill with a hairline ring.
- Sidebar: explorer/source-control panel swap reveal; smooth cross-fade on the bottom rail view switch.
- Header: consistent divider treatment and command-button hover; dropped dead code.
- Spaces: cleaner switcher trigger.

## Notes
- All animations are compositor-only (transform/opacity), no JS animation loops, one ResizeObserver total (tab strip).
- `check-types`, `pnpm test` (151) green. Lint warnings present are all pre-existing patterns, none introduced here.