### PR TITLE
feat(tabs): drag-to-reorder tabs via pointer events

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -105,6 +105,7 @@ export default function App() {
     replaceTabs,
     moveTabToSpace,
     reorderTab,
+    reorderTabByGap,
     newTabInSpace,
     removeTabsForSpace,
     markBooted,
@@ -1014,6 +1015,7 @@ export default function App() {
               onClose={handleClose}
               onPin={pinTab}
               onRename={handleRenameTab}
+              onReorder={reorderTabByGap}
               onToggleSidebar={toggleSidebar}
               onOpenCommandPalette={() => openCommandPalette("commands")}
               onActivateAgent={onActivateAgent}

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -38,6 +38,8 @@ type Props = {
   onPin: (id: number) => void;
   /** Set a terminal tab's custom label; empty string resets to default. */
   onRename: (id: number, title: string) => void;
+  /** Move a dragged tab to a new position (insertion gap index). */
+  onReorder: (fromId: number, toGapIndex: number) => void;
   onToggleSidebar: () => void;
   onOpenCommandPalette: () => void;
   onActivateAgent: (tabId: number, leafId: number) => void;
@@ -63,6 +65,7 @@ export function Header({
   onClose,
   onPin,
   onRename,
+  onReorder,
   onToggleSidebar,
   onOpenCommandPalette,
   onActivateAgent,
@@ -157,6 +160,7 @@ export function Header({
           onClose={onClose}
           onPin={onPin}
           onRename={onRename}
+          onReorder={onReorder}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -29,6 +29,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+  Fragment,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -53,6 +54,8 @@ type Props = {
   onPin: (id: number) => void;
   /** Set a terminal tab's custom label; empty string resets to default. */
   onRename: (id: number, title: string) => void;
+  /** Move a dragged tab to a new position (insertion gap index 0..tabs.length). */
+  onReorder: (fromId: number, toGapIndex: number) => void;
   compact?: boolean;
 };
 
@@ -69,11 +72,20 @@ export function TabBar({
   onClose,
   onPin,
   onRename,
+  onReorder,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const [dropGap, setDropGap] = useState<number | null>(null);
+  const drag = useRef<{
+    pointerId: number;
+    startX: number;
+    fromId: number;
+    active: boolean;
+  } | null>(null);
 
   // Play the enter animation only for tabs opened after the first paint, never
   // the restored set and never on switch/reorder (triggers are keyed, so they
@@ -124,6 +136,26 @@ export function TabBar({
       return () => cancelAnimationFrame(id);
     }
   }, [pill, pillReady]);
+
+  const gapAtX = (clientX: number) => {
+    const els = Array.from(
+      scrollRef.current?.querySelectorAll<HTMLElement>("[data-tab-id]") ?? [],
+    );
+    for (let i = 0; i < els.length; i++) {
+      const r = els[i].getBoundingClientRect();
+      if (clientX < r.left + r.width / 2) return i;
+    }
+    return els.length;
+  };
+
+  const endDrag = (currentTarget: HTMLElement) => {
+    const st = drag.current;
+    if (st) currentTarget.releasePointerCapture?.(st.pointerId);
+    drag.current = null;
+    setDraggingId(null);
+    setDropGap(null);
+    document.body.style.userSelect = "";
+  };
 
   // Horizontal wheel scroll without holding shift.
   useEffect(() => {
@@ -179,43 +211,86 @@ export function TabBar({
                   : { opacity: 0 }
               }
             />
-            {tabs.map((t) => {
+            {tabs.map((t, i) => {
               const isPreview = t.kind === "editor" && (t as EditorTab).preview;
               const isActive = t.id === activeId;
               const isNew = !firstRender && !seen.has(t.id);
+
+              const srcIndex = tabs.findIndex((x) => x.id === draggingId);
+              const showGap = (gap: number) =>
+                draggingId !== null &&
+                dropGap === gap &&
+                gap !== srcIndex &&
+                gap !== srcIndex + 1;
 
               // While renaming, render a non-button cell so the <input> is not
               // nested inside the trigger <button> (invalid HTML, and WebKit
               // blocks focus/selection on inputs inside buttons).
               if (editingId === t.id && t.kind === "terminal") {
                 return (
-                  <div
-                    key={t.id}
-                    data-tab-id={t.id}
-                    className={cn(
-                      "flex h-7 shrink-0 items-center gap-1.5 rounded-md bg-accent text-xs text-foreground",
-                      compact ? "px-1.5" : "px-2",
+                  <Fragment key={t.id}>
+                    {showGap(i) && <DropIndicator />}
+                    <div
+                      data-tab-id={t.id}
+                      className={cn(
+                        "flex h-7 shrink-0 items-center gap-1.5 rounded-md bg-accent text-xs text-foreground",
+                        compact ? "px-1.5" : "px-2",
+                      )}
+                    >
+                      <TabIcon tab={t} />
+                      <TabRenameInput
+                        initial={labelFor(t)}
+                        onCommit={(value) => {
+                          onRename(t.id, value);
+                          setEditingId(null);
+                        }}
+                        onCancel={() => setEditingId(null)}
+                      />
+                    </div>
+                    {i === tabs.length - 1 && showGap(tabs.length) && (
+                      <DropIndicator />
                     )}
-                  >
-                    <TabIcon tab={t} />
-                    <TabRenameInput
-                      initial={labelFor(t)}
-                      onCommit={(value) => {
-                        onRename(t.id, value);
-                        setEditingId(null);
-                      }}
-                      onCancel={() => setEditingId(null)}
-                    />
-                  </div>
+                  </Fragment>
                 );
               }
 
               const trigger = (
                 <TabsTrigger
-                  key={t.id}
                   value={String(t.id)}
                   data-tab-id={t.id}
                   data-tab-active={isActive ? "true" : undefined}
+                  onPointerDown={(e) => {
+                    if (e.button !== 0) return;
+                    if ((e.target as HTMLElement).closest("[data-no-drag]"))
+                      return;
+                    drag.current = {
+                      pointerId: e.pointerId,
+                      startX: e.clientX,
+                      fromId: t.id,
+                      active: false,
+                    };
+                    e.currentTarget.setPointerCapture(e.pointerId);
+                  }}
+                  onPointerMove={(e) => {
+                    const st = drag.current;
+                    if (!st || st.pointerId !== e.pointerId) return;
+                    if (!st.active) {
+                      if (Math.abs(e.clientX - st.startX) < 4) return;
+                      st.active = true;
+                      setDraggingId(st.fromId);
+                      document.body.style.userSelect = "none";
+                    }
+                    e.preventDefault();
+                    setDropGap(gapAtX(e.clientX));
+                  }}
+                  onPointerUp={(e) => {
+                    const st = drag.current;
+                    if (st?.active && dropGap !== null) {
+                      onReorder(st.fromId, dropGap);
+                    }
+                    endDrag(e.currentTarget);
+                  }}
+                  onPointerCancel={(e) => endDrag(e.currentTarget)}
                   onDoubleClick={() => isPreview && onPin(t.id)}
                   onAuxClick={(e) => {
                     if (e.button === 1 && tabs.length > 1) {
@@ -233,6 +308,7 @@ export function TabBar({
                     isActive
                       ? "text-foreground dark:text-foreground"
                       : "text-muted-foreground hover:text-foreground/80 dark:text-muted-foreground",
+                    draggingId === t.id && "opacity-50",
                     compact
                       ? "px-1.5!"
                       : tabs.length === 1
@@ -263,6 +339,7 @@ export function TabBar({
                     <span
                       role="button"
                       aria-label="Close tab"
+                      data-no-drag
                       onClick={(e) => {
                         e.stopPropagation();
                         onClose(t.id);
@@ -279,38 +356,49 @@ export function TabBar({
                 </TabsTrigger>
               );
 
-              if (t.kind !== "terminal") return trigger;
+              const tabNode =
+                t.kind === "terminal" ? (
+                  <ContextMenu>
+                    <ContextMenuTrigger asChild>{trigger}</ContextMenuTrigger>
+                    <ContextMenuContent
+                      className="min-w-36"
+                      onCloseAutoFocus={(e) => e.preventDefault()}
+                    >
+                      <ContextMenuItem onSelect={() => setEditingId(t.id)}>
+                        <HugeiconsIcon
+                          icon={PencilEdit02Icon}
+                          size={14}
+                          strokeWidth={1.75}
+                        />
+                        <span className="flex-1">Rename</span>
+                      </ContextMenuItem>
+                      {tabs.length > 1 && (
+                        <>
+                          <ContextMenuSeparator />
+                          <ContextMenuItem onSelect={() => onClose(t.id)}>
+                            <HugeiconsIcon
+                              icon={Cancel01Icon}
+                              size={14}
+                              strokeWidth={1.75}
+                            />
+                            <span className="flex-1">Close</span>
+                          </ContextMenuItem>
+                        </>
+                      )}
+                    </ContextMenuContent>
+                  </ContextMenu>
+                ) : (
+                  trigger
+                );
 
               return (
-                <ContextMenu key={t.id}>
-                  <ContextMenuTrigger asChild>{trigger}</ContextMenuTrigger>
-                  <ContextMenuContent
-                    className="min-w-36"
-                    onCloseAutoFocus={(e) => e.preventDefault()}
-                  >
-                    <ContextMenuItem onSelect={() => setEditingId(t.id)}>
-                      <HugeiconsIcon
-                        icon={PencilEdit02Icon}
-                        size={14}
-                        strokeWidth={1.75}
-                      />
-                      <span className="flex-1">Rename</span>
-                    </ContextMenuItem>
-                    {tabs.length > 1 && (
-                      <>
-                        <ContextMenuSeparator />
-                        <ContextMenuItem onSelect={() => onClose(t.id)}>
-                          <HugeiconsIcon
-                            icon={Cancel01Icon}
-                            size={14}
-                            strokeWidth={1.75}
-                          />
-                          <span className="flex-1">Close</span>
-                        </ContextMenuItem>
-                      </>
-                    )}
-                  </ContextMenuContent>
-                </ContextMenu>
+                <Fragment key={t.id}>
+                  {showGap(i) && <DropIndicator />}
+                  {tabNode}
+                  {i === tabs.length - 1 && showGap(tabs.length) && (
+                    <DropIndicator />
+                  )}
+                </Fragment>
               );
             })}
           </TabsList>
@@ -394,6 +482,15 @@ export function TabBar({
         </DropdownMenu>
       </div>
     </div>
+  );
+}
+
+function DropIndicator() {
+  return (
+    <span
+      aria-hidden
+      className="my-0.5 w-0.5 shrink-0 self-stretch rounded-full bg-primary"
+    />
   );
 }
 

--- a/src/modules/tabs/lib/reorderTabsByGap.test.ts
+++ b/src/modules/tabs/lib/reorderTabsByGap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { reorderTabsByGap, type Tab } from "./useTabs";
+
+function term(id: number, spaceId: string): Tab {
+  return {
+    id,
+    kind: "terminal",
+    spaceId,
+    title: "shell",
+    paneTree: { kind: "leaf", id: id * 10 },
+    activeLeafId: id * 10,
+  } as Tab;
+}
+
+const ids = (tabs: Tab[]) => tabs.map((t) => t.id);
+
+describe("reorderTabsByGap", () => {
+  it("moves a tab right into a middle gap without overshooting", () => {
+    const tabs = [term(1, "a"), term(2, "a"), term(3, "a")];
+    expect(ids(reorderTabsByGap(tabs, 1, 2))).toEqual([2, 1, 3]);
+  });
+
+  it("moves a tab left", () => {
+    const tabs = [term(1, "a"), term(2, "a"), term(3, "a")];
+    expect(ids(reorderTabsByGap(tabs, 3, 1))).toEqual([1, 3, 2]);
+  });
+
+  it("moves a tab to the end", () => {
+    const tabs = [term(1, "a"), term(2, "a"), term(3, "a")];
+    expect(ids(reorderTabsByGap(tabs, 1, 3))).toEqual([2, 3, 1]);
+  });
+
+  it("is a no-op for the gaps adjacent to the source", () => {
+    const tabs = [term(1, "a"), term(2, "a"), term(3, "a")];
+    expect(ids(reorderTabsByGap(tabs, 1, 0))).toEqual([1, 2, 3]);
+    expect(ids(reorderTabsByGap(tabs, 1, 1))).toEqual([1, 2, 3]);
+  });
+
+  it("reorders within a space without disturbing other spaces", () => {
+    const tabs = [term(1, "a"), term(2, "b"), term(3, "a"), term(4, "b")];
+    expect(ids(reorderTabsByGap(tabs, 1, 2))).toEqual([2, 3, 1, 4]);
+  });
+
+  it("returns the input unchanged for an unknown id", () => {
+    const tabs = [term(1, "a"), term(2, "a")];
+    expect(reorderTabsByGap(tabs, 99, 1)).toBe(tabs);
+  });
+});

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1023,6 +1023,20 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     for (const lid of toDispose) disposeSession(lid);
   }, []);
 
+  const reorderTabByGap = useCallback((fromId: number, toGapIndex: number) => {
+    setTabs((prev) => {
+      const from = prev.findIndex((t) => t.id === fromId);
+      if (from === -1) return prev;
+      const next = prev.slice();
+      const [moved] = next.splice(from, 1);
+      let target = toGapIndex > from ? toGapIndex - 1 : toGapIndex;
+      target = Math.max(0, Math.min(target, next.length));
+      if (target === from) return prev;
+      next.splice(target, 0, moved);
+      return next;
+    });
+  }, []);
+
   return {
     tabs,
     activeId,
@@ -1031,6 +1045,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     replaceTabs,
     moveTabToSpace,
     reorderTab,
+    reorderTabByGap,
     newTabInSpace,
     removeTabsForSpace,
     markBooted,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1025,14 +1025,18 @@ export function useTabs(initial?: Partial<TerminalTab>) {
 
   const reorderTabByGap = useCallback((fromId: number, toGapIndex: number) => {
     setTabs((prev) => {
-      const from = prev.findIndex((t) => t.id === fromId);
-      if (from === -1) return prev;
-      const next = prev.slice();
-      const [moved] = next.splice(from, 1);
-      let target = toGapIndex > from ? toGapIndex - 1 : toGapIndex;
-      target = Math.max(0, Math.min(target, next.length));
-      if (target === from) return prev;
-      next.splice(target, 0, moved);
+      const moved = prev.find((t) => t.id === fromId);
+      if (!moved) return prev;
+      const sameSpace = prev.filter((t) => t.spaceId === moved.spaceId);
+      const spaceFrom = sameSpace.findIndex((t) => t.id === fromId);
+      let spaceTarget = toGapIndex > spaceFrom ? toGapIndex - 1 : toGapIndex;
+      spaceTarget = Math.max(0, Math.min(spaceTarget, sameSpace.length - 1));
+      if (spaceTarget === spaceFrom) return prev;
+      const anchor = sameSpace[spaceTarget];
+      const anchorIdx = prev.findIndex((t) => t.id === anchor.id);
+      const insertIdx = spaceTarget > spaceFrom ? anchorIdx + 1 : anchorIdx;
+      const next = prev.filter((t) => t.id !== fromId);
+      next.splice(Math.min(insertIdx, next.length), 0, moved);
       return next;
     });
   }, []);

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -160,6 +160,27 @@ export function nextActiveInSpace(
   return (sameSpace[idx - 1] ?? sameSpace[idx + 1]).id;
 }
 
+// Gap index is relative to the space's own strip, including the dragged tab.
+export function reorderTabsByGap(
+  tabs: Tab[],
+  fromId: number,
+  toGapIndex: number,
+): Tab[] {
+  const moved = tabs.find((t) => t.id === fromId);
+  if (!moved) return tabs;
+  const sameSpace = tabs.filter((t) => t.spaceId === moved.spaceId);
+  const spaceFrom = sameSpace.findIndex((t) => t.id === fromId);
+  let spaceTarget = toGapIndex > spaceFrom ? toGapIndex - 1 : toGapIndex;
+  spaceTarget = Math.max(0, Math.min(spaceTarget, sameSpace.length - 1));
+  if (spaceTarget === spaceFrom) return tabs;
+  const anchor = sameSpace[spaceTarget];
+  const next = tabs.filter((t) => t.id !== fromId);
+  const anchorIdx = next.findIndex((t) => t.id === anchor.id);
+  const insertIdx = spaceTarget > spaceFrom ? anchorIdx + 1 : anchorIdx;
+  next.splice(insertIdx, 0, moved);
+  return next;
+}
+
 export function useTabs(initial?: Partial<TerminalTab>) {
   const [tabs, setTabs] = useState<Tab[]>(() => {
     const tabId = 1;
@@ -1024,21 +1045,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   }, []);
 
   const reorderTabByGap = useCallback((fromId: number, toGapIndex: number) => {
-    setTabs((prev) => {
-      const moved = prev.find((t) => t.id === fromId);
-      if (!moved) return prev;
-      const sameSpace = prev.filter((t) => t.spaceId === moved.spaceId);
-      const spaceFrom = sameSpace.findIndex((t) => t.id === fromId);
-      let spaceTarget = toGapIndex > spaceFrom ? toGapIndex - 1 : toGapIndex;
-      spaceTarget = Math.max(0, Math.min(spaceTarget, sameSpace.length - 1));
-      if (spaceTarget === spaceFrom) return prev;
-      const anchor = sameSpace[spaceTarget];
-      const anchorIdx = prev.findIndex((t) => t.id === anchor.id);
-      const insertIdx = spaceTarget > spaceFrom ? anchorIdx + 1 : anchorIdx;
-      const next = prev.filter((t) => t.id !== fromId);
-      next.splice(Math.min(insertIdx, next.length), 0, moved);
-      return next;
-    });
+    setTabs((prev) => reorderTabsByGap(prev, fromId, toGapIndex));
   }, []);
 
   return {


### PR DESCRIPTION
## Summary

Adds **drag-to-reorder for tabs** -- grab a tab and drop it at a new position; the other tabs shift to make room (insert-and-shift, like browser tabs), rather than swapping.

## Why pointer events (not HTML5 drag)

The native HTML5 drag-and-drop API does not fire reliably in Tauri's macOS WKWebView, so dragging a tab simply didn't work. This implements the gesture with **Pointer Events + `setPointerCapture`**, which work reliably in WKWebView.

## Details

- New `reorderTabByGap(fromId, toGapIndex)` in `useTabs.ts` -- removes the dragged tab and re-inserts it at the drop gap (with a no-op guard when dropped in place), wired `App.tsx -> Header.tsx -> TabBar.tsx` via a new `onReorder` prop.
- `TabBar.tsx`: `pointerdown`/`pointermove`/`pointerup` handlers with a **4px movement threshold** so a plain click still selects the tab; a vertical insertion line shows where the tab will land; the dragged tab dims while dragging.
- Grabbing the close (x) control is excluded from drag via `data-no-drag`, so closing still works.

## Test plan

- Open 2-3 tabs, drag one past another and release -> it lands at the drop position; insertion line tracks the cursor across the strip.
- Plain click still selects; x still closes; double-click still pins a preview editor tab; middle-click still closes.
- Grabbing empty tab-strip space still drags the OS window.
- `npx tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop tab reordering, with clear visual drop indicators showing the insertion point.
  * Tabs now reorder reliably during drag-and-drop, adjusting placement within the same tab set and preventing incorrect moves.
* **Tests**
  * Added automated test coverage for common and edge-case reordering behaviors (including no-op and unknown tab handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->