### PR TITLE
fix(terminal): keep IME preedit across input method switch

### DIFF
--- a/src/modules/terminal/lib/imeDedup.test.ts
+++ b/src/modules/terminal/lib/imeDedup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { createImeDedup } from "./imeDedup";
+
+describe("createImeDedup", () => {
+  it("drops an exact duplicate within the window", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(true);
+  });
+
+  it("does not drop a write outside the window", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.shouldDrop("我想要做一個功能", 1101)).toBe(false);
+  });
+
+  it("does not drop legitimate repeated identical input when never armed", () => {
+    const dedup = createImeDedup();
+    expect(dedup.shouldDrop("a", 1000)).toBe(false);
+    expect(dedup.shouldDrop("a", 1001)).toBe(false);
+  });
+
+  it("does not arm on empty data", () => {
+    const dedup = createImeDedup();
+    dedup.arm("", 1000);
+    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(false);
+  });
+
+  it("drops only once", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(true);
+    expect(dedup.shouldDrop("我想要做一個功能", 1060)).toBe(false);
+  });
+
+  it("does not consume the guard for a non-matching write within the window", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.shouldDrop("different", 1050)).toBe(false);
+    expect(dedup.shouldDrop("我想要做一個功能", 1060)).toBe(true);
+  });
+});

