### PR TITLE
feat(preview): add localhost link preview popup with toggle setting

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import {
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getLaunchDir } from "@/lib/launchDir";
+import { isLocalhostUrl } from "@/lib/localUrl";
 import { usePresence } from "@/lib/usePresence";
 import { quoteShellArg } from "@/lib/shellQuote";
 import { useZoom } from "@/lib/useZoom";
@@ -22,10 +23,7 @@ import {
 } from "@/modules/ai";
 import { AiComposerProvider } from "@/modules/ai/lib/composer";
 import { native } from "@/modules/ai/lib/native";
-import {
-  CommandPalette,
-  createCommandItems,
-} from "@/modules/command-palette";
+import { CommandPalette, createCommandItems } from "@/modules/command-palette";
 import {
   NewEditorDialog,
   useEditorFileSync,
@@ -58,19 +56,17 @@ import {
   useSourceControlContext,
 } from "@/modules/source-control";
 import { StatusBar } from "@/modules/statusbar";
-import {
-  useTabs,
-  useWindowTitle,
-  useWorkspaceCwd,
-} from "@/modules/tabs";
+import { useTabs, useWindowTitle, useWorkspaceCwd } from "@/modules/tabs";
 import {
   clearFocusedTerminal,
+  configureTerminalLinkActions,
   disposeSession,
   findLeafCwd,
   hasLeaf,
   leafIds,
   navigateFocusedBlocks,
   respawnSession,
+  type TerminalLinkHover,
   type TerminalPaneHandle,
   useTerminalFileDrop,
   writeToSession,
@@ -85,6 +81,9 @@ import { DEFAULT_SPACE_ID } from "@/modules/tabs/lib/useTabs";
 import { ThemeProvider, useThemeFileEditing } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import { useWorkspaceEnvStore } from "@/modules/workspace";
+import { LinkSquare02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CloseDialogs } from "./components/CloseDialogs";
@@ -563,6 +562,73 @@ export default function App() {
     [newPreviewTab],
   );
 
+  const alwaysOpenLocalhostLinksInPreview = usePreferencesStore(
+    (s) => s.alwaysOpenLocalhostLinksInPreview,
+  );
+  const alwaysOpenLocalhostLinksInPreviewRef = useRef(
+    alwaysOpenLocalhostLinksInPreview,
+  );
+  const [localhostLinkPopup, setLocalhostLinkPopup] =
+    useState<TerminalLinkHover | null>(null);
+  const linkPopupHideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    alwaysOpenLocalhostLinksInPreviewRef.current =
+      alwaysOpenLocalhostLinksInPreview;
+  }, [alwaysOpenLocalhostLinksInPreview]);
+
+  const clearLinkPopupHideTimer = useCallback(() => {
+    const timer = linkPopupHideTimer.current;
+    if (!timer) return;
+    clearTimeout(timer);
+    linkPopupHideTimer.current = null;
+  }, []);
+
+  const hideLinkPopupSoon = useCallback(() => {
+    clearLinkPopupHideTimer();
+    linkPopupHideTimer.current = setTimeout(() => {
+      setLocalhostLinkPopup(null);
+      linkPopupHideTimer.current = null;
+    }, 180);
+  }, [clearLinkPopupHideTimer]);
+
+  useEffect(() => clearLinkPopupHideTimer, [clearLinkPopupHideTimer]);
+
+  useEffect(() => {
+    configureTerminalLinkActions({
+      open: (_event, uri) => {
+        setLocalhostLinkPopup(null);
+        if (
+          isLocalhostUrl(uri) &&
+          alwaysOpenLocalhostLinksInPreviewRef.current
+        ) {
+          openPreviewTab(uri);
+          return;
+        }
+        void openUrl(uri).catch(console.error);
+      },
+      hover: (hover) => {
+        if (!isLocalhostUrl(hover.uri)) {
+          setLocalhostLinkPopup(null);
+          return;
+        }
+        clearLinkPopupHideTimer();
+        setLocalhostLinkPopup(hover);
+      },
+      leave: (uri) => {
+        if (isLocalhostUrl(uri)) hideLinkPopupSoon();
+      },
+    });
+    return () => {
+      configureTerminalLinkActions({
+        open: (_event, uri) => {
+          void openUrl(uri).catch(console.error);
+        },
+        hover: () => {},
+        leave: () => {},
+      });
+    };
+  }, [openPreviewTab, clearLinkPopupHideTimer, hideLinkPopupSoon]);
 
   const splitActivePaneInActiveTab = useCallback(
     (dir: "row" | "col") => {
@@ -871,8 +937,9 @@ export default function App() {
 
   const handleNewTabInSpace = useCallback(
     (spaceId: string) => {
-      const root = useSpaces.getState().spaces.find((s) => s.id === spaceId)
-        ?.root;
+      const root = useSpaces
+        .getState()
+        .spaces.find((s) => s.id === spaceId)?.root;
       newTabInSpace(spaceId, root ?? undefined);
     },
     [newTabInSpace],
@@ -1043,7 +1110,10 @@ export default function App() {
                 }}
               >
                 <div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">
-                  <div key={sidebarView} className="min-h-0 flex-1 terax-panel-in">
+                  <div
+                    key={sidebarView}
+                    className="min-h-0 flex-1 terax-panel-in"
+                  >
                     {sidebarView === "explorer" ? (
                       <FileExplorer
                         ref={explorerRef}
@@ -1137,6 +1207,16 @@ export default function App() {
             activeId={activeId}
             onActivate={onActivateAgent}
           />
+          <LocalhostLinkPreviewPopup
+            hover={localhostLinkPopup}
+            onOpen={(uri) => {
+              clearLinkPopupHideTimer();
+              setLocalhostLinkPopup(null);
+              openPreviewTab(uri);
+            }}
+            onMouseEnter={clearLinkPopupHideTimer}
+            onMouseLeave={hideLinkPopupSoon}
+          />
           <Toaster position="bottom-right" />
 
           {hasComposer ? (
@@ -1199,4 +1279,60 @@ export default function App() {
   );
 
   return <AiComposerProvider>{shell}</AiComposerProvider>;
+}
+
+function LocalhostLinkPreviewPopup({
+  hover,
+  onOpen,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  hover: TerminalLinkHover | null;
+  onOpen: (uri: string) => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}) {
+  if (!hover) return null;
+
+  const width = Math.max(180, Math.min(420, Math.round(hover.width || 0)));
+  const height = 40;
+  const margin = 8;
+  const maxLeft =
+    typeof window === "undefined"
+      ? hover.x
+      : window.innerWidth - width - margin;
+  const maxTop =
+    typeof window === "undefined"
+      ? hover.y
+      : window.innerHeight - height - margin;
+  const left = Math.max(margin, Math.min(hover.x, maxLeft));
+  const above = hover.y - height - 4;
+  const top = Math.max(
+    margin,
+    Math.min(above < margin ? hover.y + 18 : above, maxTop),
+  );
+
+  return (
+    <div
+      className="fixed z-50 rounded-md border border-border/70 bg-popover p-1 text-popover-foreground shadow-xl"
+      style={{ left, top, width }}
+    >
+      <button
+        type="button"
+        className="flex h-8 w-full items-center justify-center gap-2 rounded px-2 text-[12px] hover:bg-accent hover:text-accent-foreground"
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => onOpen(hover.uri)}
+      >
+        <HugeiconsIcon
+          icon={LinkSquare02Icon}
+          size={14}
+          strokeWidth={1.75}
+          className="shrink-0"
+        />
+        <span className="min-w-0 flex-1 truncate">Open in Preview</span>
+      </button>
+    </div>
+  );
 }

--- a/src/lib/localUrl.test.ts
+++ b/src/lib/localUrl.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isLocalhostUrl } from "./localUrl";
+
+describe("isLocalhostUrl", () => {
+  it("accepts localhost and loopback URLs", () => {
+    expect(isLocalhostUrl("http://localhost:3000")).toBe(true);
+    expect(isLocalhostUrl("https://app.localhost/path")).toBe(true);
+    expect(isLocalhostUrl("http://127.0.0.1:5173")).toBe(true);
+    expect(isLocalhostUrl("http://127.42.0.9")).toBe(true);
+    expect(isLocalhostUrl("http://0.0.0.0:8000")).toBe(true);
+    expect(isLocalhostUrl("http://[::1]:3000")).toBe(true);
+  });
+
+  it("rejects external and non-http URLs", () => {
+    expect(isLocalhostUrl("https://example.com")).toBe(false);
+    expect(isLocalhostUrl("http://local-host.test")).toBe(false);
+    expect(isLocalhostUrl("file:///tmp/index.html")).toBe(false);
+    expect(isLocalhostUrl("not a url")).toBe(false);
+  });
+});

--- a/src/lib/localUrl.ts
+++ b/src/lib/localUrl.ts
@@ -1,0 +1,16 @@
+export function isLocalhostUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    const host = url.hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "0.0.0.0" ||
+      host === "[::1]" ||
+      host.endsWith(".localhost") ||
+      /^127(?:\.\d{1,3}){3}$/.test(host)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/modules/editor/lib/dotenv.test.ts
+++ b/src/modules/editor/lib/dotenv.test.ts
@@ -1,0 +1,60 @@
+import { StringStream } from "@codemirror/language";
+import { describe, expect, it } from "vitest";
+import { dotenv } from "./dotenv";
+
+function tokenizeLine(line: string): Array<[string, string]> {
+  const state = dotenv.startState?.(2);
+  if (!state) throw new Error("dotenv parser has no start state");
+
+  const stream = new StringStream(line, 2, 2);
+  const tokens: Array<[string, string]> = [];
+
+  while (!stream.eol()) {
+    stream.start = stream.pos;
+    const style = dotenv.token(stream, state);
+    if (stream.pos === stream.start) {
+      throw new Error(`Parser did not advance at ${stream.pos}`);
+    }
+    if (style) tokens.push([stream.current(), style]);
+  }
+
+  return tokens;
+}
+
+describe("dotenv tokenizer", () => {
+  it("highlights exports, keys, values, and comments", () => {
+    expect(tokenizeLine("export API_URL=https://example.com # public")).toEqual(
+      [
+        ["export", "keyword"],
+        ["API_URL", "variableName.definition"],
+        ["=", "operator"],
+        ["https://example.com", "string"],
+        ["# public", "comment"],
+      ],
+    );
+  });
+
+  it("highlights variables inside double quoted values", () => {
+    const variableRef = "$" + "{DB_HOST}";
+
+    expect(
+      tokenizeLine(`DATABASE_URL="postgres://${variableRef}:5432/app"`),
+    ).toEqual([
+      ["DATABASE_URL", "variableName.definition"],
+      ["=", "operator"],
+      ['"', "string"],
+      ["postgres://", "string"],
+      [variableRef, "variableName.special"],
+      [":5432/app", "string"],
+      ['"', "string"],
+    ]);
+  });
+
+  it("keeps hashes inside unquoted values", () => {
+    expect(tokenizeLine("PASSWORD=abc#123")).toEqual([
+      ["PASSWORD", "variableName.definition"],
+      ["=", "operator"],
+      ["abc#123", "string"],
+    ]);
+  });
+});

--- a/src/modules/editor/lib/dotenv.ts
+++ b/src/modules/editor/lib/dotenv.ts
@@ -1,0 +1,146 @@
+import type { StreamParser, StringStream } from "@codemirror/language";
+
+type DotenvState = {
+  mode: "start" | "afterExport" | "afterKey" | "value";
+  quote: "'" | '"' | null;
+  valueStarted: boolean;
+  afterValueSpace: boolean;
+};
+
+function resetLine(state: DotenvState): void {
+  state.mode = "start";
+  state.quote = null;
+  state.valueStarted = false;
+  state.afterValueSpace = false;
+}
+
+function tokenVariable(stream: StringStream): string | null {
+  if (stream.next() !== "$") return null;
+
+  if (stream.eat("{")) {
+    stream.eatWhile(/[A-Za-z0-9_]/);
+    stream.eat("}");
+    return "variableName.special";
+  }
+
+  if (!stream.eat(/[A-Za-z_]/)) return "operator";
+  stream.eatWhile(/[A-Za-z0-9_]/);
+  return "variableName.special";
+}
+
+function tokenQuotedValue(
+  stream: StringStream,
+  state: DotenvState,
+): string | null {
+  if (stream.peek() === state.quote) {
+    stream.next();
+    state.quote = null;
+    state.mode = "value";
+    return "string";
+  }
+
+  if (state.quote === '"' && stream.peek() === "$") {
+    return tokenVariable(stream);
+  }
+
+  while (!stream.eol()) {
+    const ch = stream.peek();
+    if (ch === state.quote || (state.quote === '"' && ch === "$")) break;
+    stream.next();
+  }
+
+  return "string";
+}
+
+export const dotenv: StreamParser<DotenvState> = {
+  name: "dotenv",
+
+  startState() {
+    return {
+      mode: "start",
+      quote: null,
+      valueStarted: false,
+      afterValueSpace: false,
+    };
+  },
+
+  token(stream, state) {
+    if (stream.sol()) resetLine(state);
+    if (stream.eol()) return null;
+
+    if (state.quote) return tokenQuotedValue(stream, state);
+
+    if (stream.eatSpace()) {
+      if (state.mode === "value" && state.valueStarted) {
+        state.afterValueSpace = true;
+      }
+      return null;
+    }
+
+    if (stream.peek() === "#") {
+      stream.skipToEnd();
+      return "comment";
+    }
+
+    if (
+      state.mode === "start" &&
+      stream.match(/^export(?=\s+[A-Za-z_])/, true)
+    ) {
+      state.mode = "afterExport";
+      return "keyword";
+    }
+
+    if (state.mode === "start" || state.mode === "afterExport") {
+      if (stream.match(/^[A-Za-z_][A-Za-z0-9_]*/, true)) {
+        state.mode = "afterKey";
+        return "variableName.definition";
+      }
+
+      stream.skipToEnd();
+      return "invalid";
+    }
+
+    if (state.mode === "afterKey") {
+      if (stream.eat("=")) {
+        state.mode = "value";
+        return "operator";
+      }
+
+      stream.skipToEnd();
+      return "invalid";
+    }
+
+    if (stream.peek() === "'" || stream.peek() === '"') {
+      state.quote = stream.next() as "'" | '"';
+      state.valueStarted = true;
+      state.afterValueSpace = false;
+      return "string";
+    }
+
+    if (stream.peek() === "$") {
+      state.valueStarted = true;
+      state.afterValueSpace = false;
+      return tokenVariable(stream);
+    }
+
+    if (state.afterValueSpace && stream.peek() === "#") {
+      stream.skipToEnd();
+      return "comment";
+    }
+
+    while (!stream.eol()) {
+      const ch = stream.peek();
+      if (ch === "$" || /\s/.test(ch ?? "")) break;
+      stream.next();
+    }
+
+    state.valueStarted = true;
+    state.afterValueSpace = false;
+    return "string";
+  },
+
+  languageData: {
+    closeBrackets: { brackets: ["'", '"'] },
+    commentTokens: { line: "#" },
+  },
+};

--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -6,6 +6,9 @@ type LanguageLoader = () => Promise<LoaderResult>;
 const rubyLoader: LanguageLoader = () =>
   import("@codemirror/legacy-modes/mode/ruby").then((m) => m.ruby);
 
+const dotenvLoader: LanguageLoader = () =>
+  import("./dotenv").then((m) => m.dotenv);
+
 const jsonLoader: LanguageLoader = () =>
   import("@codemirror/lang-json").then((m) => m.json());
 
@@ -23,6 +26,8 @@ const mssqlLoader: LanguageLoader = () =>
   import("@codemirror/legacy-modes/mode/sql").then((m) => m.msSQL);
 const plsqlLoader: LanguageLoader = () =>
   import("@codemirror/legacy-modes/mode/sql").then((m) => m.plSQL);
+const dockerfileLoader: LanguageLoader = () =>
+  import("@codemirror/legacy-modes/mode/dockerfile").then((m) => m.dockerFile);
 
 /**
  * Extension → loader. Each loader is a dynamic import so language packs
@@ -53,6 +58,7 @@ const loaders: Record<string, LanguageLoader> = {
   rs: () => import("@codemirror/lang-rust").then((m) => m.rust()),
   go: () => import("@codemirror/lang-go").then((m) => m.go()),
   py: () => import("@codemirror/lang-python").then((m) => m.python()),
+  env: dotenvLoader,
   json: jsonLoader,
   jsonc: jsonLoader,
   json5: jsonLoader,
@@ -110,22 +116,18 @@ const loaders: Record<string, LanguageLoader> = {
   toml: () => import("@codemirror/legacy-modes/mode/toml").then((m) => m.toml),
   yaml: () => import("@codemirror/legacy-modes/mode/yaml").then((m) => m.yaml),
   yml: () => import("@codemirror/legacy-modes/mode/yaml").then((m) => m.yaml),
-  dockerfile: () =>
-    import("@codemirror/legacy-modes/mode/dockerfile").then(
-      (m) => m.dockerFile,
-    ),
+  dockerfile: dockerfileLoader,
 
   // LaTeX / TeX
   tex: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
-  latex: () =>
-    import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
+  latex: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
   sty: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
   cls: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
 };
 
 const filenameOverrides: Record<string, LanguageLoader> = {
-  dockerfile: loaders.dockerfile!,
-  "dockerfile.dev": loaders.dockerfile!,
+  dockerfile: dockerfileLoader,
+  "dockerfile.dev": dockerfileLoader,
   gemfile: rubyLoader,
   rakefile: rubyLoader,
   podfile: rubyLoader,
@@ -133,6 +135,11 @@ const filenameOverrides: Record<string, LanguageLoader> = {
   guardfile: rubyLoader,
   brewfile: rubyLoader,
 };
+
+function filenameLoader(base: string): LanguageLoader | undefined {
+  if (base === ".env" || base.startsWith(".env.")) return dotenvLoader;
+  return filenameOverrides[base];
+}
 
 function extOf(name: string): string | null {
   const lower = name.toLowerCase();
@@ -154,7 +161,7 @@ const cache = new Map<string, Extension | null>();
 function cacheKey(filename: string): string | null {
   const lower = filename.toLowerCase();
   const base = lower.split("/").pop() ?? lower;
-  if (filenameOverrides[base]) return `name:${base}`;
+  if (filenameLoader(base)) return `name:${base}`;
   const ext = extOf(base);
   return ext ? `ext:${ext}` : null;
 }
@@ -174,7 +181,7 @@ export async function resolveLanguage(
 
   const lower = filename.toLowerCase();
   const base = lower.split("/").pop() ?? lower;
-  const loader = filenameOverrides[base] ?? loaders[extOf(base) ?? ""];
+  const loader = filenameLoader(base) ?? loaders[extOf(base) ?? ""];
   if (!loader) {
     cache.set(key, null);
     return null;

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -1,5 +1,6 @@
 import { Alert02Icon, Globe02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { isLocalhostUrl } from "@/lib/localUrl";
 import {
   forwardRef,
   useEffect,
@@ -59,7 +60,7 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
       [url],
     );
 
-    const showXfoHint = url ? !isLocalUrl(url) : false;
+    const showXfoHint = url ? !isLocalhostUrl(url) : false;
 
     return (
       <div
@@ -171,26 +172,10 @@ function EmptyState() {
             Ports
           </span>{" "}
           dropdown to jump straight to your running dev server. Public sites
-          often block embedding — open them in your browser via the link icon
-          if you see a blank page.
+          often block embedding — open them in your browser via the link icon if
+          you see a blank page.
         </p>
       </div>
     </div>
   );
-}
-
-function isLocalUrl(url: string): boolean {
-  try {
-    const u = new URL(url);
-    const h = u.hostname;
-    return (
-      h === "localhost" ||
-      h === "127.0.0.1" ||
-      h === "0.0.0.0" ||
-      h === "[::1]" ||
-      h.endsWith(".localhost")
-    );
-  } catch {
-    return false;
-  }
 }

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -82,6 +82,7 @@ export type Preferences = {
   explorerGitDecorations: boolean;
   terminalWebglEnabled: boolean;
   terminalCursorBlink: boolean;
+  alwaysOpenLocalhostLinksInPreview: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -128,6 +129,8 @@ const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_EXPLORER_GIT_DECORATIONS = "explorerGitDecorations";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_CURSOR_BLINK = "terminalCursorBlink";
+const KEY_ALWAYS_OPEN_LOCALHOST_LINKS_IN_PREVIEW =
+  "alwaysOpenLocalhostLinksInPreview";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -187,6 +190,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   explorerGitDecorations: true,
   terminalWebglEnabled: true,
   terminalCursorBlink: false,
+  alwaysOpenLocalhostLinksInPreview: false,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -261,10 +265,8 @@ export async function loadPreferences(): Promise<Preferences> {
       get<string>(KEY_LMSTUDIO_BASE_URL) ?? DEFAULT_PREFERENCES.lmstudioBaseURL,
     lmstudioModelId:
       get<string>(KEY_LMSTUDIO_MODEL_ID) ?? DEFAULT_PREFERENCES.lmstudioModelId,
-    mlxBaseURL:
-      get<string>(KEY_MLX_BASE_URL) ?? DEFAULT_PREFERENCES.mlxBaseURL,
-    mlxModelId:
-      get<string>(KEY_MLX_MODEL_ID) ?? DEFAULT_PREFERENCES.mlxModelId,
+    mlxBaseURL: get<string>(KEY_MLX_BASE_URL) ?? DEFAULT_PREFERENCES.mlxBaseURL,
+    mlxModelId: get<string>(KEY_MLX_MODEL_ID) ?? DEFAULT_PREFERENCES.mlxModelId,
     ollamaBaseURL:
       get<string>(KEY_OLLAMA_BASE_URL) ?? DEFAULT_PREFERENCES.ollamaBaseURL,
     ollamaModelId:
@@ -292,8 +294,7 @@ export async function loadPreferences(): Promise<Preferences> {
       get<string>(KEY_OPENROUTER_MODEL_ID) ??
       DEFAULT_PREFERENCES.openrouterModelId,
     favoriteModelIds: (
-      get<string[]>(KEY_FAVORITE_MODELS) ??
-      DEFAULT_PREFERENCES.favoriteModelIds
+      get<string[]>(KEY_FAVORITE_MODELS) ?? DEFAULT_PREFERENCES.favoriteModelIds
     ).filter(isKnownModelId),
     recentModelIds: (
       get<string[]>(KEY_RECENT_MODELS) ?? DEFAULT_PREFERENCES.recentModelIds
@@ -312,6 +313,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalCursorBlink:
       get<boolean>(KEY_TERMINAL_CURSOR_BLINK) ??
       DEFAULT_PREFERENCES.terminalCursorBlink,
+    alwaysOpenLocalhostLinksInPreview:
+      get<boolean>(KEY_ALWAYS_OPEN_LOCALHOST_LINKS_IN_PREVIEW) ??
+      DEFAULT_PREFERENCES.alwaysOpenLocalhostLinksInPreview,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -336,8 +340,7 @@ export async function loadPreferences(): Promise<Preferences> {
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
     editorAutoSave:
-      get<boolean>(KEY_EDITOR_AUTO_SAVE) ??
-      DEFAULT_PREFERENCES.editorAutoSave,
+      get<boolean>(KEY_EDITOR_AUTO_SAVE) ?? DEFAULT_PREFERENCES.editorAutoSave,
     editorAutoSaveDelay: clampAutoSaveDelay(
       get<number>(KEY_EDITOR_AUTO_SAVE_DELAY) ??
         DEFAULT_PREFERENCES.editorAutoSaveDelay,
@@ -371,7 +374,9 @@ export async function setBackgroundKind(value: BackgroundKind): Promise<void> {
   await writePref(KEY_BG_KIND, value);
 }
 
-export async function setBackgroundImageId(value: string | null): Promise<void> {
+export async function setBackgroundImageId(
+  value: string | null,
+): Promise<void> {
   await writePref(KEY_BG_IMAGE_ID, value);
 }
 
@@ -382,7 +387,6 @@ export async function setBackgroundOpacity(value: number): Promise<void> {
 export async function setBackgroundBlur(value: number): Promise<void> {
   await writePref(KEY_BG_BLUR, clampBlur(value));
 }
-
 
 export async function setDefaultModel(value: ModelId): Promise<void> {
   await writePref(KEY_DEFAULT_MODEL, value);
@@ -497,12 +501,20 @@ export async function setTerminalCursorBlink(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_CURSOR_BLINK, value);
 }
 
+export async function setAlwaysOpenLocalhostLinksInPreview(
+  value: boolean,
+): Promise<void> {
+  await writePref(KEY_ALWAYS_OPEN_LOCALHOST_LINKS_IN_PREVIEW, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
 
 export async function setTerminalLetterSpacing(value: number): Promise<void> {
-  const clamped = Number.isFinite(value) ? Math.max(-10, Math.min(10, Math.round(value))) : 0;
+  const clamped = Number.isFinite(value)
+    ? Math.max(-10, Math.min(10, Math.round(value)))
+    : 0;
   await writePref(KEY_TERMINAL_LETTER_SPACING, clamped);
 }
 
@@ -602,6 +614,8 @@ export async function onPreferencesChange(
     [KEY_EXPLORER_GIT_DECORATIONS]: "explorerGitDecorations",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_CURSOR_BLINK]: "terminalCursorBlink",
+    [KEY_ALWAYS_OPEN_LOCALHOST_LINKS_IN_PREVIEW]:
+      "alwaysOpenLocalhostLinksInPreview",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -20,3 +20,7 @@ export {
   type PaneNode,
   type SplitDir,
 } from "./lib/panes";
+export {
+  configureTerminalLinkActions,
+  type TerminalLinkHover,
+} from "./lib/rendererPool";

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -71,6 +71,11 @@ export type Slot = {
 const slots: Slot[] = [];
 let recyclerEl: HTMLDivElement | null = null;
 let adapter: SlotAdapter | null = null;
+let linkActions: TerminalLinkActions = {
+  open: (_event, uri) => openUrl(uri).catch(console.error),
+  hover: () => {},
+  leave: () => {},
+};
 
 let windowActive =
   typeof document === "undefined" || (!document.hidden && document.hasFocus());
@@ -101,6 +106,25 @@ function setWindowActive(active: boolean): void {
 export function configureRendererPool(a: SlotAdapter): void {
   adapter = a;
   bindWindowActivityListeners();
+}
+
+export type TerminalLinkHover = {
+  uri: string;
+  x: number;
+  y: number;
+  width: number;
+};
+
+export type TerminalLinkActions = {
+  open: (event: MouseEvent, uri: string) => void;
+  hover: (hover: TerminalLinkHover) => void;
+  leave: (uri: string) => void;
+};
+
+export function configureTerminalLinkActions(
+  actions: TerminalLinkActions,
+): void {
+  linkActions = actions;
 }
 
 export function forEachSlot(fn: (slot: Slot) => void): void {
@@ -195,14 +219,25 @@ function createSlot(): Slot {
   const fitAddon = new FitAddon();
   const searchAddon = new SearchAddon();
   const serializeAddon = new SerializeAddon();
+  const host = document.createElement("div");
   term.loadAddon(fitAddon);
   term.loadAddon(searchAddon);
   term.loadAddon(serializeAddon);
   term.loadAddon(
-    new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
+    new WebLinksAddon((event, uri) => linkActions.open(event, uri), {
+      hover: (event, uri, range) => {
+        const rect = linkViewportRect(term, host, range);
+        linkActions.hover({
+          uri,
+          x: rect?.left ?? event.clientX,
+          y: rect?.top ?? event.clientY,
+          width: rect?.width ?? 0,
+        });
+      },
+      leave: (_event, uri) => linkActions.leave(uri),
+    }),
   );
 
-  const host = document.createElement("div");
   host.style.cssText = "width:100%;height:100%;";
   host.setAttribute("data-terax-slot", String(slots.length));
   getRecycler().appendChild(host);
@@ -304,6 +339,29 @@ function createSlot(): Slot {
 
   slots.push(slot);
   return slot;
+}
+
+function linkViewportRect(
+  term: Terminal,
+  host: HTMLDivElement,
+  range: { start: { x: number; y: number }; end: { x: number; y: number } },
+): { left: number; top: number; width: number } | null {
+  const screen =
+    host.querySelector<HTMLElement>(".xterm-screen") ??
+    host.querySelector<HTMLElement>(".xterm-viewport") ??
+    host;
+  const rect = screen.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0 || term.cols <= 0 || term.rows <= 0) {
+    return null;
+  }
+
+  const cellW = rect.width / term.cols;
+  const cellH = rect.height / term.rows;
+  const left = rect.left + (range.start.x - 1) * cellW;
+  const top = rect.top + (range.start.y - 1) * cellH;
+  const endX = range.end.y === range.start.y ? range.end.x : term.cols;
+  const cells = Math.max(1, endX - range.start.x + 1);
+  return { left, top, width: cells * cellW };
 }
 
 type PickResult = { slot: Slot; previousLeafId: number | null };

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -21,6 +21,7 @@ import {
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAgentNotifications,
+  setAlwaysOpenLocalhostLinksInPreview,
   setAutostart,
   setEditorAutoSave,
   setEditorAutoSaveDelay,
@@ -81,8 +82,9 @@ export function GeneralSection() {
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
   );
-  const terminalCursorBlink = usePreferencesStore(
-    (s) => s.terminalCursorBlink,
+  const terminalCursorBlink = usePreferencesStore((s) => s.terminalCursorBlink);
+  const alwaysOpenLocalhostLinksInPreview = usePreferencesStore(
+    (s) => s.alwaysOpenLocalhostLinksInPreview,
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
@@ -120,10 +122,7 @@ export function GeneralSection() {
 
   return (
     <div className="flex flex-col gap-6">
-      <SectionHeader
-        title="General"
-        description="Mode, editor, and startup."
-      />
+      <SectionHeader title="General" description="Mode, editor, and startup." />
 
       <div className="flex flex-col gap-2">
         <Label>Appearance</Label>
@@ -238,15 +237,12 @@ export function GeneralSection() {
                       ⓘ
                     </span>
                   </TooltipTrigger>
-                  <TooltipContent
-                    side="top"
-                    className="max-w-65 text-[11px]"
-                  >
-                    xterm's WebGL renderer caches glyphs in a GPU texture
-                    atlas. On some macOS setups (especially with Nerd Fonts),
-                    the atlas corrupts and terminal text becomes unreadable.
-                    Turn this off as a fallback — performance dips slightly,
-                    but text renders correctly via the DOM renderer.
+                  <TooltipContent side="top" className="max-w-65 text-[11px]">
+                    xterm's WebGL renderer caches glyphs in a GPU texture atlas.
+                    On some macOS setups (especially with Nerd Fonts), the atlas
+                    corrupts and terminal text becomes unreadable. Turn this off
+                    as a fallback — performance dips slightly, but text renders
+                    correctly via the DOM renderer.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -310,7 +306,11 @@ export function GeneralSection() {
             </SelectTrigger>
             <SelectContent>
               {TERMINAL_FONT_SIZES.map((size) => (
-                <SelectItem key={size} value={String(size)} className="text-[12px]">
+                <SelectItem
+                  key={size}
+                  value={String(size)}
+                  className="text-[12px]"
+                >
                   {size} px
                 </SelectItem>
               ))}
@@ -340,6 +340,21 @@ export function GeneralSection() {
               ))}
             </SelectContent>
           </Select>
+        </SettingRow>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label>Web Preview</Label>
+        <SettingRow
+          title="Always open localhost links in preview"
+          description="Open terminal localhost and loopback links in an in-app preview tab instead of the system browser."
+        >
+          <Switch
+            checked={alwaysOpenLocalhostLinksInPreview}
+            onCheckedChange={(v) =>
+              void setAlwaysOpenLocalhostLinksInPreview(v)
+            }
+          />
         </SettingRow>
       </div>
 
@@ -444,4 +459,3 @@ function AutoSaveDelayInput({
     </SettingRow>
   );
 }
-


### PR DESCRIPTION
 ## What
  Adds an in-terminal hover action for localhost and loopback links that opens
  them in Terax's web preview. Also adds a new setting to always open localhost
  terminal links in preview instead of the system browser.

  ## Why
  Terax already has an internal web preview, but localhost links printed in the
  terminal required opening an external browser or manually copying the URL
  into preview. This makes local dev server links faster to inspect inside the
  workspace.

  ## How
  Terminal web link handling now routes through app level link actions.
  Localhost links show an `Open in Preview` popup anchored to the detected link
  width, and the new persisted setting controls whether direct clicks open
  preview automatically.

  ## Testing

  - [x] `pnpm exec tsc --noEmit` clean
  - [x] Manual smoke-test of the affected feature
  - [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy
  --all-targets --locked -- -D warnings` clean
  - [ ] (If you changed a `#[tauri::command]` signature) called out below so
  the FE caller can be updated in lockstep
  - [x] (If UI) tested in `pnpm tauri dev`
  - [x] Platforms tested: Linux
  - [x] Shells tested (if relevant): bash

  Additional checks:
  - [x] `pnpm test`
  - [x] `pnpm build`
  - [x] `git diff --check`

  ## Screenshots / GIFs
<img width="903" height="201" alt="image" src="https://github.com/user-attachments/assets/98b4a3ee-da28-4070-a631-9a9993faf49c" />
<img width="1015" height="568" alt="image" src="https://github.com/user-attachments/assets/72eed01d-2de1-4456-9877-cf5edc26561c" />


  ## Notes for reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Web Preview" setting to open localhost/loopback terminal links in the in-app preview pane
  * Added .env language support for editor highlighting

* **Improvements**
  * Improved terminal link handling and hover-based preview for localhost links
  * Preview pane now uses shared localhost detection and clarifies embed-blocking guidance

* **Tests**
  * Added tests for localhost URL detection and dotenv tokenizer
<!-- end of auto-generated comment: release notes by coderabbit.ai -->