### PR TITLE
fix(pty): preserve fish cwd tracking with starship

### DIFF
--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -39,14 +39,22 @@ function __terax_restore_status
     return $argv[1]
 end
 
-if functions -q fish_prompt
+function __terax_capture_user_prompt
+    if not functions -q fish_prompt
+        return
+    end
+    if functions fish_prompt | string match -q '*__terax_user_prompt*'
+        return
+    end
+    functions -e __terax_user_prompt 2>/dev/null
     functions -c fish_prompt __terax_user_prompt
 end
 
-# Wrapped so `fish -C __terax_install_prompt` can re-run it in block mode AFTER
-# config.fish, where a framework prompt (starship etc.) would otherwise override
-# fish_prompt and drop our markers.
+# Wrapped so `fish -C __terax_install_prompt` can re-run it AFTER config.fish,
+# where a framework prompt (starship etc.) would otherwise override fish_prompt
+# and drop our markers.
 function __terax_install_prompt
+    __terax_capture_user_prompt
     if set -q TERAX_BLOCKS
         function fish_right_prompt
         end

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -16,6 +16,9 @@ const ZLOGIN_SCRIPT: &str = include_str!("scripts/zlogin.zsh");
 const ZSHRC_SCRIPT: &str = include_str!("scripts/zshrc.zsh");
 #[cfg(windows)]
 const FISH_INIT_SCRIPT: &str = include_str!("scripts/init.fish");
+#[cfg(unix)]
+const FISH_REINSTALL_PROMPT: &str =
+    "functions -q __terax_install_prompt; and __terax_install_prompt";
 
 #[cfg(windows)]
 fn bashrc_script() -> &'static str {
@@ -234,13 +237,11 @@ mod unix {
                 // fish 4.0+ writes its own OSC 133 A/B; ours would double it.
                 cmd.env("fish_features", "no-mark-prompt");
                 cmd.arg("-i");
-                // In block mode, re-assert our prompt after config.fish (-C runs
-                // last), so a framework prompt (starship etc.) loaded there can't
-                // override the markers and break the blocks.
-                if blocks {
-                    cmd.arg("-C");
-                    cmd.arg("functions -q __terax_install_prompt; and __terax_install_prompt");
-                }
+                // Re-assert our prompt after config.fish (-C runs last), so a
+                // framework prompt (starship etc.) loaded there can't override
+                // the markers and break cwd tracking.
+                cmd.arg("-C");
+                cmd.arg(super::FISH_REINSTALL_PROMPT);
             }
             Shell::Other => {
                 log::info!(


### PR DESCRIPTION
## Summary
- reinstall the fish prompt wrapper after config.fish for normal Unix fish sessions
- recapture the current fish_prompt before wrapping so starship prompts are preserved
- avoid wrapping Terax's own fish prompt wrapper recursively

## Testing
- fish + starship harness confirms OSC 7 returns after post-config reinstall
- repeated reinstall harness confirms the wrapper does not recurse and starship prompt remains visible
- git diff --check
- cargo test --locked shell_init (compiles successfully on macOS; filter runs 0 tests because matching WSL tests are cfg-windows)