### PR TITLE
feat(terminal): selection-aware copy, image paste, and Thai input fix

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5368,6 +5368,7 @@ dependencies = [
 name = "terax"
 version = "0.7.3"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "dirs 6.0.0",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ bytes = "1"
 futures-util = "0.3"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 tempfile = "3"
+base64 = "0.22"
 notify = "8.2.0"
 
 [dev-dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,6 +182,7 @@ pub fn run() {
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,
             fs::file::fs_write_file,
+            fs::file::write_temp_image,
             fs::file::fs_stat,
             fs::file::fs_canonicalize,
             fs::mutate::fs_create_file,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -128,6 +128,22 @@ pub fn fs_write_file(
     Ok(())
 }
 
+/// Save base64-encoded PNG bytes to a unique temp file and return its path.
+/// The caller is responsible for deleting the file via `fs_delete` when done.
+#[tauri::command]
+pub fn write_temp_image(data_base64: String) -> Result<String, String> {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    let bytes = STANDARD.decode(&data_base64).map_err(|e| e.to_string())?;
+    let id = std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut path = std::env::temp_dir();
+    path.push(format!("terax-paste-{id}.png"));
+    std::fs::write(&path, bytes).map_err(|e| e.to_string())?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 #[tauri::command]
 pub fn fs_canonicalize(path: String, workspace: Option<WorkspaceEnv>) -> Result<String, String> {
     let workspace = WorkspaceEnv::from_option(workspace);

--- a/src/modules/ai/components/AiComposerInput.tsx
+++ b/src/modules/ai/components/AiComposerInput.tsx
@@ -68,6 +68,8 @@ export function AiComposerInput() {
   const [activeIndex, setActiveIndex] = useState(0);
   const workspaceFiles = useWorkspaceFiles(workspaceRoot, fileTrigger !== null);
 
+  const isComposingRef = useRef(false);
+
   const [fileQuery, setFileQuery] = useState("");
   useEffect(() => {
     if (!fileTrigger) {
@@ -213,7 +215,14 @@ export function AiComposerInput() {
             <textarea
               ref={c.textareaRef}
               value={c.value}
-              onChange={(e) => c.setValue(e.target.value)}
+              onChange={(e) => {
+                if (!isComposingRef.current) c.setValue(e.target.value);
+              }}
+              onCompositionStart={() => { isComposingRef.current = true; }}
+              onCompositionEnd={(e) => {
+                isComposingRef.current = false;
+                c.setValue((e.target as HTMLTextAreaElement).value);
+              }}
               onKeyUp={updateTrigger}
               onClick={updateTrigger}
               onSelect={updateTrigger}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -265,11 +265,38 @@ function createSlot(): Slot {
       if (event.type === "keydown" && slot.term.hasSelection()) {
         const sel = slot.term.getSelection();
         if (sel) void navigator.clipboard.writeText(sel).catch(() => {});
+        const t = slot.term;
+        requestAnimationFrame(() => { t.clearSelection(); t.refresh(0, t.rows - 1); });
+      }
+      event.preventDefault();
+      return false;
+    }
+    // Ctrl+C: copy when text is selected, otherwise fall through to PTY (SIGINT).
+    if (isCtrlC(event) && slot.term.hasSelection()) {
+      if (event.type === "keydown") {
+        const sel = slot.term.getSelection();
+        if (sel) void navigator.clipboard.writeText(sel).catch(() => {});
+        const t = slot.term;
+        requestAnimationFrame(() => { t.clearSelection(); t.refresh(0, t.rows - 1); });
       }
       event.preventDefault();
       return false;
     }
     if (isTerminalPaste(event)) {
+      if (event.type === "keydown") {
+        void navigator.clipboard
+          .readText()
+          .then((text) => {
+            if (text) slot.term.paste(text);
+          })
+          .catch(() => {});
+      }
+      event.preventDefault();
+      return false;
+    }
+    // Ctrl+V: paste from clipboard (^V / literal-next is sacrificed, matching
+    // Windows Terminal behaviour where Ctrl+V always pastes).
+    if (isCtrlV(event)) {
       if (event.type === "keydown") {
         void navigator.clipboard
           .readText()
@@ -906,11 +933,33 @@ function isTerminalCopy(e: KeyboardEvent): boolean {
   );
 }
 
+function isCtrlC(e: KeyboardEvent): boolean {
+  return (
+    !IS_MAC &&
+    e.ctrlKey &&
+    !e.shiftKey &&
+    !e.altKey &&
+    !e.metaKey &&
+    (e.code === "KeyC" || e.key === "c" || e.key === "C")
+  );
+}
+
 function isTerminalPaste(e: KeyboardEvent): boolean {
   return (
     !IS_MAC &&
     e.ctrlKey &&
     e.shiftKey &&
+    !e.altKey &&
+    !e.metaKey &&
+    (e.code === "KeyV" || e.key === "v" || e.key === "V")
+  );
+}
+
+function isCtrlV(e: KeyboardEvent): boolean {
+  return (
+    !IS_MAC &&
+    e.ctrlKey &&
+    !e.shiftKey &&
     !e.altKey &&
     !e.metaKey &&
     (e.code === "KeyV" || e.key === "v" || e.key === "V")

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -231,7 +231,10 @@ function createSlot(): Slot {
     // composed string through its own compositionend handler instead.
     // keyCode 229 ("Process") is what Chromium reports for every key
     // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // Thai tone marks also get keyCode 229 in Chromium but carry a real key
+    // value (e.g. '่') — use event.key === 'Process' to distinguish IME from
+    // direct Thai keyboard input.
+    if (event.isComposing || event.key === "Process") return false;
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,6 +1,7 @@
 import { detectMonoFontFamily } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
+import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
@@ -284,12 +285,7 @@ function createSlot(): Slot {
     }
     if (isTerminalPaste(event)) {
       if (event.type === "keydown") {
-        void navigator.clipboard
-          .readText()
-          .then((text) => {
-            if (text) slot.term.paste(text);
-          })
-          .catch(() => {});
+        void pasteClipboard(slot);
       }
       event.preventDefault();
       return false;
@@ -298,12 +294,15 @@ function createSlot(): Slot {
     // Windows Terminal behaviour where Ctrl+V always pastes).
     if (isCtrlV(event)) {
       if (event.type === "keydown") {
-        void navigator.clipboard
-          .readText()
-          .then((text) => {
-            if (text) slot.term.paste(text);
-          })
-          .catch(() => {});
+        void pasteClipboard(slot);
+      }
+      event.preventDefault();
+      return false;
+    }
+    // Cmd+V on macOS: intercept to support image paste.
+    if (isMacPaste(event)) {
+      if (event.type === "keydown") {
+        void pasteClipboard(slot);
       }
       event.preventDefault();
       return false;
@@ -922,6 +921,7 @@ const IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad/.test(navigator.userAgent);
 
+
 function isTerminalCopy(e: KeyboardEvent): boolean {
   return (
     !IS_MAC &&
@@ -966,8 +966,68 @@ function isCtrlV(e: KeyboardEvent): boolean {
   );
 }
 
+function isMacPaste(e: KeyboardEvent): boolean {
+  return (
+    IS_MAC &&
+    e.metaKey &&
+    !e.ctrlKey &&
+    !e.shiftKey &&
+    !e.altKey &&
+    (e.code === "KeyV" || e.key === "v" || e.key === "V")
+  );
+}
+
 function isShiftEnter(e: KeyboardEvent): boolean {
   return (
     e.key === "Enter" && e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey
   );
+}
+
+/**
+ * Paste clipboard content into the terminal. Text pastes as usual; when the
+ * clipboard holds only an image, forward a literal ^V to the PTY so CLI tools
+ * that read the OS clipboard themselves (e.g. Claude Code) can pick it up.
+ */
+async function pasteClipboard(slot: Slot): Promise<void> {
+  try {
+    const items = await navigator.clipboard.read();
+    const hasText = items.some((i) =>
+      i.types.some((t) => t.startsWith("text/")),
+    );
+    const hasImage = items.some((i) =>
+      i.types.some((t) => t.startsWith("image/")),
+    );
+    if (!hasText && hasImage) {
+      const imgItem =
+        items.find((i) => i.types.includes("image/png")) ??
+        items.find((i) => i.types.some((t) => t.startsWith("image/")));
+      if (imgItem) {
+        const type = imgItem.types.find((t) => t.startsWith("image/")) ?? "image/png";
+        const blob = await imgItem.getType(type);
+        const b64 = await new Promise<string>((resolve) => {
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            const url = e.target!.result as string;
+            resolve(url.split(",")[1] ?? "");
+          };
+          reader.readAsDataURL(blob);
+        });
+        const path = await invoke<string>("write_temp_image", { dataBase64: b64 });
+        if (path) {
+          slot.term.paste(path);
+          setTimeout(
+            () => void invoke("fs_delete", { path, workspace: null }).catch(() => {}),
+            5 * 60 * 1000,
+          );
+          return;
+        }
+      }
+    }
+  } catch {
+    // fall through to plain-text paste
+  }
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text) slot.term.paste(text);
+  } catch {}
 }


### PR DESCRIPTION
## Summary

- Add selection-aware Ctrl+C copy in terminal (copies selection if present, otherwise passes through)
- Add Ctrl+V / Cmd+V image paste via temp file in terminal
- Fix Thai character input in terminal and AI composer

## Test plan

- [ ] Select text in terminal → Ctrl+C copies selection
- [ ] No selection → Ctrl+C passes through to process
- [ ] Ctrl+V with image in clipboard → pastes image via temp file
- [ ] Thai characters input correctly in terminal and AI composer