### PR TITLE
feat(terminal): smart Ctrl+C/Ctrl+V copy/paste

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -145,6 +145,7 @@ export type Preferences = {
   explorerGitDecorations: boolean;
   terminalWebglEnabled: boolean;
   terminalCursorBlink: boolean;
+  terminalSmartCopyPaste: boolean;
   terminalFontFamily: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
@@ -194,6 +195,7 @@ const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_EXPLORER_GIT_DECORATIONS = "explorerGitDecorations";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_CURSOR_BLINK = "terminalCursorBlink";
+const KEY_TERMINAL_SMART_COPY_PASTE = "terminalSmartCopyPaste";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
@@ -256,6 +258,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   explorerGitDecorations: true,
   terminalWebglEnabled: true,
   terminalCursorBlink: false,
+  terminalSmartCopyPaste: true,
   terminalFontFamily: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
@@ -390,6 +393,9 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalCursorBlink:
       get<boolean>(KEY_TERMINAL_CURSOR_BLINK) ??
       DEFAULT_PREFERENCES.terminalCursorBlink,
+    terminalSmartCopyPaste:
+      get<boolean>(KEY_TERMINAL_SMART_COPY_PASTE) ??
+      DEFAULT_PREFERENCES.terminalSmartCopyPaste,
     terminalFontFamily:
       get<string>(KEY_TERMINAL_FONT_FAMILY) ??
       DEFAULT_PREFERENCES.terminalFontFamily,
@@ -587,6 +593,10 @@ export async function setTerminalCursorBlink(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_CURSOR_BLINK, value);
 }
 
+export async function setTerminalSmartCopyPaste(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_SMART_COPY_PASTE, value);
+}
+
 export async function setTerminalFontFamily(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_FAMILY, value.trim());
 }
@@ -695,6 +705,7 @@ export async function onPreferencesChange(
     [KEY_EXPLORER_GIT_DECORATIONS]: "explorerGitDecorations",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_CURSOR_BLINK]: "terminalCursorBlink",
+    [KEY_TERMINAL_SMART_COPY_PASTE]: "terminalSmartCopyPaste",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",

--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -236,6 +236,20 @@ describe("terminalClipboardIntent", () => {
     ).toBe("paste");
   });
 
+  it("keys off physical position so Ctrl+C/V work on non-Latin layouts", () => {
+    // Russian layout: the physical C/V keys report code KeyC/KeyV but produce
+    // key "с"/"м" (Cyrillic). event.code is what keeps the shortcuts working.
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyC", key: "с" }),
+        opts({ hasSelection: true }),
+      ),
+    ).toBe("copy");
+    expect(
+      terminalClipboardIntent(evt({ ctrlKey: true, code: "KeyV", key: "м" }), opts({})),
+    ).toBe("paste");
+  });
+
   it("ignores Ctrl+Alt combos (AltGr) and other keys", () => {
     expect(
       terminalClipboardIntent(

--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  terminalClipboardIntent,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
   terminalWordNavigationSequence,
@@ -11,6 +12,7 @@ const evt = (partial: Partial<TerminalKeyEvent>): TerminalKeyEvent => ({
   altKey: false,
   ctrlKey: false,
   metaKey: false,
+  shiftKey: false,
   key: "",
   code: "",
   ...partial,
@@ -131,6 +133,120 @@ describe("terminalDeleteSequence", () => {
       terminalDeleteSequence(
         evt({ key: "Backspace", code: "Backspace" }),
         { isMac: true },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("terminalClipboardIntent", () => {
+  const opts = (over: Partial<Parameters<typeof terminalClipboardIntent>[1]>) => ({
+    isMac: false,
+    smartCopyPaste: true,
+    hasSelection: false,
+    ...over,
+  });
+
+  it("copies on Ctrl+Shift+C regardless of smart mode", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, shiftKey: true, code: "KeyC", key: "c" }),
+        opts({ smartCopyPaste: false }),
+      ),
+    ).toBe("copy");
+  });
+
+  it("pastes on Ctrl+Shift+V regardless of smart mode", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, shiftKey: true, code: "KeyV", key: "v" }),
+        opts({ smartCopyPaste: false }),
+      ),
+    ).toBe("paste");
+  });
+
+  it("smart Ctrl+C copies when there is a selection", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyC", key: "c" }),
+        opts({ hasSelection: true }),
+      ),
+    ).toBe("copy");
+  });
+
+  it("smart Ctrl+C passes through (SIGINT) with no selection", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyC", key: "c" }),
+        opts({ hasSelection: false }),
+      ),
+    ).toBeNull();
+  });
+
+  it("smart Ctrl+V pastes", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyV", key: "v" }),
+        opts({}),
+      ),
+    ).toBe("paste");
+  });
+
+  it("does not intercept Ctrl+C when smart mode is off", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyC", key: "c" }),
+        opts({ smartCopyPaste: false, hasSelection: true }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not intercept Ctrl+V when smart mode is off", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyV", key: "v" }),
+        opts({ smartCopyPaste: false }),
+      ),
+    ).toBeNull();
+  });
+
+  it("never intercepts on macOS (Ctrl+C stays SIGINT)", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, shiftKey: true, code: "KeyC", key: "c" }),
+        opts({ isMac: true, hasSelection: true }),
+      ),
+    ).toBeNull();
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyC", key: "c" }),
+        opts({ isMac: true, hasSelection: true }),
+      ),
+    ).toBeNull();
+  });
+
+  it("matches the uppercase key form (Shift/CapsLock report 'C'/'V')", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, key: "C" }),
+        opts({ hasSelection: true }),
+      ),
+    ).toBe("copy");
+    expect(
+      terminalClipboardIntent(evt({ ctrlKey: true, key: "V" }), opts({})),
+    ).toBe("paste");
+  });
+
+  it("ignores Ctrl+Alt combos (AltGr) and other keys", () => {
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, altKey: true, code: "KeyC", key: "c" }),
+        opts({ hasSelection: true }),
+      ),
+    ).toBeNull();
+    expect(
+      terminalClipboardIntent(
+        evt({ ctrlKey: true, code: "KeyX", key: "x" }),
+        opts({ hasSelection: true }),
       ),
     ).toBeNull();
   });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -1,6 +1,6 @@
 export type TerminalKeyEvent = Pick<
   KeyboardEvent,
