### PR TITLE
fix(explorer): empty file tree on rapid root change

### DIFF
--- a/src/modules/explorer/lib/useFileTree.ts
+++ b/src/modules/explorer/lib/useFileTree.ts
@@ -202,6 +202,12 @@ export function useFileTree(rootPath: string | null, options?: Options) {
     const restored = recallExpansion(rootPath);
     setExpanded(new Set(restored));
     setNodes({});
+    // Sync the ref synchronously: nodesRef only updates after the next render,
+    // so without this a fast (cached) fetchChildren below would read the stale
+    // pre-clear "loaded" node, hit the sameDirListing early-return, and skip
+    // re-populating — leaving a valid root with an empty tree when rootPath
+    // changes rapidly (e.g. switching folders in quick succession).
+    nodesRef.current = {};
 
     const toWatch = [rootPath, ...restored];
     void fetchChildren(rootPath);


### PR DESCRIPTION
## What
The file explorer can render a valid directory as an empty tree when the
root path changes rapidly (e.g. switching folders in quick succession).

## Why
On a root change the effect clears node state via `setNodes({})`, but the
ref mirror (`nodesRef`) only updates after the next render. A fast (cached)
`fetchChildren` then reads the stale, pre-clear "loaded" node, hits the
`sameDirListing` early-return, and skips re-populating — leaving a valid
root rendered as an empty tree.

## How
Clear `nodesRef` synchronously alongside `setNodes({})`, so an in-flight
`fetchChildren` sees the cleared state and repopulates.

## Testing
- Manually reproduced by switching the explorer root between two folders in
  quick succession; the second folder intermittently rendered empty before
  the fix, and consistently populates after it.
- `pnpm exec tsc --noEmit` clean. One-file, six-line change; no API surface
  touched.

- [x] `tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] Platforms tested: macOS

## Notes for reviewer
Timing fix in a React effect (ref-vs-state ordering). Happy to add a test
that locks the "rapid root change repopulates" invariant if you'd prefer the
contract pinned — it needs a `renderHook` + mocked `fetchChildren` harness,
so I left it out of this narrow fix but can add it on request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file explorer tree not displaying contents correctly when switching to a different root directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->