### PR TITLE
feat(ai): add Groq and Whisper.cpp STT providers

### DIFF
--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -50,6 +50,7 @@ import {
   MODELS,
   providerNeedsKey,
   PROVIDERS,
+  STT_PROVIDER_LABELS,
   type ModelCapabilities,
   type ModelId,
   type ModelInfo,
@@ -127,7 +128,7 @@ export function AiStatusBarControls() {
         <IconBtn
           title={
             !c.voice.hasKey
-              ? "Voice needs an OpenAI key"
+              ? `Voice needs a ${STT_PROVIDER_LABELS[c.voice.sttProvider]} key`
               : c.voice.recording
                 ? "Stop & transcribe"
                 : c.voice.transcribing

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -720,6 +720,16 @@ export function getAutocompleteEligibleModels(): readonly ModelInfo[] {
   );
 }
 
+export type SttProvider = "openai" | "groq" | "whispercpp";
+
+export const STT_PROVIDER_LABELS: Record<SttProvider, string> = {
+  openai: "OpenAI Whisper",
+  groq: "Groq Whisper",
+  whispercpp: "Whisper.cpp (local)",
+};
+
+export const DEFAULT_STT_PROVIDER: SttProvider = "openai";
+export const WHISPERCPP_DEFAULT_BASE_URL = "http://127.0.0.1:8080";
 export const LMSTUDIO_DEFAULT_BASE_URL = "http://localhost:1234/v1";
 export const MLX_DEFAULT_BASE_URL = "http://127.0.0.1:8080/v1";
 export const OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434/v1";

--- a/src/modules/ai/hooks/useWhisperRecording.ts
+++ b/src/modules/ai/hooks/useWhisperRecording.ts
@@ -43,7 +43,6 @@ export function useWhisperRecording({
   const sttProvider = usePreferencesStore((s) => s.sttProvider);
   const groqSttModel = usePreferencesStore((s) => s.groqSttModel);
   const whispercppBaseURL = usePreferencesStore((s) => s.whispercppBaseURL);
-  const whispercppModel = usePreferencesStore((s) => s.whispercppModel);
   const [state, setState] = useState<State>("idle");
   const recRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
@@ -61,7 +60,6 @@ export function useWhisperRecording({
   const sttOptions: SttOptions = {
     groqSttModel,
     whispercppBaseURL,
-    whispercppModel,
   };
 
   const teardownStream = () => {

--- a/src/modules/ai/hooks/useWhisperRecording.ts
+++ b/src/modules/ai/hooks/useWhisperRecording.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useChatStore } from "../store/chatStore";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { transcribeAudio, type SttOptions } from "../lib/stt";
+import type { SttProvider } from "../config";
 
 const MIME_CANDIDATES = [
   "audio/webm;codecs=opus",
@@ -16,16 +19,17 @@ function pickMime(): string | undefined {
   return undefined;
 }
 
-async function transcribeBlob(blob: Blob, apiKey: string): Promise<string> {
-  const [{ createOpenAI }, { experimental_transcribe: transcribe }] =
-    await Promise.all([import("@ai-sdk/openai"), import("ai")]);
-  const openai = createOpenAI({ apiKey });
-  const buf = new Uint8Array(await blob.arrayBuffer());
-  const { text } = await transcribe({
-    model: openai.transcription("whisper-1"),
-    audio: buf,
-  });
-  return text;
+function providerNeedsKey(provider: SttProvider): boolean {
+  return provider !== "whispercpp";
+}
+
+function getApiKeyForStt(
+  apiKeys: import("../lib/keyring").ProviderKeys,
+  provider: SttProvider,
+): string | null {
+  if (provider === "openai") return apiKeys.openai;
+  if (provider === "groq") return apiKeys.groq;
+  return null;
 }
 
 type State = "idle" | "recording" | "transcribing";
@@ -35,16 +39,30 @@ export function useWhisperRecording({
 }: {
   onResult: (text: string) => void;
 }) {
-  const apiKey = useChatStore((s) => s.apiKeys.openai);
+  const apiKeys = useChatStore((s) => s.apiKeys);
+  const sttProvider = usePreferencesStore((s) => s.sttProvider);
+  const groqSttModel = usePreferencesStore((s) => s.groqSttModel);
+  const whispercppBaseURL = usePreferencesStore((s) => s.whispercppBaseURL);
+  const whispercppModel = usePreferencesStore((s) => s.whispercppModel);
   const [state, setState] = useState<State>("idle");
   const recRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
 
+  const needsKey = providerNeedsKey(sttProvider);
+  const providerKey = needsKey ? getApiKeyForStt(apiKeys, sttProvider) : null;
+  const hasKey = needsKey ? !!providerKey : true;
+
   const supported =
     typeof navigator !== "undefined" &&
     !!navigator.mediaDevices?.getUserMedia &&
     typeof MediaRecorder !== "undefined";
+
+  const sttOptions: SttOptions = {
+    groqSttModel,
+    whispercppBaseURL,
+    whispercppModel,
+  };
 
   const teardownStream = () => {
     streamRef.current?.getTracks().forEach((t) => t.stop());
@@ -57,7 +75,7 @@ export function useWhisperRecording({
   }, []);
 
   const start = useCallback(async () => {
-    if (!supported || !apiKey || state !== "idle") return;
+    if (!supported || !hasKey || state !== "idle") return;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
@@ -79,10 +97,10 @@ export function useWhisperRecording({
         }
         setState("transcribing");
         try {
-          const text = await transcribeBlob(blob, apiKey);
+          const text = await transcribeAudio(blob, sttProvider, apiKeys, sttOptions);
           if (text.trim()) onResult(text.trim());
         } catch (e) {
-          console.error("whisper.transcribe", e);
+          console.error("stt.transcribe", e);
         } finally {
           setState("idle");
         }
@@ -91,11 +109,11 @@ export function useWhisperRecording({
       rec.start();
       setState("recording");
     } catch (e) {
-      console.error("whisper.getUserMedia", e);
+      console.error("stt.getUserMedia", e);
       teardownStream();
       setState("idle");
     }
-  }, [apiKey, onResult, state, supported]);
+  }, [apiKeys, sttProvider, sttOptions, onResult, state, supported, hasKey]);
 
   useEffect(() => {
     return () => {
@@ -111,6 +129,7 @@ export function useWhisperRecording({
     start,
     stop,
     supported,
-    hasKey: !!apiKey,
+    hasKey,
+    sttProvider,
   };
 }

--- a/src/modules/ai/hooks/useWhisperRecording.ts
+++ b/src/modules/ai/hooks/useWhisperRecording.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { useChatStore } from "../store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { transcribeAudio, type SttOptions } from "../lib/stt";
@@ -99,6 +100,7 @@ export function useWhisperRecording({
           if (text.trim()) onResult(text.trim());
         } catch (e) {
           console.error("stt.transcribe", e);
+          toast.error(e instanceof Error ? e.message : "Transcription failed");
         } finally {
           setState("idle");
         }
@@ -108,6 +110,7 @@ export function useWhisperRecording({
       setState("recording");
     } catch (e) {
       console.error("stt.getUserMedia", e);
+      toast.error("Microphone access failed");
       teardownStream();
       setState("idle");
     }

--- a/src/modules/ai/lib/stt.ts
+++ b/src/modules/ai/lib/stt.ts
@@ -1,0 +1,138 @@
+import type { ProviderKeys } from "./keyring";
+
+const GROQ_BASE_URL = "https://api.groq.com/openai/v1";
+
+async function transcribeOpenAI(blob: Blob, apiKey: string): Promise<string> {
+  const [{ createOpenAI }, { experimental_transcribe: transcribe }] =
+    await Promise.all([import("@ai-sdk/openai"), import("ai")]);
+  const openai = createOpenAI({ apiKey });
+  const buf = new Uint8Array(await blob.arrayBuffer());
+  const { text } = await transcribe({
+    model: openai.transcription("whisper-1"),
+    audio: buf,
+  });
+  return text;
+}
+
+async function transcribeViaRest(
+  baseURL: string,
+  blob: Blob,
+  apiKey: string | null,
+  model: string,
+): Promise<string> {
+  const form = new FormData();
+  form.append("file", blob, "audio.webm");
+  form.append("model", model);
+  form.append("response_format", "text");
+
+  const headers: Record<string, string> = {};
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+  const res = await fetch(`${baseURL}/audio/transcriptions`, {
+    method: "POST",
+    headers,
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `STT request failed (${res.status}): ${body || res.statusText}`,
+    );
+  }
+  return res.text();
+}
+
+async function toWav(blob: Blob): Promise<Blob> {
+  const ctx = new AudioContext();
+  try {
+    const buf = await ctx.decodeAudioData(await blob.arrayBuffer());
+    const length = buf.length;
+    const sampleRate = buf.sampleRate;
+    const channel = buf.getChannelData(0);
+    const dataLen = length * 2;
+    const buffer = new ArrayBuffer(44 + dataLen);
+    const view = new DataView(buffer);
+
+    const writeStr = (offset: number, s: string) => {
+      for (let i = 0; i < s.length; i++) view.setUint8(offset + i, s.charCodeAt(i));
+    };
+
+    writeStr(0, "RIFF");
+    view.setUint32(4, 36 + dataLen, true);
+    writeStr(8, "WAVE");
+    writeStr(12, "fmt ");
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true);
+    view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true);
+    view.setUint16(32, 2, true);
+    view.setUint16(34, 16, true);
+    writeStr(36, "data");
+    view.setUint32(40, dataLen, true);
+
+    let offset = 44;
+    for (let i = 0; i < length; i++) {
+      const s = Math.max(-1, Math.min(1, channel[i]));
+      view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+      offset += 2;
+    }
+
+    return new Blob([buffer], { type: "audio/wav" });
+  } finally {
+    ctx.close();
+  }
+}
+
+async function transcribeWhisperCpp(
+  baseURL: string,
+  blob: Blob,
+): Promise<string> {
+  const wav = await toWav(blob);
+  const form = new FormData();
+  form.append("file", wav, "audio.wav");
+  form.append("response_format", "text");
+
+  const res = await fetch(`${baseURL}/inference`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `STT request failed (${res.status}): ${body || res.statusText}`,
+    );
+  }
+  return res.text();
+}
+
+export type SttOptions = {
+  groqSttModel?: string;
+  whispercppBaseURL?: string;
+  whispercppModel?: string;
+};
+
+export async function transcribeAudio(
+  blob: Blob,
+  provider: import("../config").SttProvider,
+  apiKeys: ProviderKeys,
+  options: SttOptions = {},
+): Promise<string> {
+  switch (provider) {
+    case "openai": {
+      const key = apiKeys.openai;
+      if (!key) throw new Error("OpenAI API key is not configured");
+      return transcribeOpenAI(blob, key);
+    }
+    case "groq": {
+      const key = apiKeys.groq;
+      if (!key) throw new Error("Groq API key is not configured");
+      const model = options.groqSttModel || "whisper-large-v3-turbo";
+      return transcribeViaRest(GROQ_BASE_URL, blob, key, model);
+    }
+    case "whispercpp": {
+      const baseURL = options.whispercppBaseURL?.replace(/\/+$/, "") || "http://127.0.0.1:8080";
+      return transcribeWhisperCpp(baseURL, blob);
+    }
+  }
+}

--- a/src/modules/ai/lib/stt.ts
+++ b/src/modules/ai/lib/stt.ts
@@ -122,6 +122,24 @@ async function transcribeWhisperCpp(
   return res.text();
 }
 
+// Offline provider: never POST recorded audio to a non-loopback host.
+function assertLoopbackUrl(baseURL: string): void {
+  let url: URL;
+  try {
+    url = new URL(baseURL);
+  } catch {
+    throw new Error(`Invalid Whisper.cpp URL: ${baseURL}`);
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const loopback =
+    host === "localhost" || host === "::1" || /^127(\.\d{1,3}){3}$/.test(host);
+  if (!loopback) {
+    throw new Error(
+      "Whisper.cpp must run on a loopback address (localhost or 127.x.x.x) to keep transcription local.",
+    );
+  }
+}
+
 export type SttOptions = {
   groqSttModel?: string;
   whispercppBaseURL?: string;
@@ -146,7 +164,9 @@ export async function transcribeAudio(
       return transcribeViaRest(GROQ_BASE_URL, blob, key, model);
     }
     case "whispercpp": {
-      const baseURL = options.whispercppBaseURL?.replace(/\/+$/, "") || "http://127.0.0.1:8080";
+      const baseURL =
+        options.whispercppBaseURL?.replace(/\/+$/, "") || "http://127.0.0.1:8080";
+      assertLoopbackUrl(baseURL);
       return transcribeWhisperCpp(baseURL, blob);
     }
   }

--- a/src/modules/ai/lib/stt.ts
+++ b/src/modules/ai/lib/stt.ts
@@ -1,14 +1,16 @@
 import type { ProviderKeys } from "./keyring";
 
 const GROQ_BASE_URL = "https://api.groq.com/openai/v1";
-const STT_REQUEST_TIMEOUT_MS = 30_000;
+const STT_TIMEOUT_GROQ_MS = 30_000;
+const STT_TIMEOUT_WHISPERCPP_MS = 180_000;
 
 async function fetchWithTimeout(
   input: RequestInfo | URL,
   init: RequestInit = {},
+  timeoutMs: number,
 ): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), STT_REQUEST_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     return await fetch(input, { ...init, signal: controller.signal });
   } finally {
@@ -46,7 +48,7 @@ async function transcribeViaRest(
     method: "POST",
     headers,
     body: form,
-  });
+  }, STT_TIMEOUT_GROQ_MS);
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(
@@ -110,7 +112,7 @@ async function transcribeWhisperCpp(
   const res = await fetchWithTimeout(`${baseURL}/inference`, {
     method: "POST",
     body: form,
-  });
+  }, STT_TIMEOUT_WHISPERCPP_MS);
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(

--- a/src/modules/ai/lib/stt.ts
+++ b/src/modules/ai/lib/stt.ts
@@ -1,6 +1,20 @@
 import type { ProviderKeys } from "./keyring";
 
 const GROQ_BASE_URL = "https://api.groq.com/openai/v1";
+const STT_REQUEST_TIMEOUT_MS = 30_000;
+
+async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), STT_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function transcribeOpenAI(blob: Blob, apiKey: string): Promise<string> {
   const [{ createOpenAI }, { experimental_transcribe: transcribe }] =
@@ -28,7 +42,7 @@ async function transcribeViaRest(
   const headers: Record<string, string> = {};
   if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
-  const res = await fetch(`${baseURL}/audio/transcriptions`, {
+  const res = await fetchWithTimeout(`${baseURL}/audio/transcriptions`, {
     method: "POST",
     headers,
     body: form,
@@ -93,7 +107,7 @@ async function transcribeWhisperCpp(
   form.append("file", wav, "audio.wav");
   form.append("response_format", "text");
 
-  const res = await fetch(`${baseURL}/inference`, {
+  const res = await fetchWithTimeout(`${baseURL}/inference`, {
     method: "POST",
     body: form,
   });
@@ -109,7 +123,6 @@ async function transcribeWhisperCpp(
 export type SttOptions = {
   groqSttModel?: string;
   whispercppBaseURL?: string;
-  whispercppModel?: string;
 };
 
 export async function transcribeAudio(

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -1,15 +1,18 @@
 import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   DEFAULT_MODEL_ID,
+  DEFAULT_STT_PROVIDER,
   isKnownModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
   MLX_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_BASE_URL,
   migrateLegacyCompatEndpoint,
   OPENAI_COMPATIBLE_DEFAULT_BASE_URL,
+  WHISPERCPP_DEFAULT_BASE_URL,
   type AutocompleteProviderId,
   type CustomEndpoint,
   type ModelId,
+  type SttProvider,
 } from "@/modules/ai/config";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -75,6 +78,10 @@ export type Preferences = {
   openaiCompatibleContextLimit: number;
   customEndpoints: CustomEndpoint[];
   openrouterModelId: string;
+  sttProvider: SttProvider;
+  groqSttModel: string;
+  whispercppBaseURL: string;
+  whispercppModel: string;
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
@@ -120,6 +127,10 @@ const KEY_OPENAI_COMPAT_MODEL_ID = "openaiCompatibleModelId";
 const KEY_OPENAI_COMPAT_CONTEXT_LIMIT = "openaiCompatibleContextLimit";
 const KEY_CUSTOM_ENDPOINTS = "customEndpoints";
 const KEY_OPENROUTER_MODEL_ID = "openrouterModelId";
+const KEY_STT_PROVIDER = "sttProvider";
+const KEY_GROQ_STT_MODEL = "groqSttModel";
+const KEY_WHISPERCPP_BASE_URL = "whispercppBaseURL";
+const KEY_WHISPERCPP_MODEL = "whispercppModel";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
@@ -180,6 +191,10 @@ export const DEFAULT_PREFERENCES: Preferences = {
   openaiCompatibleContextLimit: 128_000,
   customEndpoints: [],
   openrouterModelId: "",
+  sttProvider: DEFAULT_STT_PROVIDER,
+  groqSttModel: "whisper-large-v3-turbo",
+  whispercppBaseURL: WHISPERCPP_DEFAULT_BASE_URL,
+  whispercppModel: "",
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
@@ -291,6 +306,14 @@ export async function loadPreferences(): Promise<Preferences> {
     openrouterModelId:
       get<string>(KEY_OPENROUTER_MODEL_ID) ??
       DEFAULT_PREFERENCES.openrouterModelId,
+    sttProvider:
+      get<SttProvider>(KEY_STT_PROVIDER) ?? DEFAULT_PREFERENCES.sttProvider,
+    groqSttModel:
+      get<string>(KEY_GROQ_STT_MODEL) ?? DEFAULT_PREFERENCES.groqSttModel,
+    whispercppBaseURL:
+      get<string>(KEY_WHISPERCPP_BASE_URL) ?? DEFAULT_PREFERENCES.whispercppBaseURL,
+    whispercppModel:
+      get<string>(KEY_WHISPERCPP_MODEL) ?? DEFAULT_PREFERENCES.whispercppModel,
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds
@@ -469,6 +492,22 @@ export async function setOpenrouterModelId(value: string): Promise<void> {
   await writePref(KEY_OPENROUTER_MODEL_ID, value);
 }
 
+export async function setSttProvider(value: SttProvider): Promise<void> {
+  await writePref(KEY_STT_PROVIDER, value);
+}
+
+export async function setGroqSttModel(value: string): Promise<void> {
+  await writePref(KEY_GROQ_STT_MODEL, value.trim());
+}
+
+export async function setWhispercppBaseURL(value: string): Promise<void> {
+  await writePref(KEY_WHISPERCPP_BASE_URL, value.trim());
+}
+
+export async function setWhispercppModel(value: string): Promise<void> {
+  await writePref(KEY_WHISPERCPP_MODEL, value.trim());
+}
+
 export async function setFavoriteModelIds(value: string[]): Promise<void> {
   await writePref(KEY_FAVORITE_MODELS, value);
 }
@@ -595,6 +634,10 @@ export async function onPreferencesChange(
     [KEY_OPENAI_COMPAT_CONTEXT_LIMIT]: "openaiCompatibleContextLimit",
     [KEY_CUSTOM_ENDPOINTS]: "customEndpoints",
     [KEY_OPENROUTER_MODEL_ID]: "openrouterModelId",
+    [KEY_STT_PROVIDER]: "sttProvider",
+    [KEY_GROQ_STT_MODEL]: "groqSttModel",
+    [KEY_WHISPERCPP_BASE_URL]: "whispercppBaseURL",
+    [KEY_WHISPERCPP_MODEL]: "whispercppModel",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -81,7 +81,6 @@ export type Preferences = {
   sttProvider: SttProvider;
   groqSttModel: string;
   whispercppBaseURL: string;
-  whispercppModel: string;
   favoriteModelIds: string[];
   recentModelIds: string[];
   vimMode: boolean;
@@ -130,7 +129,6 @@ const KEY_OPENROUTER_MODEL_ID = "openrouterModelId";
 const KEY_STT_PROVIDER = "sttProvider";
 const KEY_GROQ_STT_MODEL = "groqSttModel";
 const KEY_WHISPERCPP_BASE_URL = "whispercppBaseURL";
-const KEY_WHISPERCPP_MODEL = "whispercppModel";
 const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
@@ -194,7 +192,6 @@ export const DEFAULT_PREFERENCES: Preferences = {
   sttProvider: DEFAULT_STT_PROVIDER,
   groqSttModel: "whisper-large-v3-turbo",
   whispercppBaseURL: WHISPERCPP_DEFAULT_BASE_URL,
-  whispercppModel: "",
   favoriteModelIds: [],
   recentModelIds: [],
   vimMode: false,
@@ -312,8 +309,6 @@ export async function loadPreferences(): Promise<Preferences> {
       get<string>(KEY_GROQ_STT_MODEL) ?? DEFAULT_PREFERENCES.groqSttModel,
     whispercppBaseURL:
       get<string>(KEY_WHISPERCPP_BASE_URL) ?? DEFAULT_PREFERENCES.whispercppBaseURL,
-    whispercppModel:
-      get<string>(KEY_WHISPERCPP_MODEL) ?? DEFAULT_PREFERENCES.whispercppModel,
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds
@@ -504,10 +499,6 @@ export async function setWhispercppBaseURL(value: string): Promise<void> {
   await writePref(KEY_WHISPERCPP_BASE_URL, value.trim());
 }
 
-export async function setWhispercppModel(value: string): Promise<void> {
-  await writePref(KEY_WHISPERCPP_MODEL, value.trim());
-}
-
 export async function setFavoriteModelIds(value: string[]): Promise<void> {
   await writePref(KEY_FAVORITE_MODELS, value);
 }
@@ -637,7 +628,6 @@ export async function onPreferencesChange(
     [KEY_STT_PROVIDER]: "sttProvider",
     [KEY_GROQ_STT_MODEL]: "groqSttModel",
     [KEY_WHISPERCPP_BASE_URL]: "whispercppBaseURL",
-    [KEY_WHISPERCPP_MODEL]: "whispercppModel",
     [KEY_FAVORITE_MODELS]: "favoriteModelIds",
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -60,7 +60,6 @@ import {
   setGroqSttModel,
   setSttProvider,
   setWhispercppBaseURL,
-  setWhispercppModel,
 } from "@/modules/settings/store";
 import {
   Add01Icon,
@@ -1221,14 +1220,11 @@ function VoiceBlock() {
   const sttProvider = usePreferencesStore((s) => s.sttProvider);
   const groqSttModel = usePreferencesStore((s) => s.groqSttModel);
   const whispercppBaseURL = usePreferencesStore((s) => s.whispercppBaseURL);
-  const whispercppModel = usePreferencesStore((s) => s.whispercppModel);
   const [urlDraft, setUrlDraft] = useState(whispercppBaseURL);
   const [groqModelDraft, setGroqModelDraft] = useState(groqSttModel);
-  const [modelDraft, setModelDraft] = useState(whispercppModel);
 
   useEffect(() => setUrlDraft(whispercppBaseURL), [whispercppBaseURL]);
   useEffect(() => setGroqModelDraft(groqSttModel), [groqSttModel]);
-  useEffect(() => setModelDraft(whispercppModel), [whispercppModel]);
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
@@ -1308,19 +1304,6 @@ function VoiceBlock() {
                 if (v !== whispercppBaseURL) void setWhispercppBaseURL(v);
               }}
               placeholder={WHISPERCPP_DEFAULT_BASE_URL}
-              spellCheck={false}
-              className="h-8 font-mono text-[11.5px]"
-            />
-          </FieldRow>
-          <FieldRow label="Model">
-            <Input
-              value={modelDraft}
-              onChange={(e) => setModelDraft(e.target.value)}
-              onBlur={() => {
-                const v = modelDraft.trim();
-                if (v !== whispercppModel) void setWhispercppModel(v);
-              }}
-              placeholder="base, small, medium, large-v3, …"
               spellCheck={false}
               className="h-8 font-mono text-[11.5px]"
             />

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -14,6 +14,8 @@ import {
   DEFAULT_MODEL_ID,
   MODELS,
   PROVIDERS,
+  STT_PROVIDER_LABELS,
+  WHISPERCPP_DEFAULT_BASE_URL,
   compatModelIdForEndpoint,
   getAutocompleteEligibleModels,
   getModel,
@@ -23,6 +25,7 @@ import {
   type ModelId,
   type ProviderId,
   type ProviderInfo,
+  type SttProvider,
 } from "@/modules/ai/config";
 import {
   clearKey,
@@ -54,6 +57,10 @@ import {
   setOpenaiCompatibleModelId,
   setOpenrouterModelId,
   setRecentModelIds,
+  setGroqSttModel,
+  setSttProvider,
+  setWhispercppBaseURL,
+  setWhispercppModel,
 } from "@/modules/settings/store";
 import {
   Add01Icon,
@@ -62,6 +69,7 @@ import {
   Cancel01Icon,
   CheckmarkCircle02Icon,
   ChevronDown,
+  Mic01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
@@ -345,6 +353,8 @@ export function ModelsSection() {
         configuredIds={configuredIds}
         keys={keys}
       />
+
+      <VoiceBlock />
 
       <div className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
@@ -1204,6 +1214,120 @@ function StatusLine({
     <span className="text-[10.5px] text-destructive/80">
       Could not reach the server.
     </span>
+  );
+}
+
+function VoiceBlock() {
+  const sttProvider = usePreferencesStore((s) => s.sttProvider);
+  const groqSttModel = usePreferencesStore((s) => s.groqSttModel);
+  const whispercppBaseURL = usePreferencesStore((s) => s.whispercppBaseURL);
+  const whispercppModel = usePreferencesStore((s) => s.whispercppModel);
+  const [urlDraft, setUrlDraft] = useState(whispercppBaseURL);
+  const [groqModelDraft, setGroqModelDraft] = useState(groqSttModel);
+  const [modelDraft, setModelDraft] = useState(whispercppModel);
+
+  useEffect(() => setUrlDraft(whispercppBaseURL), [whispercppBaseURL]);
+  useEffect(() => setGroqModelDraft(groqSttModel), [groqSttModel]);
+  useEffect(() => setModelDraft(whispercppModel), [whispercppModel]);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-card/60 px-3 py-2.5">
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon icon={Mic01Icon} size={15} strokeWidth={1.5} />
+        <span className="text-[12.5px] font-medium">Voice input</span>
+      </div>
+
+      <FieldRow label="Provider">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="h-8 flex-1 justify-between gap-2 px-2.5 text-[11.5px]"
+            >
+              <span>{STT_PROVIDER_LABELS[sttProvider]}</span>
+              <HugeiconsIcon
+                icon={ArrowDown01Icon}
+                size={11}
+                strokeWidth={2}
+                className="opacity-70"
+              />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-44 p-1">
+            {(Object.keys(STT_PROVIDER_LABELS) as SttProvider[]).map((p) => (
+              <DropdownMenuItem
+                key={p}
+                onSelect={() => void setSttProvider(p)}
+                className={cn(
+                  "flex items-center gap-2 text-[12px]",
+                  p === sttProvider && "bg-accent/50",
+                )}
+              >
+                <span>{STT_PROVIDER_LABELS[p]}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </FieldRow>
+
+      <p className="text-[10.5px] leading-relaxed text-muted-foreground">
+        {sttProvider === "openai" &&
+          "Uses your official OpenAI API key and the Whisper model for transcription."}
+        {sttProvider === "groq" &&
+          "Uses your official Groq API key and Groq's Whisper endpoint for transcription."}
+        {sttProvider === "whispercpp" &&
+          "Connects to a local Whisper.cpp server for fully offline transcription."}
+      </p>
+
+      {sttProvider === "groq" && (
+        <div className="flex flex-col gap-2.5">
+          <FieldRow label="Model">
+            <Input
+              value={groqModelDraft}
+              onChange={(e) => setGroqModelDraft(e.target.value)}
+              onBlur={() => {
+                const v = groqModelDraft.trim();
+                if (v !== groqSttModel) void setGroqSttModel(v);
+              }}
+              placeholder="whisper-large-v3-turbo"
+              spellCheck={false}
+              className="h-8 font-mono text-[11.5px]"
+            />
+          </FieldRow>
+        </div>
+      )}
+
+      {sttProvider === "whispercpp" && (
+        <div className="flex flex-col gap-2.5">
+          <FieldRow label="Base URL">
+            <Input
+              value={urlDraft}
+              onChange={(e) => setUrlDraft(e.target.value)}
+              onBlur={() => {
+                const v = urlDraft.trim();
+                if (v !== whispercppBaseURL) void setWhispercppBaseURL(v);
+              }}
+              placeholder={WHISPERCPP_DEFAULT_BASE_URL}
+              spellCheck={false}
+              className="h-8 font-mono text-[11.5px]"
+            />
+          </FieldRow>
+          <FieldRow label="Model">
+            <Input
+              value={modelDraft}
+              onChange={(e) => setModelDraft(e.target.value)}
+              onBlur={() => {
+                const v = modelDraft.trim();
+                if (v !== whispercppModel) void setWhispercppModel(v);
+              }}
+              placeholder="base, small, medium, large-v3, …"
+              spellCheck={false}
+              className="h-8 font-mono text-[11.5px]"
+            />
+          </FieldRow>
+        </div>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

Adds 2 new speech-to-text providers, Groq and Whisper.cpp, for voice input alongside the existing OpenAI Whisper option. 

## Why

Closes #548. Users who don't have an OpenAI API key or want offline transcription had no voice input option. Groq offers fast Whisper inference without billing information, and Whisper.cpp enables fully offline transcription. 

## How

Added `src/modules/ai/lib/stt.ts`, dispatches to OpenAI SDK, Groq REST (`/v1/audio/transcriptions`), or Whisper.cpp REST (`/inference`)

Groq uses plain `fetch()` + `FormData` (no new npm deps). Whisper.cpp converts browser audio to WAV via Web Audio API before sending, since its `/inference` endpoint expects WAV/MP3, not WebM/Opus.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of Groq transcription
- [x] Manual smoke-test of Whisper.cpp transcription
- [ ] OpenAI path not tested — no OpenAI API key available
- [x] Tested in `pnpm tauri dev`
- [x] Platforms tested: Windows


## Screenshots / GIFs

Before: 
<img width="684" height="270" alt="image" src="https://github.com/user-attachments/assets/15ad47a6-0ebd-4b1a-868c-756a5be6efbd" />

After: 
<img width="735" height="453" alt="image" src="https://github.com/user-attachments/assets/b2e8cb5c-68b7-4c50-b083-4438cd47e8da" />
<img width="706" height="493" alt="image" src="https://github.com/user-attachments/assets/c00a2eb4-ca1e-4775-a1ca-3b8c375782a8" />

## Notes for reviewer

- Errors are logged via `console.error`; surfacing to the user is left as a follow-up.
- `SttProvider` is a separate type from `ProviderId`, `whispercpp` is not a text-inference provider, avoids confusion. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added multi-provider speech-to-text transcription with OpenAI, Groq, and Whisper.cpp support, including configurable Whisper.cpp local server base URL.
* Added a new **Voice input** section in Settings featuring an STT provider dropdown and provider-specific options (Groq model, Whisper.cpp base URL), saved persistently.

## Bug Fixes
* Updated voice UI messaging/tooltips to display provider-specific credential requirements instead of a fixed provider prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->