### PR TITLE
fix(command-palette): use data-checked for theme selection tick instead of manual icon

### DIFF
--- a/src/modules/command-palette/CommandPalette.tsx
+++ b/src/modules/command-palette/CommandPalette.tsx
@@ -21,7 +21,6 @@ import {
   AlertCircleIcon,
   ArrowTurnBackwardIcon,
   CommandIcon,
-  Tick02Icon,
   TerminalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -254,16 +253,9 @@ export function CommandPalette({
                     value={`theme:${t.id}`}
                     onSelect={() => commitTheme(t.id)}
                     className="text-[12.5px]"
+                    data-checked={t.id === themeId}
                   >
                     <span className="truncate">{t.name}</span>
-                    {t.id === themeId ? (
-                      <HugeiconsIcon
-                        icon={Tick02Icon}
-                        size={14}
-                        strokeWidth={2}
-                        className="ml-auto text-muted-foreground"
-                      />
-                    ) : null}
                   </CommandItem>
                 ))}
                 {themes.length === 0 ? <StatusItem label="No themes" /> : null}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->
Fix tick icon positioning for the selected theme in the Command Palette.

## Why
Theme picker in the Command Palette displays tick for the selected theme in the wrong position. This is caused by a duplicate `HugeiconsIcon` component that is passed as a child to the `CommandItem` which has its own tick icon that has 0 opacity in this case. The change is to reuse existing functionality of the `CommandItem` and to avoid passing extra icon child.


## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
Before:
<img width="483" height="495" alt="image" src="https://github.com/user-attachments/assets/453c8e5e-06fc-463d-b2d7-d85da814df1d" />
After:
<img width="472" height="492" alt="image" src="https://github.com/user-attachments/assets/77ee7223-f052-42fd-88f6-96b17858df7d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the theme selection indicator styling in the command palette for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->