### PR TITLE
feat(ai): selectable custom-endpoint chat model

### DIFF
--- a/src/modules/ai/agents/runSubagent.test.ts
+++ b/src/modules/ai/agents/runSubagent.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Spy on the two model builders so we can assert which path a model id takes.
+const { buildConfigured, buildPlain } = vi.hoisted(() => ({
+  buildConfigured: vi.fn(async () => ({}) as never),
+  buildPlain: vi.fn(async () => ({}) as never),
+}));
+
+vi.mock("../lib/agent", () => ({
+  buildConfiguredLanguageModel: buildConfigured,
+  buildLanguageModel: buildPlain,
+}));
+
+// Stub the AI SDK: tool() is used when building the subagent's read-only tools;
+// generateText must not actually call a model.
+vi.mock("ai", () => ({
+  tool: (def: unknown) => def,
+  stepCountIs: () => ({}),
+  generateText: vi.fn(async () => ({ text: "ok", steps: [] })),
+}));
+
+import { DEFAULT_MODEL_ID } from "../config";
+import type { ToolContext } from "../tools/context";
+import { runSubagent } from "./runSubagent";
+
+const ctx = {
+  getCwd: () => null,
+  getWorkspaceRoot: () => null,
+  getTerminalContext: () => null,
+  isActiveTerminalPrivate: () => false,
+  injectIntoActivePty: () => false,
+  openPreview: () => false,
+  spawnAgent: () => null,
+  readAgentOutput: () => null,
+  readCache: new Map(),
+  getSessionId: () => "session-1",
+} as ToolContext;
+
+beforeEach(() => {
+  buildConfigured.mockClear();
+  buildPlain.mockClear();
+});
+
+// Regression lock: a compat-* model selected as the chat default persists into
+// selectedModelId and flows here. getModel() throws on compat ids, so the
+// compat case must go through the endpoint-aware builder instead.
+describe("runSubagent model routing", () => {
+  it("routes a compat-* model through the compat-aware builder, never getModel", async () => {
+    await runSubagent({
+      type: "explore",
+      prompt: "x",
+      keys: {} as never,
+      modelId: "compat-abc12345",
+      toolContext: ctx,
+      customEndpoints: [
+        {
+          id: "abc12345",
+          name: "EP",
+          baseURL: "http://x/v1",
+          modelId: "m",
+          contextLimit: 1,
+        },
+      ],
+      customEndpointKeys: { abc12345: "k" },
+    });
+    expect(buildConfigured).toHaveBeenCalledTimes(1);
+    expect(buildConfigured).toHaveBeenCalledWith(
+      "compat-abc12345",
+      expect.anything(),
+      expect.objectContaining({ customEndpoints: expect.any(Array) }),
+    );
+    expect(buildPlain).not.toHaveBeenCalled();
+  });
+
+  it("routes a built-in model through buildLanguageModel", async () => {
+    await runSubagent({
+      type: "explore",
+      prompt: "x",
+      keys: {} as never,
+      modelId: DEFAULT_MODEL_ID,
+      toolContext: ctx,
+    });
+    expect(buildPlain).toHaveBeenCalledTimes(1);
+    expect(buildConfigured).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/ai/agents/runSubagent.ts
+++ b/src/modules/ai/agents/runSubagent.ts
@@ -1,7 +1,13 @@
 import { generateText, stepCountIs } from "ai";
-import { DEFAULT_MODEL_ID, getModel, type ModelId } from "../config";
-import { buildLanguageModel } from "../lib/agent";
-import type { ProviderKeys } from "../lib/keyring";
+import {
+  DEFAULT_MODEL_ID,
+  getModel,
+  isCompatModelId,
+  type CustomEndpoint,
+  type ModelId,
+} from "../config";
+import { buildConfiguredLanguageModel, buildLanguageModel } from "../lib/agent";
+import type { CustomEndpointKeys, ProviderKeys } from "../lib/keyring";
 import type { ToolContext } from "../tools/context";
 import { buildFsTools } from "../tools/fs";
 import { buildSearchTools } from "../tools/search";
@@ -16,6 +22,8 @@ type Args = {
   modelId: string;
   toolContext: ToolContext;
   lmstudioBaseURL?: string;
+  customEndpoints?: readonly CustomEndpoint[];
+  customEndpointKeys?: CustomEndpointKeys;
   onStep?: (label: string) => void;
 };
 
@@ -32,6 +40,8 @@ export async function runSubagent({
   modelId,
   toolContext,
   lmstudioBaseURL,
+  customEndpoints,
+  customEndpointKeys,
   onStep,
 }: Args): Promise<RunResult> {
   const def = SUBAGENTS[type];
@@ -46,12 +56,19 @@ export async function runSubagent({
     if (t in readOnly) tools[t] = readOnly[t];
   }
 
-  const model = await buildLanguageModel(
-    getModel(modelId as ModelId).provider,
-    keys,
-    getModel(modelId as ModelId).id,
-    { lmstudioBaseURL },
-  );
+  // Custom-endpoint (compat-*) models aren't in MODELS, so getModel would throw.
+  // Resolve them via the shared compat-aware builder (endpoint baseURL + key).
+  const model = isCompatModelId(modelId)
+    ? await buildConfiguredLanguageModel(modelId, keys, {
+        customEndpoints,
+        customEndpointKeys,
+      })
+    : await buildLanguageModel(
+        getModel(modelId as ModelId).provider,
+        keys,
+        getModel(modelId as ModelId).id,
+        { lmstudioBaseURL },
+      );
 
   const start = Date.now();
   const result = await generateText({

--- a/src/modules/ai/store/chatRuntime.ts
+++ b/src/modules/ai/store/chatRuntime.ts
@@ -3,7 +3,12 @@ import {
   type ChatTransport,
   lastAssistantMessageIsCompleteWithApprovalResponses,
 } from "ai";
-import { getModel, providerNeedsKey, type ModelId } from "../config";
+import {
+  getModel,
+  isCompatModelId,
+  providerNeedsKey,
+  type ModelId,
+} from "../config";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { BUILTIN_AGENTS } from "../lib/agents";
 import { useAgentsStore } from "./agentsStore";
@@ -132,7 +137,10 @@ export async function sendMessage(text: string): Promise<boolean> {
   const state = useChatStore.getState();
   const sessionId = state.activeSessionId;
   if (!sessionId) return false;
+  // Custom-endpoint (compat-*) models aren't in the built-in MODELS table, so
+  // getModel() would throw; they carry their own auth via getActiveProviderKey.
   if (
+    !isCompatModelId(state.selectedModelId) &&
     providerNeedsKey(getModel(state.selectedModelId as ModelId).provider) &&
     !getActiveProviderKey()
   )

--- a/src/modules/ai/tools/subagent.ts
+++ b/src/modules/ai/tools/subagent.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { runSubagent } from "../agents/runSubagent";
 import { SUBAGENTS, type SubagentType } from "../agents/registry";
 import { useChatStore } from "../store/chatStore";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { ToolContext } from "./context";
 
 const TYPE_KEYS = Object.keys(SUBAGENTS) as [SubagentType, ...SubagentType[]];
@@ -29,8 +30,9 @@ Auto-executes (no approval) — subagents are read-only by design.`,
           .describe("Short label shown in the chat UI for the spawn card."),
       }),
       execute: async ({ type, prompt, description }) => {
-        const { apiKeys, selectedModelId, patchAgentMeta } =
+        const { apiKeys, selectedModelId, customEndpointKeys, patchAgentMeta } =
           useChatStore.getState();
+        const { customEndpoints } = usePreferencesStore.getState();
         try {
           const r = await runSubagent({
             type,
@@ -38,6 +40,8 @@ Auto-executes (no approval) — subagents are read-only by design.`,
             keys: apiKeys,
             modelId: selectedModelId,
             toolContext: ctx,
+            customEndpoints,
+            customEndpointKeys,
             onStep: (label) => patchAgentMeta({ step: label }),
           });
           return {

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   DEFAULT_MODEL_ID,
   DEFAULT_STT_PROVIDER,
+  isCompatModelId,
   isKnownModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
   MLX_DEFAULT_BASE_URL,
@@ -17,6 +18,11 @@ import {
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
+
+// Accept built-in ids and compat-* (custom endpoint) ids, so a custom-endpoint
+// model chosen as chat/recent/favorite survives a reload.
+const isUsableModelId = (id: string): boolean =>
+  isKnownModelId(id) || isCompatModelId(id);
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -313,8 +319,8 @@ export async function loadPreferences(): Promise<Preferences> {
     ),
     defaultModelId: ((): ModelId => {
       const stored = get<string>(KEY_DEFAULT_MODEL);
-      return stored && isKnownModelId(stored)
-        ? stored
+      return stored && isUsableModelId(stored)
+        ? (stored as ModelId)
         : DEFAULT_PREFERENCES.defaultModelId;
     })(),
     editorTheme: ((): EditorThemePref => {
@@ -381,10 +387,10 @@ export async function loadPreferences(): Promise<Preferences> {
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ??
       DEFAULT_PREFERENCES.favoriteModelIds
-    ).filter(isKnownModelId),
+    ).filter(isUsableModelId),
     recentModelIds: (
       get<string[]>(KEY_RECENT_MODELS) ?? DEFAULT_PREFERENCES.recentModelIds
-    ).filter(isKnownModelId),
+    ).filter(isUsableModelId),
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
     editorWordWrap:
       get<boolean>(KEY_EDITOR_WORD_WRAP) ?? DEFAULT_PREFERENCES.editorWordWrap,

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   DEFAULT_MODEL_ID,
   DEFAULT_STT_PROVIDER,
+  isCompatModelId,
   isKnownModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
   MLX_DEFAULT_BASE_URL,
@@ -17,6 +18,11 @@ import {
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
+
+// Accept built-in ids and compat-* (custom endpoint) ids, so a custom-endpoint
+// model chosen as chat/recent/favorite survives a reload.
+const isUsableModelId = (id: string): boolean =>
+  isKnownModelId(id) || isCompatModelId(id);
 
 export type ThemePref = "system" | "light" | "dark";
 
@@ -377,8 +383,8 @@ export async function loadPreferences(): Promise<Preferences> {
     ),
     defaultModelId: ((): ModelId => {
       const stored = get<string>(KEY_DEFAULT_MODEL);
-      return stored && isKnownModelId(stored)
-        ? stored
+      return stored && isUsableModelId(stored)
+        ? (stored as ModelId)
         : DEFAULT_PREFERENCES.defaultModelId;
     })(),
     editorTheme: ((): EditorThemePref => {
@@ -450,10 +456,10 @@ export async function loadPreferences(): Promise<Preferences> {
       DEFAULT_PREFERENCES.whispercppBaseURL,
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ?? DEFAULT_PREFERENCES.favoriteModelIds
-    ).filter(isKnownModelId),
+    ).filter(isUsableModelId),
     recentModelIds: (
       get<string[]>(KEY_RECENT_MODELS) ?? DEFAULT_PREFERENCES.recentModelIds
-    ).filter(isKnownModelId),
+    ).filter(isUsableModelId),
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
     editorWordWrap:
       get<boolean>(KEY_EDITOR_WORD_WRAP) ?? DEFAULT_PREFERENCES.editorWordWrap,

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -19,10 +19,10 @@ import {
   compatModelIdForEndpoint,
   getAutocompleteEligibleModels,
   getCompatModelInfo,
-  getModel,
   getProvider,
   isCompatModelId,
   providerNeedsKey,
+  resolveModel,
   type CustomEndpoint,
   type ModelId,
   type ProviderId,
@@ -532,6 +532,7 @@ function DefaultsBlock({
           <DefaultModelPicker
             defaultModel={defaultModel}
             configuredIds={configuredIds}
+            customEndpoints={customEndpoints}
           />
         </FieldRow>
         <AutocompleteRow
@@ -547,12 +548,21 @@ function DefaultsBlock({
 function DefaultModelPicker({
   defaultModel,
   configuredIds,
+  customEndpoints,
 }: {
   defaultModel: ModelId;
   configuredIds: Set<ProviderId>;
+  customEndpoints: readonly CustomEndpoint[];
 }) {
-  const m = getModel(defaultModel);
-  const hasAny = configuredIds.size > 0;
+  // One chat model per configured custom endpoint, like the autocomplete row.
+  const compatItems = customEndpoints
+    .filter((e) => e.baseURL.trim() && e.modelId.trim())
+    .map((e) =>
+      getCompatModelInfo(compatModelIdForEndpoint(e.id), customEndpoints),
+    );
+  // resolveModel, not getModel: a compat-* default would make getModel throw.
+  const m = resolveModel(defaultModel, customEndpoints);
+  const hasAny = configuredIds.size > 0 || compatItems.length > 0;
 
   return (
     <DropdownMenu>
@@ -612,6 +622,31 @@ function DefaultModelPicker({
               </div>
             );
           })}
+          {compatItems.length > 0 && (
+            <div className="px-1 pt-1.5 first:pt-1">
+              <div className="mb-0.5 flex items-center gap-1.5 px-2 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+                <ProviderIcon provider="openai-compatible" size={11} />
+                <span>Custom endpoints</span>
+              </div>
+              {compatItems.map((mod) => (
+                <DropdownMenuItem
+                  key={mod.id}
+                  onSelect={() => void setDefaultModel(mod.id as ModelId)}
+                  className={cn(
+                    "flex items-start gap-2 text-[12px]",
+                    mod.id === defaultModel && "bg-accent/50",
+                  )}
+                >
+                  <span className="flex flex-1 flex-col">
+                    <span>{mod.label}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {mod.description}
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </div>
+          )}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -231,7 +231,8 @@ export function ModelsSection() {
     // Drop the now-dead model id from favorites/recents before touching the
     // selection, so the recents push from a selection reset can't race it.
     const deadModelId = compatModelIdForEndpoint(id);
-    const { favoriteModelIds, recentModelIds } = usePreferencesStore.getState();
+    const { favoriteModelIds, recentModelIds, defaultModelId } =
+      usePreferencesStore.getState();
     if (favoriteModelIds.includes(deadModelId)) {
       await setFavoriteModelIds(
         favoriteModelIds.filter((m) => m !== deadModelId),
@@ -251,6 +252,16 @@ export function ModelsSection() {
         remaining[0]
           ? compatModelIdForEndpoint(remaining[0].id)
           : DEFAULT_MODEL_ID,
+      );
+    }
+
+    // Same dangling-id risk for the persisted chat default, which useAiBootstrap
+    // mirrors back into the selection on startup.
+    if (defaultModelId === deadModelId) {
+      await setDefaultModel(
+        (remaining[0]
+          ? compatModelIdForEndpoint(remaining[0].id)
+          : DEFAULT_MODEL_ID) as ModelId,
       );
     }
 

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -27,10 +27,10 @@ import {
   DEFAULT_MODEL_ID,
   getAutocompleteEligibleModels,
   getCompatModelInfo,
-  getModel,
   getProvider,
   isCompatModelId,
   MODELS,
+  resolveModel,
   type ModelId,
   PROVIDERS,
   type ProviderId,
@@ -545,6 +545,7 @@ function DefaultsBlock({
           <DefaultModelPicker
             defaultModel={defaultModel}
             configuredIds={configuredIds}
+            customEndpoints={customEndpoints}
           />
         </FieldRow>
         <AutocompleteRow
@@ -560,12 +561,21 @@ function DefaultsBlock({
 function DefaultModelPicker({
   defaultModel,
   configuredIds,
+  customEndpoints,
 }: {
   defaultModel: ModelId;
   configuredIds: Set<ProviderId>;
+  customEndpoints: readonly CustomEndpoint[];
 }) {
-  const m = getModel(defaultModel);
-  const hasAny = configuredIds.size > 0;
+  // One chat model per configured custom endpoint, like the autocomplete row.
+  const compatItems = customEndpoints
+    .filter((e) => e.baseURL.trim() && e.modelId.trim())
+    .map((e) =>
+      getCompatModelInfo(compatModelIdForEndpoint(e.id), customEndpoints),
+    );
+  // resolveModel, not getModel: a compat-* default would make getModel throw.
+  const m = resolveModel(defaultModel, customEndpoints);
+  const hasAny = configuredIds.size > 0 || compatItems.length > 0;
 
   return (
     <DropdownMenu>
@@ -625,6 +635,31 @@ function DefaultModelPicker({
               </div>
             );
           })}
+          {compatItems.length > 0 && (
+            <div className="px-1 pt-1.5 first:pt-1">
+              <div className="mb-0.5 flex items-center gap-1.5 px-2 text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+                <ProviderIcon provider="openai-compatible" size={11} />
+                <span>Custom endpoints</span>
+              </div>
+              {compatItems.map((mod) => (
+                <DropdownMenuItem
+                  key={mod.id}
+                  onSelect={() => void setDefaultModel(mod.id as ModelId)}
+                  className={cn(
+                    "flex items-start gap-2 text-[12px]",
+                    mod.id === defaultModel && "bg-accent/50",
+                  )}
+                >
+                  <span className="flex flex-1 flex-col">
+                    <span>{mod.label}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {mod.description}
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </div>
+          )}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
Lets a fully-configured custom OpenAI-compatible endpoint be selected as the
default chat model, not just for autocomplete. The default-model picker now
lists configured custom endpoints (mirroring the autocomplete row), and
compat-* model ids persist across reload in defaults/favorites/recents.

Compat ids are resolved through the shared `buildConfiguredLanguageModel`
everywhere they flow, so `getModel()` (which throws on compat ids) is never
hit. This also fixes subagent spawning, which failed when a custom-endpoint
model was the selected default.

## Changes
- `ModelsSection`: custom endpoints appear in the default-model dropdown;
  `resolveModel` instead of `getModel` so a compat default renders.
- `store.ts`: `isUsableModelId` keeps compat ids in defaults/favorites/recents
  through reload.
- `chatRuntime`: skip the provider-key check for compat ids (own auth).
- `runSubagent` / `subagent`: route compat ids through
  `buildConfiguredLanguageModel` with endpoint baseURL + key.

## Test plan
- `pnpm test`: new `runSubagent.test.ts` locks routing (compat to the
  compat-aware builder, built-in to `buildLanguageModel`)
- `tsc` and lint clean
- Manual: configure a custom endpoint, set it as the default chat model, send a
  message, then spawn a subagent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom OpenAI-compatible “compat-*” model IDs across model selection, chat messaging, and subagent execution.
  * The default-model picker can now display a conditional **“Custom endpoints”** section and select compat models derived from configured endpoints.
* **Bug Fixes**
  * Fixed persisted settings and default-model loading so compat models are not incorrectly rejected.
  * Improved behavior when custom endpoints are removed, including updating the chat default model when needed.
* **Tests**
  * Added regression coverage to verify correct routing between compat-aware and standard model handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->