### PR TITLE
fix(linux): restore main window size before showing

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-is-maximized",
+    "core:window:allow-is-fullscreen",
     "core:window:allow-internal-toggle-maximize",
     "core:window:allow-show",
     "core:window:allow-set-focus",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,37 @@
 pub mod modules;
 
 use modules::{agent, fs, git, history, net, pty, secrets, shell, workspace};
+#[cfg(target_os = "linux")]
+use serde::Deserialize;
+#[cfg(target_os = "linux")]
+use std::fs as std_fs;
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
 use tauri::{PhysicalPosition, WindowEvent};
 use tauri_plugin_window_state::StateFlags;
+#[cfg(target_os = "linux")]
+use tauri_plugin_window_state::WindowExt;
+
+#[cfg(target_os = "linux")]
+const MAIN_WINDOW_SIZE_STORE: &str = "main-window-size.json";
+#[cfg(target_os = "linux")]
+const SETTINGS_STORE: &str = "terax-settings.json";
+#[cfg(target_os = "linux")]
+const MAIN_WINDOW_MIN_WIDTH: u32 = 420;
+#[cfg(target_os = "linux")]
+const MAIN_WINDOW_MIN_HEIGHT: u32 = 280;
+#[cfg(target_os = "linux")]
+const MAIN_WINDOW_MAX_WIDTH: u32 = 16_384;
+#[cfg(target_os = "linux")]
+const MAIN_WINDOW_MAX_HEIGHT: u32 = 16_384;
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Deserialize)]
+struct MainWindowSize {
+    width: u32,
+    height: u32,
+}
 
 /// Drained on first read so HMR / re-mounts can't replay the launch dir.
 #[derive(Default)]
@@ -30,6 +56,127 @@ fn parse_launch_dir() -> Option<String> {
         return Some(crate::modules::fs::to_canon(&canon));
     }
     None
