### PR TITLE
feat(terminal): user-selectable default shell

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,7 @@ pub fn run() {
             pty::pty_has_foreground_process,
             pty::pty_has_foreground_job,
             pty::pty_shell_name,
+            pty::pty_list_shells,
             fs::tree::list_subdirs,
             fs::tree::fs_read_dir,
             fs::file::fs_read_file,

--- a/src-tauri/src/modules/pty/mod.rs
+++ b/src-tauri/src/modules/pty/mod.rs
@@ -50,6 +50,7 @@ pub async fn pty_open(
     cwd: Option<String>,
     workspace: Option<WorkspaceEnv>,
     blocks: Option<bool>,
+    shell: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<u32, String> {
@@ -58,7 +59,7 @@ pub async fn pty_open(
     let cwd = user_spawn_cwd_or_home(&registry, cwd.as_deref(), &workspace);
     let id = state.next_id.fetch_add(1, Ordering::Relaxed);
     let session = tauri::async_runtime::spawn_blocking(move || {
-        session::spawn(id, app, cols, rows, cwd, workspace, blocks, on_data, on_exit)
+        session::spawn(id, app, cols, rows, cwd, workspace, blocks, shell, on_data, on_exit)
             .map(|(s, _)| s)
     })
     .await
@@ -305,4 +306,9 @@ pub fn pty_close_all(state: tauri::State<PtyState>) -> Result<usize, String> {
 #[tauri::command]
 pub fn pty_shell_name() -> String {
     shell_init::detect_shell_name()
+}
+
+#[tauri::command]
+pub fn pty_list_shells() -> Vec<shell_init::ShellInfo> {
+    shell_init::list_shells()
 }

--- a/src-tauri/src/modules/pty/session.rs
+++ b/src-tauri/src/modules/pty/session.rs
@@ -107,6 +107,7 @@ pub fn spawn(
     cwd: Option<String>,
     workspace: WorkspaceEnv,
     blocks: bool,
+    shell: Option<String>,
     on_data: Channel<Response>,
     on_exit: Channel<i32>,
 ) -> Result<(Arc<Session>, PtySize), String> {
@@ -122,7 +123,7 @@ pub fn spawn(
     };
     let pair = pty_system.openpty(size).map_err(|e| e.to_string())?;
 
-    let cmd = shell_init::build_command(cwd, workspace, blocks)?;
+    let cmd = shell_init::build_command(cwd, workspace, blocks, shell)?;
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
     drop(pair.slave);
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -56,6 +56,7 @@ pub fn build_command(
     blocks: bool,
     shell: Option<String>,
 ) -> Result<CommandBuilder, String> {
+    let shell = sanitize_shell_override(shell);
     #[cfg(unix)]
     {
         let _ = workspace;
@@ -64,6 +65,22 @@ pub fn build_command(
     #[cfg(windows)]
     {
         windows::build(cwd, workspace, blocks, shell)
+    }
+}
+
+// Honor the override only if it matches an enumerated shell, so a tampered
+// setting can't spawn an arbitrary binary across the IPC boundary.
+fn sanitize_shell_override(shell: Option<String>) -> Option<String> {
+    let candidate = shell.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())?;
+    let target = std::fs::canonicalize(&candidate).ok();
+    let allowed = list_shells().into_iter().any(|s| {
+        s.path == candidate || (target.is_some() && std::fs::canonicalize(&s.path).ok() == target)
+    });
+    if allowed {
+        Some(candidate)
+    } else {
+        log::warn!("ignoring non-enumerated shell override '{candidate}'");
+        None
     }
 }
 
@@ -503,6 +520,9 @@ mod windows {
                 }
             }
         } else if is_bash {
+            // git-bash's /etc/profile cd's to $HOME unless CHERE_INVOKING is
+            // set; keep the cwd we configured in apply_common.
+            cmd.env("CHERE_INVOKING", "1");
             // Native git-bash: same OSC 7/133 rcfile as Unix bash, in the
             // forward-slash form MSYS bash accepts.
             match prepare_bash_rcfile() {
@@ -1012,4 +1032,24 @@ fn which_in_path(name: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_shell_override;
+
+    #[test]
+    fn rejects_non_enumerated_override() {
+        let exe = std::env::current_exe()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(sanitize_shell_override(Some(exe)), None);
+    }
+
+    #[test]
+    fn empty_or_missing_override_is_none() {
+        assert_eq!(sanitize_shell_override(Some("   ".into())), None);
+        assert_eq!(sanitize_shell_override(None), None);
+    }
 }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -54,15 +54,16 @@ pub fn build_command(
     cwd: Option<String>,
     workspace: WorkspaceEnv,
     blocks: bool,
+    shell: Option<String>,
 ) -> Result<CommandBuilder, String> {
     #[cfg(unix)]
     {
         let _ = workspace;
-        unix::build(cwd, blocks)
+        unix::build(cwd, blocks, shell)
     }
     #[cfg(windows)]
     {
-        windows::build(cwd, workspace, blocks)
+        windows::build(cwd, workspace, blocks, shell)
     }
 }
 
@@ -79,6 +80,26 @@ pub fn detect_shell_name() -> String {
             .and_then(|s| s.to_str())
             .map(|s| s.to_ascii_lowercase())
             .unwrap_or_default()
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ShellInfo {
+    pub name: String,
+    pub path: String,
+    /// True when Terax injects OSC 7/133 integration for this shell (cwd
+    /// tracking, command blocks, agent detection). Others spawn bare.
+    pub integrated: bool,
+}
+
+pub fn list_shells() -> Vec<ShellInfo> {
+    #[cfg(unix)]
+    {
+        unix::list_shells()
+    }
+    #[cfg(windows)]
+    {
+        windows::list_shells()
     }
 }
 
@@ -159,19 +180,36 @@ mod unix {
     }
 
     impl Shell {
+        pub fn classify(path: &str) -> Shell {
+            match path.rsplit('/').next().unwrap_or("") {
+                "zsh" => Shell::Zsh,
+                "bash" => Shell::Bash,
+                "fish" => Shell::Fish,
+                _ => Shell::Other,
+            }
+        }
+
         pub fn detect() -> (Shell, String) {
             let path = login_shell()
                 .or_else(|| std::env::var("SHELL").ok())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "/bin/zsh".into());
-            let name = path.rsplit('/').next().unwrap_or("").to_string();
-            let shell = match name.as_str() {
-                "zsh" => Shell::Zsh,
-                "bash" => Shell::Bash,
-                "fish" => Shell::Fish,
-                _ => Shell::Other,
-            };
-            (shell, path)
+            (Self::classify(&path), path)
+        }
+
+        // A configured override wins only when it points at a real file;
+        // otherwise fall back to the user's login shell.
+        pub fn resolve(shell_override: Option<String>) -> (Shell, String) {
+            if let Some(path) = shell_override
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+            {
+                if Path::new(&path).is_file() {
+                    return (Self::classify(&path), path);
+                }
+                log::warn!("configured shell '{path}' not found, using auto-detect");
+            }
+            Self::detect()
         }
     }
 
@@ -191,8 +229,42 @@ mod unix {
         }
     }
 
-    pub fn build(cwd: Option<String>, blocks: bool) -> Result<CommandBuilder, String> {
-        let (shell, shell_path) = Shell::detect();
+    pub fn list_shells() -> Vec<super::ShellInfo> {
+        use std::collections::HashSet;
+        let mut out = Vec::new();
+        let mut seen = HashSet::new();
+        let (_, login) = Shell::detect();
+        let mut candidates = vec![login];
+        if let Ok(content) = fs::read_to_string("/etc/shells") {
+            for line in content.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                candidates.push(line.to_string());
+            }
+        }
+        for path in candidates {
+            if !seen.insert(path.clone()) || !Path::new(&path).is_file() {
+                continue;
+            }
+            let integrated = !matches!(Shell::classify(&path), Shell::Other);
+            let name = path.rsplit('/').next().unwrap_or(&path).to_string();
+            out.push(super::ShellInfo {
+                name,
+                path,
+                integrated,
+            });
+        }
+        out
+    }
+
+    pub fn build(
+        cwd: Option<String>,
+        blocks: bool,
+        shell_override: Option<String>,
+    ) -> Result<CommandBuilder, String> {
+        let (shell, shell_path) = Shell::resolve(shell_override);
         let mut cmd = CommandBuilder::new(&shell_path);
         super::apply_common(&mut cmd, cwd, blocks);
 
@@ -302,6 +374,45 @@ mod unix {
             format!("rename {} -> {}: {e}", tmp.display(), path.display())
         })
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::Shell;
+
+        #[test]
+        fn classify_maps_known_shells() {
+            assert!(matches!(Shell::classify("/bin/zsh"), Shell::Zsh));
+            assert!(matches!(Shell::classify("/usr/bin/bash"), Shell::Bash));
+            assert!(matches!(
+                Shell::classify("/opt/homebrew/bin/fish"),
+                Shell::Fish
+            ));
+            assert!(matches!(Shell::classify("/bin/sh"), Shell::Other));
+            assert!(matches!(Shell::classify("/usr/bin/nu"), Shell::Other));
+        }
+
+        #[test]
+        fn resolve_uses_an_existing_override() {
+            let exe = std::env::current_exe().unwrap();
+            let path = exe.to_string_lossy().into_owned();
+            let (_, resolved) = Shell::resolve(Some(path.clone()));
+            assert_eq!(resolved, path);
+        }
+
+        #[test]
+        fn resolve_falls_back_when_override_missing() {
+            let (_, path) = Shell::resolve(Some("/no/such/shell/xyz".into()));
+            assert!(!path.is_empty());
+            assert_ne!(path, "/no/such/shell/xyz");
+        }
+
+        #[test]
+        fn resolve_falls_back_on_empty_override() {
+            let (_, fallback) = Shell::resolve(Some("   ".into()));
+            let (_, detected) = Shell::detect();
+            assert_eq!(fallback, detected);
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -354,18 +465,25 @@ mod windows {
         cwd: Option<String>,
         workspace: WorkspaceEnv,
         blocks: bool,
+        shell: Option<String>,
     ) -> Result<CommandBuilder, String> {
         if let WorkspaceEnv::Wsl { distro } = workspace {
-            let _ = blocks;
+            let _ = (blocks, shell);
             return build_wsl(cwd, distro);
         }
-        let shell_path = super::windows_shell_path();
+        let shell_path = shell
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .filter(|p| p.is_file())
+            .unwrap_or_else(super::windows_shell_path);
         let shell_name = shell_path
             .file_name()
             .and_then(|s| s.to_str())
             .map(|s| s.to_ascii_lowercase())
             .unwrap_or_default();
         let is_powershell = shell_name == "pwsh.exe" || shell_name == "powershell.exe";
+        let is_bash = shell_name == "bash.exe";
 
         let mut cmd = CommandBuilder::new(&shell_path);
         super::apply_common(&mut cmd, cwd, blocks);
@@ -382,6 +500,19 @@ mod windows {
                 }
                 Err(e) => {
                     log::warn!("powershell shell integration disabled: {e}");
+                }
+            }
+        } else if is_bash {
+            // Native git-bash: same OSC 7/133 rcfile as Unix bash, in the
+            // forward-slash form MSYS bash accepts.
+            match prepare_bash_rcfile() {
+                Ok(rc) => {
+                    cmd.arg("--rcfile");
+                    cmd.arg(rc.to_string_lossy().replace('\\', "/"));
+                    cmd.arg("-i");
+                }
+                Err(e) => {
+                    log::warn!("bash shell integration disabled: {e}");
                 }
             }
         } else {
@@ -595,6 +726,76 @@ mod windows {
         let file = dir.join("profile.ps1");
         write_if_changed(&file, PROFILE_PS1)?;
         Ok(file)
+    }
+
+    fn prepare_bash_rcfile() -> Result<PathBuf, String> {
+        let dir = integration_root()?.join("bash");
+        fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+        let rc = dir.join("bashrc");
+        write_if_changed(&rc, &normalize_script(super::bashrc_script()))?;
+        Ok(rc)
+    }
+
+    pub fn list_shells() -> Vec<super::ShellInfo> {
+        fn add(out: &mut Vec<super::ShellInfo>, name: &str, path: PathBuf, integrated: bool) {
+            if path.is_file() {
+                out.push(super::ShellInfo {
+                    name: name.to_string(),
+                    path: path.to_string_lossy().into_owned(),
+                    integrated,
+                });
+            }
+        }
+
+        let mut out = Vec::new();
+        if let Some(p) = super::which_in_path("pwsh.exe") {
+            add(&mut out, "PowerShell", p, true);
+        } else if let Some(pf) = std::env::var_os("ProgramFiles").map(PathBuf::from) {
+            add(
+                &mut out,
+                "PowerShell",
+                pf.join("PowerShell").join("7").join("pwsh.exe"),
+                true,
+            );
+        }
+        let system32 = std::env::var_os("SystemRoot")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(r"C:\Windows"))
+            .join("System32");
+        add(
+            &mut out,
+            "Windows PowerShell",
+            system32
+                .join("WindowsPowerShell")
+                .join("v1.0")
+                .join("powershell.exe"),
+            true,
+        );
+        add(&mut out, "Command Prompt", system32.join("cmd.exe"), false);
+        if let Some(p) = git_bash_path() {
+            add(&mut out, "Git Bash", p, true);
+        }
+        out
+    }
+
+    fn git_bash_path() -> Option<PathBuf> {
+        // Git for Windows install locations only. A bash.exe on PATH is usually
+        // the WSL launcher in System32, which is the separate WSL switcher.
+        for var in ["ProgramFiles", "ProgramFiles(x86)", "LocalAppData"] {
+            if let Some(base) = std::env::var_os(var).map(PathBuf::from) {
+                for rel in [
+                    r"Git\bin\bash.exe",
+                    r"Git\usr\bin\bash.exe",
+                    r"Programs\Git\bin\bash.exe",
+                ] {
+                    let candidate = base.join(rel);
+                    if candidate.is_file() {
+                        return Some(candidate);
+                    }
+                }
+            }
+        }
+        None
     }
 
     fn write_if_changed(path: &Path, content: &str) -> Result<(), String> {

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -148,6 +148,7 @@ export type Preferences = {
   terminalCursorBlink: boolean;
   terminalFontFamily: string;
   terminalFontWeight: string;
+  terminalShell: string;
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
@@ -199,6 +200,7 @@ const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_CURSOR_BLINK = "terminalCursorBlink";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
 const KEY_TERMINAL_FONT_WEIGHT = "terminalFontWeight";
+const KEY_TERMINAL_SHELL = "terminalShell";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
@@ -263,6 +265,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalCursorBlink: false,
   terminalFontFamily: "",
   terminalFontWeight: "normal",
+  terminalShell: "",
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
@@ -405,6 +408,8 @@ export async function loadPreferences(): Promise<Preferences> {
       get<string>(KEY_TERMINAL_FONT_WEIGHT) ??
         DEFAULT_PREFERENCES.terminalFontWeight,
     ),
+    terminalShell:
+      get<string>(KEY_TERMINAL_SHELL) ?? DEFAULT_PREFERENCES.terminalShell,
     terminalLetterSpacing:
       get<number>(KEY_TERMINAL_LETTER_SPACING) ??
       DEFAULT_PREFERENCES.terminalLetterSpacing,
@@ -618,6 +623,10 @@ export async function setTerminalFontWeight(value: string): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_WEIGHT, coerceFontWeight(value));
 }
 
+export async function setTerminalShell(value: string): Promise<void> {
+  await writePref(KEY_TERMINAL_SHELL, value.trim());
+}
+
 export async function setTerminalLetterSpacing(value: number): Promise<void> {
   const clamped = Number.isFinite(value) ? Math.max(-10, Math.min(10, Math.round(value))) : 0;
   await writePref(KEY_TERMINAL_LETTER_SPACING, clamped);
@@ -725,6 +734,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_CURSOR_BLINK]: "terminalCursorBlink",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",
     [KEY_TERMINAL_FONT_WEIGHT]: "terminalFontWeight",
+    [KEY_TERMINAL_SHELL]: "terminalShell",
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -7,6 +7,9 @@ import {
   registerPromptTracker,
 } from "./osc-handlers";
 
+// git-bash path mapping is Windows-only; exercise that branch.
+vi.mock("@/lib/platform", () => ({ IS_WINDOWS: true }));
+
 /**
  * Minimal in-memory fake of the xterm `Terminal` surface we touch — just
  * enough to register OSC handlers and invoke them with crafted payloads.
@@ -46,6 +49,19 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     handlers.get(7)?.("file://host/home/me/project");
 
     expect(onCwd).toHaveBeenCalledWith("/home/me/project");
+  });
+
+  it("maps git-bash /c/ cwd to a Windows drive path", () => {
+    const { term, handlers } = makeFakeTerm();
+    const state = createShellIntegrationState();
+    const onCwd = vi.fn();
+    registerPromptTracker(term, state);
+    registerCwdHandler(term, onCwd, state);
+
+    handlers.get(133)?.("A");
+    handlers.get(7)?.("file:///c/Users/leo/project");
+
+    expect(onCwd).toHaveBeenCalledWith("C:/Users/leo/project");
   });
 
   it("rejects OSC 7 emitted while a command is running", () => {

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -1,3 +1,4 @@
+import { IS_WINDOWS } from "@/lib/platform";
 import type { IMarker, Terminal } from "@xterm/xterm";
 
 const MAX_OSC52_CLIPBOARD_BYTES = 1024 * 1024;
@@ -108,7 +109,13 @@ function parseOsc7(data: string): string | null {
     path = decodeURIComponent(path);
   } catch {}
   // /C:/Users/foo -> C:/Users/foo so it's a valid Windows path.
-  if (/^\/[A-Za-z]:/.test(path)) path = path.slice(1);
+  if (/^\/[A-Za-z]:/.test(path)) {
+    path = path.slice(1);
+  } else if (IS_WINDOWS) {
+    // git-bash (MSYS) reports cwd as /c/Users/foo; map it to C:/Users/foo.
+    const drive = path.match(/^\/([A-Za-z])(\/.*)?$/);
+    if (drive) path = `${drive[1].toUpperCase()}:${drive[2] ?? "/"}`;
+  }
   return path;
 }
 

--- a/src/modules/terminal/lib/pty-bridge.ts
+++ b/src/modules/terminal/lib/pty-bridge.ts
@@ -21,6 +21,7 @@ export async function openPty(
   handlers: PtyHandlers,
   cwd?: string,
   blocks?: boolean,
+  shell?: string,
 ): Promise<PtySession> {
   // Raw bytes — no base64/JSON round-trip; messages arrive as ArrayBuffer.
   const onData = new Channel<ArrayBuffer>();
@@ -47,6 +48,7 @@ export async function openPty(
     cwd: cwd ?? null,
     workspace: currentWorkspaceEnv(),
     blocks: blocks ?? false,
+    shell: shell ?? null,
     onData,
     onExit,
   });

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -545,6 +545,7 @@ async function openPtyForSession(
     },
     cwd,
     s.blocks,
+    usePreferencesStore.getState().terminalShell || undefined,
   );
   // Only resize if the bound dims changed during the spawn: a same-size
   // ResizePseudoConsole during conhost warmup is a known ConPTY trigger for

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -30,6 +30,7 @@ import {
   setShowHidden,
   setTerminalFontFamily,
   setTerminalFontWeight,
+  setTerminalShell,
   setTerminalLetterSpacing,
   setTerminalFontSize,
   setTerminalCursorBlink,
@@ -45,6 +46,7 @@ import {
   Sun03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { invoke } from "@tauri-apps/api/core";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { useEffect, useState } from "react";
 import { SectionHeader } from "../components/SectionHeader";
@@ -67,6 +69,9 @@ const TERMINAL_FONT_WEIGHTS = [
   { value: "bold", label: "Bold" },
 ] as const;
 const LETTER_SPACINGS = [-4, -3, -2, -1, 0, 1, 2, 3, 4] as const;
+
+type ShellInfo = { name: string; path: string; integrated: boolean };
+const SHELL_AUTO = "auto";
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 2.0;
 const ZOOM_STEP = 0.05;
@@ -95,6 +100,8 @@ export function GeneralSection() {
   );
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalFontWeight = usePreferencesStore((s) => s.terminalFontWeight);
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
+  const [shells, setShells] = useState<ShellInfo[]>([]);
   const terminalLetterSpacing = usePreferencesStore(
     (s) => s.terminalLetterSpacing,
   );
@@ -116,6 +123,12 @@ export function GeneralSection() {
     return () => {
       alive = false;
     };
+  }, []);
+
+  useEffect(() => {
+    void invoke<ShellInfo[]>("pty_list_shells")
+      .then(setShells)
+      .catch(() => {});
   }, []);
 
   const onToggleAutostart = async (next: boolean) => {
@@ -313,6 +326,42 @@ export function GeneralSection() {
                   className="text-[12px]"
                 >
                   {w.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+        <SettingRow
+          title="Default shell"
+          description={
+            shells.find((s) => s.path === terminalShell)?.integrated === false
+              ? "Command blocks and directory tracking are unavailable for this shell."
+              : "Shell for new terminal tabs. Existing tabs keep their shell."
+          }
+        >
+          <Select
+            value={terminalShell || SHELL_AUTO}
+            onValueChange={(v) =>
+              void setTerminalShell(v === SHELL_AUTO ? "" : v)
+            }
+          >
+            <SelectTrigger
+              value={terminalShell || SHELL_AUTO}
+              className="h-8 w-40 text-[12px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={SHELL_AUTO} className="text-[12px]">
+                Auto
+              </SelectItem>
+              {shells.map((s) => (
+                <SelectItem
+                  key={s.path}
+                  value={s.path}
+                  className="text-[12px]"
+                >
+                  {s.name}
                 </SelectItem>
               ))}
             </SelectContent>


### PR DESCRIPTION
Adds a Default shell setting (Settings, General) so users can pick the interactive terminal shell instead of always getting the auto-detected one. Closes the Windows pwsh-vs-bash pain.

## What
- New `pty_list_shells` command detects available shells (unix: /etc/shells; Windows: pwsh/powershell/cmd + git-bash from Git install paths, not PATH so it never picks up the WSL launcher).
- `shell` override threads through pty_open -> session::spawn -> build_command. Empty = auto-detect (unchanged behaviour).
- Windows: a chosen git-bash gets full OSC 7/133 integration via our bashrc + --rcfile, so command blocks and cwd tracking work, not just a bare shell.
- OSC 7 from git-bash (/c/Users/...) is normalised to C:/Users/... on Windows only.
- Settings UI flags shells that have no integration (cwd tracking / blocks unavailable).

## Notes
- Applies to new tabs; existing tabs keep their shell (no live PTY recreation).
- Supersedes #460 and #479.

## Verified
- Rust both targets (native clippy + 153 unit tests; windows-gnu cross-check compiles), frontend tsc + lint clean + 232 vitest. Windows runtime (git-bash OSC behaviour) to be confirmed on a real Windows box via CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Default shell” setting where users can choose a specific shell or “Auto”.
  * The app lists available shells and marks whether they support integrated behavior, using this to inform the setting description.
* **Bug Fixes**
  * Improved Windows path normalization for Git Bash/MSYS `file://` working-directory updates (OSC 7), converting `/c/...` to `C:/...`.
* **Tests**
  * Added Windows-focused test coverage for Git Bash cwd path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->