### PR TITLE
feat(terminal): add SSH workspace support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -225,6 +225,8 @@ pub fn run() {
             workspace::wsl_list_distros,
             workspace::wsl_default_distro,
             workspace::wsl_home,
+            workspace::ssh_home,
+            workspace::ssh_default_root,
             workspace::workspace_authorize,
             workspace::workspace_current_dir,
             get_launch_dir,

--- a/src-tauri/src/modules/fs/file.rs
+++ b/src-tauri/src/modules/fs/file.rs
@@ -46,6 +46,9 @@ pub struct FileStat {
 #[tauri::command]
 pub fn fs_read_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<ReadResult, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::read_file(&workspace, &path);
+    }
     let p = resolve_path(&path, &workspace);
     let meta = std::fs::metadata(&p).map_err(|e| {
         log::debug!("fs_read_file stat({}) failed: {e}", p.display());
@@ -107,6 +110,17 @@ pub fn fs_write_file(
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        super::ssh::write_file(&workspace, &path, &content)?;
+        let _ = app.emit(
+            "fs:file-written",
+            FileWrittenEvent {
+                path: path.clone(),
+                source,
+            },
+        );
+        return Ok(());
+    }
     let target = resolve_path(&path, &workspace);
     let original_permissions = fs::metadata(&target).ok().map(|m| m.permissions());
     write_atomic(&target, content.as_bytes()).map_err(|e| {
@@ -131,6 +145,9 @@ pub fn fs_write_file(
 #[tauri::command]
 pub fn fs_canonicalize(path: String, workspace: Option<WorkspaceEnv>) -> Result<String, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::canonicalize(&workspace, &path);
+    }
     let p = resolve_path(&path, &workspace);
     let canon = std::fs::canonicalize(&p).map_err(|e| e.to_string())?;
     Ok(super::to_canon(&canon))
@@ -139,6 +156,9 @@ pub fn fs_canonicalize(path: String, workspace: Option<WorkspaceEnv>) -> Result<
 #[tauri::command]
 pub fn fs_stat(path: String, workspace: Option<WorkspaceEnv>) -> Result<FileStat, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::stat(&workspace, &path);
+    }
     let p = resolve_path(&path, &workspace);
     let meta = std::fs::metadata(&p).map_err(|e| e.to_string())?;
     let kind = if meta.is_dir() {

--- a/src-tauri/src/modules/fs/grep.rs
+++ b/src-tauri/src/modules/fs/grep.rs
@@ -7,7 +7,7 @@ use grep_regex::{RegexMatcher, RegexMatcherBuilder};
 use grep_searcher::sinks::UTF8;
 use grep_searcher::{BinaryDetection, SearcherBuilder};
 use ignore::{WalkBuilder, WalkState};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::to_canon;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
@@ -25,7 +25,7 @@ pub struct ContentSearchState {
     generation: AtomicU64,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct GrepHit {
     pub path: String,
     pub rel: String,
@@ -33,7 +33,7 @@ pub struct GrepHit {
     pub text: String,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct GrepResponse {
     pub hits: Vec<GrepHit>,
     pub truncated: bool,
@@ -182,6 +182,20 @@ pub fn fs_grep(
         return Err("empty pattern".into());
     }
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        let cap = max_results
+            .unwrap_or(DEFAULT_MAX_RESULTS)
+            .clamp(1, HARD_MAX_RESULTS);
+        return super::ssh::grep(
+            &workspace,
+            &root,
+            &pattern,
+            glob.as_deref().unwrap_or(&[]),
+            case_insensitive.unwrap_or(false),
+            cap,
+            false,
+        );
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
@@ -225,6 +239,12 @@ pub fn fs_grep_interactive(
     let my_gen = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
 
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        let cap = max_results
+            .unwrap_or(DEFAULT_MAX_RESULTS)
+            .clamp(1, HARD_MAX_RESULTS);
+        return super::ssh::grep(&workspace, &root, &pattern, &[], false, cap, true);
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
@@ -241,23 +261,17 @@ pub fn fs_grep_interactive(
 
     let cancel = || state.generation.load(Ordering::SeqCst) != my_gen;
     Ok(search_tree(
-        &root_path,
-        &root,
-        &workspace,
-        &matcher,
-        &None,
-        cap,
-        &cancel,
+        &root_path, &root, &workspace, &matcher, &None, cap, &cancel,
     ))
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct GlobHit {
     pub path: String,
     pub rel: String,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct GlobResponse {
     pub hits: Vec<GlobHit>,
     pub truncated: bool,
@@ -274,6 +288,12 @@ pub fn fs_glob(
         return Err("empty pattern".into());
     }
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        let cap = max_results
+            .unwrap_or(DEFAULT_MAX_RESULTS)
+            .clamp(1, HARD_MAX_RESULTS);
+        return super::ssh::glob(&workspace, &root, &pattern, cap);
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
@@ -361,11 +381,26 @@ mod tests {
         let ws = WorkspaceEnv::from_option(None);
         let root_display = dir.path().to_string_lossy().to_string();
 
-        let live = search_tree(dir.path(), &root_display, &ws, &matcher, &None, 100, &|| false);
+        let live = search_tree(
+            dir.path(),
+            &root_display,
+            &ws,
+            &matcher,
+            &None,
+            100,
+            &|| false,
+        );
         assert_eq!(live.hits.len(), 1, "uncancelled search finds the match");
 
-        let stopped =
-            search_tree(dir.path(), &root_display, &ws, &matcher, &None, 100, &|| true);
+        let stopped = search_tree(
+            dir.path(),
+            &root_display,
+            &ws,
+            &matcher,
+            &None,
+            100,
+            &|| true,
+        );
         assert!(stopped.hits.is_empty(), "cancelled search yields nothing");
     }
 }

--- a/src-tauri/src/modules/fs/mod.rs
+++ b/src-tauri/src/modules/fs/mod.rs
@@ -2,6 +2,7 @@ pub mod file;
 pub mod grep;
 pub mod mutate;
 pub mod search;
+pub mod ssh;
 pub mod tree;
 pub mod watch;
 

--- a/src-tauri/src/modules/fs/mutate.rs
+++ b/src-tauri/src/modules/fs/mutate.rs
@@ -4,6 +4,9 @@ use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 #[tauri::command]
 pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::create_file(&workspace, &path);
+    }
     let p = resolve_path(&path, &workspace);
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
@@ -20,6 +23,9 @@ pub fn fs_create_file(path: String, workspace: Option<WorkspaceEnv>) -> Result<(
 #[tauri::command]
 pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::create_dir(&workspace, &path);
+    }
     let p = resolve_path(&path, &workspace);
     if p.exists() {
         return Err(format!("already exists: {}", p.display()));
@@ -34,6 +40,9 @@ pub fn fs_create_dir(path: String, workspace: Option<WorkspaceEnv>) -> Result<()
 #[tauri::command]
 pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::rename(&workspace, &from, &to);
+    }
     let from_p = resolve_path(&from, &workspace);
     let to_p = resolve_path(&to, &workspace);
     if !from_p.exists() {
@@ -57,6 +66,9 @@ pub fn fs_rename(from: String, to: String, workspace: Option<WorkspaceEnv>) -> R
 #[tauri::command]
 pub fn fs_delete(path: String, workspace: Option<WorkspaceEnv>) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::delete(&workspace, &path);
+    }
     let p = resolve_path(&path, &workspace);
     let meta = std::fs::symlink_metadata(&p).map_err(|e| {
         log::debug!("fs_delete stat({}) failed: {e}", p.display());
@@ -98,6 +110,9 @@ pub fn fs_copy(
     workspace: Option<WorkspaceEnv>,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Err("copying local files into an SSH workspace is not supported yet".into());
+    }
     let dest = resolve_path(&dest_dir, &workspace);
     for source in &sources {
         let src = std::path::PathBuf::from(source);

--- a/src-tauri/src/modules/fs/search.rs
+++ b/src-tauri/src/modules/fs/search.rs
@@ -1,12 +1,12 @@
 use ignore::WalkBuilder;
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::to_canon;
 use crate::modules::workspace::{resolve_path, WorkspaceEnv};
 
-#[derive(Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub struct SearchHit {
     /// Absolute path of the matched file.
     pub path: String,
@@ -17,7 +17,7 @@ pub struct SearchHit {
     pub is_dir: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct SearchResult {
     pub hits: Vec<SearchHit>,
     /// True if the scan stopped early (entry budget or hit cap reached).
@@ -62,6 +62,9 @@ pub fn fs_search(
     let cap = limit.unwrap_or(200).min(1000);
     let show_hidden = show_hidden.unwrap_or(false);
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::search(&workspace, &root, q, cap, show_hidden);
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));
@@ -147,7 +150,7 @@ fn rank_fuzzy(cands: Vec<SearchHit>, query: &str, cap: usize) -> Vec<SearchHit> 
         .collect()
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct ListFilesResult {
     pub files: Vec<String>,
     pub truncated: bool,
@@ -170,6 +173,9 @@ pub fn fs_list_files(
     let depth = max_depth.unwrap_or(DEFAULT_DEPTH).clamp(1, HARD_DEPTH);
     let show_hidden = show_hidden.unwrap_or(false);
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::list_files(&workspace, &root, cap, depth, show_hidden);
+    }
     let root_path = resolve_path(&root, &workspace);
     if !root_path.is_dir() {
         return Err(format!("not a directory: {root}"));

--- a/src-tauri/src/modules/fs/ssh.rs
+++ b/src-tauri/src/modules/fs/ssh.rs
@@ -1,0 +1,552 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+
+use super::file::{FileStat, ReadResult, StatKind};
+use super::grep::{GlobHit, GlobResponse, GrepHit, GrepResponse};
+use super::search::{ListFilesResult, SearchHit, SearchResult};
+use super::tree::{DirEntry, EntryKind};
+use crate::modules::workspace::{ssh_command, WorkspaceEnv};
+
+const MAX_READ_BYTES: u64 = 10 * 1024 * 1024;
+const BINARY_SNIFF_BYTES: usize = 8 * 1024;
+
+const PY_HELPER: &str = r#"
+import fnmatch, json, os, re, shutil, sys
+def arg(i):
+    return bytes.fromhex(sys.argv[i]).decode("utf-8", "surrogateescape")
+def j(value):
+    print(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+def kind_of(path):
+    if os.path.islink(path):
+        return "symlink"
+    if os.path.isdir(path):
+        return "dir"
+    return "file"
+def entry(path, name):
+    full = os.path.join(path, name)
+    st = os.stat(full)
+    return {
+        "name": name,
+        "kind": kind_of(full),
+        "size": st.st_size,
+        "mtime": int(st.st_mtime * 1000),
+        "gitignored": False,
+    }
+PRUNE = {
+    "node_modules", ".git", "target", "dist", "build", ".next", ".turbo",
+    ".cache", ".venv", "__pycache__"
+}
+"#;
+
+fn hex_arg(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() * 2);
+    for b in value.as_bytes() {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn python_command(
+    workspace: &WorkspaceEnv,
+    script: &str,
+    args: &[String],
+) -> Result<Command, String> {
+    let mut cmd = ssh_command(workspace, true)?;
+    let mut remote = format!("python3 -c {}", shell_quote(script));
+    for arg in args {
+        remote.push(' ');
+        remote.push_str(arg);
+    }
+    cmd.arg(remote);
+    Ok(cmd)
+}
+
+fn run_python(workspace: &WorkspaceEnv, body: &str, args: &[&str]) -> Result<Vec<u8>, String> {
+    run_python_with_input(workspace, body, args, None)
+}
+
+fn run_python_with_input(
+    workspace: &WorkspaceEnv,
+    body: &str,
+    args: &[&str],
+    input: Option<&[u8]>,
+) -> Result<Vec<u8>, String> {
+    let script = format!("{PY_HELPER}\n{body}");
+    let hex_args: Vec<String> = args.iter().map(|arg| hex_arg(arg)).collect();
+    let mut cmd = python_command(workspace, &script, &hex_args)?;
+    cmd.stdin(if input.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    })
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
+    crate::modules::proc::hide_console(&mut cmd);
+    let mut child = cmd.spawn().map_err(|e| e.to_string())?;
+    if let Some(bytes) = input {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "ssh stdin unavailable".to_string())?;
+        stdin.write_all(bytes).map_err(|e| e.to_string())?;
+    }
+    let output = child.wait_with_output().map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(if stderr.is_empty() {
+            "remote SSH command failed".into()
+        } else {
+            stderr
+        })
+    }
+}
+
+fn json<T: DeserializeOwned>(bytes: Vec<u8>) -> Result<T, String> {
+    serde_json::from_slice(&bytes).map_err(|e| e.to_string())
+}
+
+#[derive(Deserialize)]
+struct RemoteEntry {
+    name: String,
+    kind: String,
+    size: u64,
+    mtime: u64,
+    gitignored: bool,
+}
+
+fn entry_kind(kind: &str) -> EntryKind {
+    match kind {
+        "dir" => EntryKind::Dir,
+        "symlink" => EntryKind::Symlink,
+        _ => EntryKind::File,
+    }
+}
+
+fn stat_kind(kind: &str) -> StatKind {
+    match kind {
+        "dir" => StatKind::Dir,
+        "symlink" => StatKind::Symlink,
+        _ => StatKind::File,
+    }
+}
+
+pub fn read_dir_in(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    show_hidden: bool,
+) -> Result<Vec<DirEntry>, String> {
+    let body = r#"
+path = arg(1)
+show_hidden = sys.argv[2] == "1"
+items = []
+with os.scandir(path) as it:
+    for e in it:
+        if not show_hidden and e.name.startswith("."):
+            continue
+        try:
+            items.append(entry(path, e.name))
+        except OSError:
+            pass
+rank = {"dir": 0, "symlink": 1, "file": 2}
+items.sort(key=lambda x: (rank.get(x["kind"], 2), x["name"].lower()))
+j(items)
+"#;
+    let hidden = if show_hidden { "1" } else { "0" };
+    let entries: Vec<RemoteEntry> = json(run_python(workspace, body, &[path, hidden])?)?;
+    Ok(entries
+        .into_iter()
+        .map(|entry| DirEntry {
+            name: entry.name,
+            kind: entry_kind(&entry.kind),
+            size: entry.size,
+            mtime: entry.mtime,
+            gitignored: entry.gitignored,
+        })
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct RemoteStat {
+    size: u64,
+    mtime: u64,
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct RemoteSearchResult {
+    hits: Vec<SearchHit>,
+    truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct RemoteListFilesResult {
+    files: Vec<String>,
+    truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct RemoteGrepResponse {
+    hits: Vec<GrepHit>,
+    truncated: bool,
+    files_scanned: usize,
+}
+
+#[derive(Deserialize)]
+struct RemoteGlobResponse {
+    hits: Vec<GlobHit>,
+    truncated: bool,
+}
+
+pub fn stat(workspace: &WorkspaceEnv, path: &str) -> Result<FileStat, String> {
+    let body = r#"
+path = arg(1)
+st = os.stat(path)
+j({"size": st.st_size, "mtime": int(st.st_mtime * 1000), "kind": kind_of(path)})
+"#;
+    let stat: RemoteStat = json(run_python(workspace, body, &[path])?)?;
+    Ok(FileStat {
+        size: stat.size,
+        mtime: stat.mtime,
+        kind: stat_kind(&stat.kind),
+    })
+}
+
+pub fn canonicalize(workspace: &WorkspaceEnv, path: &str) -> Result<String, String> {
+    let body = r#"
+print(os.path.realpath(arg(1)))
+"#;
+    let out = run_python(workspace, body, &[path])?;
+    Ok(String::from_utf8_lossy(&out).trim().to_string())
+}
+
+pub fn read_file(workspace: &WorkspaceEnv, path: &str) -> Result<ReadResult, String> {
+    let meta = stat(workspace, path)?;
+    if meta.size > MAX_READ_BYTES {
+        return Ok(ReadResult::TooLarge {
+            size: meta.size,
+            limit: MAX_READ_BYTES,
+        });
+    }
+    let body = r#"
+path = arg(1)
+with open(path, "rb") as f:
+    while True:
+        chunk = f.read(65536)
+        if not chunk:
+            break
+        sys.stdout.buffer.write(chunk)
+"#;
+    let bytes = run_python(workspace, body, &[path])?;
+    let sniff_len = bytes.len().min(BINARY_SNIFF_BYTES);
+    if bytes[..sniff_len].contains(&0) {
+        return Ok(ReadResult::Binary { size: meta.size });
+    }
+    match String::from_utf8(bytes) {
+        Ok(content) => Ok(ReadResult::Text {
+            content,
+            size: meta.size,
+        }),
+        Err(_) => Ok(ReadResult::Binary { size: meta.size }),
+    }
+}
+
+pub fn write_file(workspace: &WorkspaceEnv, path: &str, content: &str) -> Result<(), String> {
+    let body = r#"
+path = arg(1)
+parent = os.path.dirname(path) or "."
+os.makedirs(parent, exist_ok=True)
+tmp = os.path.join(parent, ".terax-write-" + os.urandom(8).hex())
+with open(tmp, "wb") as f:
+    shutil.copyfileobj(sys.stdin.buffer, f)
+try:
+    st = os.stat(path)
+    os.chmod(tmp, st.st_mode)
+except OSError:
+    pass
+os.replace(tmp, path)
+"#;
+    run_python_with_input(workspace, body, &[path], Some(content.as_bytes()))?;
+    Ok(())
+}
+
+pub fn create_file(workspace: &WorkspaceEnv, path: &str) -> Result<(), String> {
+    let body = r#"
+path = arg(1)
+if os.path.exists(path):
+    raise FileExistsError(path)
+open(path, "xb").close()
+"#;
+    run_python(workspace, body, &[path]).map(|_| ())
+}
+
+pub fn create_dir(workspace: &WorkspaceEnv, path: &str) -> Result<(), String> {
+    let body = r#"
+path = arg(1)
+if os.path.exists(path):
+    raise FileExistsError(path)
+os.makedirs(path)
+"#;
+    run_python(workspace, body, &[path]).map(|_| ())
+}
+
+pub fn rename(workspace: &WorkspaceEnv, from: &str, to: &str) -> Result<(), String> {
+    let body = r#"
+src = arg(1)
+dst = arg(2)
+if not os.path.exists(src) and not os.path.islink(src):
+    raise FileNotFoundError(src)
+if os.path.exists(dst) or os.path.islink(dst):
+    raise FileExistsError(dst)
+os.rename(src, dst)
+"#;
+    run_python(workspace, body, &[from, to]).map(|_| ())
+}
+
+pub fn delete(workspace: &WorkspaceEnv, path: &str) -> Result<(), String> {
+    let body = r#"
+path = arg(1)
+if os.path.islink(path) or os.path.isfile(path):
+    os.unlink(path)
+elif os.path.isdir(path):
+    shutil.rmtree(path)
+else:
+    raise FileNotFoundError(path)
+"#;
+    run_python(workspace, body, &[path]).map(|_| ())
+}
+
+pub fn list_subdirs(
+    workspace: &WorkspaceEnv,
+    path: &str,
+    show_hidden: bool,
+) -> Result<Vec<String>, String> {
+    let body = r#"
+path = arg(1)
+show_hidden = sys.argv[2] == "1"
+items = []
+with os.scandir(path) as it:
+    for e in it:
+        if not show_hidden and e.name.startswith("."):
+            continue
+        try:
+            if e.is_dir(follow_symlinks=True):
+                items.append(e.name)
+        except OSError:
+            pass
+items.sort(key=lambda x: x.lower())
+j(items)
+"#;
+    let hidden = if show_hidden { "1" } else { "0" };
+    json(run_python(workspace, body, &[path, hidden])?)
+}
+
+pub fn search(
+    workspace: &WorkspaceEnv,
+    root: &str,
+    query: &str,
+    limit: usize,
+    show_hidden: bool,
+) -> Result<SearchResult, String> {
+    let body = r#"
+root = arg(1)
+query = arg(2).lower()
+limit = int(sys.argv[3])
+show_hidden = sys.argv[4] == "1"
+hits = []
+scanned = 0
+truncated = False
+for base, dirs, files in os.walk(root, topdown=True, followlinks=False):
+    dirs[:] = [d for d in dirs if (show_hidden or not d.startswith(".")) and d not in PRUNE]
+    names = [(d, True) for d in dirs] + [(f, False) for f in files if show_hidden or not f.startswith(".")]
+    for name, is_dir in names:
+        scanned += 1
+        if scanned > 50000:
+            truncated = True
+            break
+        full = os.path.join(base, name)
+        rel = os.path.relpath(full, root).replace(os.sep, "/")
+        hay = rel.lower()
+        if query not in hay and not all(ch in hay for ch in query):
+            continue
+        hits.append({"path": full, "rel": rel, "name": name, "is_dir": is_dir})
+        if len(hits) >= limit:
+            truncated = True
+            break
+    if truncated:
+        break
+hits.sort(key=lambda h: (0 if query in h["name"].lower() else 1, len(h["rel"]), h["rel"].lower()))
+j({"hits": hits[:limit], "truncated": truncated})
+"#;
+    let cap = limit.min(1000).to_string();
+    let hidden = if show_hidden { "1" } else { "0" };
+    let result: RemoteSearchResult =
+        json(run_python(workspace, body, &[root, query, &cap, hidden])?)?;
+    Ok(SearchResult {
+        hits: result.hits,
+        truncated: result.truncated,
+    })
+}
+
+pub fn list_files(
+    workspace: &WorkspaceEnv,
+    root: &str,
+    limit: usize,
+    max_depth: usize,
+    show_hidden: bool,
+) -> Result<ListFilesResult, String> {
+    let body = r#"
+root = arg(1)
+limit = int(sys.argv[2])
+max_depth = int(sys.argv[3])
+show_hidden = sys.argv[4] == "1"
+files = []
+scanned = 0
+truncated = False
+root_depth = root.rstrip(os.sep).count(os.sep)
+for base, dirs, names in os.walk(root, topdown=True, followlinks=False):
+    depth = base.rstrip(os.sep).count(os.sep) - root_depth
+    dirs[:] = [d for d in dirs if depth < max_depth and (show_hidden or not d.startswith(".")) and d not in PRUNE]
+    for name in names:
+        if not show_hidden and name.startswith("."):
+            continue
+        scanned += 1
+        if scanned > 50000:
+            truncated = True
+            break
+        full = os.path.join(base, name)
+        rel = os.path.relpath(full, root).replace(os.sep, "/")
+        files.append(rel)
+        if len(files) >= limit:
+            truncated = True
+            break
+    if truncated:
+        break
+files.sort(key=lambda x: x.lower())
+j({"files": files, "truncated": truncated})
+"#;
+    let limit = limit.to_string();
+    let depth = max_depth.to_string();
+    let hidden = if show_hidden { "1" } else { "0" };
+    let result: RemoteListFilesResult = json(run_python(
+        workspace,
+        body,
+        &[root, &limit, &depth, hidden],
+    )?)?;
+    Ok(ListFilesResult {
+        files: result.files,
+        truncated: result.truncated,
+    })
+}
+
+pub fn grep(
+    workspace: &WorkspaceEnv,
+    root: &str,
+    pattern: &str,
+    glob: &[String],
+    case_insensitive: bool,
+    max_results: usize,
+    literal: bool,
+) -> Result<GrepResponse, String> {
+    let body = r#"
+root = arg(1)
+pattern = arg(2)
+globs = json.loads(arg(3))
+flags = re.IGNORECASE if sys.argv[4] == "1" else 0
+cap = int(sys.argv[5])
+literal = sys.argv[6] == "1"
+rx = re.compile(re.escape(pattern) if literal else pattern, flags)
+hits = []
+files_scanned = 0
+truncated = False
+for base, dirs, names in os.walk(root, topdown=True, followlinks=False):
+    dirs[:] = [d for d in dirs if not d.startswith(".") and d not in PRUNE]
+    for name in names:
+        if name.startswith("."):
+            continue
+        full = os.path.join(base, name)
+        rel = os.path.relpath(full, root).replace(os.sep, "/")
+        if globs and not any(fnmatch.fnmatch(rel, g) for g in globs):
+            continue
+        try:
+            if os.path.getsize(full) > 5 * 1024 * 1024:
+                continue
+            with open(full, "rb") as f:
+                data = f.read()
+            if b"\0" in data[:8192]:
+                continue
+            text = data.decode("utf-8")
+        except Exception:
+            continue
+        files_scanned += 1
+        for idx, line in enumerate(text.splitlines(), 1):
+            if rx.search(line):
+                hits.append({"path": full, "rel": rel, "line": idx, "text": line})
+                if len(hits) >= cap:
+                    truncated = True
+                    break
+        if truncated:
+            break
+    if truncated:
+        break
+j({"hits": hits, "truncated": truncated, "files_scanned": files_scanned})
+"#;
+    let glob_json = serde_json::to_string(glob).map_err(|e| e.to_string())?;
+    let insensitive = if case_insensitive { "1" } else { "0" };
+    let cap = max_results.to_string();
+    let literal = if literal { "1" } else { "0" };
+    let result: RemoteGrepResponse = json(run_python(
+        workspace,
+        body,
+        &[root, pattern, &glob_json, insensitive, &cap, literal],
+    )?)?;
+    Ok(GrepResponse {
+        hits: result.hits,
+        truncated: result.truncated,
+        files_scanned: result.files_scanned,
+    })
+}
+
+pub fn glob(
+    workspace: &WorkspaceEnv,
+    root: &str,
+    pattern: &str,
+    max_results: usize,
+) -> Result<GlobResponse, String> {
+    let body = r#"
+root = arg(1)
+pattern = arg(2)
+cap = int(sys.argv[3])
+hits = []
+truncated = False
+for base, dirs, names in os.walk(root, topdown=True, followlinks=False):
+    dirs[:] = [d for d in dirs if not d.startswith(".") and d not in PRUNE]
+    for name in names:
+        if name.startswith("."):
+            continue
+        full = os.path.join(base, name)
+        rel = os.path.relpath(full, root).replace(os.sep, "/")
+        if fnmatch.fnmatch(rel, pattern):
+            hits.append({"path": full, "rel": rel})
+            if len(hits) >= cap:
+                truncated = True
+                break
+    if truncated:
+        break
+j({"hits": hits, "truncated": truncated})
+"#;
+    let cap = max_results.to_string();
+    let result: RemoteGlobResponse = json(run_python(workspace, body, &[root, pattern, &cap])?)?;
+    Ok(GlobResponse {
+        hits: result.hits,
+        truncated: result.truncated,
+    })
+}

--- a/src-tauri/src/modules/fs/ssh.rs
+++ b/src-tauri/src/modules/fs/ssh.rs
@@ -17,6 +17,10 @@ const PY_HELPER: &str = r#"
 import fnmatch, json, os, re, shutil, sys
 def arg(i):
     return bytes.fromhex(sys.argv[i]).decode("utf-8", "surrogateescape")
+def bool_arg(i):
+    return arg(i) == "1"
+def int_arg(i):
+    return int(arg(i))
 def j(value):
     print(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
 def kind_of(path):
@@ -146,7 +150,7 @@ pub fn read_dir_in(
 ) -> Result<Vec<DirEntry>, String> {
     let body = r#"
 path = arg(1)
-show_hidden = sys.argv[2] == "1"
+show_hidden = bool_arg(2)
 items = []
 with os.scandir(path) as it:
     for e in it:
@@ -331,7 +335,7 @@ pub fn list_subdirs(
 ) -> Result<Vec<String>, String> {
     let body = r#"
 path = arg(1)
-show_hidden = sys.argv[2] == "1"
+show_hidden = bool_arg(2)
 items = []
 with os.scandir(path) as it:
     for e in it:
@@ -359,8 +363,8 @@ pub fn search(
     let body = r#"
 root = arg(1)
 query = arg(2).lower()
-limit = int(sys.argv[3])
-show_hidden = sys.argv[4] == "1"
+limit = int_arg(3)
+show_hidden = bool_arg(4)
 hits = []
 scanned = 0
 truncated = False
@@ -405,9 +409,9 @@ pub fn list_files(
 ) -> Result<ListFilesResult, String> {
     let body = r#"
 root = arg(1)
-limit = int(sys.argv[2])
-max_depth = int(sys.argv[3])
-show_hidden = sys.argv[4] == "1"
+limit = int_arg(2)
+max_depth = int_arg(3)
+show_hidden = bool_arg(4)
 files = []
 scanned = 0
 truncated = False
@@ -460,9 +464,9 @@ pub fn grep(
 root = arg(1)
 pattern = arg(2)
 globs = json.loads(arg(3))
-flags = re.IGNORECASE if sys.argv[4] == "1" else 0
-cap = int(sys.argv[5])
-literal = sys.argv[6] == "1"
+flags = re.IGNORECASE if bool_arg(4) else 0
+cap = int_arg(5)
+literal = bool_arg(6)
 rx = re.compile(re.escape(pattern) if literal else pattern, flags)
 hits = []
 files_scanned = 0
@@ -524,7 +528,7 @@ pub fn glob(
     let body = r#"
 root = arg(1)
 pattern = arg(2)
-cap = int(sys.argv[3])
+cap = int_arg(3)
 hits = []
 truncated = False
 for base, dirs, names in os.walk(root, topdown=True, followlinks=False):

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -70,6 +70,9 @@ pub fn fs_read_dir(
     workspace: Option<WorkspaceEnv>,
 ) -> Result<Vec<DirEntry>, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::read_dir_in(&workspace, &path, show_hidden);
+    }
     let root = resolve_path(&path, &workspace);
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("fs_read_dir({}) failed: {e}", root.display());
@@ -156,6 +159,9 @@ pub fn list_subdirs(
     workspace: Option<WorkspaceEnv>,
 ) -> Result<Vec<String>, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return super::ssh::list_subdirs(&workspace, &path, show_hidden);
+    }
     let root = resolve_path(&path, &workspace);
     let read = std::fs::read_dir(&root).map_err(|e| {
         log::debug!("list_subdirs({}) read_dir failed: {e}", root.display());

--- a/src-tauri/src/modules/fs/watch.rs
+++ b/src-tauri/src/modules/fs/watch.rs
@@ -218,7 +218,8 @@ fn prepare_add(
         .filter_map(|raw| {
             let resolved = resolve_path(&raw, workspace);
             let canonical = std::fs::canonicalize(&resolved).ok()?;
-            if !canonical.is_dir() || is_skipped(&canonical) || !registry.is_authorized(&canonical) {
+            if !canonical.is_dir() || is_skipped(&canonical) || !registry.is_authorized(&canonical)
+            {
                 return None;
             }
             Some(canonical)
@@ -235,6 +236,9 @@ pub fn fs_watch_add(
     registry: State<'_, WorkspaceRegistry>,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Ok(());
+    }
     let prepared = prepare_add(&registry, &workspace, paths);
     if prepared.is_empty() {
         return Ok(());
@@ -254,6 +258,9 @@ pub fn fs_watch_remove(
     state: State<'_, FsWatchState>,
 ) -> Result<(), String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Ok(());
+    }
     // A removed/renamed dir no longer canonicalizes; fall back so the refcount
     // entry is still released.
     let prepared: Vec<PathBuf> = paths

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -1,6 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
+use crate::modules::fs::file::ReadResult;
 use crate::modules::git::errors::{GitError, Result};
 use crate::modules::git::parser::parse_porcelain_v2;
 use crate::modules::git::process::{
@@ -23,7 +24,7 @@ pub fn resolve_repo(
     workspace: &WorkspaceEnv,
 ) -> Result<Option<GitRepoInfo>> {
     let cwd = canonical_dir(registry, cwd, workspace)?;
-    if !registry.is_authorized(&cwd.local_path) {
+    if !workspace.is_ssh() && !registry.is_authorized(&cwd.local_path) {
         return Err(GitError::PathOutsideWorkspace(cwd.local_path));
     }
     ensure_git_available(&cwd.workspace)?;
@@ -43,7 +44,9 @@ fn resolve_repo_in_authorized(
         return Ok(None);
     };
     let canonical_root = canonical_dir(registry, &root_line, &cwd.workspace)?;
-    let _ = registry.authorize(&canonical_root.local_path);
+    if !canonical_root.workspace.is_ssh() {
+        let _ = registry.authorize(&canonical_root.local_path);
+    }
 
     let head = match git_stdout_lines(
         &canonical_root.workspace,
@@ -85,7 +88,7 @@ pub fn panel_snapshot(
     workspace: &WorkspaceEnv,
 ) -> Result<GitPanelSnapshot> {
     let cwd = canonical_dir(registry, cwd, workspace)?;
-    if !registry.is_authorized(&cwd.local_path) {
+    if !workspace.is_ssh() && !registry.is_authorized(&cwd.local_path) {
         return Err(GitError::PathOutsideWorkspace(cwd.local_path));
     }
     ensure_git_available(&cwd.workspace)?;
@@ -101,7 +104,9 @@ pub fn panel_snapshot(
         });
     };
     let canonical_root = canonical_dir(registry, &root_line, &cwd.workspace)?;
-    let _ = registry.authorize(&canonical_root.local_path);
+    if !canonical_root.workspace.is_ssh() {
+        let _ = registry.authorize(&canonical_root.local_path);
+    }
 
     let status = status_inner(&canonical_root)?;
     let repo = GitRepoInfo {
@@ -178,7 +183,7 @@ fn diff_inner(
         args.push("--cached".into());
     }
     let pathspec = match path.filter(|p| !p.is_empty()) {
-        Some(p) => Some(pathspec_from_input(&repo_root.local_path, p)?),
+        Some(p) => Some(pathspec_from_input(repo_root, p)?),
         None => None,
     };
     if let Some(spec) = pathspec.as_ref() {
@@ -213,14 +218,15 @@ pub fn diff_content(
 ) -> Result<GitDiffContentResult> {
     let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
     ensure_git_available(&repo_root.workspace)?;
-    let worktree_path = resolve_within_repo(&repo_root.local_path, path)?;
-    let rel_path = pathspec(&repo_root.local_path, &worktree_path);
+    let rel_path = pathspec_from_input(&repo_root, path)?;
+    let worktree_path = if repo_root.workspace.is_ssh() {
+        None
+    } else {
+        Some(resolve_within_repo(&repo_root.local_path, path)?)
+    };
 
     let original_rel = match original_path {
-        Some(orig) if !orig.is_empty() => {
-            let resolved = resolve_within_repo(&repo_root.local_path, orig)?;
-            Some(pathspec(&repo_root.local_path, &resolved))
-        }
+        Some(orig) if !orig.is_empty() => Some(pathspec_from_input(&repo_root, orig)?),
         _ => None,
     };
 
@@ -244,8 +250,10 @@ pub fn diff_content(
             &repo_root.git_path,
             &format!(":{rel_path}"),
         )?
+    } else if repo_root.workspace.is_ssh() {
+        read_remote_worktree_text(&repo_root, &rel_path)?
     } else {
-        read_text_file(&worktree_path)?
+        read_text_file(worktree_path.as_deref().expect("local worktree path"))?
     };
     let patch = diff_inner(&repo_root, Some(&rel_path), staged)?;
     let is_binary =
@@ -271,7 +279,7 @@ pub fn stage(
     if paths.is_empty() {
         return Ok(());
     }
-    let resolved = resolve_pathspecs(&repo_root.local_path, paths)?;
+    let resolved = resolve_pathspecs(&repo_root, paths)?;
     let mut args: Vec<OsString> = vec!["add".into(), "--".into()];
     for p in &resolved {
         args.push(p.clone().into());
@@ -296,7 +304,7 @@ pub fn unstage(
     if paths.is_empty() {
         return Ok(());
     }
-    let resolved = resolve_pathspecs(&repo_root.local_path, paths)?;
+    let resolved = resolve_pathspecs(&repo_root, paths)?;
     let mut reset_args: Vec<OsString> = vec!["reset".into(), "HEAD".into(), "--".into()];
     for p in &resolved {
         reset_args.push(p.clone().into());
@@ -354,7 +362,7 @@ pub fn discard(
     let mut tracked: Vec<String> = Vec::with_capacity(entries.len());
     let mut untracked: Vec<String> = Vec::new();
     for entry in entries {
-        let resolved = pathspec_from_input(&repo_root.local_path, &entry.path)?;
+        let resolved = pathspec_from_input(&repo_root, &entry.path)?;
         if entry.untracked {
             untracked.push(resolved);
         } else {
@@ -715,20 +723,10 @@ pub fn commit_file_diff(
     if !sha_is_safe(sha) {
         return Err(GitError::command("git show", "invalid commit sha"));
     }
-    let resolved = resolve_within_repo(&repo_root.local_path, path)?;
-    let rel = resolved
-        .strip_prefix(&repo_root.local_path)
-        .map(|p| p.to_string_lossy().replace('\\', "/"))
-        .unwrap_or_else(|_| path.replace('\\', "/"));
+    let rel = pathspec_from_input(&repo_root, path)?;
 
     let original_rel = match original_path {
-        Some(orig) if !orig.is_empty() => {
-            let resolved_orig = resolve_within_repo(&repo_root.local_path, orig)?;
-            resolved_orig
-                .strip_prefix(&repo_root.local_path)
-                .map(|p| p.to_string_lossy().replace('\\', "/"))
-                .unwrap_or_else(|_| orig.replace('\\', "/"))
-        }
+        Some(orig) if !orig.is_empty() => pathspec_from_input(&repo_root, orig)?,
         _ => rel.clone(),
     };
 
@@ -956,7 +954,7 @@ fn nothing_to_commit(output: &GitOutput) -> bool {
     stderr.contains("nothing to commit") || stdout.contains("nothing to commit")
 }
 
-fn resolve_pathspecs(repo_root: &Path, paths: &[String]) -> Result<Vec<String>> {
+fn resolve_pathspecs(repo_root: &ResolvedGitDirectory, paths: &[String]) -> Result<Vec<String>> {
     let mut out = Vec::with_capacity(paths.len());
     for p in paths {
         out.push(pathspec_from_input(repo_root, p)?);
@@ -964,9 +962,15 @@ fn resolve_pathspecs(repo_root: &Path, paths: &[String]) -> Result<Vec<String>> 
     Ok(out)
 }
 
-fn pathspec_from_input(repo_root: &Path, rel: &str) -> Result<String> {
-    let resolved = resolve_within_repo(repo_root, rel)?;
-    Ok(pathspec(repo_root, &resolved))
+fn pathspec_from_input(repo_root: &ResolvedGitDirectory, rel: &str) -> Result<String> {
+    if repo_root.workspace.is_ssh() {
+        if !crate::modules::git::utils::is_safe_pathspec(rel) {
+            return Err(GitError::InvalidPath(rel.into()));
+        }
+        return Ok(rel.replace('\\', "/"));
+    }
+    let resolved = resolve_within_repo(&repo_root.local_path, rel)?;
+    Ok(pathspec(&repo_root.local_path, &resolved))
 }
 
 fn pathspec(repo_root: &Path, absolute: &Path) -> String {
@@ -974,6 +978,28 @@ fn pathspec(repo_root: &Path, absolute: &Path) -> String {
         .strip_prefix(repo_root)
         .map(|rel| rel.to_string_lossy().replace('\\', "/"))
         .unwrap_or_else(|_| absolute.to_string_lossy().replace('\\', "/"))
+}
+
+fn read_remote_worktree_text(
+    repo_root: &ResolvedGitDirectory,
+    rel_path: &str,
+) -> Result<TextSource> {
+    let remote_path = if repo_root.git_path.ends_with('/') {
+        format!("{}{}", repo_root.git_path, rel_path)
+    } else {
+        format!("{}/{}", repo_root.git_path, rel_path)
+    };
+    match crate::modules::fs::ssh::read_file(&repo_root.workspace, &remote_path)
+        .map_err(|e| GitError::command("ssh read file", e))?
+    {
+        ReadResult::Text { content, .. } => Ok(TextSource::Text(content)),
+        ReadResult::Binary { .. } => Ok(TextSource::Binary),
+        ReadResult::TooLarge { size, limit } => Err(GitError::FileTooLarge {
+            path: Path::new(&remote_path).to_path_buf(),
+            size,
+            max: limit,
+        }),
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/git/process.rs
+++ b/src-tauri/src/modules/git/process.rs
@@ -15,9 +15,9 @@ use crate::modules::git::types::{
     GitOutput, TextSource, DEFAULT_TIMEOUT_SECS, MAX_FILE_BYTES, MAX_OUTPUT_BYTES,
     MAX_TIMEOUT_SECS, MIN_GIT_VERSION,
 };
-use crate::modules::workspace::WorkspaceEnv;
 #[cfg(windows)]
 use crate::modules::workspace::validate_wsl_distro_name;
+use crate::modules::workspace::WorkspaceEnv;
 
 #[derive(Clone)]
 enum Availability {
@@ -47,6 +47,14 @@ fn workspace_cache_key(workspace: &WorkspaceEnv) -> String {
     match workspace {
         WorkspaceEnv::Local => "local".into(),
         WorkspaceEnv::Wsl { distro } => format!("wsl:{distro}"),
+        WorkspaceEnv::Ssh {
+            host, user, port, ..
+        } => format!(
+            "ssh:{}{}{}",
+            user.as_deref().map(|u| format!("{u}@")).unwrap_or_default(),
+            host,
+            port.map(|p| format!(":{p}")).unwrap_or_default()
+        ),
     }
 }
 
@@ -309,6 +317,23 @@ fn build_git_command(
     cwd: Option<&str>,
     args: &[OsString],
 ) -> Result<Command> {
+    if _workspace.is_ssh() {
+        let mut cmd = crate::modules::workspace::ssh_command(_workspace, true)
+            .map_err(|e| GitError::command("ssh", e))?;
+        let mut remote = String::new();
+        if let Some(cwd) = cwd.filter(|s| !s.is_empty()) {
+            remote.push_str("cd ");
+            remote.push_str(&shell_quote(cwd));
+            remote.push_str(" && ");
+        }
+        remote.push_str("git");
+        for arg in args {
+            remote.push(' ');
+            remote.push_str(&shell_quote(&arg.to_string_lossy()));
+        }
+        cmd.arg(remote);
+        return Ok(cmd);
+    }
     #[cfg(windows)]
     if let WorkspaceEnv::Wsl { distro } = _workspace {
         validate_wsl_distro_name(distro)
@@ -329,6 +354,10 @@ fn build_git_command(
         cmd.current_dir(Path::new(dir));
     }
     Ok(cmd)
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 pub fn ensure_success(output: &GitOutput, context: &'static str) -> Result<()> {

--- a/src-tauri/src/modules/git/utils.rs
+++ b/src-tauri/src/modules/git/utils.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::modules::fs::file::StatKind;
 use crate::modules::git::errors::{GitError, Result};
 use crate::modules::workspace::{resolve_path, WorkspaceEnv, WorkspaceRegistry};
 
@@ -30,6 +31,19 @@ pub fn canonical_dir(
     path: &str,
     workspace: &WorkspaceEnv,
 ) -> Result<ResolvedGitDirectory> {
+    if workspace.is_ssh() {
+        let stat = crate::modules::fs::ssh::stat(workspace, path)
+            .map_err(|e| GitError::command("ssh stat", e))?;
+        if !matches!(stat.kind, StatKind::Dir) {
+            return Err(GitError::NotADirectory(path.to_string()));
+        }
+        let git_path = normalize_git_path(path);
+        return Ok(ResolvedGitDirectory {
+            workspace: workspace.clone(),
+            local_path: PathBuf::from(&git_path),
+            git_path,
+        });
+    }
     let candidate = resolve_path(path, workspace);
     if !candidate.is_dir() {
         return Err(GitError::NotADirectory(path.to_string()));
@@ -55,6 +69,9 @@ pub fn authorized_repo_root(
     workspace: &WorkspaceEnv,
 ) -> Result<ResolvedGitDirectory> {
     let canonical = canonical_dir(registry, path, workspace)?;
+    if workspace.is_ssh() {
+        return Ok(canonical);
+    }
     if !registry.is_authorized(&canonical.local_path) {
         return Err(GitError::PathOutsideWorkspace(canonical.local_path.clone()));
     }

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -409,8 +409,8 @@ mod tests {
     fn resolve_pty_cwd_keeps_ssh_cwd_remote() {
         let reg = WorkspaceRegistry::default();
         let env = WorkspaceEnv::Ssh {
-            host: "victus".into(),
-            user: Some("kaan".into()),
+            host: "example-host".into(),
+            user: Some("devuser".into()),
             port: None,
             root: None,
         };

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod shell_init;
 
 use std::collections::HashMap;
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
@@ -14,7 +15,7 @@ use std::thread;
 use portable_pty::PtySize;
 use tauri::ipc::{Channel, Response};
 
-use crate::modules::workspace::{authorize_user_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
+use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry, authorize_user_spawn_cwd};
 use session::Session;
 
 pub struct PtyState {
@@ -39,6 +40,49 @@ impl PtyState {
     }
 }
 
+fn path_string(path: PathBuf) -> String {
+    crate::modules::fs::to_canon(path)
+}
+
+fn local_home_cwd(registry: &WorkspaceRegistry) -> Option<String> {
+    let home = dirs::home_dir()?.canonicalize().ok()?;
+    if !home.is_dir() {
+        return None;
+    }
+    let canonical = registry.authorize(&home).ok()?;
+    Some(path_string(canonical))
+}
+
+fn trimmed_cwd(cwd: Option<&str>) -> Option<String> {
+    cwd.map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn resolve_pty_cwd(
+    registry: &WorkspaceRegistry,
+    cwd: Option<&str>,
+    workspace: &WorkspaceEnv,
+) -> Result<Option<String>, String> {
+    if workspace.is_ssh() {
+        return Ok(trimmed_cwd(cwd));
+    }
+    match authorize_user_spawn_cwd(registry, cwd, workspace) {
+        Ok(resolved) => {
+            if matches!(workspace, WorkspaceEnv::Local) {
+                Ok(resolved.map(path_string))
+            } else {
+                Ok(trimmed_cwd(cwd))
+            }
+        }
+        Err(e) if matches!(workspace, WorkspaceEnv::Local) => {
+            log::warn!("pty_open: cwd rejected, falling back to home: {e}");
+            Ok(local_home_cwd(registry))
+        }
+        Err(e) => Err(e),
+    }
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn pty_open(
@@ -55,14 +99,16 @@ pub async fn pty_open(
 ) -> Result<u32, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
     let blocks = blocks.unwrap_or(false);
-    authorize_user_spawn_cwd(&registry, cwd.as_deref(), &workspace).map_err(|e| {
+    let cwd = resolve_pty_cwd(&registry, cwd.as_deref(), &workspace).map_err(|e| {
         log::warn!("pty_open: cwd rejected: {e}");
         e
     })?;
     let id = state.next_id.fetch_add(1, Ordering::Relaxed);
     let session = tauri::async_runtime::spawn_blocking(move || {
-        session::spawn(id, app, cols, rows, cwd, workspace, blocks, on_data, on_exit)
-            .map(|(s, _)| s)
+        session::spawn(
+            id, app, cols, rows, cwd, workspace, blocks, on_data, on_exit,
+        )
+        .map(|(s, _)| s)
     })
     .await
     .map_err(|e| {
@@ -254,8 +300,7 @@ fn shell_has_children(shell_pid: u32) -> bool {
     use std::mem::{size_of, zeroed};
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::System::Diagnostics::ToolHelp::{
-        CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32,
-        TH32CS_SNAPPROCESS,
+        CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
     };
     unsafe {
         let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
@@ -308,4 +353,69 @@ pub fn pty_close_all(state: tauri::State<PtyState>) -> Result<usize, String> {
 #[tauri::command]
 pub fn pty_shell_name() -> String {
     shell_init::detect_shell_name()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn tempdir(label: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "terax-pty-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        fs::create_dir_all(&dir).expect("tempdir");
+        fs::canonicalize(dir).expect("canonical tempdir")
+    }
+
+    #[test]
+    fn resolve_pty_cwd_registers_existing_local_cwd() {
+        let dir = tempdir("existing");
+        let reg = WorkspaceRegistry::default();
+        let s = path_string(dir.clone());
+        let resolved = resolve_pty_cwd(&reg, Some(&s), &WorkspaceEnv::Local).expect("resolved cwd");
+
+        assert_eq!(resolved.as_deref(), Some(s.as_str()));
+        assert!(reg.is_authorized(&dir));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn resolve_pty_cwd_falls_back_to_home_for_missing_local_cwd() {
+        let Some(home) = dirs::home_dir()
+            .and_then(|p| p.canonicalize().ok())
+            .filter(|p| p.is_dir())
+            .map(path_string)
+        else {
+            return;
+        };
+        let mut missing = std::env::temp_dir();
+        missing.push(format!("terax-pty-missing-{}", std::process::id()));
+        let reg = WorkspaceRegistry::default();
+        let s = missing.to_string_lossy().into_owned();
+        let resolved = resolve_pty_cwd(&reg, Some(&s), &WorkspaceEnv::Local).expect("fallback cwd");
+
+        assert_eq!(resolved.as_deref(), Some(home.as_str()));
+    }
+
+    #[test]
+    fn resolve_pty_cwd_keeps_ssh_cwd_remote() {
+        let reg = WorkspaceRegistry::default();
+        let env = WorkspaceEnv::Ssh {
+            host: "victus".into(),
+            user: Some("kaan".into()),
+            port: None,
+            root: None,
+        };
+        let resolved = resolve_pty_cwd(&reg, Some("/remote/project"), &env).expect("ssh cwd");
+
+        assert_eq!(resolved.as_deref(), Some("/remote/project"));
+    }
 }

--- a/src-tauri/src/modules/pty/scripts/bashrc.bash
+++ b/src-tauri/src/modules/pty/scripts/bashrc.bash
@@ -3,9 +3,8 @@
 # Differences vs zsh integration:
 # - We emulate login-shell init manually (/etc/profile, profile files) because
 #   bash ignores --rcfile when started with -l.
-# - Pre-exec marker uses PS0 (bash 4.4+). On older bash (macOS default 3.2) we
-#   skip it — a fragile DEBUG-trap alternative would clobber the user's own
-#   traps and interact badly with debuggers.
+# - Pre-exec marker uses DEBUG only when the user does not already have a DEBUG
+#   trap. PS0 cannot reliably include the current command in bash.
 
 if [ -z "$__TERAX_HOOKS_LOADED" ]; then
   __TERAX_HOOKS_LOADED=1
@@ -36,7 +35,7 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
   }
 
   _terax_precmd() {
-    local _terax_ret=$?
+    local _terax_ret="${1:-$?}"
     printf '\e]133;D;%s\e\\' "$_terax_ret"
     printf '\e]7;file://%s%s\e\\' "${HOSTNAME:-$(uname -n 2>/dev/null)}" "$(_terax_urlencode "$PWD")"
     if [ -n "$TERAX_BLOCKS" ]; then
@@ -54,23 +53,43 @@ if [ -z "$__TERAX_HOOKS_LOADED" ]; then
     printf '\e]133;A\e\\'
   }
 
-  case ":${PROMPT_COMMAND:-}:" in
-    *":_terax_precmd:"*) ;;
-    *) PROMPT_COMMAND="_terax_precmd${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
-  esac
+  _terax_preexec() {
+    [ -n "$__TERAX_IN_PROMPT" ] && return
+    case "$BASH_COMMAND" in
+      :|_terax_prompt_command|_terax_precmd|_terax_preexec|__systemd_*) return ;;
+    esac
+    local cmd="$BASH_COMMAND"
+    cmd="${cmd//$'\e'/ }"
+    cmd="${cmd//$'\a'/ }"
+    cmd="${cmd//$'\r'/ }"
+    cmd="${cmd//$'\n'/ }"
+    [[ -n "$TERAX_BLOCKS" ]] && _terax_block_seen=1
+    printf '\e]133;C;%s\e\\' "${cmd:0:256}"
+  }
 
-  # Pre-exec marker via PS0 (bash 4.4+). PS0 is expanded just before a command
-  # runs — cleaner than a DEBUG trap, which would clobber user traps and fire
-  # on every command including inside PROMPT_COMMAND.
-  if [ "${BASH_VERSINFO[0]:-0}" -gt 4 ] \
-     || { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 4 ]; }; then
-    if [ -n "$TERAX_BLOCKS" ]; then
-      # PS0 only expands, never executes: the arithmetic inside the array
-      # subscript sets the seen flag while the unset array expands to nothing.
-      PS0='\[\e]133;C\e\\\]${_terax_noop[$((_terax_block_seen=1))]}'"${PS0:-}"
-    else
-      PS0='\[\e]133;C\e\\\]'"${PS0:-}"
+  ssh() {
+    command ssh \
+      -o ControlMaster=auto \
+      -o ControlPersist=1h \
+      -o ControlPath=/tmp/terax-ssh-%C \
+      "$@"
+  }
+
+  __TERAX_USER_PROMPT_COMMAND="${PROMPT_COMMAND:-}"
+  _terax_prompt_command() {
+    local _terax_ret=$?
+    __TERAX_IN_PROMPT=1
+    _terax_precmd "$_terax_ret"
+    if [ -n "$__TERAX_USER_PROMPT_COMMAND" ]; then
+      eval "$__TERAX_USER_PROMPT_COMMAND"
     fi
+    unset __TERAX_IN_PROMPT
+    return "$_terax_ret"
+  }
+  PROMPT_COMMAND="_terax_prompt_command"
+
+  if [ -z "$(trap -p DEBUG)" ]; then
+    trap _terax_preexec DEBUG
   fi
 
   _terax_precmd

--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -93,3 +93,11 @@ function __terax_preexec --on-event fish_preexec
     set -l cmd (string replace -ra '[\x00-\x1f\x7f]' ' ' -- "$argv")
     printf '\e]133;C;%s\e\\' (string sub -l 256 -- "$cmd")
 end
+
+function ssh
+    command ssh \
+        -o ControlMaster=auto \
+        -o ControlPersist=1h \
+        -o ControlPath=/tmp/terax-ssh-%C \
+        $argv
+end

--- a/src-tauri/src/modules/pty/scripts/zshrc.zsh
+++ b/src-tauri/src/modules/pty/scripts/zshrc.zsh
@@ -68,6 +68,14 @@ if [[ -z "$__TERAX_HOOKS_LOADED" ]]; then
     printf '\e]133;C;%s\e\\' "${cmd[1,256]}"
   }
 
+  ssh() {
+    command ssh \
+      -o ControlMaster=auto \
+      -o ControlPersist=1h \
+      -o ControlPath=/tmp/terax-ssh-%C \
+      "$@"
+  }
+
   if (( $+functions[add-zsh-hook] )); then
     add-zsh-hook precmd _terax_precmd
     add-zsh-hook preexec _terax_preexec

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -55,6 +55,9 @@ pub fn build_command(
     workspace: WorkspaceEnv,
     blocks: bool,
 ) -> Result<CommandBuilder, String> {
+    if workspace.is_ssh() {
+        return build_ssh_command(cwd, workspace, blocks);
+    }
     #[cfg(unix)]
     {
         let _ = workspace;
@@ -64,6 +67,41 @@ pub fn build_command(
     {
         windows::build(cwd, workspace, blocks)
     }
+}
+
+fn build_ssh_command(
+    cwd: Option<String>,
+    workspace: WorkspaceEnv,
+    blocks: bool,
+) -> Result<CommandBuilder, String> {
+    let mut cmd = CommandBuilder::new("ssh");
+    if let WorkspaceEnv::Ssh { port, .. } = &workspace {
+        cmd.arg("-tt");
+        if let Some(port) = port {
+            cmd.arg("-p");
+            cmd.arg(port.to_string());
+        }
+    }
+    cmd.arg(crate::modules::workspace::ssh_target(&workspace)?);
+    let remote_cwd = cwd
+        .filter(|p| !p.trim().is_empty())
+        .or_else(|| workspace.ssh_root().map(str::to_string));
+    let shell = if blocks {
+        "TERAX_TERMINAL=1 TERAX_BLOCKS=1 exec ${SHELL:-/bin/bash} -l"
+    } else {
+        "TERAX_TERMINAL=1 exec ${SHELL:-/bin/bash} -l"
+    };
+    let remote = if let Some(cwd) = remote_cwd {
+        format!("cd {} && {shell}", shell_quote(&cwd))
+    } else {
+        shell.to_string()
+    };
+    cmd.arg(remote);
+    Ok(cmd)
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 pub fn detect_shell_name() -> String {
@@ -340,7 +378,9 @@ mod windows {
             zdotdir: String,
             user_zdotdir: Option<String>,
         },
-        Bash { rcfile: String },
+        Bash {
+            rcfile: String,
+        },
         Fish,
         None,
     }

--- a/src-tauri/src/modules/shell/background.rs
+++ b/src-tauri/src/modules/shell/background.rs
@@ -98,9 +98,11 @@ pub fn spawn(
     if trimmed.is_empty() {
         return Err("empty command".into());
     }
-    if let Some(ref dir) = cwd {
-        if !resolve_path(dir, &workspace).is_dir() {
-            return Err(format!("cwd is not a directory: {dir}"));
+    if !workspace.is_ssh() {
+        if let Some(ref dir) = cwd {
+            if !resolve_path(dir, &workspace).is_dir() {
+                return Err(format!("cwd is not a directory: {dir}"));
+            }
         }
     }
 

--- a/src-tauri/src/modules/shell/mod.rs
+++ b/src-tauri/src/modules/shell/mod.rs
@@ -14,9 +14,9 @@ use std::time::Duration;
 use serde::Serialize;
 use shared_child::SharedChild;
 
-use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
 #[cfg(windows)]
 use crate::modules::workspace::validate_wsl_distro_name;
+use crate::modules::workspace::{authorize_spawn_cwd, WorkspaceEnv, WorkspaceRegistry};
 
 use background::{BackgroundLogResponse, BackgroundProc, BackgroundProcInfo};
 use session::{SessionRunOutput, ShellSession};
@@ -182,6 +182,8 @@ pub fn shell_session_open(
         None => {
             if let WorkspaceEnv::Wsl { distro } = &workspace {
                 crate::modules::workspace::wsl_home(distro.clone())?
+            } else if workspace.is_ssh() {
+                crate::modules::workspace::ssh_home(workspace.clone())?
             } else {
                 crate::modules::fs::to_canon(dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
             }
@@ -210,7 +212,9 @@ pub async fn shell_session_run(
         .get(&id)
         .cloned()
         .ok_or_else(|| "no shell session".to_string())?;
-    let effective_workspace = workspace.clone().unwrap_or_else(|| session.workspace.clone());
+    let effective_workspace = workspace
+        .clone()
+        .unwrap_or_else(|| session.workspace.clone());
     authorize_spawn_cwd(&registry, cwd.as_deref(), &effective_workspace)?;
     let dur = Duration::from_secs(
         timeout_secs
@@ -286,6 +290,16 @@ pub(crate) fn build_oneshot_command(
     #[cfg_attr(not(windows), allow(unused_variables))] workspace: &WorkspaceEnv,
     #[cfg_attr(not(windows), allow(unused_variables))] cwd: Option<&str>,
 ) -> Result<Command, String> {
+    if workspace.is_ssh() {
+        let mut cmd = crate::modules::workspace::ssh_command(workspace, true)?;
+        let remote = if let Some(cwd) = cwd.filter(|s| !s.trim().is_empty()) {
+            format!("cd {} && sh -lc {}", shell_quote(cwd), shell_quote(command))
+        } else {
+            format!("sh -lc {}", shell_quote(command))
+        };
+        cmd.arg(remote);
+        return Ok(cmd);
+    }
     #[cfg(windows)]
     if let WorkspaceEnv::Wsl { distro } = workspace {
         validate_wsl_distro_name(distro)?;
@@ -329,6 +343,10 @@ pub(crate) fn build_oneshot_command(
         }
         Ok(cmd)
     }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn drain<R: Read>(reader: &mut R) -> (Vec<u8>, bool) {

--- a/src-tauri/src/modules/shell/session.rs
+++ b/src-tauri/src/modules/shell/session.rs
@@ -77,9 +77,13 @@ impl ShellSession {
         if self.pristine.load(Ordering::Acquire) {
             if let Some(hint) = cwd_hint.filter(|s| !s.is_empty()) {
                 let effective_workspace = workspace_hint.as_ref().unwrap_or(&self.workspace);
-                let p = resolve_path(&hint, effective_workspace);
-                if p.is_dir() {
+                if effective_workspace.is_ssh() {
                     *self.cwd.lock().unwrap() = hint;
+                } else {
+                    let p = resolve_path(&hint, effective_workspace);
+                    if p.is_dir() {
+                        *self.cwd.lock().unwrap() = hint;
+                    }
                 }
             }
         }
@@ -102,12 +106,20 @@ impl ShellSession {
 
         let (stdout_clean, cwd_after) = strip_cwd_sentinel(&raw.stdout, &cwd, &self.sentinel);
         if let Some(ref new_cwd) = cwd_after {
-            let p = resolve_path(new_cwd, &self.workspace);
-            if p.is_dir() {
+            if self.workspace.is_ssh() {
                 *self.cwd.lock().unwrap() = new_cwd.clone();
+            } else {
+                let p = resolve_path(new_cwd, &self.workspace);
+                if p.is_dir() {
+                    *self.cwd.lock().unwrap() = new_cwd.clone();
+                }
             }
         }
-        let resolved_cwd = to_canon(self.current_cwd());
+        let resolved_cwd = if self.workspace.is_ssh() {
+            self.current_cwd()
+        } else {
+            to_canon(self.current_cwd())
+        };
 
         Ok(SessionRunOutput {
             stdout: stdout_clean,
@@ -175,7 +187,10 @@ mod tests {
         let stdout = format!("{attacker}{trailer}");
         let (clean, cwd) = strip_cwd_sentinel(&stdout, "/fallback", &s.sentinel);
         assert_eq!(cwd.as_deref(), Some("/real"));
-        assert!(clean.contains(attacker), "attacker payload survives in stdout");
+        assert!(
+            clean.contains(attacker),
+            "attacker payload survives in stdout"
+        );
     }
 
     #[test]

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -954,19 +954,19 @@ mod auth_tests {
     #[test]
     fn ssh_target_formats_user_host_portless() {
         let env = WorkspaceEnv::Ssh {
-            host: "ubuntu-box".into(),
-            user: Some("kaan".into()),
+            host: "example-host".into(),
+            user: Some("devuser".into()),
             port: None,
-            root: Some("/home/kaan/project".into()),
+            root: Some("/home/devuser/project".into()),
         };
-        assert_eq!(ssh_target(&env).unwrap(), "kaan@ubuntu-box");
+        assert_eq!(ssh_target(&env).unwrap(), "devuser@example-host");
     }
 
     #[test]
     fn ssh_target_rejects_shell_metacharacters() {
         let env = WorkspaceEnv::Ssh {
             host: "host;rm".into(),
-            user: Some("kaan".into()),
+            user: Some("devuser".into()),
             port: None,
             root: None,
         };
@@ -977,8 +977,8 @@ mod auth_tests {
     fn ssh_authorize_spawn_cwd_does_not_touch_local_filesystem() {
         let reg = WorkspaceRegistry::default();
         let env = WorkspaceEnv::Ssh {
-            host: "ubuntu-box".into(),
-            user: Some("kaan".into()),
+            host: "example-host".into(),
+            user: Some("devuser".into()),
             port: Some(22),
             root: None,
         };

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -77,6 +78,12 @@ pub fn authorize_spawn_cwd(
     cwd: Option<&str>,
     workspace: &WorkspaceEnv,
 ) -> Result<Option<PathBuf>, String> {
+    if workspace.is_ssh() {
+        return Ok(cwd
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from));
+    }
     let Some(cwd) = cwd.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
@@ -102,6 +109,12 @@ pub fn authorize_user_spawn_cwd(
     cwd: Option<&str>,
     workspace: &WorkspaceEnv,
 ) -> Result<Option<PathBuf>, String> {
+    if workspace.is_ssh() {
+        return Ok(cwd
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from));
+    }
     let Some(cwd) = cwd.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
@@ -129,6 +142,9 @@ pub async fn workspace_authorize(
     registry: tauri::State<'_, WorkspaceRegistry>,
 ) -> Result<String, String> {
     let workspace = WorkspaceEnv::from_option(workspace);
+    if workspace.is_ssh() {
+        return Ok(normalize_remote_path(&path));
+    }
     let resolved = resolve_path(&path, &workspace);
     let canonical = registry.authorize(&resolved).map_err(|e| e.to_string())?;
     Ok(crate::modules::fs::to_canon(&canonical))
@@ -299,6 +315,15 @@ pub enum WorkspaceEnv {
     Wsl {
         distro: String,
     },
+    Ssh {
+        host: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        user: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        port: Option<u16>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        root: Option<String>,
+    },
 }
 
 impl WorkspaceEnv {
@@ -308,6 +333,137 @@ impl WorkspaceEnv {
 
     pub fn is_wsl(&self) -> bool {
         matches!(self, Self::Wsl { .. })
+    }
+
+    pub fn is_ssh(&self) -> bool {
+        matches!(self, Self::Ssh { .. })
+    }
+
+    pub fn ssh_root(&self) -> Option<&str> {
+        match self {
+            Self::Ssh { root, .. } => root.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+fn safe_ssh_component(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 255
+        && !value.chars().any(|c| {
+            c.is_whitespace()
+                || c.is_control()
+                || matches!(
+                    c,
+                    '"' | '\'' | '`' | '$' | ';' | '&' | '|' | '<' | '>' | '(' | ')'
+                )
+        })
+}
+
+fn normalize_remote_path(path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return "/".into();
+    }
+    let mut out = trimmed.replace('\\', "/");
+    while out.len() > 1 && out.ends_with('/') {
+        out.pop();
+    }
+    if out.starts_with('/') {
+        out
+    } else {
+        format!("/{out}")
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+const SSH_CONTROL_PATH: &str = "/tmp/terax-ssh-%C";
+
+pub(crate) fn ssh_target(workspace: &WorkspaceEnv) -> Result<String, String> {
+    let WorkspaceEnv::Ssh { host, user, .. } = workspace else {
+        return Err("workspace is not SSH".into());
+    };
+    if !safe_ssh_component(host) {
+        return Err("invalid SSH host".into());
+    }
+    if let Some(user) = user.as_deref() {
+        if !safe_ssh_component(user) {
+            return Err("invalid SSH user".into());
+        }
+        Ok(format!("{user}@{host}"))
+    } else {
+        Ok(host.clone())
+    }
+}
+
+pub(crate) fn ssh_command(workspace: &WorkspaceEnv, batch_mode: bool) -> Result<Command, String> {
+    let WorkspaceEnv::Ssh { port, .. } = workspace else {
+        return Err("workspace is not SSH".into());
+    };
+    let target = ssh_target(workspace)?;
+    let mut cmd = Command::new("ssh");
+    cmd.arg("-o").arg("ConnectTimeout=10");
+    cmd.arg("-o").arg("ControlMaster=auto");
+    cmd.arg("-o").arg("ControlPersist=1h");
+    cmd.arg("-o").arg(format!("ControlPath={SSH_CONTROL_PATH}"));
+    if batch_mode {
+        cmd.arg("-o").arg("BatchMode=yes");
+    }
+    if let Some(port) = port {
+        cmd.arg("-p").arg(port.to_string());
+    }
+    cmd.arg(target);
+    Ok(cmd)
+}
+
+fn ssh_config_user(workspace: &WorkspaceEnv) -> Result<Option<String>, String> {
+    let WorkspaceEnv::Ssh { port, user, .. } = workspace else {
+        return Err("workspace is not SSH".into());
+    };
+    if let Some(user) = user.as_deref() {
+        if safe_ssh_component(user) {
+            return Ok(Some(user.to_string()));
+        }
+    }
+    let target = ssh_target(workspace)?;
+    let mut cmd = Command::new("ssh");
+    cmd.arg("-G");
+    if let Some(port) = port {
+        cmd.arg("-p").arg(port.to_string());
+    }
+    cmd.arg(target);
+    crate::modules::proc::hide_console(&mut cmd);
+    let out = cmd.output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    Ok(stdout.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let value = trimmed
+            .strip_prefix("user ")
+            .or_else(|| trimmed.strip_prefix("User "))?
+            .trim();
+        if safe_ssh_component(value) {
+            Some(value.to_string())
+        } else {
+            None
+        }
+    }))
+}
+
+fn linux_home_for_user(user: Option<String>) -> String {
+    match user.as_deref() {
+        Some("root") => "/root".into(),
+        Some(user) if safe_ssh_component(user) => format!("/home/{user}"),
+        _ => std::env::var("USER")
+            .ok()
+            .filter(|user| safe_ssh_component(user))
+            .map(|user| format!("/home/{user}"))
+            .unwrap_or_else(|| "/".into()),
     }
 }
 
@@ -323,6 +479,7 @@ pub fn resolve_path(path: &str, workspace: &WorkspaceEnv) -> PathBuf {
     match workspace {
         WorkspaceEnv::Local => PathBuf::from(path),
         WorkspaceEnv::Wsl { distro } => wsl_path_to_host(distro, path),
+        WorkspaceEnv::Ssh { .. } => PathBuf::from(path),
     }
 }
 
@@ -575,6 +732,63 @@ pub fn wsl_home(distro: String) -> Result<String, String> {
     }
 }
 
+#[tauri::command]
+pub fn ssh_home(workspace: WorkspaceEnv) -> Result<String, String> {
+    let root = workspace.ssh_root().map(normalize_remote_path);
+    if let Some(root) = root {
+        if !root.is_empty() {
+            let mut cmd = ssh_command(&workspace, true)?;
+            cmd.arg(format!(
+                "test -d {} && printf %s {}",
+                shell_quote(&root),
+                shell_quote(&root)
+            ));
+            crate::modules::proc::hide_console(&mut cmd);
+            let out = cmd.output().map_err(|e| e.to_string())?;
+            if out.status.success() {
+                return Ok(root);
+            }
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            return Err(if stderr.is_empty() {
+                format!("SSH root is not a directory: {root}")
+            } else {
+                stderr
+            });
+        }
+    }
+    let mut cmd = ssh_command(&workspace, true)?;
+    cmd.arg("sh").arg("-lc").arg("printf %s \"$HOME\"");
+    crate::modules::proc::hide_console(&mut cmd);
+    let out = cmd.output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            "ssh home lookup failed".into()
+        } else {
+            stderr
+        });
+    }
+    let home = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if home.is_empty() {
+        Err("could not resolve SSH home".into())
+    } else {
+        Ok(normalize_remote_path(&home))
+    }
+}
+
+#[tauri::command]
+pub fn ssh_default_root(workspace: WorkspaceEnv) -> Result<String, String> {
+    let WorkspaceEnv::Ssh { root, .. } = &workspace else {
+        return Err("workspace is not SSH".into());
+    };
+    if let Some(root) = root.as_deref().map(normalize_remote_path) {
+        if !root.is_empty() {
+            return Ok(root);
+        }
+    }
+    Ok(linux_home_for_user(ssh_config_user(&workspace)?))
+}
+
 #[cfg(windows)]
 pub fn wsl_login_shell(distro: String) -> Result<String, String> {
     const SCRIPT: &str = r#"uid="$(id -u 2>/dev/null || printf '')"
@@ -735,6 +949,43 @@ mod auth_tests {
         assert!(authorize_spawn_cwd(&reg, Some("   "), &WorkspaceEnv::Local)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn ssh_target_formats_user_host_portless() {
+        let env = WorkspaceEnv::Ssh {
+            host: "ubuntu-box".into(),
+            user: Some("kaan".into()),
+            port: None,
+            root: Some("/home/kaan/project".into()),
+        };
+        assert_eq!(ssh_target(&env).unwrap(), "kaan@ubuntu-box");
+    }
+
+    #[test]
+    fn ssh_target_rejects_shell_metacharacters() {
+        let env = WorkspaceEnv::Ssh {
+            host: "host;rm".into(),
+            user: Some("kaan".into()),
+            port: None,
+            root: None,
+        };
+        assert!(ssh_target(&env).is_err());
+    }
+
+    #[test]
+    fn ssh_authorize_spawn_cwd_does_not_touch_local_filesystem() {
+        let reg = WorkspaceRegistry::default();
+        let env = WorkspaceEnv::Ssh {
+            host: "ubuntu-box".into(),
+            user: Some("kaan".into()),
+            port: Some(22),
+            root: None,
+        };
+        let resolved = authorize_spawn_cwd(&reg, Some("/remote/path"), &env)
+            .expect("ssh cwd accepted")
+            .expect("cwd returned");
+        assert_eq!(resolved, PathBuf::from("/remote/path"));
     }
 
     #[test]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -71,6 +71,7 @@ import {
   leafIds,
   navigateFocusedBlocks,
   respawnSession,
+  setActiveTerminalWorkspaceLeaf,
   type TerminalPaneHandle,
   useTerminalFileDrop,
   writeToSession,
@@ -86,7 +87,14 @@ import { ThemeProvider, useThemeFileEditing } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
 import { useWorkspaceEnvStore } from "@/modules/workspace";
 import type { SearchAddon } from "@xterm/addon-search";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { CloseDialogs } from "./components/CloseDialogs";
 import {
   TOGGLE_BLOCK_INPUT_EVENT,
@@ -281,9 +289,14 @@ export default function App() {
     activeTab,
     tabs,
     launchCwd ?? home,
+    workspaceEnv,
   );
 
   useWindowTitle(activeTab, explorerRoot);
+
+  useLayoutEffect(() => {
+    setActiveTerminalWorkspaceLeaf(activeLeafId);
+  }, [activeLeafId]);
 
   useEffect(() => {
     setActiveSearchAddon(

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -135,6 +135,7 @@ export default function App() {
     updateTab,
     selectByIndex,
     setLeafCwd,
+    setLeafSsh,
     focusPane,
     focusNextPaneInTab,
     splitActivePane,
@@ -763,6 +764,13 @@ export default function App() {
     [setLeafCwd],
   );
 
+  const handleTerminalSsh = useCallback(
+    (leafId: number, active: boolean) => {
+      setLeafSsh(leafId, active);
+    },
+    [setLeafSsh],
+  );
+
   const handleFocusLeaf = useCallback(
     (tabId: number, leafId: number) => focusPane(tabId, leafId),
     [focusPane],
@@ -1099,6 +1107,7 @@ export default function App() {
                       registerTerminalHandle={registerTerminalHandle}
                       onSearchReady={handleSearchReady}
                       onCwd={handleTerminalCwd}
+                      onSsh={handleTerminalSsh}
                       onExit={handleLeafExit}
                       onFocusLeaf={handleFocusLeaf}
                       registerEditorHandle={registerEditorHandle}

--- a/src/app/components/WorkspaceSurface.tsx
+++ b/src/app/components/WorkspaceSurface.tsx
@@ -20,6 +20,7 @@ type Props = {
   registerTerminalHandle: TerminalStackProps["registerHandle"];
   onSearchReady: TerminalStackProps["onSearchReady"];
   onCwd: TerminalStackProps["onCwd"];
+  onSsh: TerminalStackProps["onSsh"];
   onExit: TerminalStackProps["onExit"];
   onFocusLeaf: TerminalStackProps["onFocusLeaf"];
   registerEditorHandle: EditorStackProps["registerHandle"];
@@ -46,6 +47,7 @@ export function WorkspaceSurface({
   registerTerminalHandle,
   onSearchReady,
   onCwd,
+  onSsh,
   onExit,
   onFocusLeaf,
   registerEditorHandle,
@@ -83,6 +85,7 @@ export function WorkspaceSurface({
           registerHandle={registerTerminalHandle}
           onSearchReady={onSearchReady}
           onCwd={onCwd}
+          onSsh={onSsh}
           onExit={onExit}
           onFocusLeaf={onFocusLeaf}
         />

--- a/src/app/hooks/useWorkspaceSwitcher.ts
+++ b/src/app/hooks/useWorkspaceSwitcher.ts
@@ -3,6 +3,7 @@ import { homeDir } from "@tauri-apps/api/path";
 import { native } from "@/modules/ai/lib/native";
 import type { Tab } from "@/modules/tabs";
 import {
+  getSshHome,
   getWslHome,
   LOCAL_WORKSPACE,
   type WorkspaceEnv,
@@ -57,11 +58,7 @@ export function useWorkspaceSwitcher({
 
   const switchWorkspace = useCallback(
     async (env: WorkspaceEnv) => {
-      if (
-        env.kind === workspaceEnv.kind &&
-        (env.kind === "local" ||
-          (workspaceEnv.kind === "wsl" && env.distro === workspaceEnv.distro))
-      ) {
+      if (sameWorkspace(env, workspaceEnv)) {
         return;
       }
       const dirty = tabsRef.current.some((t) => t.kind === "editor" && t.dirty);
@@ -76,6 +73,8 @@ export function useWorkspaceSwitcher({
       try {
         if (env.kind === "wsl") {
           nextHome = await getWslHome(env.distro);
+        } else if (env.kind === "ssh") {
+          nextHome = await getSshHome(env);
         } else {
           nextHome = (await homeDir()).replace(/\\/g, "/");
         }
@@ -107,4 +106,19 @@ export function useWorkspaceSwitcher({
   );
 
   return { home, launchCwd, launchCwdResolved, switchWorkspace };
+}
+
+function sameWorkspace(a: WorkspaceEnv, b: WorkspaceEnv): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "local") return true;
+  if (a.kind === "wsl" && b.kind === "wsl") return a.distro === b.distro;
+  if (a.kind === "ssh" && b.kind === "ssh") {
+    return (
+      a.host === b.host &&
+      (a.user ?? null) === (b.user ?? null) &&
+      (a.port ?? null) === (b.port ?? null) &&
+      (a.root ?? null) === (b.root ?? null)
+    );
+  }
+  return false;
 }

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -37,6 +38,8 @@ export function dirname(path: string): string {
 }
 
 const EXPANSION_CACHE_LIMIT = 8;
+const SSH_AUTH_RETRY_MS = 800;
+const SSH_AUTH_RETRY_WINDOW_MS = 30_000;
 const expansionCache = new Map<string, string[]>();
 
 function rememberExpansion(root: string, expanded: Set<string>): void {
@@ -96,6 +99,10 @@ export function useFileTree(rootPath: string | null, options?: Options) {
   const expandedRef = useRef(expanded);
   const nodesRef = useRef(nodes);
   const watchedRef = useRef<Set<string>>(new Set());
+  const retryTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+  const retryUntilRef = useRef<Map<string, number>>(new Map());
 
   useEffect(() => {
     showHiddenRef.current = showHidden;
@@ -128,13 +135,20 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     if (nodesRef.current[path]?.status !== "loaded") {
       setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
     }
+    const workspace = currentWorkspaceEnv();
     try {
       const entries = await invoke<DirEntry[]>("fs_read_dir", {
         path,
         showHidden: showHiddenRef.current,
         gitDecorations: gitDecorationsRef.current,
-        workspace: currentWorkspaceEnv(),
+        workspace,
       });
+      retryUntilRef.current.delete(path);
+      const retryTimer = retryTimersRef.current.get(path);
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimersRef.current.delete(path);
+      }
 
       const prev = nodesRef.current[path];
       if (prev?.status === "loaded" && sameDirListing(prev.entries, entries)) {
@@ -179,9 +193,32 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         watchRemove(toUnwatch);
       }
     } catch (e) {
+      const message = String(e);
+      if (workspace.kind === "ssh" && isPendingSshAuthError(message)) {
+        const now = Date.now();
+        const until =
+          retryUntilRef.current.get(path) ?? now + SSH_AUTH_RETRY_WINDOW_MS;
+        retryUntilRef.current.set(path, until);
+        if (now < until) {
+          setNodes((s) =>
+            s[path]?.status === "loaded"
+              ? s
+              : { ...s, [path]: { status: "loading" } },
+          );
+          if (!retryTimersRef.current.has(path)) {
+            const timer = setTimeout(() => {
+              retryTimersRef.current.delete(path);
+              void fetchChildren(path);
+            }, SSH_AUTH_RETRY_MS);
+            retryTimersRef.current.set(path, timer);
+          }
+          return;
+        }
+        retryUntilRef.current.delete(path);
+      }
       setNodes((s) => ({
         ...s,
-        [path]: { status: "error", message: String(e) },
+        [path]: { status: "error", message },
       }));
     }
   }, []);
@@ -211,6 +248,9 @@ export function useFileTree(rootPath: string | null, options?: Options) {
 
     return () => {
       rememberExpansion(rootPath, expandedRef.current);
+      for (const timer of retryTimersRef.current.values()) clearTimeout(timer);
+      retryTimersRef.current.clear();
+      retryUntilRef.current.clear();
       if (watchedRef.current.size > 0) {
         watchRemove([...watchedRef.current]);
         watchedRef.current.clear();
@@ -227,13 +267,35 @@ export function useFileTree(rootPath: string | null, options?: Options) {
       for (const p of paths) {
         const parent = dirname(p);
         if (current[parent]?.status === "loaded") dirs.add(parent);
-        if (current[p]?.status === "loaded") dirs.add(p);
+        if (current[p]) dirs.add(p);
       }
       for (const d of dirs) void fetchChildren(d);
     }).then((un) => {
       if (alive) unlisten = un;
       else un();
     });
+    return () => {
+      alive = false;
+      unlisten?.();
+    };
+  }, [fetchChildren]);
+
+  useEffect(() => {
+    type FileWrittenPayload = { path: string; source?: string };
+    let alive = true;
+    let unlisten: (() => void) | undefined;
+    void getCurrentWebviewWindow()
+      .listen<FileWrittenPayload>("fs:file-written", (event) => {
+        const path = event.payload.path.replace(/\\/g, "/");
+        const parent = dirname(path);
+        if (nodesRef.current[parent]?.status === "loaded") {
+          void fetchChildren(parent);
+        }
+      })
+      .then((un) => {
+        if (alive) unlisten = un;
+        else un();
+      });
     return () => {
       alive = false;
       unlisten?.();
@@ -438,4 +500,13 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     movePath,
     joinPath,
   };
+}
+
+function isPendingSshAuthError(message: string): boolean {
+  return (
+    /permission denied/i.test(message) ||
+    /publickey/i.test(message) ||
+    /keyboard-interactive/i.test(message) ||
+    /password/i.test(message)
+  );
 }

--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -1,7 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import {
+  useWorkspaceEnvStore,
+  workspaceScopeKey,
+} from "@/modules/workspace";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { listenFsChanged, watchAdd, watchRemove } from "./watch";
 
@@ -60,6 +63,10 @@ function recallExpansion(root: string): string[] {
   return v;
 }
 
+function expansionKey(workspaceKey: string, root: string): string {
+  return `${workspaceKey}|${root}`;
+}
+
 function isUnder(key: string, root: string): boolean {
   return key === root || key.startsWith(`${root}/`);
 }
@@ -85,6 +92,8 @@ type Options = {
 };
 
 export function useFileTree(rootPath: string | null, options?: Options) {
+  const workspace = useWorkspaceEnvStore((s) => s.env);
+  const workspaceKey = workspaceScopeKey(workspace);
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const showHiddenRef = useRef(showHidden);
   const gitDecorations = usePreferencesStore((s) => s.explorerGitDecorations);
@@ -103,6 +112,8 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     new Map(),
   );
   const retryUntilRef = useRef<Map<string, number>>(new Map());
+  const workspaceKeyRef = useRef(workspaceKey);
+  workspaceKeyRef.current = workspaceKey;
 
   useEffect(() => {
     showHiddenRef.current = showHidden;
@@ -123,19 +134,19 @@ export function useFileTree(rootPath: string | null, options?: Options) {
   const addWatch = useCallback((path: string) => {
     if (watchedRef.current.has(path)) return;
     watchedRef.current.add(path);
-    watchAdd([path]);
-  }, []);
+    watchAdd([path], workspace);
+  }, [workspace]);
 
   const removeWatch = useCallback((path: string) => {
     if (!watchedRef.current.delete(path)) return;
-    watchRemove([path]);
-  }, []);
+    watchRemove([path], workspace);
+  }, [workspace]);
 
   const fetchChildren = useCallback(async (path: string) => {
     if (nodesRef.current[path]?.status !== "loaded") {
       setNodes((s) => ({ ...s, [path]: { status: "loading" } }));
     }
-    const workspace = currentWorkspaceEnv();
+    const requestWorkspaceKey = workspaceKey;
     try {
       const entries = await invoke<DirEntry[]>("fs_read_dir", {
         path,
@@ -143,6 +154,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         gitDecorations: gitDecorationsRef.current,
         workspace,
       });
+      if (workspaceKeyRef.current !== requestWorkspaceKey) return;
       retryUntilRef.current.delete(path);
       const retryTimer = retryTimersRef.current.get(path);
       if (retryTimer) {
@@ -190,9 +202,10 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         });
         const toUnwatch: string[] = [];
         for (const d of dead) if (watchedRef.current.delete(d)) toUnwatch.push(d);
-        watchRemove(toUnwatch);
+        watchRemove(toUnwatch, workspace);
       }
     } catch (e) {
+      if (workspaceKeyRef.current !== requestWorkspaceKey) return;
       const message = String(e);
       if (workspace.kind === "ssh" && isPendingSshAuthError(message)) {
         const now = Date.now();
@@ -221,7 +234,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         [path]: { status: "error", message },
       }));
     }
-  }, []);
+  }, [workspace, workspaceKey]);
 
   // Root change → restore the cached expansion for this root, re-scope watches,
   // and persist the outgoing root's expansion on the way out.
@@ -236,7 +249,8 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     setPendingCreate(null);
     setRenaming(null);
 
-    const restored = recallExpansion(rootPath);
+    const cacheKey = expansionKey(workspaceKey, rootPath);
+    const restored = recallExpansion(cacheKey);
     setExpanded(new Set(restored));
     setNodes({});
 
@@ -244,19 +258,19 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     void fetchChildren(rootPath);
     for (const d of restored) void fetchChildren(d);
     for (const p of toWatch) watchedRef.current.add(p);
-    watchAdd(toWatch);
+    watchAdd(toWatch, workspace);
 
     return () => {
-      rememberExpansion(rootPath, expandedRef.current);
+      rememberExpansion(cacheKey, expandedRef.current);
       for (const timer of retryTimersRef.current.values()) clearTimeout(timer);
       retryTimersRef.current.clear();
       retryUntilRef.current.clear();
       if (watchedRef.current.size > 0) {
-        watchRemove([...watchedRef.current]);
+        watchRemove([...watchedRef.current], workspace);
         watchedRef.current.clear();
       }
     };
-  }, [rootPath, fetchChildren]);
+  }, [rootPath, workspaceKey, workspace, fetchChildren]);
 
   useEffect(() => {
     let alive = true;
@@ -395,7 +409,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
       const cmd =
         pendingCreate.kind === "dir" ? "fs_create_dir" : "fs_create_file";
       try {
-        await invoke(cmd, { path, workspace: currentWorkspaceEnv() });
+        await invoke(cmd, { path, workspace });
         await fetchChildren(pendingCreate.parentPath);
       } catch (e) {
         console.error(`${cmd} failed:`, e);
@@ -403,7 +417,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         setPendingCreate(null);
       }
     },
-    [pendingCreate, fetchChildren],
+    [pendingCreate, workspace, fetchChildren],
   );
 
   const beginRename = useCallback((path: string) => {
@@ -428,7 +442,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         await invoke("fs_rename", {
           from: renaming,
           to,
-          workspace: currentWorkspaceEnv(),
+          workspace,
         });
         options?.onPathRenamed?.(renaming, to);
         await fetchChildren(parent);
@@ -438,20 +452,20 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         setRenaming(null);
       }
     },
-    [renaming, fetchChildren, options],
+    [renaming, workspace, fetchChildren, options],
   );
 
   const deletePath = useCallback(
     async (path: string) => {
       try {
-        await invoke("fs_delete", { path, workspace: currentWorkspaceEnv() });
+        await invoke("fs_delete", { path, workspace });
         options?.onPathDeleted?.(path);
         await fetchChildren(dirname(path));
       } catch (e) {
         console.error("fs_delete failed:", e);
       }
     },
-    [fetchChildren, options],
+    [workspace, fetchChildren, options],
   );
 
   const movePath = useCallback(
@@ -471,7 +485,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         await invoke("fs_rename", {
           from,
           to,
-          workspace: currentWorkspaceEnv(),
+          workspace,
         });
         options?.onPathRenamed?.(from, to);
         await Promise.all([fetchChildren(dirname(from)), fetchChildren(toDir)]);
@@ -479,7 +493,7 @@ export function useFileTree(rootPath: string | null, options?: Options) {
         console.error("fs_rename (move) failed:", e);
       }
     },
-    [fetchChildren, options],
+    [workspace, fetchChildren, options],
   );
 
   return {

--- a/src/modules/explorer/lib/watch.ts
+++ b/src/modules/explorer/lib/watch.ts
@@ -1,24 +1,30 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import { currentWorkspaceEnv, type WorkspaceEnv } from "@/modules/workspace";
 
 const FS_CHANGED_EVENT = "fs:changed";
 
 type FsChangedPayload = { paths: string[] };
 
-export function watchAdd(paths: string[]): void {
+export function watchAdd(
+  paths: string[],
+  workspace: WorkspaceEnv = currentWorkspaceEnv(),
+): void {
   if (paths.length === 0) return;
   void invoke("fs_watch_add", {
     paths,
-    workspace: currentWorkspaceEnv(),
+    workspace,
   }).catch(() => {});
 }
 
-export function watchRemove(paths: string[]): void {
+export function watchRemove(
+  paths: string[],
+  workspace: WorkspaceEnv = currentWorkspaceEnv(),
+): void {
   if (paths.length === 0) return;
   void invoke("fs_watch_remove", {
     paths,
-    workspace: currentWorkspaceEnv(),
+    workspace,
   }).catch(() => {});
 }
 

--- a/src/modules/spaces/lib/serialize.test.ts
+++ b/src/modules/spaces/lib/serialize.test.ts
@@ -71,6 +71,19 @@ describe("serializeTabs", () => {
       expect(node.tree.children[0]).not.toHaveProperty("active");
     }
   });
+
+  it("does not persist cwd from ssh terminal leaves", () => {
+    const [s] = serializeTabs([
+      term({
+        cwd: "/remote/project",
+        paneTree: { kind: "leaf", id: 2, cwd: "/remote/project", ssh: true },
+        ssh: true,
+      }),
+    ]);
+    const node = s as Extract<SerializedTab, { kind: "terminal" }>;
+
+    expect(node.tree).toEqual({ kind: "leaf", active: true });
+  });
 });
 
 describe("hydrateTabs", () => {

--- a/src/modules/spaces/lib/serialize.ts
+++ b/src/modules/spaces/lib/serialize.ts
@@ -41,9 +41,10 @@ function titleFromUrl(url: string): string {
 
 function serializeNode(node: PaneNode, activeLeafId: number): SerializedNode {
   if (isLeaf(node)) {
+    const cwd = node.ssh ? undefined : node.cwd;
     return {
       kind: "leaf",
-      ...(node.cwd !== undefined && { cwd: node.cwd }),
+      ...(cwd !== undefined && { cwd }),
       ...(node.id === activeLeafId && { active: true }),
     };
   }

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -8,6 +8,7 @@ import {
 import { IS_WINDOWS } from "@/lib/platform";
 import {
   LOCAL_WORKSPACE,
+  sshLabel,
   useWorkspaceEnvStore,
   type WorkspaceEnv,
 } from "@/modules/workspace";
@@ -19,8 +20,6 @@ type Props = {
 };
 
 export function WorkspaceEnvSelector({ onSelect }: Props) {
-  if (!IS_WINDOWS) return null;
-
   const env = useWorkspaceEnvStore((s) => s.env);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);
@@ -33,7 +32,14 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
     }
   };
 
-  const label = env.kind === "wsl" ? `WSL: ${env.distro}` : "Windows";
+  const label =
+    env.kind === "wsl"
+      ? `WSL: ${env.distro}`
+      : env.kind === "ssh"
+        ? `SSH: ${sshLabel(env)}`
+        : IS_WINDOWS
+          ? "Windows"
+          : "Local";
 
   return (
     <DropdownMenu onOpenChange={handleOpenChange}>
@@ -53,32 +59,40 @@ export function WorkspaceEnvSelector({ onSelect }: Props) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-48">
         <DropdownMenuItem onSelect={() => onSelect(LOCAL_WORKSPACE)}>
-          Windows Local
+          {IS_WINDOWS ? "Windows Local" : "Local"}
         </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        {distros.length === 0 ? (
-          <DropdownMenuItem disabled>
-            {loading
-              ? "Loading WSL distros..."
-              : error
-                ? "WSL unavailable"
-                : "No WSL distros found"}
-          </DropdownMenuItem>
-        ) : (
-          distros.map((distro) => (
-            <DropdownMenuItem
-              key={distro.name}
-              onSelect={() => onSelect({ kind: "wsl", distro: distro.name })}
-            >
-              WSL: {distro.name}
+        {IS_WINDOWS ? (
+          <>
+            <DropdownMenuSeparator />
+            {distros.length === 0 ? (
+              <DropdownMenuItem disabled>
+                {loading
+                  ? "Loading WSL distros..."
+                  : error
+                    ? "WSL unavailable"
+                    : "No WSL distros found"}
+              </DropdownMenuItem>
+            ) : (
+              distros.map((distro) => (
+                <DropdownMenuItem
+                  key={distro.name}
+                  onSelect={() => onSelect({ kind: "wsl", distro: distro.name })}
+                >
+                  WSL: {distro.name}
+                </DropdownMenuItem>
+              ))
+            )}
+          </>
+        ) : null}
+        {IS_WINDOWS ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => void refreshDistros()}>
+              <HugeiconsIcon icon={Refresh01Icon} size={13} strokeWidth={1.75} />
+              Refresh WSL
             </DropdownMenuItem>
-          ))
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => void refreshDistros()}>
-          <HugeiconsIcon icon={Refresh01Icon} size={13} strokeWidth={1.75} />
-          Refresh
-        </DropdownMenuItem>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/modules/tabs/lib/tabLabel.test.ts
+++ b/src/modules/tabs/lib/tabLabel.test.ts
@@ -25,9 +25,25 @@ describe("labelFor (terminal tabs)", () => {
     expect(labelFor(terminalTab({ title: "private" }))).toBe("private");
   });
 
+  it("uses SSH for an ssh terminal without a custom label", () => {
+    expect(labelFor(terminalTab({ ssh: true }))).toBe("SSH");
+    expect(
+      labelFor(
+        terminalTab({
+          paneTree: { kind: "leaf", id: 2, ssh: true },
+        }),
+      ),
+    ).toBe("SSH");
+  });
+
   it("prefers a custom title over the cwd-derived name", () => {
     expect(
-      labelFor(terminalTab({ cwd: "/Users/me/projects/terax-ai", customTitle: "Server" })),
+      labelFor(
+        terminalTab({
+          cwd: "/Users/me/projects/terax-ai",
+          customTitle: "Server",
+        }),
+      ),
     ).toBe("Server");
   });
 

--- a/src/modules/tabs/lib/tabLabel.ts
+++ b/src/modules/tabs/lib/tabLabel.ts
@@ -1,3 +1,4 @@
+import { findLeafSsh } from "@/modules/terminal/lib/panes";
 import type { Tab } from "./useTabs";
 
 /**
@@ -15,6 +16,7 @@ export function labelFor(t: Tab): string {
   if (t.kind === "git-history") return t.title;
   if (t.kind === "git-commit-file") return t.title;
   if (t.customTitle) return t.customTitle;
+  if (t.ssh || findLeafSsh(t.paneTree, t.activeLeafId)) return "SSH";
   if (!t.cwd) return t.title;
   const parts = t.cwd.split(/[\\/]/).filter(Boolean);
   return parts.length ? parts[parts.length - 1] : "/";

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1,6 +1,7 @@
 import { isMarkdownPath } from "@/lib/utils";
 import {
   findLeafCwd,
+  findLeafSsh,
   hasLeaf,
   leafIds,
   nextLeafId,
@@ -8,6 +9,7 @@ import {
   removeLeaf,
   type SplitDir,
   setLeafCwd as setLeafCwdInTree,
+  setLeafSsh as setLeafSshInTree,
   siblingLeafOf,
   splitLeaf,
 } from "@/modules/terminal/lib/panes";
@@ -28,6 +30,7 @@ export type TerminalTab = TabBase & {
   kind: "terminal";
   title: string;
   cwd?: string;
+  ssh?: boolean;
   paneTree: PaneNode;
   activeLeafId: number;
   blocks?: boolean;
@@ -881,6 +884,22 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     });
   }, []);
 
+  const setLeafSsh = useCallback((leafId: number, ssh: boolean) => {
+    setTabs((curr) => {
+      let changed = false;
+      const next = curr.map((t) => {
+        if (t.kind !== "terminal" || !hasLeaf(t.paneTree, leafId)) return t;
+        const paneTree = setLeafSshInTree(t.paneTree, leafId, ssh);
+        const isActive = t.activeLeafId === leafId;
+        const sshChanged = isActive && Boolean(t.ssh) !== ssh;
+        if (paneTree === t.paneTree && !sshChanged) return t;
+        changed = true;
+        return { ...t, paneTree, ...(sshChanged && { ssh }) };
+      });
+      return changed ? next : curr;
+    });
+  }, []);
+
   const focusPane = useCallback((tabId: number, leafId: number) => {
     setTabs((curr) =>
       curr.map((t) => {
@@ -888,9 +907,11 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         if (!hasLeaf(t.paneTree, leafId)) return t;
         if (t.activeLeafId === leafId) return t;
         const cwd = findLeafCwd(t.paneTree, leafId);
+        const ssh = findLeafSsh(t.paneTree, leafId);
         return {
           ...t,
           activeLeafId: leafId,
+          ssh,
           ...(cwd !== undefined && { cwd }),
         };
       }),
@@ -904,7 +925,13 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         const next = nextLeafId(t.paneTree, t.activeLeafId, delta);
         if (next === t.activeLeafId) return t;
         const cwd = findLeafCwd(t.paneTree, next);
-        return { ...t, activeLeafId: next, ...(cwd !== undefined && { cwd }) };
+        const ssh = findLeafSsh(t.paneTree, next);
+        return {
+          ...t,
+          activeLeafId: next,
+          ssh,
+          ...(cwd !== undefined && { cwd }),
+        };
       }),
     );
   }, []);
@@ -928,7 +955,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             dir,
             t.cwd,
           );
-          return { ...t, paneTree, activeLeafId: leafId };
+          return { ...t, paneTree, activeLeafId: leafId, ssh: false };
         }),
       );
       return newLeafId;
@@ -959,9 +986,10 @@ export function useTabs(initial?: Partial<TerminalTab>) {
         newActive = sib && remaining.includes(sib) ? sib : remaining[0];
       }
       didRemove = true;
+      const ssh = findLeafSsh(newTree, newActive);
       return curr.map((x) =>
         x.id === tab.id
-          ? { ...x, paneTree: newTree, activeLeafId: newActive }
+          ? { ...x, paneTree: newTree, activeLeafId: newActive, ssh }
           : x,
       );
     });
@@ -988,10 +1016,11 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       const remaining = leafIds(newTree);
       const sib = siblingLeafOf(t.paneTree, target);
       const newActive = sib && remaining.includes(sib) ? sib : remaining[0];
+      const ssh = findLeafSsh(newTree, newActive);
       removedLeaf = target;
       return curr.map((x) =>
         x.id === tabId
-          ? { ...x, paneTree: newTree, activeLeafId: newActive }
+          ? { ...x, paneTree: newTree, activeLeafId: newActive, ssh }
           : x,
       );
     });
@@ -1054,6 +1083,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     updateTab,
     selectByIndex,
     setLeafCwd,
+    setLeafSsh,
     focusPane,
     focusNextPaneInTab,
     splitActivePane,

--- a/src/modules/tabs/lib/useWorkspaceCwd.ts
+++ b/src/modules/tabs/lib/useWorkspaceCwd.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { WorkspaceEnv } from "@/modules/workspace";
 import type { Tab } from "./useTabs";
 
 type Result = {
@@ -10,6 +11,7 @@ export function useWorkspaceCwd(
   activeTab: Tab | undefined,
   tabs: Tab[],
   home: string | null,
+  workspaceEnv: WorkspaceEnv,
 ): Result {
   const lastTerminalCwd = useRef<string | null>(null);
 
@@ -28,12 +30,13 @@ export function useWorkspaceCwd(
   }, [activeTab, tabs, home]);
 
   const inheritedCwdForNewTab = useCallback((): string | undefined => {
+    if (workspaceEnv.kind === "ssh") return home ?? undefined;
     if (activeTab?.kind === "terminal" && activeTab.cwd) return activeTab.cwd;
     // Editor tabs inherit the last terminal's cwd (or workspace home), not
     // the file's folder — opening a new terminal from a file shouldn't
     // hijack the user's working directory context.
     return lastTerminalCwd.current ?? home ?? undefined;
-  }, [activeTab, home]);
+  }, [activeTab, home, workspaceEnv.kind]);
 
   return { explorerRoot, inheritedCwdForNewTab };
 }

--- a/src/modules/terminal/PaneTreeView.tsx
+++ b/src/modules/terminal/PaneTreeView.tsx
@@ -14,6 +14,7 @@ type LeafBundle = {
   onSearchReady: (leafId: number, addon: SearchAddon) => void;
   onCwd: (leafId: number, cwd: string) => void;
   onExit: (leafId: number, code: number) => void;
+  onSsh: (leafId: number, active: boolean) => void;
 };
 
 type Props = {
@@ -54,6 +55,7 @@ export function PaneTreeView(props: Props) {
           onSearchReady={b.onSearchReady}
           onCwd={b.onCwd}
           onExit={b.onExit}
+          onSsh={b.onSsh}
         />
         <DropOverlay leafId={node.id} />
       </div>

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -35,6 +35,7 @@ type Props = {
   onSearchReady?: (leafId: number, addon: SearchAddon) => void;
   onExit?: (leafId: number, code: number) => void;
   onCwd?: (leafId: number, cwd: string) => void;
+  onSsh?: (leafId: number, active: boolean) => void;
 };
 
 export const TerminalPane = memo(
@@ -48,6 +49,7 @@ export const TerminalPane = memo(
       onSearchReady,
       onExit,
       onCwd,
+      onSsh,
     },
     ref,
   ) {
@@ -65,6 +67,7 @@ export const TerminalPane = memo(
       onSearchReady: (a) => onSearchReady?.(leafId, a),
       onExit: (c) => onExit?.(leafId, c),
       onCwd: (c) => onCwd?.(leafId, c),
+      onSsh: (active) => onSsh?.(leafId, active),
     });
 
     useEffect(() => {

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -13,6 +13,7 @@ type Props = {
   registerHandle: (leafId: number, handle: TerminalPaneHandle | null) => void;
   onSearchReady: (leafId: number, addon: SearchAddon) => void;
   onCwd: (leafId: number, cwd: string) => void;
+  onSsh: (leafId: number, active: boolean) => void;
   onExit: (leafId: number, code: number) => void;
   onFocusLeaf: (tabId: number, leafId: number) => void;
 };
@@ -21,6 +22,7 @@ type Bundle = {
   setRef: (h: TerminalPaneHandle | null) => void;
   onSearchReady: (leafId: number, addon: SearchAddon) => void;
   onCwd: (leafId: number, cwd: string) => void;
+  onSsh: (leafId: number, active: boolean) => void;
   onExit: (leafId: number, code: number) => void;
 };
 
@@ -30,6 +32,7 @@ export function TerminalStack({
   registerHandle,
   onSearchReady,
   onCwd,
+  onSsh,
   onExit,
   onFocusLeaf,
 }: Props) {
@@ -38,6 +41,7 @@ export function TerminalStack({
   const registerRef = useRef(registerHandle);
   const searchReadyRef = useRef(onSearchReady);
   const cwdRef = useRef(onCwd);
+  const sshRef = useRef(onSsh);
   const exitRef = useRef(onExit);
   useEffect(() => {
     registerRef.current = registerHandle;
@@ -48,6 +52,9 @@ export function TerminalStack({
   useEffect(() => {
     cwdRef.current = onCwd;
   }, [onCwd]);
+  useEffect(() => {
+    sshRef.current = onSsh;
+  }, [onSsh]);
   useEffect(() => {
     exitRef.current = onExit;
   }, [onExit]);
@@ -60,6 +67,7 @@ export function TerminalStack({
         setRef: (h) => registerRef.current(leafId, h),
         onSearchReady: (id, addon) => searchReadyRef.current(id, addon),
         onCwd: (id, cwd) => cwdRef.current(id, cwd),
+        onSsh: (id, active) => sshRef.current(id, active),
         onExit: (id, code) => exitRef.current(id, code),
       };
       bundles.current.set(leafId, b);

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -7,6 +7,7 @@ export {
   leafIdForPty,
   navigateFocusedBlocks,
   respawnSession,
+  setActiveTerminalWorkspaceLeaf,
   whenSessionReady,
   writeToSession,
 } from "./lib/useTerminalSession";

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -22,7 +22,9 @@ function makeFakeTerm() {
         return { dispose: () => handlers.delete(code) };
       },
     },
-    registerMarker: vi.fn().mockReturnValue({ isDisposed: false, dispose: vi.fn() }),
+    registerMarker: vi
+      .fn()
+      .mockReturnValue({ isDisposed: false, dispose: vi.fn() }),
   } as unknown as Terminal;
   return { term, handlers };
 }
@@ -57,6 +59,22 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     handlers.get(7)?.("file://host/etc"); // attacker injection
 
     expect(onCwd).not.toHaveBeenCalled();
+  });
+
+  it("accepts OSC 7 during a command only when the caller opts in", () => {
+    const { term, handlers } = makeFakeTerm();
+    const state = createShellIntegrationState();
+    const onCwd = vi.fn();
+    registerPromptTracker(term, state);
+    registerCwdHandler(term, onCwd, state, {
+      allowDuringCommand: () => true,
+    });
+
+    handlers.get(133)?.("A");
+    handlers.get(133)?.("B");
+    handlers.get(7)?.("file://host/home/me/remote");
+
+    expect(onCwd).toHaveBeenCalledWith("/home/me/remote");
   });
 
   it("re-accepts OSC 7 after command finishes (OSC 133 D)", () => {

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -6,7 +6,7 @@ import type { IMarker, Terminal } from "@xterm/xterm";
  * command (between OSC 133 B and the next OSC 133 D / A), so the cwd handler
  * can ignore OSC 7 updates emitted by *command output* (e.g. a remote SSH
  * server, a `cat` of an attacker-controlled file). Only OSC 7 issued by the
- * local shell — which fires between commands — should be honored.
+ * local shell, which fires between commands, should be honored.
  */
 export type ShellIntegrationState = {
   inCommand: boolean;
@@ -20,13 +20,14 @@ export function registerCwdHandler(
   term: Terminal,
   onCwd: (cwd: string) => void,
   state?: ShellIntegrationState,
+  opts?: { allowDuringCommand?: () => boolean },
 ): () => void {
   const d = term.parser.registerOscHandler(7, (data) => {
     // Reject OSC 7 emitted while a command is running: command stdout/stderr
     // is untrusted (it can come from a remote shell, an SSH session, a `cat`
     // of attacker-controlled bytes). The local shell only emits OSC 7
     // between commands via its precmd/PROMPT_COMMAND hook.
-    if (state?.inCommand) return true;
+    if (state?.inCommand && !opts?.allowDuringCommand?.()) return true;
     const cwd = parseOsc7(data);
     if (cwd) onCwd(cwd);
     return true;
@@ -48,22 +49,22 @@ export function registerPromptTracker(
 ): PromptTracker {
   let marker: IMarker | null = null;
   const d = term.parser.registerOscHandler(133, (data) => {
-    // OSC 133 A — start of new prompt (between commands).
+    // OSC 133 A: start of new prompt (between commands).
     if (data.startsWith("A")) {
       if (state) state.inCommand = false;
       onCommandState?.(false);
       marker?.dispose();
       marker = term.registerMarker(0);
     } else if (data.startsWith("B")) {
-      // OSC 133 B — command begins. From here on, treat all output as
+      // OSC 133 B: command begins. From here on, treat all output as
       // untrusted until we see D (command exit) or the next A (new prompt).
       if (state) state.inCommand = true;
     } else if (data.startsWith("C")) {
-      // OSC 133 C — command pre-execution marker; still inside command.
+      // OSC 133 C: command pre-execution marker; still inside command.
       if (state) state.inCommand = true;
       onCommandState?.(true);
     } else if (data.startsWith("D")) {
-      // OSC 133 D — command ends.
+      // OSC 133 D: command ends.
       if (state) state.inCommand = false;
       onCommandState?.(false);
     }

--- a/src/modules/terminal/lib/panes.ts
+++ b/src/modules/terminal/lib/panes.ts
@@ -3,7 +3,7 @@ export type PaneId = number;
 export type SplitDir = "row" | "col";
 
 export type PaneNode =
-  | { kind: "leaf"; id: PaneId; cwd?: string }
+  | { kind: "leaf"; id: PaneId; cwd?: string; ssh?: boolean }
   | {
       kind: "split";
       id: PaneId;
@@ -11,9 +11,7 @@ export type PaneNode =
       children: PaneNode[];
     };
 
-export function isLeaf(
-  n: PaneNode,
-): n is Extract<PaneNode, { kind: "leaf" }> {
+export function isLeaf(n: PaneNode): n is Extract<PaneNode, { kind: "leaf" }> {
   return n.kind === "leaf";
 }
 
@@ -31,11 +29,12 @@ export function findLeafCwd(n: PaneNode, id: PaneId): string | undefined {
   return undefined;
 }
 
-export function setLeafCwd(
-  n: PaneNode,
-  id: PaneId,
-  cwd: string,
-): PaneNode {
+export function findLeafSsh(n: PaneNode, id: PaneId): boolean {
+  if (isLeaf(n)) return n.id === id && n.ssh === true;
+  return n.children.some((c) => findLeafSsh(c, id));
+}
+
+export function setLeafCwd(n: PaneNode, id: PaneId, cwd: string): PaneNode {
   if (isLeaf(n)) {
     if (n.id !== id || n.cwd === cwd) return n;
     return { ...n, cwd };
@@ -43,6 +42,20 @@ export function setLeafCwd(
   let changed = false;
   const next = n.children.map((c) => {
     const u = setLeafCwd(c, id, cwd);
+    if (u !== c) changed = true;
+    return u;
+  });
+  return changed ? { ...n, children: next } : n;
+}
+
+export function setLeafSsh(n: PaneNode, id: PaneId, ssh: boolean): PaneNode {
+  if (isLeaf(n)) {
+    if (n.id !== id || Boolean(n.ssh) === ssh) return n;
+    return { ...n, ssh };
+  }
+  let changed = false;
+  const next = n.children.map((c) => {
+    const u = setLeafSsh(c, id, ssh);
     if (u !== c) changed = true;
     return u;
   });
@@ -102,10 +115,7 @@ export function splitLeaf(
  * Remove a leaf and collapse single-child splits left in its wake. Returns
  * `null` when the entire subtree is gone.
  */
-export function removeLeaf(
-  tree: PaneNode,
-  targetId: PaneId,
-): PaneNode | null {
+export function removeLeaf(tree: PaneNode, targetId: PaneId): PaneNode | null {
   if (isLeaf(tree)) return tree.id === targetId ? null : tree;
   const newChildren: PaneNode[] = [];
   for (const c of tree.children) {
@@ -133,10 +143,7 @@ export function nextLeafId(
 // next sibling, fall back to the previous. Used to pick the new focus
 // when a pane closes (so focus stays in the same neighborhood instead of
 // snapping to the first pane in the tree).
-export function siblingLeafOf(
-  tree: PaneNode,
-  leafId: PaneId,
-): PaneId | null {
+export function siblingLeafOf(tree: PaneNode, leafId: PaneId): PaneId | null {
   if (isLeaf(tree)) return null;
   for (let i = 0; i < tree.children.length; i++) {
     const c = tree.children[i];

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -1,5 +1,5 @@
 import { invoke, Channel } from "@tauri-apps/api/core";
-import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { WorkspaceEnv } from "@/modules/workspace";
 
 const textEncoder = new TextEncoder();
 
@@ -19,6 +19,7 @@ export async function openPty(
   cols: number,
   rows: number,
   handlers: PtyHandlers,
+  workspace: WorkspaceEnv,
   cwd?: string,
   blocks?: boolean,
 ): Promise<PtySession> {
@@ -45,7 +46,7 @@ export async function openPty(
     cols,
     rows,
     cwd: cwd ?? null,
-    workspace: currentWorkspaceEnv(),
+    workspace,
     blocks: blocks ?? false,
     onData,
     onExit,

--- a/src/modules/terminal/lib/remoteCwd.test.ts
+++ b/src/modules/terminal/lib/remoteCwd.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { remoteCwdFromCommand } from "./remoteCwd";
+
+const ctx = {
+  current: "/home/me/project/src",
+  home: "/home/me",
+  previous: "/tmp",
+};
+
+describe("remoteCwdFromCommand", () => {
+  it("resolves simple relative and absolute cd commands", () => {
+    expect(remoteCwdFromCommand("cd ..", ctx)).toEqual({
+      cwd: "/home/me/project",
+      previous: "/home/me/project/src",
+    });
+    expect(remoteCwdFromCommand("cd /var/log", ctx)).toEqual({
+      cwd: "/var/log",
+      previous: "/home/me/project/src",
+    });
+  });
+
+  it("resolves home and previous-directory cd forms", () => {
+    expect(remoteCwdFromCommand("cd", ctx)?.cwd).toBe("/home/me");
+    expect(remoteCwdFromCommand("cd ~/repo", ctx)?.cwd).toBe("/home/me/repo");
+    expect(remoteCwdFromCommand("cd -", ctx)?.cwd).toBe("/tmp");
+  });
+
+  it("ignores unsupported or compound commands", () => {
+    expect(remoteCwdFromCommand("cd missing && ls", ctx)).toBeNull();
+    expect(remoteCwdFromCommand("pushd /tmp", ctx)).toBeNull();
+    expect(remoteCwdFromCommand("cd $PROJECT", ctx)).toBeNull();
+  });
+});

--- a/src/modules/terminal/lib/remoteCwd.ts
+++ b/src/modules/terminal/lib/remoteCwd.ts
@@ -1,0 +1,58 @@
+import { tokenizeShell } from "./sshCommand";
+
+type RemoteCwdContext = {
+  current: string | null;
+  home: string | null;
+  previous: string | null;
+};
+
+export type RemoteCwdChange = {
+  cwd: string;
+  previous: string | null;
+};
+
+export function remoteCwdFromCommand(
+  command: string,
+  ctx: RemoteCwdContext,
+): RemoteCwdChange | null {
+  const trimmed = command.trim();
+  if (!trimmed || /[;&|<>`$()]/.test(trimmed)) return null;
+  const tokens = tokenizeShell(trimmed);
+  let idx = 0;
+  if (tokens[idx] === "builtin") idx += 1;
+  if (tokens[idx] !== "cd") return null;
+  idx += 1;
+  if (tokens[idx] === "--") idx += 1;
+  if (tokens.length - idx > 1) return null;
+
+  const target = tokens[idx] ?? "~";
+  const next = resolveRemotePath(target, ctx);
+  if (!next || next === ctx.current) return null;
+  return { cwd: next, previous: ctx.current };
+}
+
+function resolveRemotePath(
+  target: string,
+  { current, home, previous }: RemoteCwdContext,
+): string | null {
+  if (target === "-") return previous;
+  if (target === "~" || target === "") return home;
+  if (target.startsWith("~/")) {
+    if (!home) return null;
+    return normalizePosixPath(`${home}/${target.slice(2)}`);
+  }
+  if (target.startsWith("~")) return null;
+  if (target.startsWith("/")) return normalizePosixPath(target);
+  if (!current) return null;
+  return normalizePosixPath(`${current}/${target}`);
+}
+
+function normalizePosixPath(path: string): string {
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") parts.pop();
+    else parts.push(part);
+  }
+  return `/${parts.join("/")}`;
+}

--- a/src/modules/terminal/lib/sshCommand.ts
+++ b/src/modules/terminal/lib/sshCommand.ts
@@ -26,9 +26,7 @@ const OPTIONS_WITH_VALUE = new Set([
   "-w",
 ]);
 
-export function parseSshWorkspaceFromCommand(
-  command: string,
-): SshEnv | null {
+export function parseSshWorkspaceFromCommand(command: string): SshEnv | null {
   const tokens = tokenizeShell(command.trim());
   if (tokens.length < 2) return null;
   let idx = 0;
@@ -98,7 +96,7 @@ function hasUnsafeSshComponent(value: string): boolean {
   return /[\s"'`$;&|<>()\u0000-\u001f\u007f]/.test(value);
 }
 
-function tokenizeShell(input: string): string[] {
+export function tokenizeShell(input: string): string[] {
   const out: string[] = [];
   let current = "";
   let quote: "'" | '"' | null = null;

--- a/src/modules/terminal/lib/sshCommand.ts
+++ b/src/modules/terminal/lib/sshCommand.ts
@@ -1,0 +1,139 @@
+import type { WorkspaceEnv } from "@/modules/workspace";
+
+type SshEnv = Extract<WorkspaceEnv, { kind: "ssh" }>;
+
+const OPTIONS_WITH_VALUE = new Set([
+  "-B",
+  "-b",
+  "-c",
+  "-D",
+  "-E",
+  "-e",
+  "-F",
+  "-I",
+  "-i",
+  "-J",
+  "-L",
+  "-l",
+  "-m",
+  "-O",
+  "-o",
+  "-p",
+  "-Q",
+  "-R",
+  "-S",
+  "-W",
+  "-w",
+]);
+
+export function parseSshWorkspaceFromCommand(
+  command: string,
+): SshEnv | null {
+  const tokens = tokenizeShell(command.trim());
+  if (tokens.length < 2) return null;
+  let idx = 0;
+  if (tokens[idx] === "exec") idx += 1;
+  if (tokens[idx] !== "ssh") return null;
+  idx += 1;
+
+  let user: string | null = null;
+  let port: number | null = null;
+  let host: string | null = null;
+
+  while (idx < tokens.length) {
+    const token = tokens[idx];
+    if (token === "--") {
+      idx += 1;
+      break;
+    }
+    if (!token.startsWith("-") || token === "-") break;
+
+    if (token.startsWith("-p") && token.length > 2) {
+      port = parsePort(token.slice(2));
+      idx += 1;
+      continue;
+    }
+    if (token.startsWith("-l") && token.length > 2) {
+      user = token.slice(2);
+      idx += 1;
+      continue;
+    }
+
+    if (OPTIONS_WITH_VALUE.has(token)) {
+      const value = tokens[idx + 1];
+      if (token === "-p") port = parsePort(value);
+      if (token === "-l") user = value ?? null;
+      idx += 2;
+      continue;
+    }
+
+    idx += 1;
+  }
+
+  const destination = tokens[idx];
+  if (!destination || destination.startsWith("-")) return null;
+  const at = destination.lastIndexOf("@");
+  if (at >= 0) {
+    user = destination.slice(0, at);
+    host = destination.slice(at + 1);
+  } else {
+    host = destination;
+  }
+
+  if (!host || hasUnsafeSshComponent(host)) return null;
+  if (user != null && (!user || hasUnsafeSshComponent(user))) return null;
+
+  return { kind: "ssh", host, user, port, root: null };
+}
+
+function parsePort(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535
+    ? parsed
+    : null;
+}
+
+function hasUnsafeSshComponent(value: string): boolean {
+  return /[\s"'`$;&|<>()\u0000-\u001f\u007f]/.test(value);
+}
+
+function tokenizeShell(input: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const ch of input) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        out.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (escaped) current += "\\";
+  if (current) out.push(current);
+  return out;
+}

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -25,9 +25,8 @@ import {
   registerPromptTracker,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
-import {
-  parseSshWorkspaceFromCommand,
-} from "./sshCommand";
+import { remoteCwdFromCommand } from "./remoteCwd";
+import { parseSshWorkspaceFromCommand } from "./sshCommand";
 import "../block/block.css";
 import { ensureAgentActivityListener, isAgentActivePty } from "./agentActivity";
 import {
@@ -108,10 +107,19 @@ type Session = {
   autoSsh: {
     env: SshEnv;
     previousCwd: string | null;
+    remoteHome: string | null;
+    trackingReady: boolean;
+    cwdCheckSeq: number;
+    previousRemoteCwd: string | null;
   } | null;
 };
 
 type SshEnv = Extract<WorkspaceEnv, { kind: "ssh" }>;
+type FileStat = {
+  kind: "file" | "dir" | "symlink";
+  size: number;
+  mtime: number;
+};
 
 const sessions = new Map<number, Session>();
 let activeWorkspaceLeafId: number | null = null;
@@ -167,8 +175,11 @@ export function submitToLeaf(leafId: number, text: string): void {
   const s = sessions.get(leafId);
   if (!s?.pty) return;
   s.everSubmitted = true;
-  const env = s.autoSsh ? null : parseSshWorkspaceFromCommand(text);
-  if (env) void activateSshWorkspace(leafId, s, env);
+  if (s.autoSsh) trackRemoteSshCommand(leafId, s, text);
+  else {
+    const env = parseSshWorkspaceFromCommand(text);
+    if (env) void activateSshWorkspace(leafId, s, env);
+  }
   // Bracketed paste keeps a multiline command atomic; trailing CR runs it.
   if (text.includes("\n")) s.pty.write(`\x1b[200~${text}\x1b[201~\r`);
   else s.pty.write(`${text}\r`);
@@ -274,7 +285,7 @@ export function blockWatermarkState(leafId: number): WatermarkState {
 
 /**
  * Clear the scrollback and screen of the currently focused terminal, keeping
- * the active prompt line — macOS Terminal's ⌘K behaviour. Returns false when no
+ * the active prompt line. Matches macOS Terminal's Cmd+K behavior. Returns false when no
  * focused terminal slot is bound (e.g. focus is in the editor or AI panel).
  */
 export function clearFocusedTerminal(): boolean {
@@ -301,17 +312,77 @@ function leafBusy(s: Session): boolean {
 
 const MAX_TRACKED_INPUT_LINE = 4096;
 
-function prepareTerminalWrite(leafId: number, s: Session, data: string): string {
-  if (s.autoSsh) return data;
-  const command = data === "\r" || data === "\n" ? s.inputLine.trim() : "";
-  const env = command ? parseSshWorkspaceFromCommand(command) : null;
-  captureTerminalInput(s, data);
-  if (!env) return data;
-  void activateSshWorkspace(leafId, s, env);
+function prepareTerminalWrite(
+  leafId: number,
+  s: Session,
+  data: string,
+): string {
+  if (s.autoSsh) {
+    captureRemoteSshInput(leafId, s, data);
+    return data;
+  }
+  const commands = captureTerminalInput(s, data);
+  for (const command of commands) {
+    const env = parseSshWorkspaceFromCommand(command);
+    if (env) void activateSshWorkspace(leafId, s, env);
+  }
   return data;
 }
 
-function captureTerminalInput(s: Session, data: string): void {
+function captureRemoteSshInput(leafId: number, s: Session, data: string): void {
+  if (!s.autoSsh?.trackingReady) return;
+  const commands = captureTerminalInput(s, data);
+  for (const command of commands) trackRemoteSshCommand(leafId, s, command);
+}
+
+function trackRemoteSshCommand(
+  leafId: number,
+  s: Session,
+  command: string,
+): void {
+  const auto = s.autoSsh;
+  if (!auto?.trackingReady) return;
+  const change = remoteCwdFromCommand(command, {
+    current: s.lastCwd,
+    home: auto.remoteHome,
+    previous: auto.previousRemoteCwd,
+  });
+  if (!change) return;
+  void validateAndApplyRemoteCwd(leafId, s, auto, change.cwd, change.previous);
+}
+
+async function validateAndApplyRemoteCwd(
+  leafId: number,
+  s: Session,
+  auto: NonNullable<Session["autoSsh"]>,
+  cwd: string,
+  previous: string | null,
+): Promise<void> {
+  const seq = ++auto.cwdCheckSeq;
+  try {
+    const stat = await invoke<FileStat>("fs_stat", {
+      path: cwd,
+      workspace: auto.env,
+    });
+    if (
+      stat.kind !== "dir" ||
+      s.disposed ||
+      sessions.get(leafId) !== s ||
+      s.autoSsh !== auto ||
+      auto.cwdCheckSeq !== seq
+    ) {
+      return;
+    }
+    auto.previousRemoteCwd = previous;
+    s.lastCwd = cwd;
+    s.callbacks.onCwd?.(cwd);
+  } catch {
+    // A failed `cd` leaves the remote shell where it was; keep the sidebar there too.
+  }
+}
+
+function captureTerminalInput(s: Session, data: string): string[] {
+  const commands: string[] = [];
   let escapeState: "prefix" | "csi" | "osc" | "oscEsc" | null = null;
   for (const ch of data) {
     if (escapeState) {
@@ -323,6 +394,8 @@ function captureTerminalInput(s: Session, data: string): void {
       continue;
     }
     if (ch === "\r" || ch === "\n") {
+      const command = s.inputLine.trim();
+      if (command) commands.push(command);
       s.inputLine = "";
       continue;
     }
@@ -338,6 +411,7 @@ function captureTerminalInput(s: Session, data: string): void {
       s.inputLine = `${s.inputLine}${ch}`.slice(-MAX_TRACKED_INPUT_LINE);
     }
   }
+  return commands;
 }
 
 function nextEscapeState(
@@ -395,7 +469,14 @@ async function activateSshWorkspace(
 ): Promise<void> {
   if (s.autoSsh && sameWorkspace(s.autoSsh.env, env)) return;
   const previousCwd = s.lastCwd ?? s.initialCwd ?? null;
-  const marker = { env, previousCwd };
+  const marker: NonNullable<Session["autoSsh"]> = {
+    env,
+    previousCwd,
+    remoteHome: null,
+    trackingReady: false,
+    cwdCheckSeq: 0,
+    previousRemoteCwd: null,
+  };
   s.autoSsh = marker;
 
   try {
@@ -405,6 +486,7 @@ async function activateSshWorkspace(
     }
     const envWithRoot = { ...env, root };
     marker.env = envWithRoot;
+    marker.remoteHome = root;
     applyWorkspaceEnvForLeaf(leafId, s);
     s.lastCwd = root;
     s.callbacks.onCwd?.(root);
@@ -432,10 +514,12 @@ async function refreshWhenSshReady(
       return;
     }
     try {
-      await getSshHome(env);
+      const home = await getSshHome(env);
       if (s.disposed || sessions.get(leafId) !== s || s.autoSsh !== marker) {
         return;
       }
+      marker.remoteHome = home;
+      marker.trackingReady = true;
       await getCurrentWebviewWindow().emit("fs:changed", { paths: [root] });
       return;
     } catch {
@@ -791,7 +875,7 @@ function bindLeafToSlot(leafId: number, s: Session): void {
           },
         ];
       }
-      // Shared in-command flag — see osc-handlers.ts. The prompt tracker
+      // Shared in-command flag. See osc-handlers.ts. The prompt tracker
       // flips it on OSC 133 B/C/D/A; the cwd handler reads it to ignore OSC
       // 7 emitted by untrusted command output (remote SSH, `cat` of an
       // attacker file, etc.).
@@ -804,10 +888,12 @@ function bindLeafToSlot(leafId: number, s: Session): void {
         (next) => {
           markSessionReady(leafId);
           if (s.lastCwd === next) return;
+          if (s.autoSsh) s.autoSsh.previousRemoteCwd = s.lastCwd;
           s.lastCwd = next;
           s.callbacks.onCwd?.(next);
         },
         shellState,
+        { allowDuringCommand: () => s.autoSsh !== null },
       );
       return [prompt.dispose, cwd];
     },

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -1,6 +1,14 @@
 import { ensureMonoFontsLoaded } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  getSshDefaultRoot,
+  getSshHome,
+  useWorkspaceEnvStore,
+  workspaceScopeKey,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import type { SearchAddon } from "@xterm/addon-search";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -16,6 +24,9 @@ import {
   registerPromptTracker,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
+import {
+  parseSshWorkspaceFromCommand,
+} from "./sshCommand";
 import "../block/block.css";
 import { ensureAgentActivityListener, isAgentActivePty } from "./agentActivity";
 import {
@@ -91,7 +102,15 @@ type Session = {
   commandRunning: boolean;
   hiddenReleaseTimer: ReturnType<typeof setTimeout> | null;
   spawnFailed: boolean;
+  inputLine: string;
+  autoSsh: {
+    env: SshEnv;
+    previousEnv: WorkspaceEnv;
+    previousCwd: string | null;
+  } | null;
 };
+
+type SshEnv = Extract<WorkspaceEnv, { kind: "ssh" }>;
 
 const sessions = new Map<number, Session>();
 
@@ -138,7 +157,7 @@ export function whenSessionReady(
 export function writeToSession(leafId: number, data: string): boolean {
   const s = sessions.get(leafId);
   if (!s?.pty) return false;
-  void s.pty.write(data);
+  void s.pty.write(prepareTerminalWrite(leafId, s, data));
   return true;
 }
 
@@ -146,13 +165,18 @@ export function submitToLeaf(leafId: number, text: string): void {
   const s = sessions.get(leafId);
   if (!s?.pty) return;
   s.everSubmitted = true;
+  const env = s.autoSsh ? null : parseSshWorkspaceFromCommand(text);
+  if (env) void activateSshWorkspace(leafId, s, env);
   // Bracketed paste keeps a multiline command atomic; trailing CR runs it.
   if (text.includes("\n")) s.pty.write(`\x1b[200~${text}\x1b[201~\r`);
   else s.pty.write(`${text}\r`);
 }
 
 export function interruptLeaf(leafId: number): void {
-  sessions.get(leafId)?.pty?.write("\x03");
+  const s = sessions.get(leafId);
+  if (!s?.pty) return;
+  s.inputLine = "";
+  s.pty.write("\x03");
 }
 
 export function leafCwd(leafId: number): string | null {
@@ -273,6 +297,141 @@ function leafBusy(s: Session): boolean {
   return s.commandRunning || (s.pty !== null && isAgentActivePty(s.pty.id));
 }
 
+const MAX_TRACKED_INPUT_LINE = 4096;
+
+function prepareTerminalWrite(leafId: number, s: Session, data: string): string {
+  if (s.autoSsh) return data;
+  const command = data === "\r" || data === "\n" ? s.inputLine.trim() : "";
+  const env = command ? parseSshWorkspaceFromCommand(command) : null;
+  captureTerminalInput(s, data);
+  if (!env) return data;
+  void activateSshWorkspace(leafId, s, env);
+  return data;
+}
+
+function captureTerminalInput(s: Session, data: string): void {
+  let escapeState: "prefix" | "csi" | "osc" | "oscEsc" | null = null;
+  for (const ch of data) {
+    if (escapeState) {
+      escapeState = nextEscapeState(escapeState, ch);
+      continue;
+    }
+    if (ch === "\x1b") {
+      escapeState = "prefix";
+      continue;
+    }
+    if (ch === "\r" || ch === "\n") {
+      s.inputLine = "";
+      continue;
+    }
+    if (ch === "\x03" || ch === "\x15") {
+      s.inputLine = "";
+      continue;
+    }
+    if (ch === "\b" || ch === "\x7f") {
+      s.inputLine = s.inputLine.slice(0, -1);
+      continue;
+    }
+    if (ch >= " " && ch !== "\x7f") {
+      s.inputLine = `${s.inputLine}${ch}`.slice(-MAX_TRACKED_INPUT_LINE);
+    }
+  }
+}
+
+function nextEscapeState(
+  state: "prefix" | "csi" | "osc" | "oscEsc",
+  ch: string,
+): "prefix" | "csi" | "osc" | "oscEsc" | null {
+  if (state === "prefix") {
+    if (ch === "[") return "csi";
+    if (ch === "]") return "osc";
+    return null;
+  }
+  if (state === "csi") return ch >= "@" && ch <= "~" ? null : "csi";
+  if (state === "osc") {
+    if (ch === "\x07") return null;
+    if (ch === "\x1b") return "oscEsc";
+    return "osc";
+  }
+  return ch === "\\" ? null : "osc";
+}
+
+function sameWorkspace(a: WorkspaceEnv, b: WorkspaceEnv): boolean {
+  if (workspaceScopeKey(a) !== workspaceScopeKey(b)) return false;
+  if (a.kind !== "ssh" || b.kind !== "ssh") return true;
+  return (a.root ?? null) === (b.root ?? null);
+}
+
+async function activateSshWorkspace(
+  leafId: number,
+  s: Session,
+  env: SshEnv,
+): Promise<void> {
+  if (s.autoSsh && sameWorkspace(s.autoSsh.env, env)) return;
+  const store = useWorkspaceEnvStore.getState();
+  const previousEnv = store.env;
+  const previousCwd = s.lastCwd ?? s.initialCwd ?? null;
+  const marker = { env, previousEnv, previousCwd };
+  s.autoSsh = marker;
+
+  try {
+    const root = await getSshDefaultRoot(env);
+    if (s.disposed || sessions.get(leafId) !== s || s.autoSsh !== marker) {
+      return;
+    }
+    const envWithRoot = { ...env, root };
+    marker.env = envWithRoot;
+    useWorkspaceEnvStore.getState().setEnv(envWithRoot);
+    s.lastCwd = root;
+    s.callbacks.onCwd?.(root);
+    void refreshWhenSshReady(leafId, s, marker, envWithRoot, root);
+  } catch (e) {
+    if (s.autoSsh === marker) {
+      s.autoSsh = null;
+      useWorkspaceEnvStore.getState().setEnv(previousEnv);
+    }
+    console.warn("[terax] failed to activate SSH workspace:", e);
+  }
+}
+
+async function refreshWhenSshReady(
+  leafId: number,
+  s: Session,
+  marker: NonNullable<Session["autoSsh"]>,
+  env: SshEnv,
+  root: string,
+): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    if (s.disposed || sessions.get(leafId) !== s || s.autoSsh !== marker) {
+      return;
+    }
+    try {
+      await getSshHome(env);
+      if (s.disposed || sessions.get(leafId) !== s || s.autoSsh !== marker) {
+        return;
+      }
+      await getCurrentWebviewWindow().emit("fs:changed", { paths: [root] });
+      return;
+    } catch {
+      // Password prompt may still be in progress; keep polling briefly.
+    }
+  }
+}
+
+function restoreAutoSshWorkspace(s: Session): void {
+  const auto = s.autoSsh;
+  if (!auto) return;
+  s.autoSsh = null;
+  const store = useWorkspaceEnvStore.getState();
+  if (sameWorkspace(store.env, auto.env)) store.setEnv(auto.previousEnv);
+  if (auto.previousCwd !== null) {
+    s.lastCwd = auto.previousCwd;
+    s.callbacks.onCwd?.(auto.previousCwd);
+  }
+}
+
 const HIDDEN_RELEASE_DELAY_MS = 300;
 
 // A parked hidden leaf went idle: give the post-command prompt a moment to
@@ -318,6 +477,7 @@ function onLeafCommandState(leafId: number, running: boolean): void {
   if (!s || s.commandRunning === running) return;
   s.commandRunning = running;
   if (!running) {
+    restoreAutoSshWorkspace(s);
     scheduleHiddenRelease(leafId, s);
     return;
   }
@@ -354,7 +514,7 @@ configureRendererPool({
           if (data.includes("\r")) void respawnSession(leafId);
           return;
         }
-        s.pty?.write(data);
+        s.pty?.write(prepareTerminalWrite(leafId, s, data));
       },
       resizePty: (cols, rows) => {
         s.cols = cols;
@@ -442,6 +602,8 @@ function ensureSession(
     commandRunning: false,
     hiddenReleaseTimer: null,
     spawnFailed: false,
+    inputLine: "",
+    autoSsh: null,
   };
   sessions.set(leafId, session);
 
@@ -511,6 +673,7 @@ async function openPtyForSession(
     {
       onData: (bytes) => deliverPtyBytes(leafId, bytes),
       onExit: (code) => {
+        restoreAutoSshWorkspace(s);
         s.shellExited = true;
         s.pty = null;
         s.commandRunning = false;
@@ -693,6 +856,7 @@ export async function respawnSession(
   s.pty = null;
   s.snapshot = null;
   s.dormantRing = new DormantRing();
+  restoreAutoSshWorkspace(s);
   s.shellExited = false;
   s.pendingExit = null;
   s.altScreenAtRelease = false;
@@ -751,6 +915,7 @@ export function disposeSession(leafId: number): void {
   if (!s) return;
   s.disposed = true;
   cancelHiddenRelease(s);
+  restoreAutoSshWorkspace(s);
   disposeLeafSlot(leafId);
   s.hasSlot = false;
   s.snapshot = null;
@@ -895,7 +1060,11 @@ export function useTerminalSession({
   }, [leafId, visible, focused, blocks]);
 
   const write = useCallback(
-    (data: string) => sessions.get(leafId)?.pty?.write(data),
+    (data: string) => {
+      const s = sessions.get(leafId);
+      if (!s?.pty) return undefined;
+      return s.pty.write(prepareTerminalWrite(leafId, s, data));
+    },
     [leafId],
   );
 

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -3,6 +3,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   getSshDefaultRoot,
   getSshHome,
+  LOCAL_WORKSPACE,
   useWorkspaceEnvStore,
   workspaceScopeKey,
   type WorkspaceEnv,
@@ -103,9 +104,9 @@ type Session = {
   hiddenReleaseTimer: ReturnType<typeof setTimeout> | null;
   spawnFailed: boolean;
   inputLine: string;
+  baseEnv: WorkspaceEnv;
   autoSsh: {
     env: SshEnv;
-    previousEnv: WorkspaceEnv;
     previousCwd: string | null;
   } | null;
 };
@@ -113,6 +114,7 @@ type Session = {
 type SshEnv = Extract<WorkspaceEnv, { kind: "ssh" }>;
 
 const sessions = new Map<number, Session>();
+let activeWorkspaceLeafId: number | null = null;
 
 // Block-overlay viewport listeners, keyed by leafId at module scope so the
 // overlay (a child) can subscribe before the parent effect creates the session.
@@ -362,16 +364,38 @@ function sameWorkspace(a: WorkspaceEnv, b: WorkspaceEnv): boolean {
   return (a.root ?? null) === (b.root ?? null);
 }
 
+function sessionWorkspaceEnv(s: Session): WorkspaceEnv {
+  return s.autoSsh?.env ?? s.baseEnv;
+}
+
+function normalizePtyBaseEnv(env: WorkspaceEnv): WorkspaceEnv {
+  return env.kind === "ssh" ? LOCAL_WORKSPACE : env;
+}
+
+function applyWorkspaceEnvForLeaf(leafId: number, s: Session): void {
+  if (activeWorkspaceLeafId !== leafId) return;
+  const next = sessionWorkspaceEnv(s);
+  const store = useWorkspaceEnvStore.getState();
+  if (!sameWorkspace(store.env, next)) {
+    store.setEnv(next.kind === "local" ? LOCAL_WORKSPACE : next);
+  }
+}
+
+export function setActiveTerminalWorkspaceLeaf(leafId: number | null): void {
+  activeWorkspaceLeafId = leafId;
+  if (leafId === null) return;
+  const s = sessions.get(leafId);
+  if (s) applyWorkspaceEnvForLeaf(leafId, s);
+}
+
 async function activateSshWorkspace(
   leafId: number,
   s: Session,
   env: SshEnv,
 ): Promise<void> {
   if (s.autoSsh && sameWorkspace(s.autoSsh.env, env)) return;
-  const store = useWorkspaceEnvStore.getState();
-  const previousEnv = store.env;
   const previousCwd = s.lastCwd ?? s.initialCwd ?? null;
-  const marker = { env, previousEnv, previousCwd };
+  const marker = { env, previousCwd };
   s.autoSsh = marker;
 
   try {
@@ -381,14 +405,14 @@ async function activateSshWorkspace(
     }
     const envWithRoot = { ...env, root };
     marker.env = envWithRoot;
-    useWorkspaceEnvStore.getState().setEnv(envWithRoot);
+    applyWorkspaceEnvForLeaf(leafId, s);
     s.lastCwd = root;
     s.callbacks.onCwd?.(root);
     void refreshWhenSshReady(leafId, s, marker, envWithRoot, root);
   } catch (e) {
     if (s.autoSsh === marker) {
       s.autoSsh = null;
-      useWorkspaceEnvStore.getState().setEnv(previousEnv);
+      applyWorkspaceEnvForLeaf(leafId, s);
     }
     console.warn("[terax] failed to activate SSH workspace:", e);
   }
@@ -420,12 +444,11 @@ async function refreshWhenSshReady(
   }
 }
 
-function restoreAutoSshWorkspace(s: Session): void {
+function restoreAutoSshWorkspace(leafId: number, s: Session): void {
   const auto = s.autoSsh;
   if (!auto) return;
   s.autoSsh = null;
-  const store = useWorkspaceEnvStore.getState();
-  if (sameWorkspace(store.env, auto.env)) store.setEnv(auto.previousEnv);
+  applyWorkspaceEnvForLeaf(leafId, s);
   if (auto.previousCwd !== null) {
     s.lastCwd = auto.previousCwd;
     s.callbacks.onCwd?.(auto.previousCwd);
@@ -477,7 +500,7 @@ function onLeafCommandState(leafId: number, running: boolean): void {
   if (!s || s.commandRunning === running) return;
   s.commandRunning = running;
   if (!running) {
-    restoreAutoSshWorkspace(s);
+    restoreAutoSshWorkspace(leafId, s);
     scheduleHiddenRelease(leafId, s);
     return;
   }
@@ -603,9 +626,11 @@ function ensureSession(
     hiddenReleaseTimer: null,
     spawnFailed: false,
     inputLine: "",
+    baseEnv: normalizePtyBaseEnv(useWorkspaceEnvStore.getState().env),
     autoSsh: null,
   };
   sessions.set(leafId, session);
+  applyWorkspaceEnvForLeaf(leafId, session);
 
   session.ready = (async () => {
     await ensureMonoFontsLoaded();
@@ -673,7 +698,7 @@ async function openPtyForSession(
     {
       onData: (bytes) => deliverPtyBytes(leafId, bytes),
       onExit: (code) => {
-        restoreAutoSshWorkspace(s);
+        restoreAutoSshWorkspace(leafId, s);
         s.shellExited = true;
         s.pty = null;
         s.commandRunning = false;
@@ -684,6 +709,7 @@ async function openPtyForSession(
         else s.pendingExit = code;
       },
     },
+    s.baseEnv,
     cwd,
     s.blocks,
   );
@@ -856,7 +882,7 @@ export async function respawnSession(
   s.pty = null;
   s.snapshot = null;
   s.dormantRing = new DormantRing();
-  restoreAutoSshWorkspace(s);
+  restoreAutoSshWorkspace(leafId, s);
   s.shellExited = false;
   s.pendingExit = null;
   s.altScreenAtRelease = false;
@@ -915,7 +941,7 @@ export function disposeSession(leafId: number): void {
   if (!s) return;
   s.disposed = true;
   cancelHiddenRelease(s);
-  restoreAutoSshWorkspace(s);
+  restoreAutoSshWorkspace(leafId, s);
   disposeLeafSlot(leafId);
   s.hasSlot = false;
   s.snapshot = null;

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -58,6 +58,7 @@ type Callbacks = {
   onSearchReady?: (addon: SearchAddon) => void;
   onExit?: (code: number) => void;
   onCwd?: (cwd: string) => void;
+  onSsh?: (active: boolean) => void;
 };
 
 type Session = {
@@ -478,6 +479,7 @@ async function activateSshWorkspace(
     previousRemoteCwd: null,
   };
   s.autoSsh = marker;
+  s.callbacks.onSsh?.(true);
 
   try {
     const root = await getSshDefaultRoot(env);
@@ -494,6 +496,7 @@ async function activateSshWorkspace(
   } catch (e) {
     if (s.autoSsh === marker) {
       s.autoSsh = null;
+      s.callbacks.onSsh?.(false);
       applyWorkspaceEnvForLeaf(leafId, s);
     }
     console.warn("[terax] failed to activate SSH workspace:", e);
@@ -532,6 +535,7 @@ function restoreAutoSshWorkspace(leafId: number, s: Session): void {
   const auto = s.autoSsh;
   if (!auto) return;
   s.autoSsh = null;
+  s.callbacks.onSsh?.(false);
   applyWorkspaceEnvForLeaf(leafId, s);
   if (auto.previousCwd !== null) {
     s.lastCwd = auto.previousCwd;
@@ -1056,6 +1060,7 @@ type Options = {
   onSearchReady?: (addon: SearchAddon) => void;
   onExit?: (code: number) => void;
   onCwd?: (cwd: string) => void;
+  onSsh?: (active: boolean) => void;
 };
 
 export function useTerminalSession({
@@ -1068,9 +1073,10 @@ export function useTerminalSession({
   onSearchReady,
   onExit,
   onCwd,
+  onSsh,
 }: Options) {
-  const cbRef = useRef({ onSearchReady, onExit, onCwd });
-  cbRef.current = { onSearchReady, onExit, onCwd };
+  const cbRef = useRef({ onSearchReady, onExit, onCwd, onSsh });
+  cbRef.current = { onSearchReady, onExit, onCwd, onSsh };
 
   // initialCwd seeds the first PTY spawn only. It must NOT be an effect dep:
   // OSC 7 updates the leaf cwd on every `cd`, and re-running the bind effect
@@ -1089,6 +1095,7 @@ export function useTerminalSession({
         onSearchReady: (a) => cbRef.current.onSearchReady?.(a),
         onExit: (c) => cbRef.current.onExit?.(c),
         onCwd: (c) => cbRef.current.onCwd?.(c),
+        onSsh: (active) => cbRef.current.onSsh?.(active),
       });
       if (s.visibleNow && s.focusedNow && !s.blocks) focusSlot(leafId);
     });

--- a/src/modules/workspace/env.ts
+++ b/src/modules/workspace/env.ts
@@ -19,84 +19,25 @@ export type WslDistro = {
   running: boolean;
 };
 
-export type SshConnection = Extract<WorkspaceEnv, { kind: "ssh" }> & {
-  id: string;
-  label: string;
-};
-
 type State = {
   env: WorkspaceEnv;
   distros: WslDistro[];
-  sshConnections: SshConnection[];
   loading: boolean;
   error: string | null;
   setEnv: (env: WorkspaceEnv) => void;
-  addSshConnection: (connection: SshConnection) => void;
-  removeSshConnection: (id: string) => void;
   refreshDistros: () => Promise<WslDistro[]>;
 };
 
 export const LOCAL_WORKSPACE: WorkspaceEnv = { kind: "local" };
-const SSH_CONNECTIONS_KEY = "terax:ssh-connections";
-
-function loadSshConnections(): SshConnection[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(SSH_CONNECTIONS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(
-      (item): item is SshConnection =>
-        item?.kind === "ssh" &&
-        typeof item.id === "string" &&
-        typeof item.host === "string" &&
-        typeof item.label === "string",
-    );
-  } catch {
-    return [];
-  }
-}
-
-function saveSshConnections(connections: SshConnection[]): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(SSH_CONNECTIONS_KEY, JSON.stringify(connections));
-  } catch {
-    /* ignore */
-  }
-}
 
 export const useWorkspaceEnvStore = create<State>((set) => ({
   env: LOCAL_WORKSPACE,
   distros: [],
-  sshConnections: loadSshConnections(),
   loading: false,
   error: null,
   setEnv: (env) => {
     set({ env });
     if (env.kind === "wsl") void setLastWslDistro(env.distro);
-  },
-  addSshConnection: (connection) => {
-    set((state) => {
-      const next = [
-        connection,
-        ...state.sshConnections.filter((item) => item.id !== connection.id),
-      ];
-      saveSshConnections(next);
-      return { sshConnections: next };
-    });
-  },
-  removeSshConnection: (id) => {
-    set((state) => {
-      const next = state.sshConnections.filter((item) => item.id !== id);
-      saveSshConnections(next);
-      const env =
-        state.env.kind === "ssh" && sshLabel(state.env) === id
-          ? LOCAL_WORKSPACE
-          : state.env;
-      return { sshConnections: next, env };
-    });
   },
   refreshDistros: async () => {
     set({ loading: true, error: null });
@@ -147,45 +88,4 @@ export function sshLabel(env: Extract<WorkspaceEnv, { kind: "ssh" }>): string {
   const user = env.user ? `${env.user}@` : "";
   const port = env.port ? `:${env.port}` : "";
   return `${user}${env.host}${port}`;
-}
-
-export function parseSshConnection(input: string): SshConnection | null {
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  const [targetRaw, rootRaw] = splitSshInput(trimmed);
-  const at = targetRaw.lastIndexOf("@");
-  const user = at >= 0 ? targetRaw.slice(0, at) : null;
-  let hostPort = at >= 0 ? targetRaw.slice(at + 1) : targetRaw;
-  let root = rootRaw;
-  const pathIdx = hostPort.indexOf(":/");
-  if (pathIdx >= 0) {
-    root = hostPort.slice(pathIdx + 1);
-    hostPort = hostPort.slice(0, pathIdx);
-  }
-  const portMatch = hostPort.match(/^(.*):(\d+)$/);
-  const host = portMatch ? portMatch[1] : hostPort;
-  const port = portMatch ? Number(portMatch[2]) : null;
-  if (!host || /\s/.test(host) || (user != null && (!user || /\s/.test(user)))) {
-    return null;
-  }
-  const env = {
-    kind: "ssh" as const,
-    host,
-    user,
-    port: port && port > 0 && port <= 65535 ? port : null,
-    root: root || null,
-  };
-  return {
-    ...env,
-    id: sshLabel(env),
-    label: sshLabel(env),
-  };
-}
-
-function splitSshInput(input: string): [string, string | null] {
-  const firstSpace = input.search(/\s/);
-  if (firstSpace < 0) return [input, null];
-  const target = input.slice(0, firstSpace).trim();
-  const root = input.slice(firstSpace).trim();
-  return [target, root || null];
 }

--- a/src/modules/workspace/env.ts
+++ b/src/modules/workspace/env.ts
@@ -4,7 +4,14 @@ import { setLastWslDistro } from "@/modules/settings/store";
 
 export type WorkspaceEnv =
   | { kind: "local" }
-  | { kind: "wsl"; distro: string };
+  | { kind: "wsl"; distro: string }
+  | {
+      kind: "ssh";
+      host: string;
+      user?: string | null;
+      port?: number | null;
+      root?: string | null;
+    };
 
 export type WslDistro = {
   name: string;
@@ -12,25 +19,84 @@ export type WslDistro = {
   running: boolean;
 };
 
+export type SshConnection = Extract<WorkspaceEnv, { kind: "ssh" }> & {
+  id: string;
+  label: string;
+};
+
 type State = {
   env: WorkspaceEnv;
   distros: WslDistro[];
+  sshConnections: SshConnection[];
   loading: boolean;
   error: string | null;
   setEnv: (env: WorkspaceEnv) => void;
+  addSshConnection: (connection: SshConnection) => void;
+  removeSshConnection: (id: string) => void;
   refreshDistros: () => Promise<WslDistro[]>;
 };
 
 export const LOCAL_WORKSPACE: WorkspaceEnv = { kind: "local" };
+const SSH_CONNECTIONS_KEY = "terax:ssh-connections";
+
+function loadSshConnections(): SshConnection[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(SSH_CONNECTIONS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item): item is SshConnection =>
+        item?.kind === "ssh" &&
+        typeof item.id === "string" &&
+        typeof item.host === "string" &&
+        typeof item.label === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveSshConnections(connections: SshConnection[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SSH_CONNECTIONS_KEY, JSON.stringify(connections));
+  } catch {
+    /* ignore */
+  }
+}
 
 export const useWorkspaceEnvStore = create<State>((set) => ({
   env: LOCAL_WORKSPACE,
   distros: [],
+  sshConnections: loadSshConnections(),
   loading: false,
   error: null,
   setEnv: (env) => {
     set({ env });
     if (env.kind === "wsl") void setLastWslDistro(env.distro);
+  },
+  addSshConnection: (connection) => {
+    set((state) => {
+      const next = [
+        connection,
+        ...state.sshConnections.filter((item) => item.id !== connection.id),
+      ];
+      saveSshConnections(next);
+      return { sshConnections: next };
+    });
+  },
+  removeSshConnection: (id) => {
+    set((state) => {
+      const next = state.sshConnections.filter((item) => item.id !== id);
+      saveSshConnections(next);
+      const env =
+        state.env.kind === "ssh" && sshLabel(state.env) === id
+          ? LOCAL_WORKSPACE
+          : state.env;
+      return { sshConnections: next, env };
+    });
   },
   refreshDistros: async () => {
     set({ loading: true, error: null });
@@ -50,7 +116,13 @@ export function currentWorkspaceEnv(): WorkspaceEnv {
 }
 
 export function workspaceScopeKey(env: WorkspaceEnv): string {
-  return env.kind === "wsl" ? `wsl:${env.distro}` : "local";
+  if (env.kind === "wsl") return `wsl:${env.distro}`;
+  if (env.kind === "ssh") {
+    const user = env.user ? `${env.user}@` : "";
+    const port = env.port ? `:${env.port}` : "";
+    return `ssh:${user}${env.host}${port}`;
+  }
+  return "local";
 }
 
 export function currentWorkspaceScopeKey(): string {
@@ -59,4 +131,61 @@ export function currentWorkspaceScopeKey(): string {
 
 export async function getWslHome(distro: string): Promise<string> {
   return invoke<string>("wsl_home", { distro });
+}
+
+export async function getSshHome(env: Extract<WorkspaceEnv, { kind: "ssh" }>): Promise<string> {
+  return invoke<string>("ssh_home", { workspace: env });
+}
+
+export async function getSshDefaultRoot(
+  env: Extract<WorkspaceEnv, { kind: "ssh" }>,
+): Promise<string> {
+  return invoke<string>("ssh_default_root", { workspace: env });
+}
+
+export function sshLabel(env: Extract<WorkspaceEnv, { kind: "ssh" }>): string {
+  const user = env.user ? `${env.user}@` : "";
+  const port = env.port ? `:${env.port}` : "";
+  return `${user}${env.host}${port}`;
+}
+
+export function parseSshConnection(input: string): SshConnection | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const [targetRaw, rootRaw] = splitSshInput(trimmed);
+  const at = targetRaw.lastIndexOf("@");
+  const user = at >= 0 ? targetRaw.slice(0, at) : null;
+  let hostPort = at >= 0 ? targetRaw.slice(at + 1) : targetRaw;
+  let root = rootRaw;
+  const pathIdx = hostPort.indexOf(":/");
+  if (pathIdx >= 0) {
+    root = hostPort.slice(pathIdx + 1);
+    hostPort = hostPort.slice(0, pathIdx);
+  }
+  const portMatch = hostPort.match(/^(.*):(\d+)$/);
+  const host = portMatch ? portMatch[1] : hostPort;
+  const port = portMatch ? Number(portMatch[2]) : null;
+  if (!host || /\s/.test(host) || (user != null && (!user || /\s/.test(user)))) {
+    return null;
+  }
+  const env = {
+    kind: "ssh" as const,
+    host,
+    user,
+    port: port && port > 0 && port <= 65535 ? port : null,
+    root: root || null,
+  };
+  return {
+    ...env,
+    id: sshLabel(env),
+    label: sshLabel(env),
+  };
+}
+
+function splitSshInput(input: string): [string, string | null] {
+  const firstSpace = input.search(/\s/);
+  if (firstSpace < 0) return [input, null];
+  const target = input.slice(0, firstSpace).trim();
+  const root = input.slice(firstSpace).trim();
+  return [target, root || null];
 }

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -5,11 +5,9 @@ export {
   getSshHome,
   getWslHome,
   LOCAL_WORKSPACE,
-  parseSshConnection,
   sshLabel,
   useWorkspaceEnvStore,
   workspaceScopeKey,
-  type SshConnection,
   type WorkspaceEnv,
   type WslDistro,
 } from "./env";

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -1,10 +1,15 @@
 export {
   currentWorkspaceScopeKey,
   currentWorkspaceEnv,
+  getSshDefaultRoot,
+  getSshHome,
   getWslHome,
   LOCAL_WORKSPACE,
+  parseSshConnection,
+  sshLabel,
   useWorkspaceEnvStore,
   workspaceScopeKey,
+  type SshConnection,
   type WorkspaceEnv,
   type WslDistro,
 } from "./env";


### PR DESCRIPTION
## What

Adds SSH-aware workspace support so a terminal session that enters SSH can update the explorer/sidebar, file operations, Git actions, tab label, and cwd tracking against the remote machine.

## Why

Terax previously treated `ssh <host>` as a normal local terminal command, so the sidebar and file/editor operations stayed tied to the local machine instead of followingthe active remote shell.

## How

  Detects SSH commands from terminal input, switches the active workspace environment to SSH, routes fs/search/git/shell operations through SSHbacked commands, and tracks remote cwd changes while the SSH session is active. It also avoids persisting remote cwd values as local terminal restore state.

  ## Testing

  - [x] `pnpm exec tsc --noEmit` clean
  - [x] Manual smoke-test of the affected feature
  - [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
  - [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
  - [x] (If UI) tested in `pnpm tauri dev`
  - [x] Platforms tested: Linux
  - [x] Shells tested (if relevant): bash

  Manual flows exercised:
  - Opened a local terminal and confirmed the explorer starts in the local workspace.
  - Ran `ssh <host-alias>` from the terminal and confirmed the active workspace switches to SSH after authentication.
  - Confirmed the sidebar follows the remote cwd and refreshes after remote `cd`.
  - Opened/read/saved remote files through the explorer/editor.
  - Switched to another terminal and confirmed it stays local unless SSH is entered there too.
  - Closed/reopened after an SSH cwd restore case and confirmed missing local cwd falls back safely.

  ## Screenshots / GIFs

  ## Notes for reviewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSH workspace support—users can now connect to and work with remote SSH hosts
  * Enabled remote file operations including read, write, search, grep, and glob on SSH servers
  * Added remote git operations support for SSH workspaces
  * Integrated SSH terminal with auto-detection of SSH commands and automatic workspace switching
  * Added SSH home directory and default root path resolution

* **Improvements**
  * File watching disabled for SSH workspaces due to remote nature
  * Enhanced terminal working directory handling for SSH sessions
  * Improved OSC handler flexibility for command tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->