### PR TITLE
feat: persistent terminal session en layout restore. 

### DIFF
--- a/smsml
+++ b/smsml
@@ -1,0 +1,156 @@
+[1mdiff --git a/src/app/App.tsx b/src/app/App.tsx[m
+[1mindex 6fc9a1a..45f49c6 100644[m
+[1m--- a/src/app/App.tsx[m
+[1m+++ b/src/app/App.tsx[m
+[36m@@ -137,7 +137,7 @@[m [mexport default function App({ initialSession }: { initialSession?: SessionState[m
+     closeActivePane,[m
+     closePaneByLeaf,[m
+     resetWorkspace,[m
+[31m-  } = useTabs(initialSession, getLaunchDir() ? { cwd: getLaunchDir() } : undefined);[m
+[32m+[m[32m  } = useTabs(initialSession, getLaunchDir().path ? { cwd: getLaunchDir().path } : undefined);[m
+ [m
+   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`[m
+   // (e.g. cdInNewTab) read the latest pane state instead of a stale closure.[m
+[36m@@ -217,6 +217,7 @@[m [mexport default function App({ initialSession }: { initialSession?: SessionState[m
+     markBooted,[m
+     setActiveSpaceForNewTabs,[m
+     adoptWorkspaceEnv,[m
+[32m+[m[32m    restoredSession: !!initialSession,[m
+   });[m
+ [m
+   useSpacePersistence({[m
+[1mdiff --git a/src/lib/launchDir.ts b/src/lib/launchDir.ts[m
+[1mindex c61298f..b4b7bc0 100644[m
+[1m--- a/src/lib/launchDir.ts[m
+[1m+++ b/src/lib/launchDir.ts[m
+[36m@@ -1,14 +1,17 @@[m
+ import { invoke } from "@tauri-apps/api/core";[m
+ [m
+[31m-let cached: string | undefined;[m
+[32m+[m[32mlet cached: { path: string | undefined; isExplicit: boolean } = { path: undefined, isExplicit: false };[m
+ [m
+ export async function initLaunchDir(): Promise<void> {[m
+[31m-  const dir =[m
+[31m-    (await invoke<string | null>("get_launch_dir").catch(() => null)) ??[m
+[31m-    (await invoke<string>("workspace_current_dir").catch(() => null));[m
+[31m-  cached = dir ? dir.replace(/\\/g, "/") : undefined;[m
+[32m+[m[32m  const explicitDir = await invoke<string | null>("get_launch_dir").catch(() => null);[m
+[32m+[m[32m  const fallbackDir = await invoke<string>("workspace_current_dir").catch(() => null);[m
+[32m+[m[32m  const dir = explicitDir ?? fallbackDir;[m
+[32m+[m[32m  cached = {[m
+[32m+[m[32m    path: dir ? dir.replace(/\\/g, "/") : undefined,[m
+[32m+[m[32m    isExplicit: !!explicitDir,[m
+[32m+[m[32m  };[m
+ }[m
+ [m
+[31m-export function getLaunchDir(): string | undefined {[m
+[32m+[m[32mexport function getLaunchDir(): { path: string | undefined; isExplicit: boolean } {[m
+   return cached;[m
+ }[m
+[1mdiff --git a/src/main.tsx b/src/main.tsx[m
+[1mindex 04aa384..7207239 100644[m
+[1m--- a/src/main.tsx[m
+[1m+++ b/src/main.tsx[m
+[36m@@ -27,7 +27,15 @@[m [mawait invoke("pty_close_all").catch(() => {});[m
+ await initLaunchDir();[m
+ [m
+ // Only restore session if we weren't launched with a specific directory argument.[m
+[31m-const session = getLaunchDir() ? null : await loadSession();[m
+[32m+[m[32mconst { isExplicit } = getLaunchDir();[m
+[32m+[m[32mlet session = null;[m
+[32m+[m[32mif (!isExplicit) {[m
+[32m+[m[32m  try {[m
+[32m+[m[32m    session = await loadSession();[m
+[32m+[m[32m  } catch (err) {[m
+[32m+[m[32m    console.error("Failed to load session:", err);[m
+[32m+[m[32m  }[m
+[32m+[m[32m}[m
+ [m
+ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render([m
+   <App initialSession={session} />,[m
+[1mdiff --git a/src/modules/spaces/lib/useSpacesBoot.ts b/src/modules/spaces/lib/useSpacesBoot.ts[m
+[1mindex da8cd16..62d74d1 100644[m
+[1m--- a/src/modules/spaces/lib/useSpacesBoot.ts[m
+[1m+++ b/src/modules/spaces/lib/useSpacesBoot.ts[m
+[36m@@ -18,6 +18,7 @@[m [mtype Params = {[m
+   markBooted: () => void;[m
+   setActiveSpaceForNewTabs: (id: string) => void;[m
+   adoptWorkspaceEnv: (env: WorkspaceEnv) => Promise<string | null>;[m
+[32m+[m[32m  restoredSession?: boolean;[m
+ };[m
+ [m
+ function uniqueCwds(tabs: Tab[]): string[] {[m
+[36m@@ -42,6 +43,7 @@[m [mexport function useSpacesBoot({[m
+   markBooted,[m
+   setActiveSpaceForNewTabs,[m
+   adoptWorkspaceEnv,[m
+[32m+[m[32m  restoredSession,[m
+ }: Params) {[m
+   const done = useRef(false);[m
+ [m
+[36m@@ -106,7 +108,9 @@[m [mexport function useSpacesBoot({[m
+         const inActive = restored.filter((t) => t.spaceId === active);[m
+         const idx = states.get(active)?.activeTabIndex ?? 0;[m
+         const activeTab = inActive[idx] ?? inActive[0] ?? restored[0];[m
+[31m-        replaceTabs(restored, activeTab.id);[m
+[32m+[m[32m        if (!restoredSession) {[m
+[32m+[m[32m          replaceTabs(restored, activeTab.id);[m
+[32m+[m[32m        }[m
+       } catch (e) {[m
+         console.error("[terax] spaces boot failed:", e);[m
+       } finally {[m
+[36m@@ -122,5 +126,6 @@[m [mexport function useSpacesBoot({[m
+     markBooted,[m
+     setActiveSpaceForNewTabs,[m
+     adoptWorkspaceEnv,[m
+[32m+[m[32m    restoredSession,[m
+   ]);[m
+ }[m
+[1mdiff --git a/src/modules/tabs/lib/sessionStore.ts b/src/modules/tabs/lib/sessionStore.ts[m
+[1mindex 33dbc21..0153841 100644[m
+[1m--- a/src/modules/tabs/lib/sessionStore.ts[m
+[1m+++ b/src/modules/tabs/lib/sessionStore.ts[m
+[36m@@ -36,6 +36,9 @@[m [mexport async function saveSession(tabs: Tab[], activeId: number): Promise<void>[m
+     if (t.kind === "terminal") {[m
+       return { ...t, cold: true };[m
+     }[m
+[32m+[m[32m    if (t.kind === "editor") {[m
+[32m+[m[32m      return { ...t, dirty: false };[m
+[32m+[m[32m    }[m
+     return t;[m
+   });[m
+ [m
+[36m@@ -48,8 +51,31 @@[m [mexport async function saveSession(tabs: Tab[], activeId: number): Promise<void>[m
+   await store.save();[m
+ }[m
+ [m
+[32m+[m[32mfunction isSessionState(state: any): state is SessionState {[m
+[32m+[m[32m  if (!state || typeof state !== "object") return false;[m
+[32m+[m[32m  if (!Array.isArray(state.tabs) || state.tabs.length === 0) return false;[m
+[32m+[m[41m  [m
+[32m+[m[32m  const supportedKinds = ["terminal", "editor", "preview", "ai-diff", "git-diff", "git-history", "git-commit-file"];[m
+[32m+[m[41m  [m
+[32m+[m[32m  for (const t of state.tabs) {[m
+[32m+[m[32m    if (!t || typeof t !== "object") return false;[m
+[32m+[m[32m    if (typeof t.id !== "number") return false;[m
+[32m+[m[32m    if (!supportedKinds.includes(t.kind)) return false;[m
+[32m+[m[41m    [m
+[32m+[m[32m    if (t.kind === "terminal") {[m
+[32m+[m[32m      if (!t.paneTree || typeof t.paneTree !== "object") return false;[m
+[32m+[m[32m      if (typeof t.activeLeafId !== "number") return false;[m
+[32m+[m[32m    }[m
+[32m+[m[32m  }[m
+[32m+[m[41m  [m
+[32m+[m[32m  if (typeof state.activeId !== "number") return false;[m
+[32m+[m[32m  if (!state.tabs.some((t: any) => t.id === state.activeId)) return false;[m
+[32m+[m[41m  [m
+[32m+[m[32m  return true;[m
+[32m+[m[32m}[m
+[32m+[m
+ export async function loadSession(): Promise<SessionState | null> {[m
+[31m-  const state = await store.get<SessionState>(KEY_SESSION);[m
+[31m-  if (!state || !state.tabs || state.tabs.length === 0) return null;[m
+[32m+[m[32m  const state = await store.get<any>(KEY_SESSION);[m
+[32m+[m[32m  if (!isSessionState(state)) return null;[m
+   return state;[m
+ }[m

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -98,8 +98,9 @@ import { WorkspaceSurface } from "./components/WorkspaceSurface";
 import { useAppCloseGuard } from "./hooks/useAppCloseGuard";
 import { useTabCloseGuards } from "./hooks/useTabCloseGuards";
 import { useWorkspaceSwitcher } from "./hooks/useWorkspaceSwitcher";
+import type { SessionState } from "@/modules/tabs/lib/sessionStore";
 
-export default function App() {
+export default function App({ initialSession }: { initialSession?: SessionState | null }) {
   const {
     tabs,
     activeId,
@@ -137,7 +138,7 @@ export default function App() {
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
-  } = useTabs(getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
+  } = useTabs(initialSession, getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
   // (e.g. cdInNewTab) read the latest pane state instead of a stale closure.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -138,7 +138,7 @@ export default function App({ initialSession }: { initialSession?: SessionState 
     closeActivePane,
     closePaneByLeaf,
     resetWorkspace,
-  } = useTabs(initialSession, getLaunchDir() ? { cwd: getLaunchDir() } : undefined);
+  } = useTabs(initialSession, getLaunchDir().path ? { cwd: getLaunchDir().path } : undefined);
 
   // Mirror `tabs` into a ref so callbacks scheduled with `setTimeout`
   // (e.g. cdInNewTab) read the latest pane state instead of a stale closure.
@@ -218,6 +218,7 @@ export default function App({ initialSession }: { initialSession?: SessionState 
     markBooted,
     setActiveSpaceForNewTabs,
     adoptWorkspaceEnv,
+    restoredSession: !!initialSession,
   });
 
   useSpacePersistence({

--- a/src/lib/launchDir.ts
+++ b/src/lib/launchDir.ts
@@ -1,14 +1,17 @@
 import { invoke } from "@tauri-apps/api/core";
 
-let cached: string | undefined;
+let cached: { path: string | undefined; isExplicit: boolean } = { path: undefined, isExplicit: false };
 
 export async function initLaunchDir(): Promise<void> {
-  const dir =
-    (await invoke<string | null>("get_launch_dir").catch(() => null)) ??
-    (await invoke<string>("workspace_current_dir").catch(() => null));
-  cached = dir ? dir.replace(/\\/g, "/") : undefined;
+  const explicitDir = await invoke<string | null>("get_launch_dir").catch(() => null);
+  const fallbackDir = await invoke<string>("workspace_current_dir").catch(() => null);
+  const dir = explicitDir ?? fallbackDir;
+  cached = {
+    path: dir ? dir.replace(/\\/g, "/") : undefined,
+    isExplicit: !!explicitDir,
+  };
 }
 
-export function getLaunchDir(): string | undefined {
+export function getLaunchDir(): { path: string | undefined; isExplicit: boolean } {
   return cached;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,7 +27,15 @@ await invoke("pty_close_all").catch(() => {});
 await initLaunchDir();
 
 // Only restore session if we weren't launched with a specific directory argument.
-const session = getLaunchDir() ? null : await loadSession();
+const { isExplicit } = getLaunchDir();
+let session = null;
+if (!isExplicit) {
+  try {
+    session = await loadSession();
+  } catch (err) {
+    console.error("Failed to load session:", err);
+  }
+}
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <App initialSession={session} />,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
-import { initLaunchDir } from "./lib/launchDir";
+import { initLaunchDir, getLaunchDir } from "./lib/launchDir";
 import { USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
+import { loadSession } from "./modules/tabs/lib/sessionStore";
 
 if (USE_CUSTOM_WINDOW_CONTROLS) {
   document.documentElement.dataset.chrome = "borderless";
@@ -25,8 +26,11 @@ await invoke("pty_close_all").catch(() => {});
 // Seed before first paint so default tab mounts at target cwd (no flicker).
 await initLaunchDir();
 
+// Only restore session if we weren't launched with a specific directory argument.
+const session = getLaunchDir() ? null : await loadSession();
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <App />,
+  <App initialSession={session} />,
 );
 
 // Window starts hidden (per tauri.conf.json) so users never see a transparent

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -18,6 +18,7 @@ type Params = {
   markBooted: () => void;
   setActiveSpaceForNewTabs: (id: string) => void;
   adoptWorkspaceEnv: (env: WorkspaceEnv) => Promise<string | null>;
+  restoredSession?: boolean;
 };
 
 function uniqueCwds(tabs: Tab[]): string[] {
@@ -42,6 +43,7 @@ export function useSpacesBoot({
   markBooted,
   setActiveSpaceForNewTabs,
   adoptWorkspaceEnv,
+  restoredSession,
 }: Params) {
   const done = useRef(false);
 
@@ -106,7 +108,9 @@ export function useSpacesBoot({
         const inActive = restored.filter((t) => t.spaceId === active);
         const idx = states.get(active)?.activeTabIndex ?? 0;
         const activeTab = inActive[idx] ?? inActive[0] ?? restored[0];
-        replaceTabs(restored, activeTab.id);
+        if (!restoredSession) {
+          replaceTabs(restored, activeTab.id);
+        }
       } catch (e) {
         console.error("[terax] spaces boot failed:", e);
       } finally {
@@ -122,5 +126,6 @@ export function useSpacesBoot({
     markBooted,
     setActiveSpaceForNewTabs,
     adoptWorkspaceEnv,
+    restoredSession,
   ]);
 }

--- a/src/modules/tabs/lib/sessionStore.ts
+++ b/src/modules/tabs/lib/sessionStore.ts
@@ -12,44 +12,77 @@ const KEY_SESSION = "session";
 // Use autoSave to automatically debounce and flush writes.
 const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 500 });
 
-export async function saveSession(tabs: Tab[], activeId: number): Promise<void> {
-  // Filter out volatile tabs that shouldn't be restored
-  const persistentTabs = tabs.filter((t) => {
-    if (t.kind === "preview" || t.kind === "ai-diff" || t.kind === "git-diff" || t.kind === "git-history" || t.kind === "git-commit-file") {
-      return false;
-    }
-    // For editor tabs, only save if they are not in preview mode.
-    if (t.kind === "editor" && t.preview) {
-      return false;
-    }
-    return true;
-  });
+let saveQueue = Promise.resolve();
 
-  // Ensure activeId points to a tab that is actually saved. If not, fallback to the last saved tab or 1.
-  let savedActiveId = activeId;
-  if (!persistentTabs.find(t => t.id === savedActiveId)) {
-    savedActiveId = persistentTabs.length > 0 ? persistentTabs[persistentTabs.length - 1].id : 1;
-  }
+export function saveSession(tabs: Tab[], activeId: number): Promise<void> {
+  const op = async () => {
+    // Filter out volatile tabs that shouldn't be restored
+    const persistentTabs = tabs.filter((t) => {
+      if (t.kind === "preview" || t.kind === "ai-diff" || t.kind === "git-diff" || t.kind === "git-history" || t.kind === "git-commit-file") {
+        return false;
+      }
+      // For editor tabs, only save if they are not in preview mode.
+      if (t.kind === "editor" && t.preview) {
+        return false;
+      }
+      return true;
+    });
 
-  // Force cold state on all terminal tabs so they don't immediately spawn PTYs upon restore
-  const sessionTabs = persistentTabs.map(t => {
-    if (t.kind === "terminal") {
-      return { ...t, cold: true };
+    // Ensure activeId points to a tab that is actually saved. If not, fallback to the last saved tab or 1.
+    let savedActiveId = activeId;
+    if (!persistentTabs.find(t => t.id === savedActiveId)) {
+      savedActiveId = persistentTabs.length > 0 ? persistentTabs[persistentTabs.length - 1].id : 1;
     }
-    return t;
-  });
 
-  const state: SessionState = {
-    tabs: sessionTabs,
-    activeId: savedActiveId,
+    // Force cold state on all terminal tabs so they don't immediately spawn PTYs upon restore
+    const sessionTabs = persistentTabs.map(t => {
+      if (t.kind === "terminal") {
+        return { ...t, cold: true };
+      }
+      if (t.kind === "editor") {
+        return { ...t, dirty: false };
+      }
+      return t;
+    });
+
+    const state: SessionState = {
+      tabs: sessionTabs,
+      activeId: savedActiveId,
+    };
+
+    await store.set(KEY_SESSION, state);
+    await store.save();
   };
 
-  await store.set(KEY_SESSION, state);
-  await store.save();
+  saveQueue = saveQueue.then(op).catch(console.error);
+  return saveQueue;
+}
+
+function isSessionState(state: any): state is SessionState {
+  if (!state || typeof state !== "object") return false;
+  if (!Array.isArray(state.tabs) || state.tabs.length === 0) return false;
+  
+  const supportedKinds = ["terminal", "editor", "preview", "ai-diff", "git-diff", "git-history", "git-commit-file"];
+  
+  for (const t of state.tabs) {
+    if (!t || typeof t !== "object") return false;
+    if (typeof t.id !== "number") return false;
+    if (!supportedKinds.includes(t.kind)) return false;
+    
+    if (t.kind === "terminal") {
+      if (!t.paneTree || typeof t.paneTree !== "object") return false;
+      if (typeof t.activeLeafId !== "number") return false;
+    }
+  }
+  
+  if (typeof state.activeId !== "number") return false;
+  if (!state.tabs.some((t: any) => t.id === state.activeId)) return false;
+  
+  return true;
 }
 
 export async function loadSession(): Promise<SessionState | null> {
-  const state = await store.get<SessionState>(KEY_SESSION);
-  if (!state || !state.tabs || state.tabs.length === 0) return null;
+  const state = await store.get<any>(KEY_SESSION);
+  if (!isSessionState(state)) return null;
   return state;
 }

--- a/src/modules/tabs/lib/sessionStore.ts
+++ b/src/modules/tabs/lib/sessionStore.ts
@@ -1,0 +1,55 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+import type { Tab } from "./useTabs";
+
+export type SessionState = {
+  tabs: Tab[];
+  activeId: number;
+};
+
+const STORE_PATH = "terax-session.json";
+const KEY_SESSION = "session";
+
+// Use autoSave to automatically debounce and flush writes.
+const store = new LazyStore(STORE_PATH, { defaults: {}, autoSave: 500 });
+
+export async function saveSession(tabs: Tab[], activeId: number): Promise<void> {
+  // Filter out volatile tabs that shouldn't be restored
+  const persistentTabs = tabs.filter((t) => {
+    if (t.kind === "preview" || t.kind === "ai-diff" || t.kind === "git-diff" || t.kind === "git-history" || t.kind === "git-commit-file") {
+      return false;
+    }
+    // For editor tabs, only save if they are not in preview mode.
+    if (t.kind === "editor" && t.preview) {
+      return false;
+    }
+    return true;
+  });
+
+  // Ensure activeId points to a tab that is actually saved. If not, fallback to the last saved tab or 1.
+  let savedActiveId = activeId;
+  if (!persistentTabs.find(t => t.id === savedActiveId)) {
+    savedActiveId = persistentTabs.length > 0 ? persistentTabs[persistentTabs.length - 1].id : 1;
+  }
+
+  // Force cold state on all terminal tabs so they don't immediately spawn PTYs upon restore
+  const sessionTabs = persistentTabs.map(t => {
+    if (t.kind === "terminal") {
+      return { ...t, cold: true };
+    }
+    return t;
+  });
+
+  const state: SessionState = {
+    tabs: sessionTabs,
+    activeId: savedActiveId,
+  };
+
+  await store.set(KEY_SESSION, state);
+  await store.save();
+}
+
+export async function loadSession(): Promise<SessionState | null> {
+  const state = await store.get<SessionState>(KEY_SESSION);
+  if (!state || !state.tabs || state.tabs.length === 0) return null;
+  return state;
+}

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -13,6 +13,7 @@ import {
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { saveSession, type SessionState } from "./sessionStore";
 
 // Matches the renderer slot pool size — over this we'd evict an active leaf.
 export const MAX_PANES_PER_TAB = 4;
@@ -228,8 +229,11 @@ export function planSpaceRemoval(
   return { tabs: next, disposeLeafIds, activeId };
 }
 
-export function useTabs(initial?: Partial<TerminalTab>) {
+export function useTabs(initialSession?: SessionState | null, initial?: Partial<TerminalTab>) {
   const [tabs, setTabs] = useState<Tab[]>(() => {
+    if (initialSession && initialSession.tabs.length > 0) {
+      return initialSession.tabs;
+    }
     const tabId = 1;
     const leafId = 2;
     return [
@@ -245,10 +249,24 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       },
     ];
   });
-  const [activeId, setActiveId] = useState(1);
+  const [activeId, setActiveId] = useState(() => initialSession ? initialSession.activeId : 1);
   // Gates warming until boot resolves the restore, so no shell spawns before it.
   const [booted, setBooted] = useState(false);
+  
   const nextIdRef = useRef(3);
+  useState(() => {
+    if (initialSession && initialSession.tabs.length > 0) {
+      let maxId = 0;
+      for (const t of initialSession.tabs) {
+        maxId = Math.max(maxId, t.id);
+        if (t.kind === "terminal") {
+          const ids = leafIds((t as TerminalTab).paneTree);
+          for (const lid of ids) maxId = Math.max(maxId, lid);
+        }
+      }
+      nextIdRef.current = maxId + 1;
+    }
+  });
   const activeSpaceIdRef = useRef(DEFAULT_SPACE_ID);
   const tabsRef = useRef(tabs);
   const activeIdRef = useRef(activeId);
@@ -260,6 +278,12 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   useEffect(() => {
     activeIdRef.current = activeId;
   }, [activeId]);
+
+  useEffect(() => {
+    if (booted) {
+      saveSession(tabs, activeId).catch(console.error);
+    }
+  }, [tabs, activeId, booted]);
 
   // Activating a cold tab warms it: one choke point for every activation path.
   useEffect(() => {


### PR DESCRIPTION
  ### What changed

  • Session Store ( src/modules/tabs/lib/sessionStore.ts ): Introduced a new module leveraging Tauri's        
  LazyStore  to serialize and save the workspace state (the  tabs  array and  activeId ) to disk.
  • Auto-Persistence ( useTabs.ts ): Hooked the layout state into the new  saveSession  mechanism so that     
  every tab creation, split, reorder, or focus change is automatically backed up.
  • Application Bootstrap ( main.tsx  &  App.tsx ): Added logic to load the saved session on startup and      
  seed  useTabs  with the restored pane tree, recreating the user's workspace seamlessly.
  • Cold Terminal Boot: Configured terminal tabs to restore in a "cold" state. PTY processes are not
  immediately spawned upon restore to conserve resources; they only initialize when the user focuses or       
  interacts with that specific terminal pane.
  • Volatile Tab Filtering: Configured the save mechanism to intentionally exclude volatile views (like       
  previews, AI diffs, and git history) to keep the stored session clean and strictly focused on core
  editor/terminal work.

  ### Why

  • Before this change, closing the application or reloading the window would instantly wipe out the user's   
  workspace layout.
  • For users working on complex projects, setting up the perfect arrangement of terminal splits, editors,    
  and working directories takes time. This feature ensures that their environment is preserved exactly as     
  they left it across application restarts, significantly improving developer experience and continuity.      

  ### How I tested

  • Tested manually by:  Juko-div 
  • Created a complex layout with multiple tabs, deeply nested terminal splits, and open editor files.        
  • Restarted the application and verified that the exact layout, pane hierarchy, and active focus were       
  perfectly restored.
  • Confirmed that restoring many terminals at once did not spike CPU/memory, thanks to the "cold state"      
  deferred PTY initialization.
  • Verified that volatile tabs (e.g., git diffs) were successfully ignored and not restored on the next      
  boot.
  • Ran  pnpm exec tsc --noEmit  locally to ensure full type-safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session persistence—tabs and active tab state are now saved and restored when relaunching the app
  * Smart session restoration that respects explicit launch directory arguments

* **Bug Fixes**
  * Session loading errors are now caught and logged safely, preventing startup failures

* **Improvements**
  * Enhanced launch directory detection and handling for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->