### PR TITLE
fix(explorer): close context menu after deleting an item

### DIFF
--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -742,9 +742,14 @@ export const FileExplorer = memo(
                     className={COMPACT_ITEM}
                     variant="destructive"
                     onSelect={(e) => {
-                      e.preventDefault();
-                      if (deleteConfirm) void tree.deletePath(menuTarget.path);
-                      else setDeleteConfirm(true);
+                      if (deleteConfirm) {
+                        void tree.deletePath(menuTarget.path);
+                      } else {
+                        // Keep the menu open on the first click so the user
+                        // can confirm; let it close normally on the second.
+                        e.preventDefault();
+                        setDeleteConfirm(true);
+                      }
                     }}
                   >
                     {deleteConfirm ? "Click again to confirm" : "Delete"}


### PR DESCRIPTION
## Problem

In the file-tree (left sidebar) **explorer**, right-clicking a file/folder opens the context menu. Deleting that item via the menu removes it from the tree, but **the context menu stays open** — anchored to a row that no longer exists.

## Steps to reproduce

1. Right-click any file or folder in the explorer.
2. Click **Delete** → the item shows **"Click again to confirm"**.
3. Click again to confirm the deletion.
4. The item is deleted from the tree, **but the context menu remains open** (expected: it should close, since there's nothing to act on anymore).

## Root cause

The `Delete` `ContextMenuItem` called `e.preventDefault()` **unconditionally** in its `onSelect`:

```tsx
onSelect={(e) => {
  e.preventDefault();
  if (deleteConfirm) void tree.deletePath(menuTarget.path);
  else setDeleteConfirm(true);
}}
```

In Radix, `e.preventDefault()` inside `onSelect` suppresses the menu's normal close-on-select. That's intentional on the **first** click — we want to keep the menu open to show the "Click again to confirm" state. But it also ran on the **second (confirming)** click, so after the delete the menu lingered open.

## Fix

Only prevent default on the confirmation step. On the confirmed click, let the menu close normally — exactly like every other item in this menu (Open, New File, Copy Path, …), none of which call `preventDefault`. `onOpenChange` already resets `deleteConfirm` on close, so no extra state cleanup is needed.

```tsx
onSelect={(e) => {
  if (deleteConfirm) {
    void tree.deletePath(menuTarget.path);
  } else {
    // Keep the menu open on the first click so the user
    // can confirm; let it close normally on the second.
    e.preventDefault();
    setDeleteConfirm(true);
  }
}}
```

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — 228/228 pass
- `biome lint ./src` — no new warnings
- Manual: confirmed the two-step delete still works (first click shows confirm, second deletes) and the menu now closes after the delete.

One file changed, +8/-3. No behavior change to any other menu item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file explorer delete functionality to require confirmation before permanently removing files. First click initiates the deletion process; second click confirms and completes the action, preventing accidental file loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->