### PR TITLE
feat(shortcuts): TUI focus passthrough

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -626,7 +626,6 @@ export default function App() {
   const explorerGitDecorations = usePreferencesStore(
     (s) => s.explorerGitDecorations,
   );
-  const terminalTuiFocus = usePreferencesStore((s) => s.terminalTuiFocus);
 
   const openPreviewTab = useCallback(
     (url: string) => {
@@ -731,7 +730,9 @@ export default function App() {
       "terminal.toggleInput": () =>
         window.dispatchEvent(new CustomEvent(TOGGLE_BLOCK_INPUT_EVENT)),
       "terminal.toggleTuiFocus": () => {
-        void setTerminalTuiFocus(!terminalTuiFocus);
+        void setTerminalTuiFocus(
+          !usePreferencesStore.getState().terminalTuiFocus,
+        );
       },
       "blocks.prev": () => navigateFocusedBlocks(-1),
       "blocks.next": () => navigateFocusedBlocks(1),
@@ -793,7 +794,6 @@ export default function App() {
       zoomOut,
       zoomReset,
       activateAgentTarget,
-      terminalTuiFocus,
       setTerminalTuiFocus,
     ],
   );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -42,6 +42,7 @@ import {
 import type { PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setTerminalTuiFocus } from "@/modules/settings/store";
 import { isMarkdownPath } from "@/lib/utils";
 import {
   useGlobalShortcuts,
@@ -593,6 +594,7 @@ export default function App() {
   const explorerGitDecorations = usePreferencesStore(
     (s) => s.explorerGitDecorations,
   );
+  const terminalTuiFocus = usePreferencesStore((s) => s.terminalTuiFocus);
 
   const openPreviewTab = useCallback(
     (url: string) => {
@@ -653,6 +655,9 @@ export default function App() {
       },
       "terminal.toggleInput": () =>
         window.dispatchEvent(new CustomEvent(TOGGLE_BLOCK_INPUT_EVENT)),
+      "terminal.toggleTuiFocus": () => {
+        void setTerminalTuiFocus(!terminalTuiFocus);
+      },
       "blocks.prev": () => navigateFocusedBlocks(-1),
       "blocks.next": () => navigateFocusedBlocks(1),
       "search.focus": () => searchInlineRef.current?.focus(),
@@ -689,6 +694,8 @@ export default function App() {
       zoomIn,
       zoomOut,
       zoomReset,
+      terminalTuiFocus,
+      setTerminalTuiFocus,
     ],
   );
 
@@ -721,19 +728,7 @@ export default function App() {
       ) {
         return !(activeTab?.kind === "terminal" && activeTab.blocks === true);
       }
-      if (id === "sidebar.toggle") {
-        // Ctrl+B is also Claude Code's "run in background" key. While a terminal
-        // is focused, let Ctrl+B reach the shell/Claude instead of toggling the
-        // sidebar. Ctrl+Shift+B (second binding) still toggles it from anywhere.
-        const target =
-          (e.target as HTMLElement | null) ?? document.activeElement;
-        const inTerminal = !!(target as HTMLElement | null)?.closest?.(
-          ".xterm",
-        );
-        // Only defer the plain (no-shift) Ctrl/⌘+B binding; the Shift variant
-        // is the always-on toggle and is never claimed by the terminal.
-        return inTerminal && !e.shiftKey;
-      }
+      // sidebar.toggle deferral is handled in shouldDeferForTerminalFocus.
       return false;
     },
     [activeTab],

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -44,6 +44,7 @@ import { setLspNavigator } from "@/modules/lsp";
 import type { PreviewPaneHandle } from "@/modules/preview";
 import { openSettingsWindow } from "@/modules/settings/openSettingsWindow";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setTerminalTuiFocus } from "@/modules/settings/store";
 import {
   shouldDisablePaneSwapShortcut,
   type ShortcutHandlers,
@@ -625,6 +626,7 @@ export default function App() {
   const explorerGitDecorations = usePreferencesStore(
     (s) => s.explorerGitDecorations,
   );
+  const terminalTuiFocus = usePreferencesStore((s) => s.terminalTuiFocus);
 
   const openPreviewTab = useCallback(
     (url: string) => {
@@ -728,6 +730,9 @@ export default function App() {
       },
       "terminal.toggleInput": () =>
         window.dispatchEvent(new CustomEvent(TOGGLE_BLOCK_INPUT_EVENT)),
+      "terminal.toggleTuiFocus": () => {
+        void setTerminalTuiFocus(!terminalTuiFocus);
+      },
       "blocks.prev": () => navigateFocusedBlocks(-1),
       "blocks.next": () => navigateFocusedBlocks(1),
       "search.focus": () => {
@@ -788,6 +793,8 @@ export default function App() {
       zoomOut,
       zoomReset,
       activateAgentTarget,
+      terminalTuiFocus,
+      setTerminalTuiFocus,
     ],
   );
 
@@ -830,19 +837,7 @@ export default function App() {
       ) {
         return !(activeTab?.kind === "terminal" && activeTab.blocks === true);
       }
-      if (id === "sidebar.toggle") {
-        // Ctrl+B is also Claude Code's "run in background" key. While a terminal
-        // is focused, let Ctrl+B reach the shell/Claude instead of toggling the
-        // sidebar. Ctrl+Shift+B (second binding) still toggles it from anywhere.
-        const target =
-          (e.target as HTMLElement | null) ?? document.activeElement;
-        const inTerminal = !!(target as HTMLElement | null)?.closest?.(
-          ".xterm",
-        );
-        // Only defer the plain (no-shift) Ctrl/⌘+B binding; the Shift variant
-        // is the always-on toggle and is never claimed by the terminal.
-        return inTerminal && !e.shiftKey;
-      }
+      // sidebar.toggle deferral is handled in shouldDeferForTerminalFocus.
       return false;
     },
     [activeTab],

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -156,6 +156,7 @@ export type Preferences = {
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  terminalTuiFocus: boolean;
   lastWslDistro: string | null;
   zoomLevel: number;
   agentNotifications: boolean;
@@ -245,6 +246,7 @@ const KEY_TERMINAL_SHELL = "terminalShell";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_TERMINAL_TUI_FOCUS = "terminalTuiFocus";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
@@ -326,6 +328,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  terminalTuiFocus: true,
   lastWslDistro: null,
   zoomLevel: 1.0,
   agentNotifications: true,
@@ -489,6 +492,9 @@ export async function loadPreferences(): Promise<Preferences> {
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
     ),
+    terminalTuiFocus:
+      get<boolean>(KEY_TERMINAL_TUI_FOCUS) ??
+      DEFAULT_PREFERENCES.terminalTuiFocus,
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
@@ -783,6 +789,10 @@ export async function setTerminalScrollback(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_SCROLLBACK, clampScrollback(value));
 }
 
+export async function setTerminalTuiFocus(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_TUI_FOCUS, value);
+}
+
 export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
@@ -901,6 +911,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_TERMINAL_TUI_FOCUS]: "terminalTuiFocus",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -152,6 +152,7 @@ export type Preferences = {
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  terminalTuiFocus: boolean;
   lastWslDistro: string | null;
   zoomLevel: number;
   agentNotifications: boolean;
@@ -204,6 +205,7 @@ const KEY_TERMINAL_SHELL = "terminalShell";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_TERMINAL_TUI_FOCUS = "terminalTuiFocus";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
@@ -269,6 +271,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  terminalTuiFocus: true,
   lastWslDistro: null,
   zoomLevel: 1.0,
   agentNotifications: true,
@@ -420,6 +423,9 @@ export async function loadPreferences(): Promise<Preferences> {
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
     ),
+    terminalTuiFocus:
+      get<boolean>(KEY_TERMINAL_TUI_FOCUS) ??
+      DEFAULT_PREFERENCES.terminalTuiFocus,
     lastWslDistro:
       get<string | null>(KEY_LAST_WSL_DISTRO) ??
       DEFAULT_PREFERENCES.lastWslDistro,
@@ -654,6 +660,10 @@ export async function setTerminalScrollback(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_SCROLLBACK, clampScrollback(value));
 }
 
+export async function setTerminalTuiFocus(value: boolean): Promise<void> {
+  await writePref(KEY_TERMINAL_TUI_FOCUS, value);
+}
+
 export async function setLastWslDistro(value: string | null): Promise<void> {
   await writePref(KEY_LAST_WSL_DISTRO, value);
 }
@@ -738,6 +748,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_TERMINAL_TUI_FOCUS]: "terminalTuiFocus",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",

--- a/src/modules/shortcuts/lib/useGlobalShortcuts.ts
+++ b/src/modules/shortcuts/lib/useGlobalShortcuts.ts
@@ -3,6 +3,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   SHORTCUTS,
   matchBinding,
+  shouldDeferForTerminalFocus,
   type ShortcutId,
 } from "../shortcuts";
 
@@ -22,6 +23,7 @@ export function useGlobalShortcuts(
 
   // Access the shortcuts from the store
   const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+  const tuiFocus = usePreferencesStore((s) => s.terminalTuiFocus);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -31,6 +33,12 @@ export function useGlobalShortcuts(
         const bindings = userShortcuts[s.id] || s.defaultBindings;
         const isMatch = bindings.some((b) => matchBinding(e, b, s.id));
         if (!isMatch) continue;
+        const inTerminal = !!(e.target as HTMLElement | null)?.closest?.(
+          ".xterm",
+        );
+        if (shouldDeferForTerminalFocus(s, e, { enabled: tuiFocus, inTerminal })) {
+          return;
+        }
         if (options?.isDisabled?.(s.id, e)) return;
         const h = handlers[s.id];
         if (!h) return;
@@ -43,5 +51,5 @@ export function useGlobalShortcuts(
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [userShortcuts]);
+  }, [userShortcuts, tuiFocus]);
 }

--- a/src/modules/shortcuts/shortcuts.test.ts
+++ b/src/modules/shortcuts/shortcuts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SHORTCUTS,
+  shouldDeferForTerminalFocus,
+  type Shortcut,
+} from "./shortcuts";
+
+const evt = (shiftKey: boolean): KeyboardEvent =>
+  ({ shiftKey }) as unknown as KeyboardEvent;
+
+const findShortcut = (id: Shortcut["id"]): Shortcut => {
+  const s = SHORTCUTS.find((x) => x.id === id);
+  if (!s) throw new Error(`test setup: missing shortcut ${id}`);
+  return s;
+};
+
+describe("shouldDeferForTerminalFocus", () => {
+  it("never defers when TUI passthrough is disabled (even inside a terminal)", () => {
+    const s = findShortcut("commandPalette.open");
+    expect(shouldDeferForTerminalFocus(s, evt(false), { enabled: false, inTerminal: true })).toBe(false);
+  });
+
+  it("never defers a terminalAlwaysOn shortcut (Find in files)", () => {
+    const s = findShortcut("commandPalette.content");
+    expect(shouldDeferForTerminalFocus(s, evt(true), { enabled: true, inTerminal: true })).toBe(false);
+  });
+
+  it("never defers a terminalAlwaysOn shortcut (toggleTuiFocus itself)", () => {
+    const s = findShortcut("terminal.toggleTuiFocus");
+    expect(shouldDeferForTerminalFocus(s, evt(false), { enabled: true, inTerminal: true })).toBe(false);
+  });
+
+  it("defers sidebar.toggle plain binding when terminal is focused", () => {
+    const s = findShortcut("sidebar.toggle");
+    expect(shouldDeferForTerminalFocus(s, evt(false), { enabled: true, inTerminal: true })).toBe(true);
+  });
+
+  it("does NOT defer sidebar.toggle Shift binding when terminal is focused", () => {
+    const s = findShortcut("sidebar.toggle");
+    expect(shouldDeferForTerminalFocus(s, evt(true), { enabled: true, inTerminal: true })).toBe(false);
+  });
+
+  it("does NOT defer sidebar.toggle plain binding when terminal is NOT focused", () => {
+    const s = findShortcut("sidebar.toggle");
+    expect(shouldDeferForTerminalFocus(s, evt(false), { enabled: true, inTerminal: false })).toBe(false);
+  });
+
+  it("defers a generic shortcut (commandPalette.open) when terminal is focused", () => {
+    const s = findShortcut("commandPalette.open");
+    expect(shouldDeferForTerminalFocus(s, evt(false), { enabled: true, inTerminal: true })).toBe(true);
+  });
+
+  it("does NOT defer a generic shortcut when terminal is NOT focused", () => {
+    const s = findShortcut("commandPalette.open");
+    expect(shouldDeferForTerminalFocus(s, evt(false), { enabled: true, inTerminal: false })).toBe(false);
+  });
+});

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -26,6 +26,7 @@ export type ShortcutId =
   | "pane.source"
   | "terminal.clear"
   | "terminal.toggleInput"
+  | "terminal.toggleTuiFocus"
   | "blocks.prev"
   | "blocks.next"
   | "search.focus"
@@ -67,6 +68,8 @@ export type Shortcut = {
   group: ShortcutGroup;
   defaultBindings: KeyBinding[];
   allowRepeat?: boolean;
+  // Fires even when a terminal pane is focused (not deferred by TUI passthrough).
+  terminalAlwaysOn?: boolean;
 };
 
 export const SHORTCUTS: Shortcut[] = [
@@ -81,6 +84,7 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Find in files",
     group: "General",
     defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "p" }],
+    terminalAlwaysOn: true,
   },
   {
     id: "settings.open",
@@ -163,12 +167,22 @@ export const SHORTCUTS: Shortcut[] = [
     // macOS — on other platforms Ctrl+K is readline's kill-line, so we leave it
     // unbound and let users assign their own in settings.
     defaultBindings: IS_MAC ? [{ meta: true, key: "k" }] : [],
+    terminalAlwaysOn: true,
   },
   {
     id: "terminal.toggleInput",
     label: "Toggle Shell / AI input",
     group: "Terminal",
     defaultBindings: [{ [MOD_PROP]: true, key: "u" }],
+    terminalAlwaysOn: true,
+  },
+  {
+    id: "terminal.toggleTuiFocus",
+    label: "Toggle TUI focus passthrough",
+    group: "Terminal",
+    // Always-on so the user can't get stuck in passthrough with no way out.
+    defaultBindings: [{ key: "F6" }],
+    terminalAlwaysOn: true,
   },
   {
     id: "blocks.prev",
@@ -176,6 +190,7 @@ export const SHORTCUTS: Shortcut[] = [
     group: "Terminal",
     defaultBindings: [{ [MOD_PROP]: true, key: "ArrowUp" }],
     allowRepeat: true,
+    terminalAlwaysOn: true,
   },
   {
     id: "blocks.next",
@@ -183,6 +198,7 @@ export const SHORTCUTS: Shortcut[] = [
     group: "Terminal",
     defaultBindings: [{ [MOD_PROP]: true, key: "ArrowDown" }],
     allowRepeat: true,
+    terminalAlwaysOn: true,
   },
   {
     id: "tab.next",
@@ -325,6 +341,25 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   "AI",
   "Editor",
 ];
+
+export type DeferOpts = {
+  enabled: boolean;
+  inTerminal: boolean;
+};
+
+// Skip a global shortcut when a terminal pane is focused and passthrough is on,
+// so the key reaches the TUI. sidebar.toggle keeps its Shift binding always-on.
+// Pure so it can be unit-tested without React.
+export function shouldDeferForTerminalFocus(
+  shortcut: Shortcut,
+  e: KeyboardEvent,
+  opts: DeferOpts,
+): boolean {
+  if (!opts.enabled) return false;
+  if (shortcut.terminalAlwaysOn) return false;
+  if (shortcut.id === "sidebar.toggle" && e.shiftKey) return false;
+  return opts.inTerminal;
+}
 
 /**
  * Matching logic: checks if a KeyboardEvent matches a KeyBinding.

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -30,6 +30,7 @@ export type ShortcutId =
   | "pane.source"
   | "terminal.clear"
   | "terminal.toggleInput"
+  | "terminal.toggleTuiFocus"
   | "blocks.prev"
   | "blocks.next"
   | "search.focus"
@@ -75,6 +76,8 @@ export type Shortcut = {
   group: ShortcutGroup;
   defaultBindings: KeyBinding[];
   allowRepeat?: boolean;
+  // Fires even when a terminal pane is focused (not deferred by TUI passthrough).
+  terminalAlwaysOn?: boolean;
 };
 
 export const SHORTCUTS: Shortcut[] = [
@@ -89,6 +92,7 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Find in files",
     group: "General",
     defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "p" }],
+    terminalAlwaysOn: true,
   },
   {
     id: "settings.open",
@@ -195,12 +199,22 @@ export const SHORTCUTS: Shortcut[] = [
     // macOS — on other platforms Ctrl+K is readline's kill-line, so we leave it
     // unbound and let users assign their own in settings.
     defaultBindings: IS_MAC ? [{ meta: true, key: "k" }] : [],
+    terminalAlwaysOn: true,
   },
   {
     id: "terminal.toggleInput",
     label: "Toggle Shell / AI input",
     group: "Terminal",
     defaultBindings: [{ [MOD_PROP]: true, key: "u" }],
+    terminalAlwaysOn: true,
+  },
+  {
+    id: "terminal.toggleTuiFocus",
+    label: "Toggle TUI focus passthrough",
+    group: "Terminal",
+    // Always-on so the user can't get stuck in passthrough with no way out.
+    defaultBindings: [{ key: "F6" }],
+    terminalAlwaysOn: true,
   },
   {
     id: "blocks.prev",
@@ -208,6 +222,7 @@ export const SHORTCUTS: Shortcut[] = [
     group: "Terminal",
     defaultBindings: [{ [MOD_PROP]: true, key: "ArrowUp" }],
     allowRepeat: true,
+    terminalAlwaysOn: true,
   },
   {
     id: "blocks.next",
@@ -215,6 +230,7 @@ export const SHORTCUTS: Shortcut[] = [
     group: "Terminal",
     defaultBindings: [{ [MOD_PROP]: true, key: "ArrowDown" }],
     allowRepeat: true,
+    terminalAlwaysOn: true,
   },
   {
     id: "tab.next",
@@ -381,6 +397,25 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
   "AI",
   "Editor",
 ];
+
+export type DeferOpts = {
+  enabled: boolean;
+  inTerminal: boolean;
+};
+
+// Skip a global shortcut when a terminal pane is focused and passthrough is on,
+// so the key reaches the TUI. sidebar.toggle keeps its Shift binding always-on.
+// Pure so it can be unit-tested without React.
+export function shouldDeferForTerminalFocus(
+  shortcut: Shortcut,
+  e: KeyboardEvent,
+  opts: DeferOpts,
+): boolean {
+  if (!opts.enabled) return false;
+  if (shortcut.terminalAlwaysOn) return false;
+  if (shortcut.id === "sidebar.toggle" && e.shiftKey) return false;
+  return opts.inTerminal;
+}
 
 /**
  * Matching logic: checks if a KeyboardEvent matches a KeyBinding.


### PR DESCRIPTION
Closes #603

## Summary
When a terminal pane is focused and TUI passthrough is on (default), most
global shortcuts are skipped so a focused TUI (Claude Code, OpenCode, vim)
receives its own keys. A per-shortcut `terminalAlwaysOn` flag marks the
escape-hatch shortcuts that always fire (the command-palette opener, terminal
navigation, and the toggle itself). F6 toggles passthrough at runtime via the
new `terminalTuiFocus` preference.

The defer decision lives in a pure `shouldDeferForTerminalFocus` function,
replacing an inline special-case in `App.tsx`, so it is unit-tested without
React.

## Test plan
- `pnpm test`: new `shortcuts.test.ts` covers the defer matrix (enabled/
  disabled, terminalAlwaysOn, the sidebar.toggle Shift exception, in/out of a
  terminal)
- `tsc` and lint clean
- Manual: focus a terminal running Claude Code, confirm Ctrl+P reaches it;
  press F6 to toggle; Ctrl+Shift+P still opens the palette


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new shortcut (`F6`) to toggle whether terminal UI focus should be prioritized.
  * Introduced a persisted preference (`terminalTuiFocus`) controlling terminal focus behavior.
* **Bug Fixes**
  * Improved global shortcut handling when the terminal is focused, reducing conflicts.
  * Refined deferral rules for terminal and sidebar toggle shortcuts (including modifier-specific behavior).
* **Tests**
  * Added automated coverage for terminal-focus deferral logic to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->