### PR TITLE
fix(tabs): skip close dialog for last tab in space

### DIFF
--- a/src/app/hooks/useTabCloseGuards.ts
+++ b/src/app/hooks/useTabCloseGuards.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { leafHasForegroundProcess, leafIds } from "@/modules/terminal";
-import type { Tab } from "@/modules/tabs";
+import { nextActiveInSpace, type Tab } from "@/modules/tabs";
 
 type Params = {
   tabs: Tab[];
@@ -23,6 +23,9 @@ export function useTabCloseGuards({ tabs, disposeTab }: Params) {
 
   const handleClose = useCallback(
     async (id: number) => {
+      // Last tab in its space can't be closed (closeTab refuses). Skip the
+      // dialog entirely so confirming it doesn't appear to silently fail.
+      if (nextActiveInSpace(tabs, id) === null) return;
       const t = tabs.find((x) => x.id === id);
       if (t?.kind === "editor" && t.dirty) {
         setPendingCloseTab(id);

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -4,6 +4,7 @@ export {
   MAX_PANES_PER_TAB,
   DEFAULT_SPACE_ID,
   useTabs,
+  nextActiveInSpace,
   type Tab,
   type TerminalTab,
   type EditorTab,


### PR DESCRIPTION
## What
When only one tab is left in a space, pressing cmd+w opened a confirmation dialog, but confirming did nothing because `closeTab` refuses to close the last tab. This change skips the dialog entirely in that case so it no longer looks broken.

## Why
The TabBar already hides the close button on the last tab, but the cmd+w shortcut path still went through `handleClose`, which showed a dialog whose confirm action was silently dropped downstream.

## How
In `useTabCloseGuards.handleClose`, bail out early when `nextActiveInSpace` returns `null` (the existing "refuse to close" sentinel), so the dirty-editor / running-process dialogs are never opened for the last tab.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test: with one terminal tab open and a running foreground process, cmd+w no longer opens the dialog; with multiple tabs, cmd+w still routes through the dialog as before.
- [x] Platforms tested: macOS