### PR TITLE
Add macOS installation instructions using Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Terax is a lightweight open-source terminal (ADE) built on Tauri 2 + Rust and Re
 
 Latest installers are on the [Releases](https://github.com/crynta/terax-ai/releases/latest) page. Terax auto-updates from there.
 
+### macOS notes
+
+- **Homebrew:** `brew install --cask terax`
+
 ### Windows notes
 
 - On first launch Windows shows "Windows protected your PC" because Terax isn't code-signed yet. Click **More info** then **Run anyway**.


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

Closes #177 

## What
Add brew installation method for macOS.

## Why
<!-- This allows users to install Terax on macOs using the brew package manager.
## How
simply run:
`brew install --cask terax`

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: <!-- macOS / Linux / Windows -->
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
