### PR TITLE
feat(source-control): add 'create worktree' button

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -213,6 +213,8 @@ pub fn run() {
             git::commands::git_commit_files,
             git::commands::git_commit_file_diff,
             git::commands::git_remote_url,
+            git::commands::git_suggest_worktree_name,
+            git::commands::git_add_worktree,
             shell::shell_run_command,
             shell::shell_session_open,
             shell::shell_session_run,

--- a/src-tauri/src/modules/git/commands.rs
+++ b/src-tauri/src/modules/git/commands.rs
@@ -4,6 +4,7 @@ use crate::modules::git::operations;
 use crate::modules::git::types::{
     DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult, GitDiffResult,
     GitLogEntry, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
+    GitWorktreeAddResult, GitWorktreeNameSuggestion,
 };
 use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
 
@@ -278,6 +279,35 @@ pub async fn git_remote_url(
     let workspace = WorkspaceEnv::from_option(workspace);
     blocking(app, move |r| {
         operations::remote_url(r, &repo_root, &remote, &workspace).map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn git_suggest_worktree_name(
+    repo_root: String,
+    user_input: Option<String>,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<GitWorktreeNameSuggestion, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::suggest_worktree_name(r, &repo_root, user_input.as_deref(), &workspace)
+            .map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn git_add_worktree(
+    repo_root: String,
+    branch_name: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<GitWorktreeAddResult, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::add_worktree(r, &repo_root, &branch_name, &workspace).map_err(Into::into)
     })
     .await
 }

--- a/src-tauri/src/modules/git/mod.rs
+++ b/src-tauri/src/modules/git/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod errors;
+pub mod names;
 pub mod operations;
 pub mod parser;
 mod process;

--- a/src-tauri/src/modules/git/names.rs
+++ b/src-tauri/src/modules/git/names.rs
@@ -1,0 +1,168 @@
+use std::ffi::OsString;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::modules::git::errors::Result;
+use crate::modules::git::process::run_git;
+use crate::modules::git::types::{GitWorktreeNameSuggestion, DEFAULT_TIMEOUT_SECS};
+use crate::modules::workspace::WorkspaceEnv;
+
+const ADJECTIVES: &[&str] = &[
+    "able", "aged", "agile", "alert", "alive", "amber", "ample", "apt", "arid", "ashen",
+    "basic", "black", "bland", "blank", "bleak", "blind", "bliss", "blue", "bold", "brave",
+    "brief", "bright", "broad", "brown", "calm", "cheap", "chief", "chill", "clean", "clear",
+    "close", "cloudy", "cold", "cool", "crisp", "crude", "curly", "daily", "damp", "dark",
+    "deep", "dense", "dim", "dizzy", "dry", "dull", "dusty", "early", "easy", "eager",
+    "empty", "equal", "even", "faint", "fair", "false", "fancy", "fast", "final", "fine",
+    "firm", "fixed", "flat", "fluid", "fond", "frail", "frank", "fresh", "full", "gentle",
+    "giant", "glad", "grand", "gray", "great", "green", "grim", "happy", "hard", "harsh",
+    "heavy", "high", "hollow", "holy", "hot", "huge", "humble", "icy", "ideal", "idle",
+    "jolly", "keen", "kind", "large", "late", "lazy", "lean", "level", "light", "lively",
+    "loose", "loud", "low", "loyal", "lucky", "lush", "major", "meek", "merry", "mild",
+    "minor", "misty", "mixed", "modest", "murky", "mute", "narrow", "near", "neat", "new",
+    "nimble", "noble", "noisy", "odd", "old", "open", "pale", "plain", "plump", "polite",
+    "poor", "prime", "proud", "pure", "quick", "quiet", "rapid", "rare", "raw", "ready",
+    "real", "red", "rich", "rigid", "ripe", "rough", "round", "royal", "safe", "salty",
+    "sandy", "sharp", "shiny", "short", "shy", "silent", "silky", "simple", "slim", "slow",
+    "small", "smart", "smoky", "smooth", "soft", "solid", "sour", "spare", "spry", "stark",
+    "steep", "still", "stout", "subtle", "sunny", "sweet", "swift", "tall", "tame", "tart",
+    "tidy", "tiny", "tough", "true", "vast", "vivid", "warm", "weak", "white", "wide",
+    "wild", "wise", "witty", "young", "zesty",
+];
+
+const NOUNS: &[&str] = &[
+    "acorn", "ant", "arc", "ash", "bay", "beach", "bear", "beast", "bee", "birch",
+    "bird", "bloom", "bog", "branch", "breeze", "brook", "bud", "bush", "canyon", "cave",
+    "cedar", "clay", "cliff", "cloud", "coast", "cove", "crane", "creek", "crow", "crystal",
+    "dawn", "deer", "dell", "dove", "drift", "dune", "dust", "eagle", "echo", "edge",
+    "elm", "ember", "falcon", "fade", "fawn", "fern", "field", "finch", "fir", "flame",
+    "flint", "flood", "flora", "foam", "fog", "ford", "forest", "forge", "fox", "frog",
+    "frost", "gale", "gate", "gem", "glade", "glen", "goose", "grass", "grove", "gust",
+    "hawk", "haze", "hedge", "hill", "hollow", "isle", "ivy", "jade", "lake", "lark",
+    "leaf", "lily", "loon", "lotus", "loom", "lunar", "lynx", "maple", "mare", "marsh",
+    "meadow", "mist", "moon", "moss", "moth", "mount", "nest", "night", "nova", "oak",
+    "oasis", "ocean", "opal", "orbit", "otter", "owl", "palm", "peak", "pearl", "pine",
+    "plain", "pond", "prairie", "quail", "quartz", "rabbit", "rain", "raven", "reef", "ridge",
+    "river", "robin", "rock", "rook", "rose", "sage", "sand", "sea", "shade", "shell",
+    "shore", "sky", "slope", "snail", "snow", "sparrow", "spark", "spring", "spruce", "star",
+    "stem", "stone", "storm", "stream", "summit", "sun", "surf", "swan", "thicket", "thorn",
+    "tide", "trail", "tree", "tulip", "tundra", "turtle", "vale", "valley", "vine", "violet",
+    "wave", "weed", "willow", "wind", "wing", "wisp", "wolf", "wood", "wren", "yield",
+    "zenith",
+];
+
+static NAME_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn name_seed() -> u64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+    let n = NAME_COUNTER.fetch_add(1, Ordering::Relaxed);
+    now ^ n.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+}
+
+fn word_pair() -> String {
+    let seed = name_seed();
+    let adjective = ADJECTIVES[(seed as usize) % ADJECTIVES.len()];
+    let noun = NOUNS[((seed >> 32) as usize) % NOUNS.len()];
+    format!("{adjective}-{noun}")
+}
+
+fn short_suffix() -> String {
+    format!("{:04x}", name_seed() & 0xffff)
+}
+
+pub fn suggest_branch_name(
+    workspace: &WorkspaceEnv,
+    repo_root: &str,
+    user_input: Option<&str>,
+) -> Result<GitWorktreeNameSuggestion> {
+    let base = match user_input {
+        Some(input) if !input.trim().is_empty() => slugify(input.trim()),
+        _ => word_pair(),
+    };
+
+    let branch_name = if branch_exists(workspace, repo_root, &base)? {
+        format!("{base}-{}", short_suffix())
+    } else {
+        base
+    };
+
+    Ok(GitWorktreeNameSuggestion {
+        display_name: branch_name.clone(),
+        branch_name,
+    })
+}
+
+fn branch_exists(workspace: &WorkspaceEnv, repo_root: &str, name: &str) -> Result<bool> {
+    let output = run_git(
+        workspace,
+        Some(repo_root),
+        [
+            OsString::from("rev-parse"),
+            OsString::from("--verify"),
+            OsString::from("--quiet"),
+            OsString::from(format!("refs/heads/{name}")),
+        ],
+        DEFAULT_TIMEOUT_SECS,
+    )?;
+    Ok(output.exit_code == Some(0))
+}
+
+fn slugify(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.to_lowercase().chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else if matches!(c, '-' | ' ' | '.' | '_' | '/' | '\\') && !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out
+        .trim_start_matches('-')
+        .trim_end_matches('-')
+        .to_string();
+    if trimmed.is_empty() {
+        word_pair()
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_drops_spaces_and_dots() {
+        assert_eq!(slugify("my new feature"), "my-new-feature");
+        assert_eq!(slugify("Hello World"), "hello-world");
+        assert_eq!(slugify("fix/button"), "fix-button");
+        assert_eq!(slugify("  leading trailing  "), "leading-trailing");
+        assert_eq!(slugify("already-slug"), "already-slug");
+        assert_eq!(slugify("UPPERCASE"), "uppercase");
+        assert_eq!(slugify("special!@#$chars"), "specialchars");
+    }
+
+    #[test]
+    fn hex_has_correct_length() {
+        let suffix = short_suffix();
+        assert_eq!(suffix.len(), 4);
+        for c in suffix.chars() {
+            assert!(c.is_ascii_hexdigit());
+        }
+    }
+
+    #[test]
+    fn word_lists_are_populated() {
+        assert!(ADJECTIVES.len() >= 50);
+        assert!(NOUNS.len() >= 50);
+    }
+
+    #[test]
+    fn slugify_empty_falls_back() {
+        let result = slugify("");
+        assert!(result.contains('-'), "expected hyphen in '{result}'");
+    }
+}

--- a/src-tauri/src/modules/git/names.rs
+++ b/src-tauri/src/modules/git/names.rs
@@ -86,11 +86,10 @@ pub fn suggest_branch_name(
         _ => word_pair(),
     };
 
-    let branch_name = if branch_exists(workspace, repo_root, &base)? {
-        format!("{base}-{}", short_suffix())
-    } else {
-        base
-    };
+    let mut branch_name = base.clone();
+    while branch_exists(workspace, repo_root, &branch_name)? {
+        branch_name = format!("{base}-{}", short_suffix());
+    }
 
     Ok(GitWorktreeNameSuggestion {
         display_name: branch_name.clone(),

--- a/src-tauri/src/modules/git/names.rs
+++ b/src-tauri/src/modules/git/names.rs
@@ -73,6 +73,9 @@ fn short_suffix() -> String {
     format!("{:04x}", name_seed() & 0xffff)
 }
 
+/// Generates a unique branch name from optional user input or a
+/// random word pair. The name is guaranteed not to collide with any
+/// existing branch in the repo by adding a 4 digit hex string.
 pub fn suggest_branch_name(
     workspace: &WorkspaceEnv,
     repo_root: &str,

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -10,12 +10,13 @@ use crate::modules::git::process::{
 use crate::modules::git::types::{
     DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult, GitDiffResult,
     GitLogEntry, GitOutput, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
-    TextSource, DEFAULT_TIMEOUT_SECS, NETWORK_TIMEOUT_SECS,
+    GitWorktreeAddResult, GitWorktreeNameSuggestion, TextSource, DEFAULT_TIMEOUT_SECS,
+NETWORK_TIMEOUT_SECS,
 };
 use crate::modules::git::utils::{
     authorized_repo_root, canonical_dir, resolve_within_repo, split_upstream, ResolvedGitDirectory,
 };
-use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
+use crate::modules::workspace::{resolve_path, workspace_home, WorkspaceEnv, WorkspaceRegistry};
 
 pub fn resolve_repo(
     registry: &WorkspaceRegistry,
@@ -809,6 +810,143 @@ pub fn remote_url(
 
 fn is_remote_name_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'
+}
+
+pub fn suggest_worktree_name(
+    registry: &WorkspaceRegistry,
+    repo_root: &str,
+    user_input: Option<&str>,
+    workspace: &WorkspaceEnv,
+) -> Result<GitWorktreeNameSuggestion> {
+    let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
+    ensure_git_available(&repo_root.workspace)?;
+}
+
+pub fn add_worktree(
+    registry: &WorkspaceRegistry,
+    repo_root: &str,
+    branch_name: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<GitWorktreeAddResult> {
+    let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
+    ensure_git_available(&repo_root.workspace)?;
+
+    validate_worktree_branch_name(&repo_root.workspace, &repo_root.git_path, branch_name)?;
+
+    let project_name = {
+        let terax_prefix = ".terax/worktrees/";
+        let repo_path = &repo_root.git_path;
+        if let Some(pos) = repo_path.find(terax_prefix) {
+            let after = &repo_path[pos + terax_prefix.len()..];
+            let end = after.find('/').unwrap_or(after.len());
+            let name = after[..end].to_string();
+            if !name.is_empty() {
+                name
+            } else {
+                Path::new(repo_path)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "project".to_string())
+            }
+        } else {
+            Path::new(repo_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "project".to_string())
+        }
+    };
+
+    let home = workspace_home(workspace).map_err(|e| GitError::command("worktree", e))?;
+    let worktree_base = join_git_path(&home, &[".terax", "worktrees", &project_name]);
+    let target_display = join_git_path(&worktree_base, &[branch_name]);
+    let target_local = resolve_path(&target_display, workspace);
+
+    let parent_local = target_local
+        .parent()
+        .ok_or_else(|| GitError::command("worktree", "invalid worktree path"))?;
+    std::fs::create_dir_all(parent_local).map_err(|e| {
+        GitError::command(
+            "worktree",
+            format!("failed to create worktree directory: {e}"),
+        )
+    })?;
+
+    if target_local.exists() {
+        return Err(GitError::command(
+            "worktree",
+            format!("directory already exists: {target_display}"),
+        ));
+    }
+
+    let output = run_git(
+        &repo_root.workspace,
+        Some(&repo_root.git_path),
+        [
+            OsStr::new("worktree"),
+            OsStr::new("add"),
+            OsStr::new(&target_display),
+            OsStr::new("-b"),
+            OsStr::new(branch_name),
+        ],
+        DEFAULT_TIMEOUT_SECS,
+    )?;
+    ensure_success(&output, "git worktree add failed")?;
+
+    Ok(GitWorktreeAddResult {
+        worktree_path: target_display,
+        branch_name: branch_name.to_string(),
+    })
+}
+
+fn validate_worktree_branch_name(
+    workspace: &WorkspaceEnv,
+    repo_root: &str,
+    branch_name: &str,
+) -> Result<()> {
+    if locally_invalid_worktree_branch_name(branch_name) {
+        return Err(GitError::command("worktree", "invalid branch name"));
+    }
+
+    let output = run_git(
+        workspace,
+        Some(repo_root),
+        [
+            OsStr::new("check-ref-format"),
+            OsStr::new("--branch"),
+            OsStr::new(branch_name),
+        ],
+        DEFAULT_TIMEOUT_SECS,
+    )?;
+    if output.timed_out {
+        return Err(GitError::TimedOut("git check-ref-format"));
+    }
+    if output.exit_code != Some(0) {
+        return Err(GitError::command("worktree", "invalid branch name"));
+    }
+    Ok(())
+}
+
+fn locally_invalid_worktree_branch_name(branch_name: &str) -> bool {
+    branch_name.is_empty()
+        || branch_name.len() > 200
+        || branch_name.contains(' ')
+        || branch_name.contains("..")
+        || branch_name.contains(':')
+        || branch_name.contains('\0')
+        || branch_name.contains("@{")
+        || branch_name == "@"
+        || branch_name.starts_with('-')
+        || branch_name.ends_with('/')
+        || branch_name.ends_with('.')
+}
+
+fn join_git_path(base: &str, parts: &[&str]) -> String {
+    let mut out = base.trim_end_matches(['/', '\\']).replace('\\', "/");
+    for part in parts {
+        out.push('/');
+        out.push_str(part.trim_matches(['/', '\\']));
+    }
+    out
 }
 
 fn parse_diff_tree_name_status(bytes: &[u8]) -> Vec<GitCommitFileChange> {

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -2,6 +2,7 @@ use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 use crate::modules::git::errors::{GitError, Result};
+use crate::modules::git::names;
 use crate::modules::git::parser::parse_porcelain_v2;
 use crate::modules::git::process::{
     ensure_git_available, ensure_success, git_show_text, git_stdout_line_opt, git_stdout_lines,
@@ -820,6 +821,7 @@ pub fn suggest_worktree_name(
 ) -> Result<GitWorktreeNameSuggestion> {
     let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
     ensure_git_available(&repo_root.workspace)?;
+    names::suggest_branch_name(&repo_root.workspace, &repo_root.git_path, user_input)
 }
 
 pub fn add_worktree(
@@ -1191,5 +1193,47 @@ mod tests {
             "fatal: your current branch 'main' does not have any commits yet"
         )));
         assert!(!looks_like_no_head(&mk("fatal: pathspec did not match")));
+    }
+
+    #[test]
+    fn join_git_path_normalizes_separators() {
+        assert_eq!(
+            join_git_path(r"C:\Users\me", &[".terax", "worktrees", "repo", "branch"]),
+            "C:/Users/me/.terax/worktrees/repo/branch"
+        );
+        assert_eq!(
+            join_git_path("/home/me/", &["/.terax/", "worktrees", "repo"]),
+            "/home/me/.terax/worktrees/repo"
+        );
+    }
+
+    #[test]
+    fn validate_worktree_branch_name_reject_path_escapes() {
+        assert!(!locally_invalid_worktree_branch_name("feature/new-panel"));
+        assert!(locally_invalid_worktree_branch_name("../escape"));
+        assert!(locally_invalid_worktree_branch_name("-bad"));
+        assert!(locally_invalid_worktree_branch_name("bad name"));
+        assert!(locally_invalid_worktree_branch_name("bad:ref"));
+        assert!(locally_invalid_worktree_branch_name("bad@{ref"));
+    }
+
+    #[test]
+    fn validate_worktree_branch_name_uses_git_ref_rules() {
+        let git = std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .ok()
+            .is_some_and(|o| o.status.success());
+        if !git {
+            return;
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_string_lossy().to_string();
+        assert!(
+            validate_worktree_branch_name(&WorkspaceEnv::Local, &root, "feature/new-panel").is_ok()
+        );
+        assert!(validate_worktree_branch_name(&WorkspaceEnv::Local, &root, "bad.lock").is_err());
+        assert!(validate_worktree_branch_name(&WorkspaceEnv::Local, &root, "bad?ref").is_err());
     }
 }

--- a/src-tauri/src/modules/git/types.rs
+++ b/src-tauri/src/modules/git/types.rs
@@ -109,6 +109,20 @@ pub struct GitLogEntry {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct GitWorktreeAddResult {
+    pub worktree_path: String,
+    pub branch_name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitWorktreeNameSuggestion {
+    pub branch_name: String,
+    pub display_name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GitPushResult {
     pub remote: Option<String>,
     pub branch: Option<String>,

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -491,6 +491,31 @@ pub fn wsl_home(distro: String) -> Result<String, String> {
     }
 }
 
+pub(crate) fn workspace_home(workspace: &WorkspaceEnv) -> Result<String, String> {
+    match workspace {
+        WorkspaceEnv::Local => dirs::home_dir()
+            .map(|p| crate::modules::fs::to_canon(&p))
+            .ok_or_else(|| "could not resolve home directory".to_string()),
+        WorkspaceEnv::Wsl { distro } => {
+            #[cfg(not(windows))]
+            {
+                let _ = distro;
+                Err("WSL is only available on Windows".to_string())
+            }
+            #[cfg(windows)]
+            {
+                let out = run_wsl_sh(distro, "printf %s \"$HOME\"")?;
+                let home = normalize_wsl_value(out, "");
+                if home.is_empty() {
+                    Err(format!("could not resolve WSL home for {distro}"))
+                } else {
+                    Ok(home)
+                }
+            }
+        }
+    }
+}
+
 #[cfg(windows)]
 pub fn wsl_login_shell(distro: String) -> Result<String, String> {
     const SCRIPT: &str = r#"uid="$(id -u 2>/dev/null || printf '')"

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1052,6 +1052,7 @@ export default function App() {
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}
                         onOpenFile={handleOpenFile}
+                        onOpenTerminal={newTab}
                       />
                     )}
                   </div>

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -123,6 +123,16 @@ export type GitDiscardEntry = {
   untracked: boolean;
 };
 
+export type GitAddWorktreeResult = {
+  worktreePath: string;
+  branchName: string;
+};
+
+export type GitWorktreeNameSuggestion = {
+  branchName: string;
+  displayName: string;
+};
+
 export const native = {
   workspaceCurrentDir: () => invoke<string>("workspace_current_dir"),
   workspaceAuthorize: (path: string) =>
@@ -355,6 +365,18 @@ export const native = {
     invoke<string | null>("git_remote_url", {
       repoRoot,
       name: name ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
+  gitSuggestWorktreeName: (repoRoot: string, userInput?: string | null) =>
+    invoke<GitWorktreeNameSuggestion>("git_suggest_worktree_name", {
+      repoRoot,
+      userInput: userInput ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
+  gitWorktreeAdd: (repoRoot: string, branchName: string) =>
+    invoke<GitAddWorktreeResult>("git_add_worktree", {
+      repoRoot,
+      branchName,
       workspace: currentWorkspaceEnv(),
     }),
 };

--- a/src/modules/source-control/NewWorktreePopover.tsx
+++ b/src/modules/source-control/NewWorktreePopover.tsx
@@ -43,9 +43,7 @@ function projectNameFromRepoRoot(repoRoot: string): string {
 function slugify(input: string): string {
   return input
     .toLowerCase()
-    .replace(/[^a-z0-9\-/._\\]/g, "-")
-    .replace(/[\s./_\\]+/g, "-")
-    .replace(/-+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
 

--- a/src/modules/source-control/NewWorktreePopover.tsx
+++ b/src/modules/source-control/NewWorktreePopover.tsx
@@ -30,13 +30,14 @@ function basename(path: string): string {
  *  e.g. if inside ~/.terax/worktrees/{project}/{branch}, extract {project}.
  *  otherwise use the repo root basename. */
 function projectNameFromRepoRoot(repoRoot: string): string {
-  const id = repoRoot.indexOf(".terax/worktrees/");
+  const normalized = repoRoot.replace(/\\/g, "/");
+  const id = normalized.indexOf(".terax/worktrees/");
   if (id !== -1) {
-    const after = repoRoot.slice(id + ".terax/worktrees/".length);
+    const after = normalized.slice(id + ".terax/worktrees/".length);
     const slash = after.indexOf("/");
     return slash !== -1 ? after.slice(0, slash) : after;
   }
-  return basename(repoRoot);
+  return basename(normalized);
 }
 
 function slugify(input: string): string {

--- a/src/modules/source-control/NewWorktreePopover.tsx
+++ b/src/modules/source-control/NewWorktreePopover.tsx
@@ -1,0 +1,144 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { GitBranchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  children: React.ReactNode;
+  repoRoot: string | null;
+  suggestedName: string;
+  onCreate: (branchName: string) => Promise<string | void>;
+  busy: boolean;
+  error: string | null;
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : path;
+}
+
+/** When creating a worktree from a worktree, extract the project name.
+ *  e.g. if inside ~/.terax/worktrees/{project}/{branch}, extract {project}.
+ *  otherwise use the repo root basename. */
+function projectNameFromRepoRoot(repoRoot: string): string {
+  const id = repoRoot.indexOf(".terax/worktrees/");
+  if (id !== -1) {
+    const after = repoRoot.slice(id + ".terax/worktrees/".length);
+    const slash = after.indexOf("/");
+    return slash !== -1 ? after.slice(0, slash) : after;
+  }
+  return basename(repoRoot);
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\-/._\\]/g, "-")
+    .replace(/[\s./_\\]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function NewWorktreePopover({
+  children,
+  repoRoot,
+  suggestedName,
+  onCreate,
+  busy,
+  error,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+  }, [open]);
+
+  const resolvedName = slugify(name) || suggestedName;
+  const projectName = repoRoot ? projectNameFromRepoRoot(repoRoot) : "project";
+  const previewPath = `~/.terax/worktrees/${projectName}/${resolvedName || "…"}/`;
+
+  const submit = async () => {
+    const branchName = slugify(name) || suggestedName;
+    if (!branchName) return;
+    await onCreate(branchName);
+    setOpen(false);
+    setName("");
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        sideOffset={6}
+        className="w-50 p-3">
+        <PopoverHeader className="gap-0">
+          <PopoverTitle className="flex items-center gap-1.5 text-sm font-semibold">
+            <HugeiconsIcon
+              icon={GitBranchIcon}
+              size={14}
+              strokeWidth={1.75}/>
+            New worktree
+          </PopoverTitle>
+        </PopoverHeader>
+
+        <div className="flex flex-col gap-2">
+          <Input
+            ref={inputRef}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !busy) {
+                e.preventDefault();
+                void submit();
+              }
+            }}
+            placeholder={suggestedName || "branch-name"}
+            disabled={busy}
+            className="h-8 text-xs"/>
+          {error ? (
+            <div className="text-[10.5px] leading-tight text-destructive">
+              {error}
+            </div>
+          ) : (
+            <div className="text-[10px] leading-tight text-muted-foreground truncate">
+              {previewPath}
+            </div>
+          )}
+          <div className="flex items-center justify-end gap-1.5 pt-0.5">
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+              className="h-7 text-[11px]">
+              Cancel
+            </Button>
+            <Button
+              size="xs"
+              onClick={() => void submit()}
+              disabled={busy || !resolvedName}
+              className="h-7 text-[11px]">
+              {busy ? "Creating…" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/modules/source-control/NewWorktreePopover.tsx
+++ b/src/modules/source-control/NewWorktreePopover.tsx
@@ -15,9 +15,10 @@ interface Props {
   children: React.ReactNode;
   repoRoot: string | null;
   suggestedName: string;
-  onCreate: (branchName: string) => Promise<string | void>;
+  onCreate: (branchName: string) => Promise<string>;
   busy: boolean;
   error: string | null;
+  onClearError?: () => void;
 }
 
 function basename(path: string): string {
@@ -54,6 +55,7 @@ export function NewWorktreePopover({
   onCreate,
   busy,
   error,
+  onClearError,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
@@ -62,10 +64,11 @@ export function NewWorktreePopover({
   useEffect(() => {
     if (!open) return;
     setName("");
+    onClearError?.();
     setTimeout(() => {
       inputRef.current?.focus();
     }, 0);
-  }, [open]);
+  }, [open, onClearError]);
 
   const resolvedName = slugify(name) || suggestedName;
   const projectName = repoRoot ? projectNameFromRepoRoot(repoRoot) : "project";
@@ -74,7 +77,8 @@ export function NewWorktreePopover({
   const submit = async () => {
     const branchName = slugify(name) || suggestedName;
     if (!branchName) return;
-    await onCreate(branchName);
+    const worktreePath = await onCreate(branchName);
+    if (!worktreePath) return;
     setOpen(false);
     setName("");
   };
@@ -86,13 +90,11 @@ export function NewWorktreePopover({
         side="bottom"
         align="start"
         sideOffset={6}
-        className="w-50 p-3">
+        className="w-50 p-3"
+      >
         <PopoverHeader className="gap-0">
           <PopoverTitle className="flex items-center gap-1.5 text-sm font-semibold">
-            <HugeiconsIcon
-              icon={GitBranchIcon}
-              size={14}
-              strokeWidth={1.75}/>
+            <HugeiconsIcon icon={GitBranchIcon} size={14} strokeWidth={1.75} />
             New worktree
           </PopoverTitle>
         </PopoverHeader>
@@ -101,7 +103,10 @@ export function NewWorktreePopover({
           <Input
             ref={inputRef}
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              setName(e.target.value);
+              onClearError?.();
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter" && !busy) {
                 e.preventDefault();
@@ -110,9 +115,10 @@ export function NewWorktreePopover({
             }}
             placeholder={suggestedName || "branch-name"}
             disabled={busy}
-            className="h-8 text-xs"/>
+            className="h-8 text-xs"
+          />
           {error ? (
-            <div className="text-[10.5px] leading-tight text-destructive">
+            <div className="wrap-break-word text-[10.5px] leading-tight text-destructive">
               {error}
             </div>
           ) : (
@@ -126,14 +132,16 @@ export function NewWorktreePopover({
               size="xs"
               onClick={() => setOpen(false)}
               disabled={busy}
-              className="h-7 text-[11px]">
+              className="h-7 text-[11px]"
+            >
               Cancel
             </Button>
             <Button
               size="xs"
               onClick={() => void submit()}
               disabled={busy || !resolvedName}
-              className="h-7 text-[11px]">
+              className="h-7 text-[11px]"
+            >
               {busy ? "Creating…" : "Create"}
             </Button>
           </div>

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -466,9 +466,12 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 onCreate={async (branchName) => {
                   const path = await scm.createWorktree(branchName);
                   if (path) onOpenTerminal?.(path);
+                  return path;
                 }}
                 busy={scm.worktreeBusy}
-                error={scm.worktreeError}>
+                error={scm.worktreeError}
+                onClearError={scm.clearWorktreeError}
+              >
                 <button
                   type="button"
                   aria-label="New worktree"

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -40,6 +40,7 @@ import { joinPath } from "@/modules/explorer/lib/useFileTree";
 import {
   AiContentGenerator02Icon,
   Alert02Icon,
+  Add01Icon,
   ArrowDown01Icon,
   ArrowRight01Icon,
   ArrowUp01Icon,
@@ -69,6 +70,7 @@ import {
   type CheckState,
   type SourceControlFileEntry,
 } from "./useSourceControlPanel";
+import { NewWorktreePopover } from "./NewWorktreePopover";
 
 type Props = {
   open: boolean;
@@ -456,6 +458,24 @@ export const SourceControlPanel = memo(function SourceControlPanel({
               <span className="rounded bg-muted/55 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                 detached
               </span>
+            ) : null}
+            {scm.panelState === "ready" && scm.repo ? (
+              <NewWorktreePopover
+                repoRoot={scm.repo?.repoRoot ?? null}
+                suggestedName={scm.suggestedWorktreeName}
+                onCreate={async (branchName) => {
+                  const path = await scm.createWorktree(branchName);
+                  if (path) onOpenTerminal?.(path);
+                }}
+                busy={scm.worktreeBusy}
+                error={scm.worktreeError}>
+                <button
+                  type="button"
+                  aria-label="New worktree"
+                  className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/6 hover:text-foreground">
+                  <HugeiconsIcon icon={Add01Icon} size={13} strokeWidth={2} />
+                </button>
+              </NewWorktreePopover>
             ) : null}
           </div>
           <div className="flex shrink-0 items-center gap-0.5">

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -461,6 +461,8 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 detached
               </span>
             ) : null}
+          </div>
+          <div className="flex shrink-0 items-center gap-0.5">
             {scm.panelState === "ready" && scm.repo ? (
               <NewWorktreePopover
                 repoRoot={scm.repo?.repoRoot ?? null}
@@ -483,8 +485,6 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 </button>
               </NewWorktreePopover>
             ) : null}
-          </div>
-          <div className="flex shrink-0 items-center gap-0.5">
             <IconActionButton
               label={fetchBusy ? "Fetching…" : "Fetch from remote"}
               disabled={!canFetch}

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -418,7 +418,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
 
   return (
     <TooltipProvider delayDuration={800} skipDelayDuration={300}>
-      <aside className="flex h-full min-w-0 flex-col bg-card/80 backdrop-blur [contain:layout_style]">
+      <aside className="flex h-full min-w-0 flex-col bg-card/80 backdrop-blur contain-[layout_style]">
         <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border/50 px-3 pb-2.5 pt-3">
           <div className="flex min-w-0 items-center gap-1.5">
             <div className="inline-flex min-w-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10">
@@ -472,7 +472,8 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 <button
                   type="button"
                   aria-label="New worktree"
-                  className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/6 hover:text-foreground">
+                  className="inline-flex size-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/6 hover:text-foreground"
+                >
                   <HugeiconsIcon icon={Add01Icon} size={13} strokeWidth={2} />
                 </button>
               </NewWorktreePopover>

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -84,6 +84,7 @@ type Props = {
     title?: string;
   }) => void;
   onOpenFile?: (absolutePath: string) => void;
+  onOpenTerminal?: (cwd: string) => void;
 };
 
 const SOURCE_CONTROL_TOOLTIP_CLASS =
@@ -151,6 +152,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   onOpenGitGraph,
   onOpenDiff,
   onOpenFile,
+  onOpenTerminal,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
   const refreshAnimationRef = useRef<number | null>(null);

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -108,6 +108,11 @@ type SourceControlPanelState = {
   generateCommitMessage: () => Promise<void>;
   commit: () => Promise<void>;
   push: () => Promise<void>;
+  worktreeBusy: boolean;
+  worktreeError: string | null;
+  clearWorktreeError: () => void;
+  suggestedWorktreeName: string;
+  createWorktree: (branchName: string) => Promise<string>;
 };
 
 function normalizeError(error: unknown): string {
@@ -258,7 +263,8 @@ function optimisticStage(
     if (!paths.has(file.path)) return file;
     if (file.staged && !file.unstaged) return file;
     changed = true;
-    const wt = file.worktreeStatus !== " " ? file.worktreeStatus : file.indexStatus;
+    const wt =
+      file.worktreeStatus !== " " ? file.worktreeStatus : file.indexStatus;
     return {
       ...file,
       indexStatus: wt,
@@ -288,7 +294,8 @@ function optimisticUnstage(
       continue;
     }
     changed = true;
-    const idx = file.indexStatus !== " " ? file.indexStatus : file.worktreeStatus;
+    const idx =
+      file.indexStatus !== " " ? file.indexStatus : file.worktreeStatus;
     if (idx === "R" && file.originalPath) {
       next.push({
         path: file.originalPath,
@@ -399,6 +406,10 @@ export function useSourceControlPanel(
     | { scope: "all"; entries: SourceControlEntry[] }
     | null
   >(null);
+  const [worktreeBusy, setWorktreeBusy] = useState(false);
+  const [worktreeError, setWorktreeError] = useState<string | null>(null);
+  const [suggestedWorktreeName, setSuggestedWorktreeName] = useState("");
+  const clearWorktreeError = useCallback(() => setWorktreeError(null), []);
   const selectedRef = useRef<DiffSelection | null>(null);
   const reconcileTimerRef = useRef(0);
 
@@ -543,7 +554,11 @@ export function useSourceControlPanel(
   useEffect(() => () => cancelReconcile(), [cancelReconcile]);
 
   const openSelection = useCallback(
-    (sel: DiffSelection, repoRoot: string, file: GitChangedFile | undefined) => {
+    (
+      sel: DiffSelection,
+      repoRoot: string,
+      file: GitChangedFile | undefined,
+    ) => {
       onOpenDiff?.({
         path: sel.path,
         repoRoot,
@@ -641,7 +656,10 @@ export function useSourceControlPanel(
   const selectEntry = useCallback(
     async (entry: SourceControlEntry) => {
       if (!repo) return;
-      const nextSelection: DiffSelection = { path: entry.path, mode: entry.mode };
+      const nextSelection: DiffSelection = {
+        path: entry.path,
+        mode: entry.mode,
+      };
       if (sameSelection(selected, nextSelection)) {
         setActionError(null);
         setActionMessage(null);
@@ -965,6 +983,41 @@ export function useSourceControlPanel(
     }
   }, [repo, status?.upstream, summary]);
 
+  useEffect(() => {
+    if (panelState !== "ready" || !summary.repo) return;
+    let cancelled = false;
+    void native
+      .gitSuggestWorktreeName(summary.repo.repoRoot, null)
+      .then((result) => {
+        if (!cancelled) setSuggestedWorktreeName(result.branchName);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [panelState, summary.repo]);
+
+  const createWorktree = useCallback(
+    async (branchName: string): Promise<string> => {
+      if (!repo || worktreeBusy) return "";
+      setWorktreeBusy(true);
+      setWorktreeError(null);
+      try {
+        const result = await native.gitWorktreeAdd(repo.repoRoot, branchName);
+        setActionMessage(`Created worktree for ${branchName}`);
+        invalidateRepoDiffs(repo.repoRoot);
+        await summary.refresh({ remote: "never" });
+        return result.worktreePath;
+      } catch (error) {
+        setWorktreeError(normalizeError(error));
+        return "";
+      } finally {
+        setWorktreeBusy(false);
+      }
+    },
+    [repo, worktreeBusy, summary],
+  );
+
   const pendingDiscardView = useMemo<PendingDiscard | null>(() => {
     if (!pendingDiscard) return null;
     if (pendingDiscard.scope === "single") {
@@ -1025,5 +1078,10 @@ export function useSourceControlPanel(
     generateCommitMessage,
     commit,
     push,
+    worktreeBusy,
+    worktreeError,
+    clearWorktreeError,
+    suggestedWorktreeName,
+    createWorktree,
   };
 }


### PR DESCRIPTION
## What
Adds a new button in the source control pane, next to the unpushed commits, that lets users quickly create new worktrees for the current repo. 

## Why
One thing i was missing from Warp terminal is the easy creation of worktrees. So i decided to build this, which in my opinion works just as great.

## How
On opening the popover, an autogenerated name existing of an adjective and a noun (chosen from an integrated list) is created and shown as placeholder. Users can either add their own worktree name, or use the generated one. When accepting, in the folder ~/.terax/worktrees/{Reponame}/{Worktreename} the worktree is created.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS & Windows
- [ ] Shells tested (if relevant):


## Screenshots / GIFs
<img width="1236" height="720" alt="new-worktree" src="https://github.com/user-attachments/assets/2bc864ef-a45e-4729-99f7-4acfa387201e" />


## Notes for reviewer
Not sure about the position of the button yet. Also, i dont know if people need the configuration that e.g. warp offers for worktree creation. I never changed anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Git worktree creation from the source control panel, including suggested branch/worktree names.
  * Introduced a new worktree creation popover with a local preview and create flow.
  * Automatically opens the newly created worktree in the terminal.
* **Other**
  * Added backend/API support for suggesting worktree names and creating worktrees, including branch-name validation and result reporting.
  * Improved workspace “home” resolution for better WSL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->