### PR TITLE
feat(source-control): checkout branches in UI

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,6 +214,8 @@ pub fn run() {
             git::commands::git_commit_files,
             git::commands::git_commit_file_diff,
             git::commands::git_remote_url,
+            git::commands::git_list_branches,
+            git::commands::git_checkout_branch,
             shell::shell_run_command,
             shell::shell_session_open,
             shell::shell_session_run,

--- a/src-tauri/src/modules/git/commands.rs
+++ b/src-tauri/src/modules/git/commands.rs
@@ -2,8 +2,9 @@ use tauri::{AppHandle, Manager};
 
 use crate::modules::git::operations;
 use crate::modules::git::types::{
-    DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult, GitDiffResult,
-    GitLogEntry, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
+    DiscardEntry, GitBranchListResult, GitCommitFileChange, GitCommitResult,
+    GitDiffContentResult, GitDiffResult, GitLogEntry, GitPanelSnapshot, GitPushResult,
+    GitRepoInfo, GitStatusSnapshot,
 };
 use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
 
@@ -278,6 +279,33 @@ pub async fn git_remote_url(
     let workspace = WorkspaceEnv::from_option(workspace);
     blocking(app, move |r| {
         operations::remote_url(r, &repo_root, &remote, &workspace).map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn git_list_branches(
+    repo_root: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<GitBranchListResult, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::list_branches(r, &repo_root, &workspace).map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn git_checkout_branch(
+    repo_root: String,
+    branch: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::checkout_branch(r, &repo_root, &branch, &workspace).map_err(Into::into)
     })
     .await
 }

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -8,12 +8,14 @@ use crate::modules::git::process::{
     read_text_file, run_git,
 };
 use crate::modules::git::types::{
-    DiscardEntry, GitCommitFileChange, GitCommitResult, GitDiffContentResult, GitDiffResult,
-    GitLogEntry, GitOutput, GitPanelSnapshot, GitPushResult, GitRepoInfo, GitStatusSnapshot,
-    TextSource, DEFAULT_TIMEOUT_SECS, NETWORK_TIMEOUT_SECS,
+    DiscardEntry, GitBranchEntry, GitBranchListResult, GitCommitFileChange, GitCommitResult,
+    GitDiffContentResult, GitDiffResult, GitLogEntry, GitOutput, GitPanelSnapshot,
+    GitPushResult, GitRepoInfo, GitStatusSnapshot, TextSource, DEFAULT_TIMEOUT_SECS,
+    NETWORK_TIMEOUT_SECS,
 };
 use crate::modules::git::utils::{
-    authorized_repo_root, canonical_dir, resolve_within_repo, split_upstream, ResolvedGitDirectory,
+    authorized_repo_root, canonical_dir, resolve_within_repo, split_upstream,
+    ResolvedGitDirectory,
 };
 use crate::modules::workspace::{WorkspaceEnv, WorkspaceRegistry};
 
@@ -974,6 +976,178 @@ fn pathspec(repo_root: &Path, absolute: &Path) -> String {
         .strip_prefix(repo_root)
         .map(|rel| rel.to_string_lossy().replace('\\', "/"))
         .unwrap_or_else(|_| absolute.to_string_lossy().replace('\\', "/"))
+}
+
+pub fn list_branches(
+    registry: &WorkspaceRegistry,
+    repo_root: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<GitBranchListResult> {
+    let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
+    ensure_git_available(&repo_root.workspace)?;
+
+    let mut branches: Vec<GitBranchEntry> = Vec::new();
+
+    let current_branch = git_stdout_line_opt(
+        &repo_root.workspace,
+        &repo_root.git_path,
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+    )
+    .ok()
+    .flatten();
+    let is_detached_head = current_branch.as_deref() == Some("HEAD");
+
+    if let Ok(lines) = git_stdout_lines(
+        &repo_root.workspace,
+        &repo_root.git_path,
+        ["branch", "--format=%(refname:short)%00%(HEAD)"],
+    ) {
+        for line in &lines {
+            let mut parts = line.split('\0');
+            let name = parts.next().unwrap_or("").to_string();
+            let head_marker = parts.next().unwrap_or("");
+            let is_head = head_marker == "*";
+            if !name.is_empty() {
+                branches.push(GitBranchEntry {
+                    name,
+                    kind: "local".into(),
+                    worktree_path: None,
+                    is_head,
+                    is_detached: is_head && is_detached_head,
+                });
+            }
+        }
+    }
+
+    if let Ok(lines) = git_stdout_lines(
+        &repo_root.workspace,
+        &repo_root.git_path,
+        ["worktree", "list", "--porcelain"],
+    ) {
+        let mut current_worktree: Option<String> = None;
+        let mut worktree_branch: Option<String> = None;
+        let mut worktree_bare = false;
+        let mut head_sha: Option<String> = None;
+        for line in &lines {
+            if line.starts_with("worktree ") {
+                if let Some(wt_path) = current_worktree.take() {
+                    if !worktree_bare {
+                        push_worktree(
+                            &mut branches,
+                            wt_path,
+                            worktree_branch.take(),
+                            head_sha.take(),
+                        );
+                    }
+                }
+                current_worktree = Some(line[9..].trim().to_string());
+                worktree_branch = None;
+                worktree_bare = false;
+                head_sha = None;
+            } else if line.starts_with("HEAD ") {
+                head_sha = Some(line[5..].trim().to_string());
+            } else if line.starts_with("branch ") {
+                let raw = line[7..].trim();
+                worktree_branch = Some(
+                    raw.strip_prefix("refs/heads/")
+                        .unwrap_or(raw)
+                        .to_string(),
+                );
+            } else if line.starts_with("bare") {
+                worktree_bare = true;
+            }
+        }
+        if let Some(wt_path) = current_worktree.take() {
+            if !worktree_bare {
+                push_worktree(
+                    &mut branches,
+                    wt_path,
+                    worktree_branch.take(),
+                    head_sha.take(),
+                );
+            }
+        }
+    }
+
+    // dedupe: a worktree branch can also appear in local branches
+    // -> prefer the worktree entry (it has the path) but preserve is_head from local.
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut deduped: Vec<GitBranchEntry> = Vec::with_capacity(branches.len());
+    for b in branches {
+        if let Some(&existing_idx) = seen.get(&b.name) {
+            let existing = &deduped[existing_idx];
+            let should_replace = b.kind == "worktree"
+                && existing.kind == "local"
+                && existing.worktree_path.is_none();
+            if should_replace {
+                let is_head = existing.is_head || b.is_head;
+                deduped[existing_idx] = GitBranchEntry {
+                    is_head,
+                    ..b
+                };
+            } else if b.is_head && !existing.is_head {
+                let mut updated = deduped[existing_idx].clone();
+                updated.is_head = true;
+                deduped[existing_idx] = updated;
+            }
+        } else {
+            seen.insert(b.name.clone(), deduped.len());
+            deduped.push(b);
+        }
+    }
+
+    deduped.sort_by(|a, b| {
+        let kind_ord = |k: &str| if k == "local" { 0u8 } else { 1u8 };
+        kind_ord(&a.kind)
+            .cmp(&kind_ord(&b.kind))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    Ok(GitBranchListResult { branches: deduped })
+}
+
+fn push_worktree(
+    branches: &mut Vec<GitBranchEntry>,
+    path: String,
+    branch: Option<String>,
+    head_sha: Option<String>,
+) {
+    let name = if let Some(ref b) = branch {
+        b.clone()
+    } else if let Some(ref sha) = head_sha {
+        // if detached HEAD with no branch — show shortened SHA as name
+        let short = if sha.len() >= 7 { &sha[..7] } else { sha.as_str() };
+        format!("(detached @ {})", short)
+    } else {
+        return;
+    };
+    branches.push(GitBranchEntry {
+        name,
+        kind: "worktree".into(),
+        worktree_path: Some(path),
+        is_head: false,
+        is_detached: branch.is_none(),
+    });
+}
+
+pub fn checkout_branch(
+    registry: &WorkspaceRegistry,
+    repo_root: &str,
+    branch_name: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<()> {
+    let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
+    ensure_git_available(&repo_root.workspace)?;
+    if branch_name.starts_with('-') || branch_name.is_empty() {
+        return Err(GitError::InvalidPath(branch_name.into()));
+    }
+    let output = run_git(
+        &repo_root.workspace,
+        Some(&repo_root.git_path),
+        ["checkout", branch_name],
+        DEFAULT_TIMEOUT_SECS,
+    )?;
+    ensure_success(&output, "git checkout failed")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -1029,7 +1029,7 @@ pub fn list_branches(
         let mut worktree_bare = false;
         let mut head_sha: Option<String> = None;
         for line in &lines {
-            if line.starts_with("worktree ") {
+            if let Some(rest) = line.strip_prefix("worktree ") {
                 if let Some(wt_path) = current_worktree.take() {
                     if !worktree_bare {
                         push_worktree(
@@ -1040,19 +1040,15 @@ pub fn list_branches(
                         );
                     }
                 }
-                current_worktree = Some(line[9..].trim().to_string());
+                current_worktree = Some(rest.trim().to_string());
                 worktree_branch = None;
                 worktree_bare = false;
                 head_sha = None;
-            } else if line.starts_with("HEAD ") {
-                head_sha = Some(line[5..].trim().to_string());
-            } else if line.starts_with("branch ") {
-                let raw = line[7..].trim();
-                worktree_branch = Some(
-                    raw.strip_prefix("refs/heads/")
-                        .unwrap_or(raw)
-                        .to_string(),
-                );
+            } else if let Some(rest) = line.strip_prefix("HEAD ") {
+                head_sha = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("branch ") {
+                let raw = rest.trim();
+                worktree_branch = Some(raw.strip_prefix("refs/heads/").unwrap_or(raw).to_string());
             } else if line.starts_with("bare") {
                 worktree_bare = true;
             }
@@ -1069,8 +1065,8 @@ pub fn list_branches(
         }
     }
 
-    // dedupe: a worktree branch can also appear in local branches
-    // -> prefer the worktree entry (it has the path) but preserve is_head from local.
+    // Prefer a branch's worktree entry over its local one, except for the current
+    // branch: the main worktree is always listed, so !is_head keeps it local.
     let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     let mut deduped: Vec<GitBranchEntry> = Vec::with_capacity(branches.len());
     for b in branches {
@@ -1078,7 +1074,8 @@ pub fn list_branches(
             let existing = &deduped[existing_idx];
             let should_replace = b.kind == "worktree"
                 && existing.kind == "local"
-                && existing.worktree_path.is_none();
+                && existing.worktree_path.is_none()
+                && !existing.is_head;
             if should_replace {
                 let is_head = existing.is_head || b.is_head;
                 deduped[existing_idx] = GitBranchEntry {

--- a/src-tauri/src/modules/git/types.rs
+++ b/src-tauri/src/modules/git/types.rs
@@ -115,6 +115,22 @@ pub struct GitPushResult {
     pub pushed: bool,
 }
 
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GitBranchEntry {
+    pub name: String,
+    pub kind: String, // "local" | "worktree"
+    pub worktree_path: Option<String>,
+    pub is_head: bool,
+    pub is_detached: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitBranchListResult {
+    pub branches: Vec<GitBranchEntry>,
+}
+
 pub(crate) struct GitOutput {
     pub(crate) stdout: Vec<u8>,
     pub(crate) stderr: Vec<u8>,

--- a/src-tauri/tests/git_operations.rs
+++ b/src-tauri/tests/git_operations.rs
@@ -529,3 +529,38 @@ fn checkout_branch_rejects_unsafe_names() {
     let err_dash_long = operations::checkout_branch(&fx.registry, &fx.repo_str(), "--detach", &fx.workspace).unwrap_err();
     assert!(matches!(err_dash_long, GitError::InvalidPath(p) if p == "--detach"));
 }
+
+#[test]
+fn list_branches_keeps_current_branch_local_and_surfaces_worktrees() {
+    if skip_if_no_git() {
+        return;
+    }
+    let fx = GitRepoFixture::new();
+    fx.write_file("a.txt", "a\n");
+    fx.run_git(&["add", "."]);
+    fx.run_git(&["commit", "-q", "-m", "init"]);
+    fx.run_git(&["branch", "feature"]);
+
+    let wt = TempDir::new().unwrap();
+    let wt_path = wt.path().join("linked");
+    fx.run_git(&["worktree", "add", "-q", wt_path.to_str().unwrap(), "feature"]);
+
+    let result = operations::list_branches(&fx.registry, &fx.repo_str(), &fx.workspace)
+        .expect("list_branches");
+
+    // current branch stays local+head despite the main worktree being listed
+    let main = result
+        .branches
+        .iter()
+        .find(|b| b.name == "main")
+        .expect("main branch present");
+    assert_eq!(main.kind, "local");
+    assert!(main.is_head);
+    assert!(main.worktree_path.is_none());
+
+    let feature: Vec<_> = result.branches.iter().filter(|b| b.name == "feature").collect();
+    assert_eq!(feature.len(), 1);
+    assert_eq!(feature[0].kind, "worktree");
+    assert!(!feature[0].is_head);
+    assert!(feature[0].worktree_path.is_some());
+}

--- a/src-tauri/tests/git_operations.rs
+++ b/src-tauri/tests/git_operations.rs
@@ -512,3 +512,20 @@ fn unauthorized_path_is_rejected() {
         Ok(_) => panic!("expected error for unauthorized dir"),
     }
 }
+
+#[test]
+fn checkout_branch_rejects_unsafe_names() {
+    if skip_if_no_git() {
+        return;
+    }
+    let fx = GitRepoFixture::new();
+    
+    let err_empty = operations::checkout_branch(&fx.registry, &fx.repo_str(), "", &fx.workspace).unwrap_err();
+    assert!(matches!(err_empty, GitError::InvalidPath(p) if p.is_empty()));
+
+    let err_dash = operations::checkout_branch(&fx.registry, &fx.repo_str(), "-f", &fx.workspace).unwrap_err();
+    assert!(matches!(err_dash, GitError::InvalidPath(p) if p == "-f"));
+
+    let err_dash_long = operations::checkout_branch(&fx.registry, &fx.repo_str(), "--detach", &fx.workspace).unwrap_err();
+    assert!(matches!(err_dash_long, GitError::InvalidPath(p) if p == "--detach"));
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1065,6 +1065,7 @@ export default function App() {
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}
                         onOpenFile={handleOpenFile}
+                        onNavigateToPath={cdInNewTab}
                       />
                     )}
                   </div>

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -124,6 +124,18 @@ export type GitDiscardEntry = {
   untracked: boolean;
 };
 
+export type GitBranchEntry = {
+  name: string;
+  kind: "local" | "worktree";
+  worktreePath: string | null;
+  isHead: boolean;
+  isDetached: boolean;
+};
+
+export type GitBranchListResult = {
+  branches: GitBranchEntry[];
+};
+
 export const native = {
   workspaceCurrentDir: () => invoke<string>("workspace_current_dir"),
   workspaceAuthorize: (path: string) =>
@@ -356,6 +368,17 @@ export const native = {
     invoke<string | null>("git_remote_url", {
       repoRoot,
       name: name ?? null,
+      workspace: currentWorkspaceEnv(),
+    }),
+  gitListBranches: (repoRoot: string) =>
+    invoke<GitBranchListResult>("git_list_branches", {
+      repoRoot,
+      workspace: currentWorkspaceEnv(),
+    }),
+  gitCheckoutBranch: (repoRoot: string, branch: string) =>
+    invoke<void>("git_checkout_branch", {
+      repoRoot,
+      branch,
       workspace: currentWorkspaceEnv(),
     }),
 };

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -172,11 +172,18 @@ function BranchDropdown({
   const [branches, setBranches] = useState<GitBranchEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [checkingOut, setCheckingOut] = useState(false);
   const requestRef = useRef(0);
+  const checkoutInFlight = useRef(false);
 
   const loadBranches = useCallback(async () => {
-    if (!repoRoot) return;
     const id = ++requestRef.current;
+    if (!repoRoot) {
+      setBranches([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -202,16 +209,19 @@ function BranchDropdown({
 
   const handleCheckout = useCallback(
     async (branch: string) => {
-      if (!repoRoot) return;
-      setError(null);
+      if (!repoRoot || checkoutInFlight.current) return;
+      checkoutInFlight.current = true;
+      setCheckingOut(true);
       try {
         await native.gitCheckoutBranch(repoRoot, branch);
         setBranches([]);
         setOpen(false);
         onRefresh();
       } catch (e) {
-        setError(String(e));
         toast.error(String(e));
+      } finally {
+        checkoutInFlight.current = false;
+        setCheckingOut(false);
       }
     },
     [repoRoot, onRefresh],
@@ -231,7 +241,8 @@ function BranchDropdown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10"
+          disabled={checkingOut}
+          className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10 disabled:cursor-default disabled:opacity-70"
         >
           <HugeiconsIcon
             icon={FolderGitTwoIcon}

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -27,6 +27,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
+import { toast } from "sonner";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
@@ -210,6 +211,7 @@ function BranchDropdown({
         onRefresh();
       } catch (e) {
         setError(String(e));
+        toast.error(String(e));
       }
     },
     [repoRoot, onRefresh],

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -17,6 +17,15 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -27,6 +36,7 @@ import {
 } from "@/components/ui/tooltip";
 import { IS_MAC } from "@/lib/platform";
 import { cn } from "@/lib/utils";
+import { type GitBranchEntry, native } from "@/modules/ai/lib/native";
 import {
   copyToClipboard,
   revealInFinder,
@@ -45,11 +55,13 @@ import {
   ArrowUp01Icon,
   CheckmarkCircle01Icon,
   Download01Icon,
+  Folder01Icon,
   FolderCloudIcon,
   FolderGitTwoIcon,
   GitBranchIcon,
   Refresh01Icon,
   RemoveSquareIcon,
+  Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -82,6 +94,7 @@ type Props = {
     title?: string;
   }) => void;
   onOpenFile?: (absolutePath: string) => void;
+  onNavigateToPath?: (path: string) => void;
 };
 
 const SOURCE_CONTROL_TOOLTIP_CLASS =
@@ -143,12 +156,185 @@ function checkboxValue(state: CheckState): boolean | "indeterminate" {
   return false;
 }
 
+function BranchDropdown({
+  repoRoot,
+  repoLabel,
+  onNavigateToPath,
+  onRefresh,
+}: {
+  repoRoot: string | null;
+  repoLabel: string;
+  onNavigateToPath?: (path: string) => void;
+  onRefresh: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [branches, setBranches] = useState<GitBranchEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
+
+  const loadBranches = useCallback(async () => {
+    if (!repoRoot) return;
+    const id = ++requestRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await native.gitListBranches(repoRoot);
+      if (id !== requestRef.current) return;
+      setBranches(result.branches);
+    } catch (e) {
+      if (id !== requestRef.current) return;
+      setError(String(e));
+      setBranches([]);
+    } finally {
+      if (id === requestRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [repoRoot]);
+
+  useEffect(() => {
+    if (open) {
+      void loadBranches();
+    }
+  }, [open, loadBranches]);
+
+  const handleCheckout = useCallback(
+    async (branch: string) => {
+      if (!repoRoot) return;
+      setError(null);
+      try {
+        await native.gitCheckoutBranch(repoRoot, branch);
+        setBranches([]);
+        setOpen(false);
+        onRefresh();
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [repoRoot, onRefresh],
+  );
+
+  const localBranches = useMemo(
+    () => branches.filter((b) => b.kind === "local"),
+    [branches],
+  );
+  const worktrees = useMemo(
+    () => branches.filter((b) => b.kind === "worktree"),
+    [branches],
+  );
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10"
+        >
+          <HugeiconsIcon
+            icon={FolderGitTwoIcon}
+            size={12}
+            strokeWidth={1.9}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span className="max-w-35 truncate">{repoLabel}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        {loading ? (
+          <div className="flex items-center gap-2 px-3 py-3 text-[11px] text-muted-foreground">
+            <Spinner className="size-3" />
+            Loading branches…
+          </div>
+        ) : error ? (
+          <div className="px-3 py-3 text-[11px] leading-snug text-destructive">
+            {error}
+          </div>
+        ) : (
+          <>
+            {localBranches.length > 0 && (
+              <>
+                <DropdownMenuLabel className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/85">
+                  Local Branches
+                </DropdownMenuLabel>
+                <DropdownMenuGroup>
+                  {localBranches.map((b) => (
+                    <DropdownMenuItem
+                      key={b.name}
+                      onSelect={() => void handleCheckout(b.name)}
+                      className="flex cursor-pointer items-center gap-2 text-[12px]"
+                    >
+                      {b.isHead ? (
+                        <HugeiconsIcon
+                          icon={Tick02Icon}
+                          size={14}
+                          strokeWidth={1.8}
+                          className="shrink-0"
+                        />
+                      ) : (
+                        <span className="w-3.5 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate">{b.name}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+              </>
+            )}
+            {worktrees.length > 0 && (
+              <>
+                {localBranches.length > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuLabel className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/85">
+                  Worktrees
+                </DropdownMenuLabel>
+                <DropdownMenuGroup>
+                  {worktrees.map((b) => (
+                    <DropdownMenuItem
+                      key={b.worktreePath ?? b.name}
+                      onSelect={() => {
+                        if (b.worktreePath && onNavigateToPath) {
+                          onNavigateToPath(b.worktreePath);
+                        }
+                      }}
+                      className="flex cursor-pointer items-center gap-2 text-[12px]"
+                    >
+                      <HugeiconsIcon
+                        icon={Folder01Icon}
+                        size={14}
+                        strokeWidth={1.5}
+                        className="shrink-0 text-muted-foreground"
+                      />
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate">{b.name}</span>
+                        {b.worktreePath && (
+                          <span className="truncate text-[10px] text-muted-foreground">
+                            {b.worktreePath}
+                          </span>
+                        )}
+                      </div>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+              </>
+            )}
+            {branches.length === 0 && (
+              <div className="px-3 py-3 text-[11px] text-muted-foreground">
+                No branches found.
+              </div>
+            )}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export const SourceControlPanel = memo(function SourceControlPanel({
   open,
   sourceControl,
   onOpenGitGraph,
   onOpenDiff,
   onOpenFile,
+  onNavigateToPath,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
   const refreshAnimationRef = useRef<number | null>(null);
@@ -419,15 +605,12 @@ export const SourceControlPanel = memo(function SourceControlPanel({
       <aside className="flex h-full min-w-0 flex-col bg-card/80 backdrop-blur [contain:layout_style]">
         <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border/50 px-3 pb-2.5 pt-3">
           <div className="flex min-w-0 items-center gap-1.5">
-            <div className="inline-flex min-w-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10">
-              <HugeiconsIcon
-                icon={FolderGitTwoIcon}
-                size={12}
-                strokeWidth={1.9}
-                className="shrink-0 text-muted-foreground"
-              />
-              <span className="max-w-[140px] truncate">{repoLabel}</span>
-            </div>
+            <BranchDropdown
+              repoRoot={scm.repo?.repoRoot ?? null}
+              repoLabel={repoLabel}
+              onNavigateToPath={onNavigateToPath}
+              onRefresh={handleRefresh}
+            />
             {scm.status && (scm.status.ahead > 0 || scm.status.behind > 0) ? (
               <div className="flex shrink-0 items-center gap-0.5 text-[10px] font-semibold tabular-nums leading-none text-muted-foreground">
                 {scm.status.ahead > 0 ? (


### PR DESCRIPTION
## What
Changes the current branch display to a button that lets users checkout branches and worktree.

## Why
I just enjoy using the UI, i hate checking out branches in terminal

## How
Dont think much explaination is needed

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS / Windows 


## Screenshots / GIFs
<img width="1236" height="720" alt="checkout" src="https://github.com/user-attachments/assets/c7b735f8-1ae1-4138-9cab-8d92a36443bd" />
<img width="232" height="519" alt="image" src="https://github.com/user-attachments/assets/a31a1187-896e-42e6-928c-5fab62136861" />


## Notes for reviewer
2 new tauri::commands:
git_list_branches
git_checkout_branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a branch selector to Source Control to list local branches and worktrees.
  * You can now switch branches from the app, and open worktrees by navigating to their path.
* **Bug Fixes**
  * Improved branch checkout safety by rejecting invalid branch names and surfacing checkout failures.
  * Enhanced branch listing to correctly mark the current branch and represent worktree entries.
* **Tests**
  * Added coverage for unsafe branch-name rejection and branch/worktree classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->