-  "altKey" | "ctrlKey" | "metaKey" | "key" | "code"
+  "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "key" | "code"
 >;
 
 export type PlatformOpts = { isMac: boolean };
@@ -42,4 +42,44 @@ export function terminalDeleteSequence(
   }
   if (event.ctrlKey && !event.altKey && !event.metaKey) return "\x17";
   return null;
+}
+
+export type TerminalClipboardIntent = "copy" | "paste";
+
+export type ClipboardOpts = {
+  isMac: boolean;
+  /** Windows-Terminal-style no-Shift copy/paste (default on, toggleable). */
+  smartCopyPaste: boolean;
+  hasSelection: boolean;
+};
+
+/**
+ * Decide whether a key event is a terminal clipboard action.
+ *
+ * Ctrl+Shift+C / Ctrl+Shift+V always copy/paste; those combos never collide
+ * with the shell, so they work regardless of the smart-mode preference.
+ *
+ * Smart mode (Windows-Terminal style, on by default):
+ *   Ctrl+C → "copy" only when text is selected; with no selection it returns
+ *            null so the SIGINT (\x03) reaches the shell unchanged.
+ *   Ctrl+V → "paste".
+ *
+ * macOS owns Cmd+C/Cmd+V natively and keeps Ctrl+C as SIGINT, so this returns
+ * null there and never shadows the interrupt.
+ */
+export function terminalClipboardIntent(
+  event: TerminalKeyEvent,
+  opts: ClipboardOpts,
+): TerminalClipboardIntent | null {
+  if (opts.isMac) return null;
+  if (!event.ctrlKey || event.altKey || event.metaKey) return null;
+  const isC = event.code === "KeyC" || event.key === "c" || event.key === "C";
+  const isV = event.code === "KeyV" || event.key === "v" || event.key === "V";
+  if (!isC && !isV) return null;
+
+  if (event.shiftKey) return isC ? "copy" : "paste";
+
+  if (!opts.smartCopyPaste) return null;
+  if (isV) return "paste";
+  return opts.hasSelection ? "copy" : null;
 }

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -73,8 +73,10 @@ export function terminalClipboardIntent(
 ): TerminalClipboardIntent | null {
   if (opts.isMac) return null;
   if (!event.ctrlKey || event.altKey || event.metaKey) return null;
-  const isC = event.code === "KeyC" || event.key === "c" || event.key === "C";
-  const isV = event.code === "KeyV" || event.key === "v" || event.key === "V";
+  // Match physical position (event.code) as well as the character so Ctrl+C/V
+  // work on non-Latin layouts (e.g. Cyrillic) where event.key is not "c"/"v".
+  const isC = event.code === "KeyC" || event.key.toLowerCase() === "c";
+  const isV = event.code === "KeyV" || event.key.toLowerCase() === "v";
   if (!isC && !isV) return null;
 
   if (event.shiftKey) return isC ? "copy" : "paste";

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -10,6 +10,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import { shouldCursorBlink } from "./cursorBlink";
 import {
+  terminalClipboardIntent,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
   terminalWordNavigationSequence,
@@ -76,6 +77,8 @@ let windowActive =
   typeof document === "undefined" || (!document.hidden && document.hasFocus());
 let windowActivityBound = false;
 let cursorBlinkEnabled = false;
+// Default matches the preference default; the real value is pushed on mount.
+let smartCopyPaste = true;
 
 function bindWindowActivityListeners(): void {
   if (windowActivityBound || typeof window === "undefined") return;
@@ -273,15 +276,23 @@ function createSlot(): Slot {
       if (event.type === "keydown") bridge.writeToPty("\x1b\r");
       return false;
     }
-    if (isTerminalCopy(event)) {
-      if (event.type === "keydown" && slot.term.hasSelection()) {
+    const clipboard = terminalClipboardIntent(event, {
+      isMac: IS_MAC,
+      smartCopyPaste,
+      hasSelection: slot.term.hasSelection(),
+    });
+    if (clipboard === "copy") {
+      if (event.type === "keydown") {
         const sel = slot.term.getSelection();
         if (sel) void navigator.clipboard.writeText(sel).catch(() => {});
+        // Smart (no-Shift) copy clears the highlight so a second Ctrl+C
+        // interrupts instead of re-copying. Ctrl+Shift+C keeps the selection.
+        if (!event.shiftKey) slot.term.clearSelection();
       }
       event.preventDefault();
       return false;
     }
-    if (isTerminalPaste(event)) {
+    if (clipboard === "paste") {
       if (event.type === "keydown") {
         void navigator.clipboard
           .readText()
@@ -943,6 +954,10 @@ export function setSlotFocused(leafId: number, focused: boolean): void {
   applyCursorBlinkOnSlot(slot, focused);
 }
 
+export function applySmartCopyPaste(enabled: boolean): void {
+  smartCopyPaste = enabled;
+}
+
 export function applyCursorBlink(enabled: boolean): void {
   cursorBlinkEnabled = enabled;
   for (const slot of slots) {
@@ -1033,28 +1048,6 @@ export function getLiveSlotForLeaf(leafId: number): Slot | null {
 const IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad/.test(navigator.userAgent);
-
-function isTerminalCopy(e: KeyboardEvent): boolean {
-  return (
-    !IS_MAC &&
-    e.ctrlKey &&
-    e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyC" || e.key === "c" || e.key === "C")
-  );
-}
-
-function isTerminalPaste(e: KeyboardEvent): boolean {
-  return (
-    !IS_MAC &&
-    e.ctrlKey &&
-    e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyV" || e.key === "v" || e.key === "V")
-  );
-}
 
 function isShiftEnter(e: KeyboardEvent): boolean {
   return (

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -28,6 +28,7 @@ import {
   applyLetterSpacing,
   applyTheme as applyPoolTheme,
   applyScrollback,
+  applySmartCopyPaste,
   applyWebglPreference,
   configureRendererPool,
   discardRetainedSlot,
@@ -899,6 +900,11 @@ export function useTerminalSession({
   useEffect(() => {
     applyCursorBlink(cursorBlink);
   }, [cursorBlink]);
+
+  const smartCopyPaste = usePreferencesStore((p) => p.terminalSmartCopyPaste);
+  useEffect(() => {
+    applySmartCopyPaste(smartCopyPaste);
+  }, [smartCopyPaste]);
 
   const bgActive = usePreferencesStore(
     (p) => p.backgroundKind === "image" && !!p.backgroundImageId,

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -14,6 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { ThemePref } from "@/modules/settings/store";
@@ -32,6 +33,7 @@ import {
   setTerminalFontSize,
   setTerminalCursorBlink,
   setTerminalScrollback,
+  setTerminalSmartCopyPaste,
   setTerminalWebglEnabled,
   setVimMode,
   setZoomLevel,
@@ -83,6 +85,9 @@ export function GeneralSection() {
   );
   const terminalCursorBlink = usePreferencesStore(
     (s) => s.terminalCursorBlink,
+  );
+  const terminalSmartCopyPaste = usePreferencesStore(
+    (s) => s.terminalSmartCopyPaste,
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalLetterSpacing = usePreferencesStore(
@@ -268,6 +273,17 @@ export function GeneralSection() {
             onCheckedChange={(v) => void setTerminalCursorBlink(v)}
           />
         </SettingRow>
+        {!IS_MAC && (
+          <SettingRow
+            title="Smart copy / paste"
+            description="When on, Ctrl+C copies the selection (and only interrupts when nothing is selected) and Ctrl+V pastes. When off, Ctrl+C always interrupts. Ctrl+Shift+C / Ctrl+Shift+V copy and paste either way."
+          >
+            <Switch
+              checked={terminalSmartCopyPaste}
+              onCheckedChange={(v) => void setTerminalSmartCopyPaste(v)}
+            />
+          </SettingRow>
+        )}
         <FontFamilyInput
           value={terminalFontFamily}
           onCommit={(v) => void setTerminalFontFamily(v)}


### PR DESCRIPTION
## What
Adds Windows-Terminal-style clipboard behavior in the terminal on Windows and Linux: Ctrl+C copies the selection when text is selected and otherwise sends SIGINT, and Ctrl+V pastes. Ctrl+Shift+C / Ctrl+Shift+V keep copying/pasting unconditionally. Gated behind a new `terminalSmartCopyPaste` setting (default on).

## Why
Closes #607. On Windows/Linux, Ctrl+C only sent SIGINT and Ctrl+V inserted a literal control char, so the clipboard required Ctrl+Shift+C/V. This matches what people expect from Windows Terminal while keeping Ctrl+C as a reliable interrupt when nothing is selected.

## How
- New pure function `terminalClipboardIntent(event, opts)` in `terminal/lib/keymap.ts` returns `"copy" | "paste" | null` from the key event, the preference, and whether there is a selection. Unit-tested.
- `terminal/lib/rendererPool.ts` calls it inside the existing `attachCustomKeyEventHandler` and acts on the result; the old `isTerminalCopy`/`isTerminalPaste` helpers are removed. A smart (no-Shift) copy clears the selection so a second Ctrl+C interrupts; Ctrl+Shift+C keeps the selection.
- Preference `terminalSmartCopyPaste` is plumbed through `settings/store.ts` and pushed to the pool via `applySmartCopyPaste` in `useTerminalSession.ts`, mirroring the existing cursor-blink/webgl wiring.
- Settings toggle under General > Terminal (hidden on macOS).
- No new dependencies and no IPC: paste reuses the same `navigator.clipboard` path Ctrl+Shift+V already used.

macOS is intentionally untouched: Cmd+C/Cmd+V stay native and Ctrl+C stays SIGINT, so the logic early-returns there.

## Testing
Added `terminalClipboardIntent` unit tests (macOS no-op, Ctrl+Shift+C/V, smart Ctrl+C with/without selection, smart Ctrl+V, smart-off, AltGr/other-key, uppercase key form). Manually exercised in `pnpm tauri dev` on Windows/pwsh: selection + Ctrl+C copies and clears the highlight; Ctrl+C with no selection interrupts a running command; Ctrl+V pastes; Ctrl+Shift+C/V still work; toggling the setting off restores Ctrl+C-always-interrupts live.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test`/`clippy` -- N/A, no Rust changes
- [x] (If you changed a `#[tauri::command]` signature) -- N/A
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows (Linux shares the same non-mac path; macOS is a no-op by design)
- [x] Shells tested: pwsh / powershell

## Screenshots / GIFs
The only new on-screen UI is the settings toggle (General > Terminal):

<img width="902" height="702" alt="image" src="https://github.com/user-attachments/assets/2402e280-e111-4bd9-9182-dcefb83e2554" />

The rest of the change is keyboard behavior (Ctrl+C / Ctrl+V / Ctrl+Shift+C / Ctrl+Shift+V), which a recording cannot show meaningfully without a keystroke overlay; the exact flows are in Testing above.

## Notes for reviewer
- Default is **on** to match Windows Terminal and #607. This changes default behavior on Windows/Linux, but only in the narrow case of pressing Ctrl+C while text is selected. Happy to flip to opt-in (default off) if you would prefer no behavior change on update.
- Kept paste on `navigator.clipboard` (no `tauri-plugin-clipboard-manager`) to avoid a new dependency and per-paste IPC, consistent with the existing Ctrl+Shift+V code and the OSC 52 handler. On WebView2 the first `readText()` shows a one-time clipboard-read permission prompt; that is pre-existing (Ctrl+Shift+V hit it too) and out of scope here.
- The empty `.catch(() => {})` on clipboard read/write matches the existing pattern in this file and `osc-handlers.ts`; left as-is for consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Smart copy / paste** terminal setting in **General** that controls clipboard behavior for Ctrl-based copy/paste shortcuts.
  * When enabled, Ctrl+V always triggers paste, and Ctrl+C triggers copy only when text is selected; Shift+Ctrl/Cmd versions always perform copy/paste.
  * The setting is not available on macOS.

* **Tests**
  * Expanded clipboard-intent detection tests to cover smart vs non-smart modes, selection gating, macOS-specific behavior, non-Latin layouts, and additional key-combination edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->