### PR TITLE
feat(editor): add per-tab language override via icon dropdown

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -122,6 +122,7 @@ export default function App() {
     newPreviewTab,
     newMarkdownTab,
     setMarkdownView,
+    setOverrideLanguage,
     openAiDiffTab,
     closeAiDiffTab,
     openGitDiffTab,
@@ -1067,6 +1068,7 @@ export default function App() {
               spaceSwitcher={spaceSwitcher}
               searchTarget={searchTarget}
               searchRef={searchInlineRef}
+              onOverrideLanguage={setOverrideLanguage}
             />
           )}
 
@@ -1142,6 +1144,7 @@ export default function App() {
                       onAiDiffReject={(id) => respondToApproval(id, false)}
                       onOpenCommitFile={openCommitFileDiffTab}
                       onGitHistorySearchHandle={setGitHistoryHandle}
+                      onEditorOverrideLanguage={setOverrideLanguage}
                       onSetMarkdownView={setMarkdownView}
                     />
                   </div>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1144,7 +1144,6 @@ export default function App() {
                       onAiDiffReject={(id) => respondToApproval(id, false)}
                       onOpenCommitFile={openCommitFileDiffTab}
                       onGitHistorySearchHandle={setGitHistoryHandle}
-                      onEditorOverrideLanguage={setOverrideLanguage}
                       onSetMarkdownView={setMarkdownView}
                     />
                   </div>

--- a/src/app/components/WorkspaceSurface.tsx
+++ b/src/app/components/WorkspaceSurface.tsx
@@ -25,7 +25,6 @@ type Props = {
   registerEditorHandle: EditorStackProps["registerHandle"];
   onEditorDirtyChange: EditorStackProps["onDirtyChange"];
   onEditorCloseTab: EditorStackProps["onCloseTab"];
-  onEditorOverrideLanguage: EditorStackProps["onOverrideLanguage"];
   registerPreviewHandle: PreviewStackProps["registerHandle"];
   onPreviewUrlChange: PreviewStackProps["onUrlChange"];
   onAiDiffAccept: AiDiffStackProps["onAccept"];
@@ -52,7 +51,6 @@ export function WorkspaceSurface({
   registerEditorHandle,
   onEditorDirtyChange,
   onEditorCloseTab,
-  onEditorOverrideLanguage,
   registerPreviewHandle,
   onPreviewUrlChange,
   onAiDiffAccept,
@@ -102,7 +100,6 @@ export function WorkspaceSurface({
           registerHandle={registerEditorHandle}
           onDirtyChange={onEditorDirtyChange}
           onCloseTab={onEditorCloseTab}
-          onOverrideLanguage={onEditorOverrideLanguage}
           onSetMarkdownView={onSetMarkdownView}
         />
       </div>

--- a/src/app/components/WorkspaceSurface.tsx
+++ b/src/app/components/WorkspaceSurface.tsx
@@ -25,6 +25,7 @@ type Props = {
   registerEditorHandle: EditorStackProps["registerHandle"];
   onEditorDirtyChange: EditorStackProps["onDirtyChange"];
   onEditorCloseTab: EditorStackProps["onCloseTab"];
+  onEditorOverrideLanguage: EditorStackProps["onOverrideLanguage"];
   registerPreviewHandle: PreviewStackProps["registerHandle"];
   onPreviewUrlChange: PreviewStackProps["onUrlChange"];
   onAiDiffAccept: AiDiffStackProps["onAccept"];
@@ -51,6 +52,7 @@ export function WorkspaceSurface({
   registerEditorHandle,
   onEditorDirtyChange,
   onEditorCloseTab,
+  onEditorOverrideLanguage,
   registerPreviewHandle,
   onPreviewUrlChange,
   onAiDiffAccept,
@@ -100,6 +102,7 @@ export function WorkspaceSurface({
           registerHandle={registerEditorHandle}
           onDirtyChange={onEditorDirtyChange}
           onCloseTab={onEditorCloseTab}
+          onOverrideLanguage={onEditorOverrideLanguage}
           onSetMarkdownView={onSetMarkdownView}
         />
       </div>

--- a/src/modules/editor/AiDiffPane.tsx
+++ b/src/modules/editor/AiDiffPane.tsx
@@ -97,7 +97,7 @@ export function AiDiffPane({
   const extensions = useMemo(
     () => [
       ...SHARED_EXT,
-      languageCompartment.of(initialLang ?? []),
+      languageCompartment.of(initialLang?.ext ?? []),
       ...READONLY_EXT,
       unifiedMergeView({
         original: originalContent,
@@ -115,12 +115,12 @@ export function AiDiffPane({
   useEffect(() => {
     if (initialLang) return;
     let cancelled = false;
-    resolveLanguage(path).then((ext) => {
+    resolveLanguage(path).then((res) => {
       if (cancelled) return;
       const view = cmRef.current?.view;
       if (!view) return;
       view.dispatch({
-        effects: languageCompartment.reconfigure(ext ?? []),
+        effects: languageCompartment.reconfigure(res?.ext ?? []),
       });
     });
     return () => {

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -20,7 +20,6 @@ import {
   useImperativeHandle,
   useMemo,
   useRef,
-  useState,
 } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import {
@@ -57,7 +56,6 @@ export type EditorPaneHandle = {
 type Props = {
   path: string;
   overrideLanguage?: string | null;
-  onOverrideLanguageChange?: (lang: string | null) => void;
   onDirtyChange?: (dirty: boolean) => void;
   onSaved?: () => void;
   onClose?: () => void;
@@ -71,14 +69,7 @@ function formatBytes(n: number): string {
 
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
   function EditorPane(props, ref) {
-    const {
-      path,
-      overrideLanguage: propOverrideLanguage,
-      onOverrideLanguageChange,
-      onDirtyChange,
-      onSaved,
-      onClose,
-    } = props;
+    const { path, overrideLanguage, onDirtyChange, onSaved, onClose } = props;
 
     const { doc, onChange, save, reload } = useDocument({
       path,
@@ -92,21 +83,6 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const editorWordWrap = usePreferencesStore((s) => s.editorWordWrap);
     const languageRef = useRef<string | null>(null);
     const apiKeyRef = useRef<string | null>(null);
-
-    const [localOverrideLanguage, setLocalOverrideLanguage] = useState<
-      string | null
-    >(null);
-
-    const overrideLanguage =
-      propOverrideLanguage !== undefined
-        ? propOverrideLanguage
-        : localOverrideLanguage;
-
-    useEffect(() => {
-      if (!onOverrideLanguageChange) {
-        setLocalOverrideLanguage(null);
-      }
-    }, [onOverrideLanguageChange]);
 
     useEffect(() => {
       let cancelled = false;
@@ -288,14 +264,17 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
         const resolvePath = overrideLanguage
           ? `dummy.${overrideLanguage}`
           : path;
-        return (await resolveLanguage(resolvePath)) ?? { ext: [], name: "" };
+        return (
+          (await resolveLanguage(resolvePath)) ?? { ext: [], name: "", id: "" }
+        );
       };
       void resolve().then((result) => {
         if (cancelled) return;
+        if (result.id) languageRef.current = result.id;
         const view = cmRef.current?.view;
         if (!view) return;
         view.dispatch({
-          effects: languageCompartment.reconfigure(result?.ext),
+          effects: languageCompartment.reconfigure(result.ext),
         });
       });
       return () => {

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -9,7 +9,7 @@ import {
   SearchQuery,
   setSearchQuery,
 } from "@codemirror/search";
-import { type Extension, Prec } from "@codemirror/state";
+import { Prec } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { vim } from "@replit/codemirror-vim";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
@@ -20,6 +20,7 @@ import {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import {
@@ -28,7 +29,7 @@ import {
   vimCompartment,
   wrapCompartment,
 } from "./lib/extensions";
-import { resolveLanguage } from "./lib/languageResolver";
+import { type LanguageResult, resolveLanguage } from "./lib/languageResolver";
 import { useEditorThemeExt } from "./lib/useEditorThemeExt";
 import { useDocument } from "./lib/useDocument";
 import { initVimGlobals, vimHandlersExtension } from "./lib/vim";
@@ -55,6 +56,8 @@ export type EditorPaneHandle = {
 
 type Props = {
   path: string;
+  overrideLanguage?: string | null;
+  onOverrideLanguageChange?: (lang: string | null) => void;
   onDirtyChange?: (dirty: boolean) => void;
   onSaved?: () => void;
   onClose?: () => void;
@@ -67,7 +70,16 @@ function formatBytes(n: number): string {
 }
 
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
-  function EditorPane({ path, onDirtyChange, onSaved, onClose }, ref) {
+  function EditorPane(props, ref) {
+    const {
+      path,
+      overrideLanguage: propOverrideLanguage,
+      onOverrideLanguageChange,
+      onDirtyChange,
+      onSaved,
+      onClose,
+    } = props;
+
     const { doc, onChange, save, reload } = useDocument({
       path,
       onDirtyChange,
@@ -80,6 +92,21 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const editorWordWrap = usePreferencesStore((s) => s.editorWordWrap);
     const languageRef = useRef<string | null>(null);
     const apiKeyRef = useRef<string | null>(null);
+
+    const [localOverrideLanguage, setLocalOverrideLanguage] = useState<
+      string | null
+    >(null);
+
+    const overrideLanguage =
+      propOverrideLanguage !== undefined
+        ? propOverrideLanguage
+        : localOverrideLanguage;
+
+    useEffect(() => {
+      if (!onOverrideLanguageChange) {
+        setLocalOverrideLanguage(null);
+      }
+    }, [onOverrideLanguageChange]);
 
     useEffect(() => {
       let cancelled = false;
@@ -252,32 +279,29 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     }, [editorWordWrap]);
 
     useEffect(() => {
-      const ext = path.split(".").pop()?.toLowerCase() ?? null;
+      const ext =
+        overrideLanguage || (path.split(".").pop()?.toLowerCase() ?? null);
       languageRef.current = ext;
       if (doc.status !== "ready") return;
       let cancelled = false;
-      const resolve = async (): Promise<Extension> => {
-        if (path.toLowerCase().endsWith(".terax-theme")) {
-          const [{ json }, { colorSwatches }] = await Promise.all([
-            import("@codemirror/lang-json"),
-            import("./lib/colorSwatches"),
-          ]);
-          return [json(), colorSwatches()];
-        }
-        return (await resolveLanguage(path)) ?? [];
+      const resolve = async (): Promise<LanguageResult> => {
+        const resolvePath = overrideLanguage
+          ? `dummy.${overrideLanguage}`
+          : path;
+        return (await resolveLanguage(resolvePath)) ?? { ext: [], name: "" };
       };
-      void resolve().then((extension) => {
+      void resolve().then((result) => {
         if (cancelled) return;
         const view = cmRef.current?.view;
         if (!view) return;
         view.dispatch({
-          effects: languageCompartment.reconfigure(extension),
+          effects: languageCompartment.reconfigure(result?.ext),
         });
       });
       return () => {
         cancelled = true;
       };
-    }, [path, doc.status]);
+    }, [path, doc.status, overrideLanguage]);
 
     useImperativeHandle(
       ref,

--- a/src/modules/editor/EditorStack.tsx
+++ b/src/modules/editor/EditorStack.tsx
@@ -10,7 +10,6 @@ type Props = {
   onDirtyChange: (id: number, dirty: boolean) => void;
   registerHandle: (id: number, handle: EditorPaneHandle | null) => void;
   onCloseTab: (id: number) => void;
-  onOverrideLanguage?: (id: number, lang: string | null) => void;
   onSetMarkdownView: (id: number, mode: "rendered" | "raw") => void;
 };
 
@@ -20,7 +19,6 @@ export function EditorStack({
   onDirtyChange,
   registerHandle,
   onCloseTab,
-  onOverrideLanguage,
   onSetMarkdownView,
 }: Props) {
   const editors = tabs.filter(
@@ -34,7 +32,6 @@ export function EditorStack({
   const registerRef = useRef(registerHandle);
   const dirtyRef = useRef(onDirtyChange);
   const closeRef = useRef(onCloseTab);
-  const overrideRef = useRef(onOverrideLanguage);
 
   useEffect(() => {
     registerRef.current = registerHandle;
@@ -45,18 +42,12 @@ export function EditorStack({
   useEffect(() => {
     closeRef.current = onCloseTab;
   }, [onCloseTab]);
-  useEffect(() => {
-    overrideRef.current = onOverrideLanguage;
-  }, [onOverrideLanguage]);
 
   const refCallbacks = useRef(
     new Map<number, (h: EditorPaneHandle | null) => void>(),
   );
   const dirtyCallbacks = useRef(new Map<number, (dirty: boolean) => void>());
   const closeCallbacks = useRef(new Map<number, () => void>());
-  const overrideCallbacks = useRef(
-    new Map<number, (lang: string | null) => void>(),
-  );
 
   const getRefCallback = (id: number) => {
     let cb = refCallbacks.current.get(id);
@@ -82,14 +73,6 @@ export function EditorStack({
     }
     return cb;
   };
-  const getOverrideCallback = (id: number) => {
-    let cb = overrideCallbacks.current.get(id);
-    if (!cb) {
-      cb = (lang: string | null) => overrideRef.current?.(id, lang);
-      overrideCallbacks.current.set(id, cb);
-    }
-    return cb;
-  };
 
   // Drop callback entries for closed tabs to avoid unbounded growth.
   useEffect(() => {
@@ -102,9 +85,6 @@ export function EditorStack({
     }
     for (const id of closeCallbacks.current.keys()) {
       if (!live.has(id)) closeCallbacks.current.delete(id);
-    }
-    for (const id of overrideCallbacks.current.keys()) {
-      if (!live.has(id)) overrideCallbacks.current.delete(id);
     }
   }, [editors]);
 
@@ -135,7 +115,6 @@ export function EditorStack({
                 ref={getRefCallback(t.id)}
                 path={t.path}
                 overrideLanguage={t.overrideLanguage}
-                onOverrideLanguageChange={getOverrideCallback(t.id)}
                 onDirtyChange={getDirtyCallback(t.id)}
                 onClose={getCloseCallback(t.id)}
               />

--- a/src/modules/editor/EditorStack.tsx
+++ b/src/modules/editor/EditorStack.tsx
@@ -10,6 +10,7 @@ type Props = {
   onDirtyChange: (id: number, dirty: boolean) => void;
   registerHandle: (id: number, handle: EditorPaneHandle | null) => void;
   onCloseTab: (id: number) => void;
+  onOverrideLanguage?: (id: number, lang: string | null) => void;
   onSetMarkdownView: (id: number, mode: "rendered" | "raw") => void;
 };
 
@@ -19,6 +20,7 @@ export function EditorStack({
   onDirtyChange,
   registerHandle,
   onCloseTab,
+  onOverrideLanguage,
   onSetMarkdownView,
 }: Props) {
   const editors = tabs.filter(
@@ -32,6 +34,8 @@ export function EditorStack({
   const registerRef = useRef(registerHandle);
   const dirtyRef = useRef(onDirtyChange);
   const closeRef = useRef(onCloseTab);
+  const overrideRef = useRef(onOverrideLanguage);
+
   useEffect(() => {
     registerRef.current = registerHandle;
   }, [registerHandle]);
@@ -41,12 +45,18 @@ export function EditorStack({
   useEffect(() => {
     closeRef.current = onCloseTab;
   }, [onCloseTab]);
+  useEffect(() => {
+    overrideRef.current = onOverrideLanguage;
+  }, [onOverrideLanguage]);
 
   const refCallbacks = useRef(
     new Map<number, (h: EditorPaneHandle | null) => void>(),
   );
   const dirtyCallbacks = useRef(new Map<number, (dirty: boolean) => void>());
   const closeCallbacks = useRef(new Map<number, () => void>());
+  const overrideCallbacks = useRef(
+    new Map<number, (lang: string | null) => void>(),
+  );
 
   const getRefCallback = (id: number) => {
     let cb = refCallbacks.current.get(id);
@@ -72,6 +82,14 @@ export function EditorStack({
     }
     return cb;
   };
+  const getOverrideCallback = (id: number) => {
+    let cb = overrideCallbacks.current.get(id);
+    if (!cb) {
+      cb = (lang: string | null) => overrideRef.current?.(id, lang);
+      overrideCallbacks.current.set(id, cb);
+    }
+    return cb;
+  };
 
   // Drop callback entries for closed tabs to avoid unbounded growth.
   useEffect(() => {
@@ -84,6 +102,9 @@ export function EditorStack({
     }
     for (const id of closeCallbacks.current.keys()) {
       if (!live.has(id)) closeCallbacks.current.delete(id);
+    }
+    for (const id of overrideCallbacks.current.keys()) {
+      if (!live.has(id)) overrideCallbacks.current.delete(id);
     }
   }, [editors]);
 
@@ -113,6 +134,8 @@ export function EditorStack({
               <EditorPane
                 ref={getRefCallback(t.id)}
                 path={t.path}
+                overrideLanguage={t.overrideLanguage}
+                onOverrideLanguageChange={getOverrideCallback(t.id)}
                 onDirtyChange={getDirtyCallback(t.id)}
                 onClose={getCloseCallback(t.id)}
               />

--- a/src/modules/editor/GitDiffPane.tsx
+++ b/src/modules/editor/GitDiffPane.tsx
@@ -200,7 +200,7 @@ export function GitDiffPane({ source, chipLabel, active }: Props) {
   const extensions = useMemo(
     () => [
       ...SHARED_EXT,
-      languageCompartment.of(initialLang ?? []),
+      languageCompartment.of(initialLang?.ext ?? []),
       ...READONLY_EXT,
       unifiedMergeView({
         original: originalContent,
@@ -225,12 +225,12 @@ export function GitDiffPane({ source, chipLabel, active }: Props) {
     if (useFallback || initialLang) return;
     if (state.kind !== "loaded") return;
     let cancelled = false;
-    resolveLanguage(path).then((ext) => {
+    resolveLanguage(path).then((res) => {
       if (cancelled) return;
       const view = cmRef.current?.view;
       if (!view) return;
       view.dispatch({
-        effects: languageCompartment.reconfigure(ext ?? []),
+        effects: languageCompartment.reconfigure(res?.ext ?? []),
       });
     });
     return () => {

--- a/src/modules/editor/lib/languageDefinitions.ts
+++ b/src/modules/editor/lib/languageDefinitions.ts
@@ -1,10 +1,9 @@
 import type { StreamParser } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 
-type LoaderResult = Extension | { token: unknown };
-type LanguageLoader = () => Promise<LoaderResult>;
+type LanguageLoader = () => Promise<Extension>;
 
-interface LanguageDefinition {
+export interface LanguageDefinition {
   name: string;
   extensions: string[];
   loader: LanguageLoader;

--- a/src/modules/editor/lib/languageDefinitions.ts
+++ b/src/modules/editor/lib/languageDefinitions.ts
@@ -1,0 +1,470 @@
+import type { StreamParser } from "@codemirror/language";
+import type { Extension } from "@codemirror/state";
+
+type LoaderResult = Extension | { token: unknown };
+type LanguageLoader = () => Promise<LoaderResult>;
+
+interface LanguageDefinition {
+  name: string;
+  extensions: string[];
+  loader: LanguageLoader;
+
+  filenames?: string[];
+  userSelectable?: boolean;
+}
+
+async function defineLanguage(
+  parser: Promise<StreamParser<unknown>>,
+): Promise<Extension> {
+  const [{ StreamLanguage }, resolvedParser] = await Promise.all([
+    import("@codemirror/language"),
+    parser,
+  ]);
+  return StreamLanguage.define(resolvedParser);
+}
+
+export const LANGUAGES: LanguageDefinition[] = [
+  {
+    name: "JavaScript",
+    extensions: ["js", "cjs", "mjs"],
+    loader: () =>
+      import("@codemirror/lang-javascript").then((m) => m.javascript()),
+    userSelectable: true,
+  },
+  {
+    name: "TypeScript",
+    extensions: ["ts", "cts", "mts"],
+    loader: () =>
+      import("@codemirror/lang-javascript").then((m) =>
+        m.javascript({ typescript: true }),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "JavaScript React",
+    extensions: ["jsx"],
+    loader: () =>
+      import("@codemirror/lang-javascript").then((m) =>
+        m.javascript({ jsx: true }),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "TypeScript React",
+    extensions: ["tsx"],
+    loader: () =>
+      import("@codemirror/lang-javascript").then((m) =>
+        m.javascript({ jsx: true, typescript: true }),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "Rust",
+    extensions: ["rs"],
+    loader: () => import("@codemirror/lang-rust").then((m) => m.rust()),
+    userSelectable: true,
+  },
+  {
+    name: "Go",
+    extensions: ["go"],
+    loader: () => import("@codemirror/lang-go").then((m) => m.go()),
+    userSelectable: true,
+  },
+  {
+    name: "Python",
+    extensions: ["py"],
+    loader: () => import("@codemirror/lang-python").then((m) => m.python()),
+    userSelectable: true,
+  },
+  {
+    name: "JSON",
+    extensions: ["json", "jsonc", "json5"],
+    loader: () => import("@codemirror/lang-json").then((m) => m.json()),
+    filenames: [".eslintrc", ".babelrc", ".prettierrc"],
+    userSelectable: true,
+  },
+  {
+    name: "SQL",
+    extensions: ["sql"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.standardSQL),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "PostgreSQL",
+    extensions: ["psql", "pgsql"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.pgSQL),
+      ),
+  },
+  {
+    name: "MySQL",
+    extensions: ["mysql"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.mySQL),
+      ),
+  },
+  {
+    name: "SQLite",
+    extensions: ["sqlite"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.sqlite),
+      ),
+  },
+  {
+    name: "MariaDB",
+    extensions: ["mariadb"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.mariaDB),
+      ),
+  },
+  {
+    name: "MSSQL",
+    extensions: ["mssql"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.msSQL),
+      ),
+  },
+  {
+    name: "PL/SQL",
+    extensions: ["plsql"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/sql").then((m) => m.plSQL),
+      ),
+  },
+  {
+    name: "Markdown",
+    extensions: ["md", "markdown"],
+    loader: () => import("@codemirror/lang-markdown").then((m) => m.markdown()),
+    userSelectable: true,
+  },
+  {
+    name: "HTML",
+    extensions: ["html", "htm", "svelte", "twig"],
+    loader: () => import("@codemirror/lang-html").then((m) => m.html()),
+    userSelectable: true,
+  },
+  {
+    name: "Astro",
+    extensions: ["astro"],
+    loader: () =>
+      import("@codemirror/lang-html").then((m) =>
+        m.html({ selfClosingTags: true }),
+      ),
+  },
+  {
+    name: "CSS",
+    extensions: ["css"],
+    loader: () => import("@codemirror/lang-css").then((m) => m.css()),
+    userSelectable: true,
+  },
+  {
+    name: "Vue",
+    extensions: ["vue"],
+    loader: () => import("@codemirror/lang-vue").then((m) => m.vue()),
+  },
+  {
+    name: "PHP",
+    extensions: ["php"],
+    loader: () =>
+      import("@codemirror/lang-php").then((m) => m.php({ plain: true })),
+  },
+  {
+    name: "C",
+    extensions: ["c", "h"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.c),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "C++",
+    extensions: ["cpp", "cc", "cxx", "hpp", "hxx"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "C#",
+    extensions: ["cs"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.csharp),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "Java",
+    extensions: ["java"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.java),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "Kotlin",
+    extensions: ["kt", "kts"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.kotlin),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "Scala",
+    extensions: ["scala", "sc"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.scala),
+      ),
+  },
+  {
+    name: "Swift",
+    extensions: ["swift"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/swift").then((m) => m.swift),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "Ruby",
+    extensions: ["rb", "rake", "gemspec", "ru"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/ruby").then((m) => m.ruby),
+      ),
+    filenames: [
+      "gemfile",
+      "rakefile",
+      "podfile",
+      "fastfile",
+      "guardfile",
+      "brewfile",
+    ],
+    userSelectable: true,
+  },
+  {
+    name: "Shell",
+    extensions: ["sh", "bash", "zsh"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/shell").then((m) => m.shell),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "TOML",
+    extensions: ["toml"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/toml").then((m) => m.toml),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "YAML",
+    extensions: ["yaml", "yml"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/yaml").then((m) => m.yaml),
+      ),
+    filenames: ["pubspec.yaml", "pubspec.lock", "analysis_options.yaml"],
+    userSelectable: true,
+  },
+  {
+    name: "Dockerfile",
+    extensions: ["dockerfile"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/dockerfile").then(
+          (m) => m.dockerFile,
+        ),
+      ),
+    filenames: ["dockerfile", "dockerfile.dev"],
+  },
+  {
+    name: "LaTeX",
+    extensions: ["tex", "latex", "sty", "cls"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
+      ),
+  },
+  {
+    name: "Dart",
+    extensions: ["dart"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clike").then((m) => m.dart),
+      ),
+  },
+  {
+    name: "Visual Basic",
+    extensions: ["vb"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/vb").then((m) => m.vb),
+      ),
+  },
+  {
+    name: "XML",
+    extensions: [
+      "xml",
+      "iml",
+      "xsd",
+      "xsl",
+      "xslt",
+      "svg",
+      "plist",
+      "csproj",
+      "props",
+      "targets",
+    ],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
+      ),
+    userSelectable: true,
+  },
+  {
+    name: "nginx",
+    extensions: ["conf", "nginx"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/nginx").then((m) => m.nginx),
+      ),
+    filenames: ["nginx.conf"],
+  },
+  {
+    name: "CMake",
+    extensions: ["cmake"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/cmake").then((m) => m.cmake),
+      ),
+    filenames: ["cmakelists.txt"],
+  },
+  {
+    name: "Properties",
+    extensions: ["ini", "cfg", "properties", "env"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/properties").then(
+          (m) => m.properties,
+        ),
+      ),
+    filenames: [".env", ".editorconfig"],
+  },
+  {
+    name: "Lua",
+    extensions: ["lua"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/lua").then((m) => m.lua),
+      ),
+  },
+  {
+    name: "PowerShell",
+    extensions: ["ps1", "psm1", "psd1"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/powershell").then(
+          (m) => m.powerShell,
+        ),
+      ),
+  },
+  {
+    name: "Perl",
+    extensions: ["pl", "pm"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/perl").then((m) => m.perl),
+      ),
+  },
+  {
+    name: "Groovy",
+    extensions: ["groovy", "gradle"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/groovy").then((m) => m.groovy),
+      ),
+  },
+  {
+    name: "Clojure",
+    extensions: ["clj", "cljs", "cljc", "edn"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/clojure").then((m) => m.clojure),
+      ),
+  },
+  {
+    name: "Haskell",
+    extensions: ["hs"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/haskell").then((m) => m.haskell),
+      ),
+  },
+  {
+    name: "Diff",
+    extensions: ["diff", "patch"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/diff").then((m) => m.diff),
+      ),
+  },
+  {
+    name: "Proto",
+    extensions: ["proto"],
+    loader: () =>
+      defineLanguage(
+        import("@codemirror/legacy-modes/mode/protobuf").then(
+          (m) => m.protobuf,
+        ),
+      ),
+  },
+  {
+    name: "Terax Theme",
+    extensions: ["terax-theme"],
+    loader: async () => {
+      const [{ json }, { colorSwatches }] = await Promise.all([
+        import("@codemirror/lang-json"),
+        import("./colorSwatches"),
+      ]);
+      return [json(), colorSwatches()];
+    },
+  },
+];
+
+export const ALL_LANGUAGES = [...LANGUAGES]
+  .sort((a, b) => a.name.localeCompare(b.name))
+  .map((l) => ({ name: l.name, ext: l.extensions[0] }));
+
+export const EXPOSED_LANGUAGES = LANGUAGES.filter((l) => l.userSelectable).map(
+  (l) => ({ name: l.name, ext: l.extensions[0] }),
+);
+
+export const extensionMap = new Map<string, LanguageDefinition>();
+export const filenameMap = new Map<string, LanguageDefinition>();
+
+for (const lang of LANGUAGES) {
+  lang.extensions?.forEach((ext) => {
+    extensionMap.set(ext.toLowerCase(), lang);
+  });
+  lang.filenames?.forEach((file) => {
+    filenameMap.set(file.toLowerCase(), lang);
+  });
+}

--- a/src/modules/editor/lib/languageResolver.test.ts
+++ b/src/modules/editor/lib/languageResolver.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveDisplayName } from "./languageResolver";
+
+describe("resolveDisplayName", () => {
+  it("resolves real extensions", () => {
+    expect(resolveDisplayName("App.tsx")).toBe("TypeScript React");
+    expect(resolveDisplayName("main.go")).toBe("Go");
+    expect(resolveDisplayName("README.md")).toBe("Markdown");
+    expect(resolveDisplayName("query.sql")).toBe("SQL");
+  });
+
+  it("strips directories before resolving", () => {
+    expect(resolveDisplayName("/Users/foo/src/index.ts")).toBe("TypeScript");
+    expect(resolveDisplayName("C:\\proj\\Dockerfile.prod")).toBe("Dockerfile");
+  });
+
+  it("matches fixed filenames", () => {
+    expect(resolveDisplayName("Dockerfile")).toBe("Dockerfile");
+    expect(resolveDisplayName(".env")).toBe("Properties");
+    expect(resolveDisplayName(".eslintrc")).toBe("JSON");
+  });
+
+  // Regression: removing isDockerfileLike dropped highlighting for Dockerfile
+  // variants. The name-scoped prefix fallback restores it generically.
+  it("resolves filename-prefix variants of name-based languages", () => {
+    expect(resolveDisplayName("Dockerfile.web")).toBe("Dockerfile");
+    expect(resolveDisplayName("Dockerfile.dev")).toBe("Dockerfile");
+    expect(resolveDisplayName("web.dockerfile")).toBe("Dockerfile");
+  });
+
+  // The prefix fallback must not let extension languages capture lookalike
+  // files: `go.sum` / `go.mod` are not Go, `json.backup` is not JSON.
+  it("does not let extension languages capture prefix lookalikes", () => {
+    expect(resolveDisplayName("go.sum")).not.toBe("Go");
+    expect(resolveDisplayName("go.mod")).not.toBe("Go");
+    expect(resolveDisplayName("json.backup")).not.toBe("JSON");
+  });
+
+  it("falls back to a capitalized basename for unknown files", () => {
+    expect(resolveDisplayName("notes")).toBe("Notes");
+    expect(resolveDisplayName(null)).toBe("Plain Text");
+    expect(resolveDisplayName("")).toBe("Plain Text");
+  });
+});

--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -1,17 +1,28 @@
 import type { Extension } from "@codemirror/state";
-import { extensionMap, filenameMap } from "./languageDefinitions";
+import {
+  extensionMap,
+  filenameMap,
+  type LanguageDefinition,
+} from "./languageDefinitions";
 
 export interface LanguageResult {
   ext: Extension;
   name: string;
+  /** Canonical language id (primary extension), in sync with the resolved mode. */
+  id: string;
 }
+
 const cache = new Map<string, LanguageResult | null>();
 
-function extOf(name: string): string | null {
-  const lower = name.toLowerCase();
-  const dot = lower.lastIndexOf(".");
-  if (dot === -1 || dot === lower.length - 1) return null;
-  return lower.slice(dot + 1);
+function basenameOf(filename: string): string {
+  const lower = filename.toLowerCase();
+  return lower.split(/[\\/]/).pop() ?? lower;
+}
+
+function extOf(base: string): string | null {
+  const dot = base.lastIndexOf(".");
+  if (dot === -1 || dot === base.length - 1) return null;
+  return base.slice(dot + 1);
 }
 
 function prefixOf(base: string): string | null {
@@ -19,67 +30,62 @@ function prefixOf(base: string): string | null {
   return dot > 0 ? base.slice(0, dot) : null;
 }
 
-function isStreamParser(v: unknown): boolean {
-  return (
-    typeof v === "object" &&
-    v !== null &&
-    typeof (v as { token?: unknown }).token === "function"
-  );
+// Order: exact filename, real extension, then filename prefix scoped to
+// name-based languages (so `Dockerfile.web` resolves while Go never captures
+// `go.sum`). Always returns a key so misses are negative-cached too.
+function match(base: string): {
+  key: string;
+  def: LanguageDefinition | undefined;
+} {
+  const byName = filenameMap.get(base);
+  if (byName) return { key: `name:${base}`, def: byName };
+
+  const ext = extOf(base);
+  if (ext) {
+    const byExt = extensionMap.get(ext);
+    if (byExt) return { key: `ext:${ext}`, def: byExt };
+  }
+
+  const prefix = prefixOf(base);
+  if (prefix) {
+    const byPrefix = filenameMap.get(prefix);
+    if (byPrefix) return { key: `name:${prefix}`, def: byPrefix };
+  }
+
+  return { key: ext ? `ext:${ext}` : `name:${base}`, def: undefined };
 }
 
-function cacheKey(filename: string): string | null {
-  const lower = filename.toLowerCase();
-  const base = lower.split(/[\\/]/).pop() ?? lower;
-  if (filenameMap.has(base)) return `name:${base}`;
-  const ext = extOf(base) ?? prefixOf(base);
-  return ext ? `ext:${ext}` : `name:${base}`;
-}
-
-export function resolveDisplayName(extOrFilename: string | null): string {
-  if (!extOrFilename) return "Plain Text";
-  const lower = extOrFilename.toLowerCase();
-  const base = lower.split(/[\\/]/).pop() ?? lower;
-
-  const def = filenameMap.get(base) ?? extensionMap.get(extOf(base) ?? base);
+export function resolveDisplayName(filename: string | null): string {
+  if (!filename) return "Plain Text";
+  const base = basenameOf(filename);
+  const { def } = match(base);
   if (def) return def.name;
-
   return base.charAt(0).toUpperCase() + base.slice(1);
 }
 
 export function resolveLanguageSync(filename: string): LanguageResult | null {
-  const key = cacheKey(filename);
-  return key ? (cache.get(key) ?? null) : null;
+  return cache.get(match(basenameOf(filename)).key) ?? null;
 }
 
 export async function resolveLanguage(
   filename: string,
 ): Promise<LanguageResult | null> {
-  const key = cacheKey(filename);
-  if (!key) return null;
+  const { key, def } = match(basenameOf(filename));
   const cached = cache.get(key);
   if (cached !== undefined) return cached;
-
-  const lower = filename.toLowerCase();
-  const base = lower.split(/[\\/]/).pop() ?? lower;
-  const extension = extOf(base) ?? prefixOf(base) ?? "";
-
-  const def = filenameMap.get(base) ?? extensionMap.get(extension);
   if (!def) {
     cache.set(key, null);
     return null;
   }
-
-  const raw = await def.loader();
-  const ext = isStreamParser(raw)
-    ? (raw as { token: Extension }).token
-    : (raw as Extension);
-  const result = { ext, name: def.name } as LanguageResult;
+  const result: LanguageResult = {
+    ext: await def.loader(),
+    name: def.name,
+    id: def.extensions[0] ?? "",
+  };
   cache.set(key, result);
   return result;
 }
 
 export function preloadLanguages(filenames: string[]): void {
-  for (const f of filenames) {
-    void resolveLanguage(f).catch(() => {});
-  }
+  for (const f of filenames) void resolveLanguage(f).catch(() => {});
 }

--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -29,9 +29,10 @@ function isStreamParser(v: unknown): boolean {
 
 function cacheKey(filename: string): string | null {
   const lower = filename.toLowerCase();
-  const base = lower.split("/").pop() ?? lower;
+  const base = lower.split(/[\\/]/).pop() ?? lower;
+  if (filenameMap.has(base)) return `name:${base}`;
   const ext = extOf(base) ?? prefixOf(base);
-  return ext ? `ext:${ext}` : null;
+  return ext ? `ext:${ext}` : `name:${base}`;
 }
 
 export function resolveDisplayName(extOrFilename: string | null): string {
@@ -59,7 +60,7 @@ export async function resolveLanguage(
   if (cached !== undefined) return cached;
 
   const lower = filename.toLowerCase();
-  const base = lower.split("/").pop() ?? lower;
+  const base = lower.split(/[\\/]/).pop() ?? lower;
   const extension = extOf(base) ?? prefixOf(base) ?? "";
 
   const def = filenameMap.get(base) ?? extensionMap.get(extension);

--- a/src/modules/editor/lib/languageResolver.ts
+++ b/src/modules/editor/lib/languageResolver.ts
@@ -1,257 +1,22 @@
 import type { Extension } from "@codemirror/state";
+import { extensionMap, filenameMap } from "./languageDefinitions";
 
-type LoaderResult = Extension | { token: unknown };
-type LanguageLoader = () => Promise<LoaderResult>;
-
-const rubyLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/ruby").then((m) => m.ruby);
-
-const jsonLoader: LanguageLoader = () =>
-  import("@codemirror/lang-json").then((m) => m.json());
-
-const sqlLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.standardSQL);
-const pgsqlLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.pgSQL);
-const mysqlLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.mySQL);
-const sqliteLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.sqlite);
-const mariadbLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.mariaDB);
-const mssqlLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.msSQL);
-const plsqlLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/sql").then((m) => m.plSQL);
-
-/**
- * Extension → loader. Each loader is a dynamic import so language packs
- * only enter the bundle when a matching file is opened.
- *
- * Loaders may return either a ready Extension (lang-* packages) or a raw
- * StreamParser (legacy-modes). `resolveLanguage` wraps the latter in
- * StreamLanguage before returning.
- */
-const loaders: Record<string, LanguageLoader> = {
-  // JavaScript / TypeScript family
-  js: () => import("@codemirror/lang-javascript").then((m) => m.javascript()),
-  jsx: () =>
-    import("@codemirror/lang-javascript").then((m) =>
-      m.javascript({ jsx: true }),
-    ),
-  mjs: () => import("@codemirror/lang-javascript").then((m) => m.javascript()),
-  cjs: () => import("@codemirror/lang-javascript").then((m) => m.javascript()),
-  ts: () =>
-    import("@codemirror/lang-javascript").then((m) =>
-      m.javascript({ typescript: true }),
-    ),
-  tsx: () =>
-    import("@codemirror/lang-javascript").then((m) =>
-      m.javascript({ jsx: true, typescript: true }),
-    ),
-
-  rs: () => import("@codemirror/lang-rust").then((m) => m.rust()),
-  go: () => import("@codemirror/lang-go").then((m) => m.go()),
-  py: () => import("@codemirror/lang-python").then((m) => m.python()),
-  json: jsonLoader,
-  jsonc: jsonLoader,
-  json5: jsonLoader,
-
-  sql: sqlLoader,
-  psql: pgsqlLoader,
-  pgsql: pgsqlLoader,
-  mysql: mysqlLoader,
-  sqlite: sqliteLoader,
-  mariadb: mariadbLoader,
-  mssql: mssqlLoader,
-  plsql: plsqlLoader,
-
-  md: () => import("@codemirror/lang-markdown").then((m) => m.markdown()),
-  markdown: () => import("@codemirror/lang-markdown").then((m) => m.markdown()),
-
-  html: () => import("@codemirror/lang-html").then((m) => m.html()),
-  htm: () => import("@codemirror/lang-html").then((m) => m.html()),
-  twig: () => import("@codemirror/lang-html").then((m) => m.html()),
-  astro: () =>
-    import("@codemirror/lang-html").then((m) =>
-      m.html({ selfClosingTags: true }),
-    ),
-  css: () => import("@codemirror/lang-css").then((m) => m.css()),
-  vue: () => import("@codemirror/lang-vue").then((m) => m.vue()),
-
-  php: () => import("@codemirror/lang-php").then((m) => m.php({ plain: true })),
-  rb: rubyLoader,
-  rake: rubyLoader,
-  gemspec: rubyLoader,
-  ru: rubyLoader,
-
-  // C / C++ family
-  c: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.c),
-  h: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.c),
-  cpp: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
-  cc: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
-  cxx: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
-  hpp: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
-  hxx: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.cpp),
-
-  // Java
-  java: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.java),
-
-  // C#
-  cs: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.csharp),
-
-  // Swift
-  swift: () =>
-    import("@codemirror/legacy-modes/mode/swift").then((m) => m.swift),
-
-  // Legacy-modes: loaders return the raw StreamParser; wrapped below.
-  sh: () => import("@codemirror/legacy-modes/mode/shell").then((m) => m.shell),
-  bash: () =>
-    import("@codemirror/legacy-modes/mode/shell").then((m) => m.shell),
-  zsh: () => import("@codemirror/legacy-modes/mode/shell").then((m) => m.shell),
-  toml: () => import("@codemirror/legacy-modes/mode/toml").then((m) => m.toml),
-  yaml: () => import("@codemirror/legacy-modes/mode/yaml").then((m) => m.yaml),
-  yml: () => import("@codemirror/legacy-modes/mode/yaml").then((m) => m.yaml),
-  dockerfile: () =>
-    import("@codemirror/legacy-modes/mode/dockerfile").then(
-      (m) => m.dockerFile,
-    ),
-
-  // LaTeX / TeX
-  tex: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
-  latex: () =>
-    import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
-  sty: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
-  cls: () => import("@codemirror/legacy-modes/mode/stex").then((m) => m.stex),
-
-  // Dart / Flutter, Kotlin, Scala (clike family)
-  dart: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.dart),
-  kt: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.kotlin),
-  kts: () =>
-    import("@codemirror/legacy-modes/mode/clike").then((m) => m.kotlin),
-  scala: () =>
-    import("@codemirror/legacy-modes/mode/clike").then((m) => m.scala),
-  sc: () => import("@codemirror/legacy-modes/mode/clike").then((m) => m.scala),
-
-  // XML family (.iml from IntelliJ, build/project files, plists, SVG)
-  xml: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  iml: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  xsd: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  xsl: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  xslt: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  svg: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  plist: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  csproj: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  props: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-  targets: () => import("@codemirror/legacy-modes/mode/xml").then((m) => m.xml),
-
-  // nginx / generic .conf
-  conf: () =>
-    import("@codemirror/legacy-modes/mode/nginx").then((m) => m.nginx),
-  nginx: () =>
-    import("@codemirror/legacy-modes/mode/nginx").then((m) => m.nginx),
-
-  // CMake
-  cmake: () =>
-    import("@codemirror/legacy-modes/mode/cmake").then((m) => m.cmake),
-
-  // INI / properties / env
-  ini: () =>
-    import("@codemirror/legacy-modes/mode/properties").then(
-      (m) => m.properties,
-    ),
-  cfg: () =>
-    import("@codemirror/legacy-modes/mode/properties").then(
-      (m) => m.properties,
-    ),
-  properties: () =>
-    import("@codemirror/legacy-modes/mode/properties").then(
-      (m) => m.properties,
-    ),
-  env: () =>
-    import("@codemirror/legacy-modes/mode/properties").then(
-      (m) => m.properties,
-    ),
-
-  // Other common languages
-  lua: () => import("@codemirror/legacy-modes/mode/lua").then((m) => m.lua),
-  ps1: () =>
-    import("@codemirror/legacy-modes/mode/powershell").then(
-      (m) => m.powerShell,
-    ),
-  psm1: () =>
-    import("@codemirror/legacy-modes/mode/powershell").then(
-      (m) => m.powerShell,
-    ),
-  psd1: () =>
-    import("@codemirror/legacy-modes/mode/powershell").then(
-      (m) => m.powerShell,
-    ),
-  pl: () => import("@codemirror/legacy-modes/mode/perl").then((m) => m.perl),
-  pm: () => import("@codemirror/legacy-modes/mode/perl").then((m) => m.perl),
-  groovy: () =>
-    import("@codemirror/legacy-modes/mode/groovy").then((m) => m.groovy),
-  gradle: () =>
-    import("@codemirror/legacy-modes/mode/groovy").then((m) => m.groovy),
-  clj: () =>
-    import("@codemirror/legacy-modes/mode/clojure").then((m) => m.clojure),
-  cljs: () =>
-    import("@codemirror/legacy-modes/mode/clojure").then((m) => m.clojure),
-  cljc: () =>
-    import("@codemirror/legacy-modes/mode/clojure").then((m) => m.clojure),
-  edn: () =>
-    import("@codemirror/legacy-modes/mode/clojure").then((m) => m.clojure),
-  hs: () =>
-    import("@codemirror/legacy-modes/mode/haskell").then((m) => m.haskell),
-  jl: () => import("@codemirror/legacy-modes/mode/julia").then((m) => m.julia),
-  diff: () => import("@codemirror/legacy-modes/mode/diff").then((m) => m.diff),
-  patch: () => import("@codemirror/legacy-modes/mode/diff").then((m) => m.diff),
-  proto: () =>
-    import("@codemirror/legacy-modes/mode/protobuf").then((m) => m.protobuf),
-  vb: () => import("@codemirror/legacy-modes/mode/vb").then((m) => m.vb),
-  svelte: () => import("@codemirror/lang-html").then((m) => m.html()),
-};
-
-const yamlLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/yaml").then((m) => m.yaml);
-const propertiesLoader: LanguageLoader = () =>
-  import("@codemirror/legacy-modes/mode/properties").then((m) => m.properties);
-
-const filenameOverrides: Record<string, LanguageLoader> = {
-  dockerfile: loaders.dockerfile!,
-  "dockerfile.dev": loaders.dockerfile!,
-  gemfile: rubyLoader,
-  rakefile: rubyLoader,
-  podfile: rubyLoader,
-  fastfile: rubyLoader,
-  guardfile: rubyLoader,
-  brewfile: rubyLoader,
-  // Flutter / Dart project files
-  "pubspec.yaml": yamlLoader,
-  "pubspec.lock": yamlLoader,
-  "analysis_options.yaml": yamlLoader,
-  // Build / config files with fixed names
-  "cmakelists.txt": loaders.cmake!,
-  "nginx.conf": loaders.nginx!,
-  ".env": propertiesLoader,
-  ".editorconfig": propertiesLoader,
-  ".eslintrc": jsonLoader,
-  ".babelrc": jsonLoader,
-  ".prettierrc": jsonLoader,
-};
-
-// Any Dockerfile variant: `Dockerfile`, `Dockerfile.web`, `dockerfile.prod`,
-// `web.dockerfile` (the last is already covered by the `dockerfile` extension).
-// Pattern-based so new variants need no code change.
-function isDockerfileLike(base: string): boolean {
-  return base === "dockerfile" || base.startsWith("dockerfile.");
+export interface LanguageResult {
+  ext: Extension;
+  name: string;
 }
+const cache = new Map<string, LanguageResult | null>();
 
 function extOf(name: string): string | null {
   const lower = name.toLowerCase();
   const dot = lower.lastIndexOf(".");
   if (dot === -1 || dot === lower.length - 1) return null;
   return lower.slice(dot + 1);
+}
+
+function prefixOf(base: string): string | null {
+  const dot = base.indexOf(".");
+  return dot > 0 ? base.slice(0, dot) : null;
 }
 
 function isStreamParser(v: unknown): boolean {
@@ -262,25 +27,32 @@ function isStreamParser(v: unknown): boolean {
   );
 }
 
-const cache = new Map<string, Extension | null>();
-
 function cacheKey(filename: string): string | null {
   const lower = filename.toLowerCase();
   const base = lower.split("/").pop() ?? lower;
-  if (filenameOverrides[base]) return `name:${base}`;
-  if (isDockerfileLike(base)) return "name:dockerfile";
-  const ext = extOf(base);
+  const ext = extOf(base) ?? prefixOf(base);
   return ext ? `ext:${ext}` : null;
 }
 
-export function resolveLanguageSync(filename: string): Extension | null {
+export function resolveDisplayName(extOrFilename: string | null): string {
+  if (!extOrFilename) return "Plain Text";
+  const lower = extOrFilename.toLowerCase();
+  const base = lower.split(/[\\/]/).pop() ?? lower;
+
+  const def = filenameMap.get(base) ?? extensionMap.get(extOf(base) ?? base);
+  if (def) return def.name;
+
+  return base.charAt(0).toUpperCase() + base.slice(1);
+}
+
+export function resolveLanguageSync(filename: string): LanguageResult | null {
   const key = cacheKey(filename);
   return key ? (cache.get(key) ?? null) : null;
 }
 
 export async function resolveLanguage(
   filename: string,
-): Promise<Extension | null> {
+): Promise<LanguageResult | null> {
   const key = cacheKey(filename);
   if (!key) return null;
   const cached = cache.get(key);
@@ -288,27 +60,21 @@ export async function resolveLanguage(
 
   const lower = filename.toLowerCase();
   const base = lower.split("/").pop() ?? lower;
-  const loader =
-    filenameOverrides[base] ??
-    (isDockerfileLike(base) ? loaders.dockerfile : undefined) ??
-    loaders[extOf(base) ?? ""];
-  if (!loader) {
+  const extension = extOf(base) ?? prefixOf(base) ?? "";
+
+  const def = filenameMap.get(base) ?? extensionMap.get(extension);
+  if (!def) {
     cache.set(key, null);
     return null;
   }
 
-  const result = await loader();
-  let ext: Extension;
-  if (isStreamParser(result)) {
-    const { StreamLanguage } = await import("@codemirror/language");
-    ext = StreamLanguage.define(
-      result as Parameters<typeof StreamLanguage.define>[0],
-    );
-  } else {
-    ext = result as Extension;
-  }
-  cache.set(key, ext);
-  return ext;
+  const raw = await def.loader();
+  const ext = isStreamParser(raw)
+    ? (raw as { token: Extension }).token
+    : (raw as Extension);
+  const result = { ext, name: def.name } as LanguageResult;
+  cache.set(key, result);
+  return result;
 }
 
 export function preloadLanguages(filenames: string[]): void {

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -40,6 +40,7 @@ type Props = {
   onRename: (id: number, title: string) => void;
   /** Move a dragged tab to a new position (insertion gap index). */
   onReorder: (fromId: number, toGapIndex: number) => void;
+  onOverrideLanguage?: (id: number, lang: string | null) => void;
   onToggleSidebar: () => void;
   onOpenCommandPalette: () => void;
   onActivateAgent: (tabId: number, leafId: number) => void;
@@ -66,6 +67,7 @@ export function Header({
   onPin,
   onRename,
   onReorder,
+  onOverrideLanguage,
   onToggleSidebar,
   onOpenCommandPalette,
   onActivateAgent,
@@ -161,6 +163,7 @@ export function Header({
           onPin={onPin}
           onRename={onRename}
           onReorder={onReorder}
+          onOverrideLanguage={onOverrideLanguage}
           compact={compact}
         />
         <div data-tauri-drag-region className="h-full min-w-2 flex-1" />

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -395,10 +395,9 @@ export function TabBar({
                               />
                             )}
                           </DropdownMenuItem>
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.stopPropagation();
+                          <DropdownMenuItem
+                            onSelect={(e) => {
+                              e.preventDefault();
                               setShowAllLanguages((v) => !v);
                             }}
                             className="w-full px-2.5 py-1.5 text-left text-xs text-primary/60 hover:text-primary rounded-lg transition-colors hover:bg-accent"
@@ -406,7 +405,7 @@ export function TabBar({
                             {showAllLanguages
                               ? "↑ Fewer languages"
                               : "↓ All languages"}
-                          </button>
+                          </DropdownMenuItem>
                           <DropdownMenuSeparator className="my-1 border-t border-border/30" />
                           {(showAllLanguages
                             ? ALL_LANGUAGES

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -10,11 +10,17 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fmtShortcut, MOD_KEY, SHIFT_KEY } from "@/lib/platform";
 import { cn } from "@/lib/utils";
+import {
+  ALL_LANGUAGES,
+  EXPOSED_LANGUAGES,
+} from "@/modules/editor/lib/languageDefinitions";
+import { resolveDisplayName } from "@/modules/editor/lib/languageResolver";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
 import {
   Cancel01Icon,
@@ -26,6 +32,7 @@ import {
   IncognitoIcon,
   PencilEdit02Icon,
   PlusSignIcon,
+  Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -56,6 +63,7 @@ type Props = {
   onRename: (id: number, title: string) => void;
   /** Move a dragged tab to a new position (insertion gap index 0..tabs.length). */
   onReorder: (fromId: number, toGapIndex: number) => void;
+  onOverrideLanguage?: (id: number, lang: string | null) => void;
   compact?: boolean;
 };
 
@@ -73,6 +81,7 @@ export function TabBar({
   onPin,
   onRename,
   onReorder,
+  onOverrideLanguage,
   compact,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -80,6 +89,7 @@ export function TabBar({
   const [editingId, setEditingId] = useState<number | null>(null);
   const [draggingId, setDraggingId] = useState<number | null>(null);
   const [dropGap, setDropGap] = useState<number | null>(null);
+  const [showAllLanguages, setShowAllLanguages] = useState(false);
   const drag = useRef<{
     pointerId: number;
     startX: number;
@@ -331,11 +341,107 @@ export function TabBar({
                 >
                   <span
                     className={cn(
-                      "flex items-center gap-1.5 truncate",
+                      "flex min-w-0 items-center gap-1.5",
                       compact ? "max-w-48" : "max-w-80",
                     )}
                   >
-                    <TabIcon tab={t} />
+                    {t.kind === "editor" ? (
+                      <DropdownMenu
+                        onOpenChange={(open) => {
+                          if (!open) setShowAllLanguages(false);
+                        }}
+                      >
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            tabIndex={-1}
+                            data-no-drag
+                            className="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-sm p-1 -m-1 transition-all hover:bg-accent hover:text-accent-foreground hover:ring-1 hover:ring-primary/30 hover:shadow-[0_0_4px_var(--color-popover-foreground)]"
+                          >
+                            <TabIcon tab={t} />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="start"
+                          side="bottom"
+                          sideOffset={6}
+                          alignOffset={-4}
+                          className="max-h-75 w-48 overflow-y-auto rounded-xl border border-border/40 bg-popover/90 p-1 backdrop-blur-md shadow-lg"
+                          onClick={(e) => e.stopPropagation()}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          onPointerUp={(e) => e.stopPropagation()}
+                        >
+                          <DropdownMenuItem
+                            onSelect={() => {
+                              onOverrideLanguage?.(t.id, null);
+                            }}
+                            className="flex items-center gap-2 px-2.5 py-1.5 text-xs rounded-lg cursor-default focus:bg-accent focus:text-accent-foreground"
+                          >
+                            <img
+                              src={fileIconUrl(t.title)}
+                              className="size-3.5 shrink-0 object-contain"
+                              alt=""
+                            />
+                            <div className="flex flex-1 flex-col">
+                              <span>Auto Detect</span>
+                              <span className="text-[10px] text-muted-foreground italic">
+                                Mode: {resolveDisplayName(t.title)}
+                              </span>
+                            </div>
+                            {!(t as EditorTab).overrideLanguage && (
+                              <HugeiconsIcon
+                                icon={Tick02Icon}
+                                className="size-3.5 text-primary"
+                              />
+                            )}
+                          </DropdownMenuItem>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setShowAllLanguages((v) => !v);
+                            }}
+                            className="w-full px-2.5 py-1.5 text-left text-xs text-primary/60 hover:text-primary rounded-lg transition-colors hover:bg-accent"
+                          >
+                            {showAllLanguages
+                              ? "↑ Fewer languages"
+                              : "↓ All languages"}
+                          </button>
+                          <DropdownMenuSeparator className="my-1 border-t border-border/30" />
+                          {(showAllLanguages
+                            ? ALL_LANGUAGES
+                            : EXPOSED_LANGUAGES
+                          ).map((lang) => {
+                            const isSelected =
+                              (t as EditorTab).overrideLanguage === lang.ext;
+                            return (
+                              <DropdownMenuItem
+                                key={lang.ext}
+                                onSelect={() =>
+                                  onOverrideLanguage?.(t.id, lang.ext)
+                                }
+                                className="flex items-center gap-2 px-2.5 py-1.5 text-xs rounded-lg cursor-default focus:bg-accent focus:text-accent-foreground"
+                              >
+                                <img
+                                  src={fileIconUrl(`dummy.${lang.ext}`)}
+                                  className="size-3.5 shrink-0 object-contain"
+                                  alt=""
+                                />
+                                <span className="flex-1">{lang.name}</span>
+                                {isSelected && (
+                                  <HugeiconsIcon
+                                    icon={Tick02Icon}
+                                    className="size-3.5 text-primary"
+                                  />
+                                )}
+                              </DropdownMenuItem>
+                            );
+                          })}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : (
+                      <TabIcon tab={t} />
+                    )}
                     {/* Preview tabs use italic to signal the transient state,
                         matching the visual convention from VSCode. */}
                     <span className={cn("truncate", isPreview && "italic")}>
@@ -349,8 +455,8 @@ export function TabBar({
                     ) : null}
                   </span>
                   {tabs.length > 1 && (
-                    <span
-                      role="button"
+                    <button
+                      type="button"
                       aria-label="Close tab"
                       data-no-drag
                       onClick={(e) => {
@@ -364,7 +470,7 @@ export function TabBar({
                         size={11}
                         strokeWidth={2}
                       />
-                    </span>
+                    </button>
                   )}
                 </TabsTrigger>
               );
@@ -515,8 +621,20 @@ function DropIndicator() {
 
 export function TabIcon({ tab }: { tab: Tab }) {
   if (tab.kind === "editor" || tab.kind === "markdown") {
-    const url = fileIconUrl(tab.title);
-    return url ? <img src={url} alt="" className="size-3.5 shrink-0" /> : null;
+    const url =
+      tab.kind === "editor" && tab.overrideLanguage
+        ? fileIconUrl(`dummy.${tab.overrideLanguage}`)
+        : fileIconUrl(tab.title);
+    return url ? (
+      <img
+        src={url}
+        alt=""
+        className="size-3.5 shrink-0 object-contain"
+        onError={(e) => {
+          e.currentTarget.src = fileIconUrl("dummy.txt");
+        }}
+      />
+    ) : null;
   }
   if (tab.kind === "preview") {
     return (

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -352,14 +352,15 @@ export function TabBar({
                         }}
                       >
                         <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
+                          {/* span, not button: a button nested in the TabsTrigger button is invalid DOM and breaks WebKit focus. */}
+                          <span
+                            role="button"
                             tabIndex={-1}
                             data-no-drag
                             className="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-sm p-1 -m-1 transition-all hover:bg-accent hover:text-accent-foreground hover:ring-1 hover:ring-primary/30 hover:shadow-[0_0_4px_var(--color-popover-foreground)]"
                           >
                             <TabIcon tab={t} />
-                          </button>
+                          </span>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent
                           align="start"
@@ -454,8 +455,8 @@ export function TabBar({
                     ) : null}
                   </span>
                   {tabs.length > 1 && (
-                    <button
-                      type="button"
+                    <span
+                      role="button"
                       aria-label="Close tab"
                       data-no-drag
                       onClick={(e) => {
@@ -469,7 +470,7 @@ export function TabBar({
                         size={11}
                         strokeWidth={2}
                       />
-                    </button>
+                    </span>
                   )}
                 </TabsTrigger>
               );
@@ -630,7 +631,10 @@ export function TabIcon({ tab }: { tab: Tab }) {
         alt=""
         className="size-3.5 shrink-0 object-contain"
         onError={(e) => {
-          e.currentTarget.src = fileIconUrl("dummy.txt");
+          const img = e.currentTarget;
+          if (img.dataset.fallback) return;
+          img.dataset.fallback = "1";
+          img.src = fileIconUrl("dummy.txt");
         }}
       />
     ) : null;

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -713,6 +713,9 @@ export function useTabs(initial?: Partial<TerminalTab>) {
               kind: "editor" as const,
               dirty: false,
               preview: false,
+              overrideLanguage:
+                (t as { overrideLanguage?: string | null }).overrideLanguage ??
+                null,
             };
           }
           if (mode === "rendered" && t.kind === "editor") {
@@ -724,6 +727,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
               cold: t.cold,
               title: t.title,
               path: t.path,
+              overrideLanguage: t.overrideLanguage ?? null,
             };
           }
           return t;

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -49,6 +49,7 @@ export type EditorTab = TabBase & {
    * is replaced by the next single-click rather than accumulating.
    */
   preview: boolean;
+  overrideLanguage?: string | null;
 };
 
 export type PreviewTab = TabBase & {
@@ -128,6 +129,7 @@ export type TabPatch = Partial<{
   url: string;
   /** Empty string resets a terminal tab to its cwd-derived name. */
   customTitle: string;
+  overrideLanguage: string | null;
 }>;
 
 function basename(path: string): string {
@@ -684,6 +686,18 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return targetId;
   }, []);
 
+  const setOverrideLanguage = useCallback((id: number, lang: string | null) => {
+    setTabs((curr) =>
+      curr.map((t) => {
+        if (t.id !== id || t.kind !== "editor") return t;
+        return {
+          ...t,
+          overrideLanguage: lang,
+        };
+      }),
+    );
+  }, []);
+
   const setMarkdownView = useCallback(
     (id: number, mode: "rendered" | "raw") => {
       setTabs((curr) =>
@@ -924,6 +938,9 @@ export function useTabs(initial?: Partial<TerminalTab>) {
           ...(patch.title !== undefined && { title: patch.title }),
           ...(patch.dirty !== undefined && { dirty: patch.dirty }),
           ...(patch.path !== undefined && { path: patch.path }),
+          ...(patch.overrideLanguage !== undefined && {
+            overrideLanguage: patch.overrideLanguage,
+          }),
         };
       }),
     );
@@ -1117,6 +1134,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     removeTabsForSpace,
     markBooted,
     setActiveSpaceForNewTabs,
+    setOverrideLanguage,
     newTab,
     newBlockTab,
     newAgentTab,


### PR DESCRIPTION
## What
Adds a per-tab syntax highlighting override for editor tabs, extracts language definitions into a dedicated `languageDefinitions.ts` module.

## Why
There was no way to manually override the auto-detected language mode on an editor tab. Users working with files that have ambiguous or missing extensions (e.g. bare `Dockerfile` variants, `.env` files, scripts without extensions) had no escape hatch.

## How
The file icon on each editor tab is now a dropdown trigger. It exposes an "Auto Detect" entry (showing the currently resolved mode as a subtitle), and a list of languages to force. A toggle reveals all defined languages sorted alphabetically, vs. a default curated `userSelectable` list in definition order.

The `isDockerfileLike()` special-case in the resolver is removed in favor of a `prefixOf()` fallback. When `extOf()` finds no extension, the base filename prefix is checked against `extensionMap`, so `Dockerfile.web` resolves naturally without hardcoding, but `dockerfile.json` would still hit JSON via `extOf` first.

Language definitions and their lookup maps are moved from `languageResolver.ts` into a new `languageDefinitions.ts` to give them a stable home as the export surface grows. This also consolidates per-extension loaders so that extensions sharing a loader (e.g. json, jsonc and json5) use a single definition rather than one per extension.

## Testing
Opened editor tabs with various filenames and confirmed auto-detect subtitle reflects the correct mode. Forced overrides on `.html` (see screen recording), `.ts`, `.py`, bare `Dockerfile` and many more extension tabs and confirmed the icon and highlighting updated. Toggled "All languages" and confirmed the list switches to alphabetical order and resets on close or toggling "Fewer languages". Verified `overrideLanguage: null` restores auto-detect with checkmark.

- [x] `pnpm check-types` clean
- [x] `pnpm lint` clean for changed files
- [x] Manual smoke-test of the affected feature
- [x] ~~(If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean~~
- [x] ~~(If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep~~
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS
- [x] ~~Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->~~

## Screenshots / GIFs
https://github.com/user-attachments/assets/c67d4328-6155-4b63-a8b7-9ba96c24b5b1

## Notes for reviewer
- The styling of everything is, obviously, changeable as reviewer seems fit.
- `languageDefinitions.ts` is in an arbitrary order.
- Feature respects the rendered Markdown preview mode, only allows overriding the "Raw" tab state.
- `showAllLanguages` is a single boolean on `TabBar` rather than per-tab state. Safe since only one dropdown can be open at a time, and it resets via `onOpenChange` on close. If per-tab memory of the expanded state is ever wanted, it would need to be moved to a `Map<tabId, boolean>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-editor language override dropdown for tabs, including “Auto Detect” and a language picker (with exposed/all options).
  * Updated editor tab icons to reflect the selected override.

* **Bug Fixes**
  * Improved language detection and display-name resolution across editor, AI diff, and Git diff views, including better handling of dotfiles and Docker-style filenames.
  * Improved fallback behavior when tab icons fail to load.

* **Tests**
  * Added automated test coverage for display-name resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->