+}
+
+#[cfg(target_os = "linux")]
+fn linux_window_state_flags() -> StateFlags {
+    let mut flags = StateFlags::all() & !StateFlags::VISIBLE & !StateFlags::SIZE;
+
+    if !linux_position_restore_supported() {
+        flags &= !StateFlags::POSITION;
+    }
+
+    flags
+}
+
+fn window_state_flags() -> StateFlags {
+    #[cfg(target_os = "linux")]
+    {
+        linux_window_state_flags()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        StateFlags::all() & !StateFlags::VISIBLE
+    }
+}
+
+fn window_state_plugin() -> tauri_plugin_window_state::Builder {
+    let builder = tauri_plugin_window_state::Builder::new().with_state_flags(window_state_flags());
+
+    #[cfg(target_os = "linux")]
+    {
+        builder.skip_initial_state("main")
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        builder
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_position_restore_supported() -> bool {
+    if let Ok(backends) = std::env::var("GDK_BACKEND") {
+        if let Some(backend) = backends
+            .split(',')
+            .map(str::trim)
+            .find(|backend| !backend.is_empty())
+        {
+            return backend.eq_ignore_ascii_case("x11");
+        }
+    }
+
+    !std::env::var("XDG_SESSION_TYPE")
+        .map(|value| value.eq_ignore_ascii_case("wayland"))
+        .unwrap_or(false)
+        && std::env::var_os("WAYLAND_DISPLAY").is_none()
+}
+
+#[cfg(target_os = "linux")]
+fn restore_window_state_enabled(app: &tauri::AppHandle) -> bool {
+    let Some(path) = app
+        .path()
+        .app_data_dir()
+        .ok()
+        .map(|dir| dir.join(SETTINGS_STORE))
+    else {
+        return true;
+    };
+
+    let Ok(settings) = std_fs::read(path) else {
+        return true;
+    };
+    let Ok(settings) = serde_json::from_slice::<serde_json::Value>(&settings) else {
+        return true;
+    };
+    settings
+        .get("restoreWindowState")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(true)
+}
+
+#[cfg(target_os = "linux")]
+fn read_main_window_size(app: &tauri::AppHandle) -> Option<MainWindowSize> {
+    let path = app.path().app_data_dir().ok()?.join(MAIN_WINDOW_SIZE_STORE);
+    let size = serde_json::from_slice::<MainWindowSize>(&std_fs::read(path).ok()?).ok()?;
+    ((MAIN_WINDOW_MIN_WIDTH..=MAIN_WINDOW_MAX_WIDTH).contains(&size.width)
+        && (MAIN_WINDOW_MIN_HEIGHT..=MAIN_WINDOW_MAX_HEIGHT).contains(&size.height))
+    .then_some(size)
+}
+
+#[cfg(target_os = "linux")]
+fn create_linux_main_window(app: &mut tauri::App) -> tauri::Result<()> {
+    let app_handle = app.handle().clone();
+    let Some(mut config) = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|window| window.label == "main")
+        .cloned()
+    else {
+        return Ok(());
+    };
+
+    let restore_state = restore_window_state_enabled(&app_handle);
+    if restore_state {
+        if let Some(size) = read_main_window_size(&app_handle) {
+            config.width = size.width as f64;
+            config.height = size.height as f64;
+        }
+    }
+
+    let window = WebviewWindowBuilder::from_config(&app_handle, &config)?.build()?;
+
+    // Some Linux compositors ignore the builder-time decorations flag.
+    let _ = window.set_decorations(false);
+
+    if restore_state {
+        let _ = window.restore_state(window_state_flags());
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -139,11 +286,7 @@ pub fn run() {
         // Skip restoring VISIBLE — frontend calls window.show() after first
         // paint so the user never sees a transparent window-shadow flash on
         // Windows/Linux.
-        .plugin(
-            tauri_plugin_window_state::Builder::new()
-                .with_state_flags(StateFlags::all() & !StateFlags::VISIBLE)
-                .build(),
-        )
+        .plugin(window_state_plugin().build())
         .plugin(tauri_plugin_autostart::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_os::init())
@@ -155,6 +298,9 @@ pub fn run() {
         )
         .plugin(tauri_plugin_opener::init())
         .setup(|_app| {
+            #[cfg(target_os = "linux")]
+            create_linux_main_window(_app)?;
+
             // macOS skips parent() for the settings window, so tie its lifecycle
             // to the main window here instead. Other platforms keep parent().
             #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -4,6 +4,7 @@
     "windows": [
       {
         "label": "main",
+        "create": false,
         "decorations": false,
         "transparent": true
       }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,27 @@ import "./styles/globals.css";
 
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { LazyStore } from "@tauri-apps/plugin-store";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import { initLaunchDir } from "./lib/launchDir";
-import { USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
+import { IS_LINUX, USE_CUSTOM_WINDOW_CONTROLS } from "./lib/platform";
+
+type WindowSize = {
+  width: number;
+  height: number;
+};
+
+const MAIN_WINDOW_SIZE_STORE = "main-window-size.json";
+const MAIN_WINDOW_MIN_WIDTH = 420;
+const MAIN_WINDOW_MIN_HEIGHT = 280;
+const MAIN_WINDOW_SAVE_DELAY_MS = 200;
+const MAIN_WINDOW_RESIZE_READY_MS = 1000;
+
+const mainWindowSizeStore = new LazyStore(MAIN_WINDOW_SIZE_STORE, {
+  defaults: {},
+  autoSave: false,
+});
 
 if (USE_CUSTOM_WINDOW_CONTROLS) {
   document.documentElement.dataset.chrome = "borderless";
@@ -29,12 +46,81 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <App />,
 );
 
+function isUsableWindowSize(size: WindowSize): boolean {
+  return (
+    Number.isFinite(size.width) &&
+    Number.isFinite(size.height) &&
+    size.width >= MAIN_WINDOW_MIN_WIDTH &&
+    size.height >= MAIN_WINDOW_MIN_HEIGHT
+  );
+}
+
+function currentWindowSize(): WindowSize {
+  return {
+    width: Math.round(window.innerWidth),
+    height: Math.round(window.innerHeight),
+  };
+}
+
+async function saveLinuxMainWindowSize(
+  appWindow: ReturnType<typeof getCurrentWindow>,
+): Promise<void> {
+  const size = currentWindowSize();
+  if (!isUsableWindowSize(size)) return;
+
+  const [maximized, fullscreen] = await Promise.all([
+    appWindow.isMaximized(),
+    appWindow.isFullscreen(),
+  ]);
+  if (maximized || fullscreen) return;
+
+  await mainWindowSizeStore.set("width", size.width);
+  await mainWindowSizeStore.set("height", size.height);
+  await mainWindowSizeStore.save();
+}
+
+function startLinuxMainWindowSizePersistence(
+  appWindow: ReturnType<typeof getCurrentWindow>,
+): void {
+  let ready = false;
+  let saveTimer: number | undefined;
+
+  const scheduleSave = () => {
+    if (!ready) return;
+    if (saveTimer !== undefined) window.clearTimeout(saveTimer);
+    saveTimer = window.setTimeout(() => {
+      saveTimer = undefined;
+      void saveLinuxMainWindowSize(appWindow).catch((e) =>
+        console.error("window size save failed:", e),
+      );
+    }, MAIN_WINDOW_SAVE_DELAY_MS);
+  };
+
+  window.setTimeout(() => {
+    ready = true;
+    scheduleSave();
+  }, MAIN_WINDOW_RESIZE_READY_MS);
+
+  void appWindow
+    .onResized(() => scheduleSave())
+    .catch((e) => console.error("window resize listener failed:", e));
+}
+
+let linuxSizePersistenceStarted = false;
+
 // Window starts hidden (per tauri.conf.json) so users never see a transparent
 // shadow-only frame before React paints. Use setTimeout — rAF is throttled
 // while the window is hidden and would never fire.
 const showWindow = () => {
-  getCurrentWindow()
+  const appWindow = getCurrentWindow();
+  appWindow
     .show()
+    .then(() => {
+      if (IS_LINUX && !linuxSizePersistenceStarted) {
+        linuxSizePersistenceStarted = true;
+        startLinuxMainWindowSizePersistence(appWindow);
+      }
+    })
     .catch((e) => console.error("window.show failed:", e));
 };
 setTimeout(showWindow, 50);


### PR DESCRIPTION
## What

Fixes Linux main-window size restoration so the window no longer shrinks across app restarts on Fedora KDE/RPM.

Also allows the existing guarded close flow to complete by permitting Tauri's `window.destroy()` command, which `onCloseRequested` uses internally after the close guard allows the window to close.

## Why

On Fedora KDE, the RPM build could reopen the main window progressively smaller after each close/reopen cycle. The settings window was unaffected.

After moving Linux size restoration earlier, the custom close button also exposed a missing permission: the existing close guard calls `close()`, Tauri emits `onCloseRequested`, and when the handler does not prevent closing, Tauri finalizes with `destroy()`. Without `core:window:allow-destroy`, the app looked like it ignored the close request.

## How

- On Linux, create the main window manually with the saved size before the first show.
- Keep `tauri-plugin-window-state` from restoring main-window size on Linux, avoiding compositor/WebKit resize drift.
- Persist Linux main-window size separately via the existing Tauri store plugin.
- Keep position restore only where it is reliable; skip position restore on Wayland.
- Add the missing `core:window:allow-destroy` permission required by the existing close guard flow.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] No `#[tauri::command]` signature changed
- [ ] UI tested in `pnpm tauri dev`
- [x] Platforms tested: Linux, Fedora KDE Plasma Wayland, RPM package
- [ ] Shells tested: not relevant

Manual smoke test:

- Built RPM with `pnpm tauri build --bundles rpm`.
- Installed with `sudo rpm -Uvh --replacepkgs`.
- Resized the main window, closed Terax, reopened it, and confirmed the saved size is restored instead of shrinking.
- Repeated close/reopen cycles to verify the size remains stable.
- Confirmed the custom `X` close button closes the app correctly.
- Confirmed the settings window remains unaffected.

Note: local RPM build produced the RPM successfully, then exited with the existing updater signing error because `TAURI_SIGNING_PRIVATE_KEY` is not set.

## Screenshots / GIFs

Not applicable; no visual UI changes.

## Notes for reviewer

Full `pnpm lint` and full `cargo fmt --check` currently report pre-existing issues in unrelated files. The files touched by this PR were checked directly, and the required type-check, tests, and clippy checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced Linux window state restoration on startup, including safer width/height validation and conditional position restoration support.
- Added Linux-only persistence of the main window’s width/height across sessions (skips saving when maximized or fullscreen).
- Updated capabilities to better support fullscreen detection.

**Bug Fixes**
- Window size persistence now begins only after the main window is successfully shown, improving Linux startup reliability.
- Window state restoration can be disabled via settings (defaults to enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->