--- a/src/modules/terminal/lib/imeDedup.test.ts
+++ b/src/modules/terminal/lib/imeDedup.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import { createImeDedup } from "./imeDedup";
 
 describe("createImeDedup", () => {
-  it("drops an exact duplicate within the window", () => {
+  it("passes the first exact match within the window", () => {
     const dedup = createImeDedup();
     dedup.arm("我想要做一個功能", 1000);
-    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(true);
+    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(false);
   });
 
   it("does not drop a write outside the window", () => {
@@ -27,17 +27,38 @@ describe("createImeDedup", () => {
     expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(false);
   });
 
-  it("drops only once", () => {
+  it("drops only after the first matching write emitted", () => {
     const dedup = createImeDedup();
     dedup.arm("我想要做一個功能", 1000);
-    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(true);
-    expect(dedup.shouldDrop("我想要做一個功能", 1060)).toBe(false);
+    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(false);
+    expect(dedup.shouldDrop("我想要做一個功能", 1060)).toBe(true);
   });
 
   it("does not consume the guard for a non-matching write within the window", () => {
     const dedup = createImeDedup();
     dedup.arm("我想要做一個功能", 1000);
     expect(dedup.shouldDrop("different", 1050)).toBe(false);
+    expect(dedup.shouldDrop("我想要做一個功能", 1060)).toBe(false);
+    expect(dedup.shouldDrop("我想要做一個功能", 1070)).toBe(true);
+  });
+
+  it("flushes pending armed data when never emitted", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.flushPending(1050)).toBe("我想要做一個功能");
     expect(dedup.shouldDrop("我想要做一個功能", 1060)).toBe(true);
+  });
+
+  it("does not flush pending data after it already emitted", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.shouldDrop("我想要做一個功能", 1050)).toBe(false);
+    expect(dedup.flushPending(1060)).toBeNull();
+  });
+
+  it("does not flush pending data outside the window", () => {
+    const dedup = createImeDedup();
+    dedup.arm("我想要做一個功能", 1000);
+    expect(dedup.flushPending(1101)).toBeNull();
   });
 });

--- a/src/modules/terminal/lib/imeDedup.ts
+++ b/src/modules/terminal/lib/imeDedup.ts
@@ -1,20 +1,22 @@
-const IME_DEDUP_WINDOW_MS = 100;
+export const IME_DEDUP_WINDOW_MS = 100;
 
 type ImeDedupState = {
   data: string;
   ts: number;
+  emitted: boolean;
 };
 
 export function createImeDedup(): {
   arm(data: string, now: number): void;
   shouldDrop(write: string, now: number): boolean;
+  flushPending(now: number): string | null;
 } {
   let state: ImeDedupState | null = null;
 
   return {
     arm(data, now) {
       if (!data) return;
-      state = { data, ts: now };
+      state = { data, ts: now, emitted: false };
     },
     shouldDrop(write, now) {
       if (!state) return false;
@@ -23,8 +25,21 @@ export function createImeDedup(): {
         return false;
       }
       if (write !== state.data) return false;
-      state = null;
+      if (!state.emitted) {
+        state.emitted = true;
+        return false;
+      }
       return true;
+    },
+    flushPending(now) {
+      if (!state) return null;
+      if (now - state.ts > IME_DEDUP_WINDOW_MS) {
+        state = null;
+        return null;
+      }
+      if (state.emitted) return null;
+      state.emitted = true;
+      return state.data;
     },
   };
 }

--- a/src/modules/terminal/lib/imeDedup.ts
+++ b/src/modules/terminal/lib/imeDedup.ts
@@ -1,0 +1,30 @@
+const IME_DEDUP_WINDOW_MS = 100;
+
+type ImeDedupState = {
+  data: string;
+  ts: number;
+};
+
+export function createImeDedup(): {
+  arm(data: string, now: number): void;
+  shouldDrop(write: string, now: number): boolean;
+} {
+  let state: ImeDedupState | null = null;
+
+  return {
+    arm(data, now) {
+      if (!data) return;
+      state = { data, ts: now };
+    },
+    shouldDrop(write, now) {
+      if (!state) return false;
+      if (now - state.ts > IME_DEDUP_WINDOW_MS) {
+        state = null;
+        return false;
+      }
+      if (write !== state.data) return false;
+      state = null;
+      return true;
+    },
+  };
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -9,7 +9,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import { shouldCursorBlink } from "./cursorBlink";
-import { createImeDedup } from "./imeDedup";
+import { createImeDedup, IME_DEDUP_WINDOW_MS } from "./imeDedup";
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
@@ -61,6 +61,7 @@ export type Slot = {
   ptyTimer: ReturnType<typeof setTimeout> | null;
   webglReapTimer: ReturnType<typeof setTimeout> | null;
   slotReapTimer: ReturnType<typeof setTimeout> | null;
+  imeFlushTimer: ReturnType<typeof setTimeout> | null;
   unhideRaf: number | null;
   lastCols: number;
   lastRows: number;
@@ -209,9 +210,6 @@ function createSlot(): Slot {
   getRecycler().appendChild(host);
   term.open(host);
   const imeDedup = createImeDedup();
-  term.textarea?.addEventListener("compositionend", (e) =>
-    imeDedup.arm((e as CompositionEvent).data ?? "", performance.now()),
-  );
 
   const slot: Slot = {
     id: slots.length,
@@ -231,6 +229,7 @@ function createSlot(): Slot {
     ptyTimer: null,
     webglReapTimer: null,
     slotReapTimer: null,
+    imeFlushTimer: null,
     unhideRaf: null,
     lastCols: term.cols,
     lastRows: term.rows,
@@ -238,6 +237,26 @@ function createSlot(): Slot {
     lastH: 0,
     lastUsedAt: 0,
   };
+
+  term.textarea?.addEventListener(
+    "compositionend",
+    (e) => {
+      const data = (e as CompositionEvent).data ?? "";
+      const armedAt = performance.now();
+      imeDedup.arm(data, armedAt);
+      cancelImeFlush(slot);
+      if (!data) return;
+      slot.imeFlushTimer = setTimeout(() => {
+        slot.imeFlushTimer = null;
+        const pending = imeDedup.flushPending(armedAt + IME_DEDUP_WINDOW_MS);
+        if (pending === null) return;
+        const leafId = slot.currentLeafId;
+        if (leafId === null) return;
+        adapter?.resolveLeaf(leafId)?.writeToPty(pending);
+      }, IME_DEDUP_WINDOW_MS);
+    },
+    { capture: true },
+  );
 
   term.attachCustomKeyEventHandler((event) => {
     // During IME composition the browser is assembling a multi-keystroke
@@ -667,6 +686,7 @@ function detachSlotFromLeaf(slot: Slot, retain: boolean): void {
   if (slot.ptyTimer) clearTimeout(slot.ptyTimer);
   slot.fitTimer = null;
   slot.ptyTimer = null;
+  cancelImeFlush(slot);
 
   cancelPendingUnhide(slot);
   slot.host.style.visibility = "";
@@ -722,6 +742,13 @@ function cancelSlotReap(slot: Slot): void {
   }
 }
 
+function cancelImeFlush(slot: Slot): void {
+  if (slot.imeFlushTimer !== null) {
+    clearTimeout(slot.imeFlushTimer);
+    slot.imeFlushTimer = null;
+  }
+}
+
 function reapIdleSlot(slot: Slot): void {
   if (slot.currentLeafId !== null) return;
   const idle = slots.filter((s) => s.currentLeafId === null);
@@ -743,6 +770,7 @@ function disposeSlot(slot: Slot): void {
   if (slot.ptyTimer) clearTimeout(slot.ptyTimer);
   slot.fitTimer = null;
   slot.ptyTimer = null;
+  cancelImeFlush(slot);
   slot.observer?.disconnect();
   slot.observer = null;
   for (const d of slot.oscDisposers) {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -9,6 +9,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import { shouldCursorBlink } from "./cursorBlink";
+import { createImeDedup } from "./imeDedup";
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
@@ -207,6 +208,10 @@ function createSlot(): Slot {
   host.setAttribute("data-terax-slot", String(slots.length));
   getRecycler().appendChild(host);
   term.open(host);
+  const imeDedup = createImeDedup();
+  term.textarea?.addEventListener("compositionend", (e) =>
+    imeDedup.arm((e as CompositionEvent).data ?? "", performance.now()),
+  );
 
   const slot: Slot = {
     id: slots.length,
@@ -297,6 +302,7 @@ function createSlot(): Slot {
   });
 
   term.onData((data) => {
+    if (imeDedup.shouldDrop(data, performance.now())) return;
     const leafId = slot.currentLeafId;
     if (leafId === null) return;
     adapter?.resolveLeaf(leafId)?.writeToPty(data);


### PR DESCRIPTION
## What
Make an in-progress IME composition survive an input-method switch in the terminal: the uncommitted preedit is now committed to the PTY exactly once — never duplicated, never lost.

## Why
Closes #785.

Switching input method mid-composition on macOS WKWebView made the committed preedit string reach the PTY twice. The first pass (#785, commit in this branch) added a dedup window that dropped the duplicate — but it dropped the *first* matching write within the window. That only works for the Enter-commit path, where xterm's write lands before the guard is armed. On an actual input-method switch the single legitimate commit arrives *after* arming, so the dedup ate it and the preedit silently vanished.

## How
Commit-once instead of drop-first:
- Arm the dedup in the **capture phase** so ordering is deterministic (our `arm()` always runs before xterm's bubble-phase `compositionend` → `onData`).
- Let the **first** matching write within the window through (mark it emitted); drop only **subsequent** duplicates.
- **Flush fallback**: if xterm emits no `onData` at all on the switch, a `setTimeout(IME_DEDUP_WINDOW_MS)` writes the preedit to the PTY once. The timer is stored on the slot and cleared on re-arm / detach / dispose (no leak, no double-write).

`imeDedup.ts` stays pure and timer-free (`now` passed in, new `flushPending(now)` returns data-or-null); the timer lives in `rendererPool.ts`.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run imeDedup` — 9/9 pass (commit-once first-pass/second-drop, flush-pending, window, empty-data, non-match, unarmed)
- [x] Manual smoke-test: typed a Chinese pinyin preedit, switched input method mid-composition — preedit commits exactly once (no duplicate, no loss); re-checked the Enter-commit path still produces no duplicate
- [x] Platforms tested: macOS (WKWebView). Linux/Windows IME not exercised.
- [x] Shells tested: zsh / fish

## Screenshots / GIFs
N/A — terminal input behavior, not a visual change.

## Notes for reviewer
Touches the terminal renderer hot path. The behavior contract is locked by `imeDedup.test.ts`. The capture-phase listener assumes xterm registers its own `compositionend` in the bubble phase (verified); worth a second look on non-macOS IME stacks where the no-`onData` flush path may behave differently.