### PR TITLE
feat: persistent terminal sessions and layout restore

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -97,8 +97,9 @@ import {
 import { WorkspaceSurface } from "./components/WorkspaceSurface";
 import { useTabCloseGuards } from "./hooks/useTabCloseGuards";
 import { useWorkspaceSwitcher } from "./hooks/useWorkspaceSwitcher";
+import type { SessionState } from "@/modules/tabs/lib/sessionStore";
 
-export default function App() {
+export default function App({ initialSession }: { initialSession?: SessionState | null }) {
   const {
     tabs,
     activeId,
@@ -136,7 +137,7 @@ export default function App() {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
-  } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
+  } = useTabs(initialSession, getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
   // (e.g. cdInNewTab) read the latest pane state instead of a stale closure.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
-import { initLaunchDir } from "./lib/launchDir";
+import { initLaunchDir, getLaunchDir } from "./lib/launchDir";
 import { USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
+import { loadSession } from "./modules/tabs/lib/sessionStore";
 
 if (USE_CUSTOM_WINDOW_CONTROLS) {
   document.documentElement.dataset.chrome = "borderless";
@@ -25,8 +26,11 @@ await invoke("pty_close_all").catch(() => {});
 // Seed before first paint so default tab mounts at target cwd (no flicker).
 await initLaunchDir();
 
+// Only restore session if we weren't launched with a specific directory argument.
+const session = getLaunchDir() ? null : await loadSession();
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <App />,
+  <App initialSession={session} />,
 );
 
 // Window starts hidden (per tauri.conf.json) so users never see a transparent

--- a/src/modules/tabs/lib/sessionStore.ts
+++ b/src/modules/tabs/lib/sessionStore.ts
@@ -1,0 +1,55 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+import type { Tab } from "./useTabs";
+
+export type SessionState = {
+  tabs: Tab[];
+  activeId: number;
+};
+
+const STORE_PATH = "terax-session.json";
+const KEY_SESSION = "session";
+
+// Use autoSave to automatically debounce and flush writes.
+const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 500 });
+
+export async function saveSession(tabs: Tab[], activeId: number): Promise<void> {
+  // Filter out volatile tabs that shouldn't be restored
+  const persistentTabs = tabs.filter((t) => {
+    if (t.kind === "preview" || t.kind === "ai-diff" || t.kind === "git-diff" || t.kind === "git-history" || t.kind === "git-commit-file") {
+      return false;
+    }
+    // For editor tabs, only save if they are not in preview mode.
+    if (t.kind === "editor" && t.preview) {
+      return false;
+    }
+    return true;
+  });
+
+  // Ensure activeId points to a tab that is actually saved. If not, fallback to the last saved tab or 1.
+  let savedActiveId = activeId;
+  if (!persistentTabs.find(t => t.id === savedActiveId)) {
+    savedActiveId = persistentTabs.length > 0 ? persistentTabs[persistentTabs.length - 1].id : 1;
+  }
+
+  // Force cold state on all terminal tabs so they don't immediately spawn PTYs upon restore
+  const sessionTabs = persistentTabs.map(t => {
+    if (t.kind === "terminal") {
+      return { ...t, cold: true };
+    }
+    return t;
+  });
+
+  const state: SessionState = {
+    tabs: sessionTabs,
+    activeId: savedActiveId,
+  };
+
+  await store.set(KEY_SESSION, state);
+  await store.save();
+}
+
+export async function loadSession(): Promise<SessionState | null> {
+  const state = await store.get<SessionState>(KEY_SESSION);
+  if (!state || !state.tabs || state.tabs.length === 0) return null;
+  return state;
+}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -13,6 +13,7 @@ import {
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { saveSession, type SessionState } from "./sessionStore";
 
 // Matches the renderer slot pool size — over this we'd evict an active leaf.
 export const MAX_PANES_PER_TAB = 4;
@@ -228,8 +229,11 @@ export function planSpaceRemoval(
   return { tabs: next, disposeLeafIds, activeId };
 }
 
-export function useTabs(initial?: Partial<TerminalTab>) {
+export function useTabs(initialSession?: SessionState | null, initial?: Partial<TerminalTab>) {
   const [tabs, setTabs] = useState<Tab[]>(() => {
+    if (initialSession && initialSession.tabs.length > 0) {
+      return initialSession.tabs;
+    }
     const tabId = 1;
     const leafId = 2;
     return [
@@ -245,10 +249,24 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       },
     ];
   });
-  const [activeId, setActiveId] = useState(1);
+  const [activeId, setActiveId] = useState(() => initialSession ? initialSession.activeId : 1);
   // Gates warming until boot resolves the restore, so no shell spawns before it.
   const [booted, setBooted] = useState(false);
+  
   const nextIdRef = useRef(3);
+  useState(() => {
+    if (initialSession && initialSession.tabs.length > 0) {
+      let maxId = 0;
+      for (const t of initialSession.tabs) {
+        maxId = Math.max(maxId, t.id);
+        if (t.kind === "terminal") {
+          const ids = leafIds((t as TerminalTab).paneTree);
+          for (const lid of ids) maxId = Math.max(maxId, lid);
+        }
+      }
+      nextIdRef.current = maxId + 1;
+    }
+  });
   const activeSpaceIdRef = useRef(DEFAULT_SPACE_ID);
   const tabsRef = useRef(tabs);
   const activeIdRef = useRef(activeId);
@@ -260,6 +278,12 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   useEffect(() => {
     activeIdRef.current = activeId;
   }, [activeId]);
+
+  useEffect(() => {
+    if (booted) {
+      saveSession(tabs, activeId).catch(console.error);
+    }
+  }, [tabs, activeId, booted]);
 
   // Activating a cold tab warms it: one choke point for every activation path.
   useEffect(() => {


### PR DESCRIPTION
    ## Description
    This PR implements persistent terminal sessions and layout restore across app restarts, ensuring users       
  don't lose their workspace context when closing Terax.

    ## Technical Details
    * **State Persistence**: Created a dedicated `sessionStore.ts` using `@tauri-apps/plugin-store` to
  automatically persist the state of all non-volatile tabs (Terminal, pinned Editor, and Markdown tabs) along    
  with their split-pane structures.
    * **Flicker-Free Boot**: Modified `main.tsx` to asynchronously load the session state *before* React's       
  initial render (`ReactDOM.createRoot`), completely eliminating layout shifts or default shell flickers
  during startup.
    * **Smart Hydration (`cold: true`)**: When restoring terminal tabs, all tabs are explicitly forced into a    
  `cold` state. This prevents a mass spawning of background PTY processes on startup, ensuring that shells are   
  only instantiated when the user actively focuses their respective pane.
    * **CLI Passthrough**: The layout restore is automatically bypassed if the app is launched via CLI with a    
  specific directory argument (e.g. `terax .`), preserving expected terminal boot behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session persistence: Your open tabs and currently active tab are now automatically saved and restored each time the application restarts. When launching normally (without specifying a directory), your previous session is automatically restored, allowing seamless workflow continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->