### PR TITLE
feat(terminal): add osc52 clipboard handler 

### DIFF
--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -3,6 +3,7 @@ import type { Terminal } from "@xterm/xterm";
 import {
   createShellIntegrationState,
   registerCwdHandler,
+  registerOsc52ClipboardHandler,
   registerPromptTracker,
 } from "./osc-handlers";
 
@@ -122,5 +123,49 @@ describe("OSC 133 command-state tracking", () => {
     expect(onCommandState).toHaveBeenLastCalledWith(true);
     handlers.get(133)?.("A");
     expect(onCommandState).toHaveBeenLastCalledWith(false);
+  });
+});
+
+describe("OSC 52 clipboard handler", () => {
+  it("writes decoded clipboard payloads", async () => {
+    const { term, handlers } = makeFakeTerm();
+    const writeClipboard = vi.fn();
+    registerOsc52ClipboardHandler(term, writeClipboard);
+
+    await handlers.get(52)?.("c;SGVsbG8=");
+
+    expect(writeClipboard).toHaveBeenCalledWith("Hello");
+  });
+
+  it("decodes UTF-8 payloads", async () => {
+    const { term, handlers } = makeFakeTerm();
+    const writeClipboard = vi.fn();
+    registerOsc52ClipboardHandler(term, writeClipboard);
+
+    await handlers.get(52)?.("c;8J+YgCBtZXJoYWJh");
+
+    expect(writeClipboard).toHaveBeenCalledWith("😀 merhaba");
+  });
+
+  it("ignores clipboard queries and malformed payloads", async () => {
+    const { term, handlers } = makeFakeTerm();
+    const writeClipboard = vi.fn();
+    registerOsc52ClipboardHandler(term, writeClipboard);
+
+    await handlers.get(52)?.("c;?");
+    await handlers.get(52)?.("c;not base64!");
+    await handlers.get(52)?.("s;SGVsbG8=");
+
+    expect(writeClipboard).not.toHaveBeenCalled();
+  });
+
+  it("ignores oversized payloads", async () => {
+    const { term, handlers } = makeFakeTerm();
+    const writeClipboard = vi.fn();
+    registerOsc52ClipboardHandler(term, writeClipboard);
+
+    await handlers.get(52)?.(`c;${"A".repeat(1_398_110)}`);
+
+    expect(writeClipboard).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -28,6 +28,10 @@ function makeFakeTerm() {
   return { term, handlers };
 }
 
+async function flushClipboardQueue() {
+  await Promise.resolve();
+}
+
 describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
   it("accepts OSC 7 when no command is running", () => {
     const { term, handlers } = makeFakeTerm();
@@ -132,8 +136,10 @@ describe("OSC 52 clipboard handler", () => {
     const writeClipboard = vi.fn();
     registerOsc52ClipboardHandler(term, writeClipboard);
 
-    await handlers.get(52)?.("c;SGVsbG8=");
+    const result = handlers.get(52)?.("c;SGVsbG8=");
+    await flushClipboardQueue();
 
+    expect(result).toBe(true);
     expect(writeClipboard).toHaveBeenCalledWith("Hello");
   });
 
@@ -142,9 +148,34 @@ describe("OSC 52 clipboard handler", () => {
     const writeClipboard = vi.fn();
     registerOsc52ClipboardHandler(term, writeClipboard);
 
-    await handlers.get(52)?.("c;8J+YgCBtZXJoYWJh");
+    handlers.get(52)?.("c;8J+YgCBtZXJoYWJh");
+    await flushClipboardQueue();
 
     expect(writeClipboard).toHaveBeenCalledWith("😀 merhaba");
+  });
+
+  it("does not block the parser on clipboard writes", async () => {
+    const { term, handlers } = makeFakeTerm();
+    const writeClipboard = vi.fn(() => new Promise<void>(() => {}));
+    registerOsc52ClipboardHandler(term, writeClipboard);
+
+    const result = handlers.get(52)?.("c;SGVsbG8=");
+
+    expect(result).toBe(true);
+    expect(writeClipboard).not.toHaveBeenCalled();
+    await flushClipboardQueue();
+    expect(writeClipboard).toHaveBeenCalledWith("Hello");
+  });
+
+  it("ignores primary-selection-only payloads", async () => {
+    const { term, handlers } = makeFakeTerm();
+    const writeClipboard = vi.fn();
+    registerOsc52ClipboardHandler(term, writeClipboard);
+
+    await handlers.get(52)?.("p;SGVsbG8=");
+    await flushClipboardQueue();
+
+    expect(writeClipboard).not.toHaveBeenCalled();
   });
 
   it("ignores clipboard queries and malformed payloads", async () => {
@@ -155,6 +186,7 @@ describe("OSC 52 clipboard handler", () => {
     await handlers.get(52)?.("c;?");
     await handlers.get(52)?.("c;not base64!");
     await handlers.get(52)?.("s;SGVsbG8=");
+    await flushClipboardQueue();
 
     expect(writeClipboard).not.toHaveBeenCalled();
   });
@@ -165,6 +197,7 @@ describe("OSC 52 clipboard handler", () => {
     registerOsc52ClipboardHandler(term, writeClipboard);
 
     await handlers.get(52)?.(`c;${"A".repeat(1_398_110)}`);
+    await flushClipboardQueue();
 
     expect(writeClipboard).not.toHaveBeenCalled();
   });

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -1,5 +1,7 @@
 import type { IMarker, Terminal } from "@xterm/xterm";
 
+const MAX_OSC52_CLIPBOARD_BYTES = 1024 * 1024;
+
 /**
  * Cross-handler state shared between the OSC 7 cwd handler and the OSC 133
  * prompt-marker handler. Tracks whether we are currently inside a running
@@ -79,6 +81,23 @@ export function registerPromptTracker(
   };
 }
 
+export type ClipboardWriter = (text: string) => void | Promise<void>;
+
+export function registerOsc52ClipboardHandler(
+  term: Terminal,
+  writeClipboard: ClipboardWriter = writeSystemClipboard,
+): () => void {
+  const d = term.parser.registerOscHandler(52, async (data) => {
+    const text = parseOsc52Clipboard(data);
+    if (text === null) return true;
+    try {
+      await writeClipboard(text);
+    } catch {}
+    return true;
+  });
+  return () => d.dispose();
+}
+
 function parseOsc7(data: string): string | null {
   const m = data.match(/^file:\/\/[^/]*(\/.*)$/);
   if (!m) return null;
@@ -89,4 +108,30 @@ function parseOsc7(data: string): string | null {
   // /C:/Users/foo -> C:/Users/foo so it's a valid Windows path.
   if (/^\/[A-Za-z]:/.test(path)) path = path.slice(1);
   return path;
+}
+
+function parseOsc52Clipboard(data: string): string | null {
+  const parts = data.split(";");
+  if (parts.length < 2) return null;
+  const selection = parts[0] || "c";
+  if (!selection.includes("c") && !selection.includes("p")) return null;
+  const encoded = parts.slice(1).join(";");
+  if (!encoded || encoded === "?") return null;
+  if (encoded.length > Math.ceil((MAX_OSC52_CLIPBOARD_BYTES * 4) / 3) + 4) {
+    return null;
+  }
+  const compact = encoded.replace(/\s/g, "");
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(compact)) return null;
+
+  try {
+    const bytes = Uint8Array.from(atob(compact), (c) => c.charCodeAt(0));
+    if (bytes.byteLength > MAX_OSC52_CLIPBOARD_BYTES) return null;
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+async function writeSystemClipboard(text: string): Promise<void> {
+  await navigator.clipboard.writeText(text);
 }

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -87,12 +87,14 @@ export function registerOsc52ClipboardHandler(
   term: Terminal,
   writeClipboard: ClipboardWriter = writeSystemClipboard,
 ): () => void {
-  const d = term.parser.registerOscHandler(52, async (data) => {
+  const d = term.parser.registerOscHandler(52, (data) => {
     const text = parseOsc52Clipboard(data);
     if (text === null) return true;
-    try {
-      await writeClipboard(text);
-    } catch {}
+    queueMicrotask(() => {
+      try {
+        void Promise.resolve(writeClipboard(text)).catch(() => {});
+      } catch {}
+    });
     return true;
   });
   return () => d.dispose();
@@ -114,7 +116,7 @@ function parseOsc52Clipboard(data: string): string | null {
   const parts = data.split(";");
   if (parts.length < 2) return null;
   const selection = parts[0] || "c";
-  if (!selection.includes("c") && !selection.includes("p")) return null;
+  if (!selection.includes("c")) return null;
   const encoded = parts.slice(1).join(";");
   if (!encoded || encoded === "?") return null;
   if (encoded.length > Math.ceil((MAX_OSC52_CLIPBOARD_BYTES * 4) / 3) + 4) {

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -13,6 +13,7 @@ import { DormantRing } from "./dormantRing";
 import {
   createShellIntegrationState,
   registerCwdHandler,
+  registerOsc52ClipboardHandler,
   registerPromptTracker,
 } from "./osc-handlers";
 import { openPty, type PtySession } from "./pty-bridge";
@@ -596,6 +597,7 @@ function bindLeafToSlot(leafId: number, s: Session): void {
     rows: s.rows,
     registerOsc: (term) => {
       if (s.blocks) {
+        const osc52 = registerOsc52ClipboardHandler(term);
         const deco = new BlockDecorations(term, {
           onCwd: (next) => {
             markSessionReady(leafId);
@@ -617,6 +619,7 @@ function bindLeafToSlot(leafId: number, s: Session): void {
         return [
           () => {
             s.blockDecorations = null;
+            osc52();
             deco.dispose();
             term.textarea?.removeEventListener("focus", onGridFocus);
           },
@@ -640,7 +643,8 @@ function bindLeafToSlot(leafId: number, s: Session): void {
         },
         shellState,
       );
-      return [prompt.dispose, cwd];
+      const osc52 = registerOsc52ClipboardHandler(term);
+      return [prompt.dispose, cwd, osc52];
     },
     onSearchReady: (addon) => s.callbacks.onSearchReady?.(addon),
   });


### PR DESCRIPTION
## What

Adds OSC52 clipboard handling to Terax terminals so terminal apps like Claude Code can copy text through terminal escape sequences.

  ## Why

Claude Code emits OSC52 copy sequences, but Terax was not handling OSC52, so copy actions appeared to run but nothing reached the system clipboard.

  ## How

  Registers an OSC52 handler in the shared terminal OSC handling path, decodes valid base64 clipboard payloads, writes them to the clipboard, and ignores malformed, query, non-clipboard, or oversized payloads.

  ## Testing

  - [x] `pnpm exec tsc --noEmit` clean
  - [ ] Manual smoke-test of the affected feature
  - [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
  - [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
  - [ ] (If UI) tested in `pnpm tauri dev`
  - [x] Platforms tested: Linux/Claude Code
  - [ ] Shells tested (if relevant): Not manually tested

  Additional checks run:

  - `pnpm test -- src/modules/terminal/lib/osc-handlers.test.ts`
  - `pnpm check-types`
  - 
  ## Screenshots / GIFs

  ## Notes for reviewer

  This is specifically to support Claude Code's OSC52 copy behavior in the terminal. The handler is generic OSC52 support, so it should also help other terminal programs that use the same protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OSC 52 clipboard protocol support to the terminal, including validated payload parsing, UTF-8 decoding, and a maximum decoded-size cap.
  * Integrated the clipboard handler into terminal session lifecycle so it initializes per terminal and cleans up appropriately.

* **Tests**
  * Added coverage for valid Base64 payloads (including UTF-8), correct selection handling, rejection of malformed/unsupported payloads, and oversized payload protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->