### PR TITLE
feat(workspace): default environment for new spaces

### DIFF
--- a/src/modules/settings/preferences.ts
+++ b/src/modules/settings/preferences.ts
@@ -12,7 +12,7 @@ type State = Preferences & {
   init: () => Promise<void>;
 };
 
-let initialized = false;
+let initPromise: Promise<void> | null = null;
 
 const FAST_BG_KIND_KEY = "terax-ui-bg-kind-shadow";
 const FAST_BG_IMAGE_ID_KEY = "terax-ui-bg-image-shadow";
@@ -48,18 +48,20 @@ export function readBgFastPath(): {
 export const usePreferencesStore = create<State>((set) => ({
   ...DEFAULT_PREFERENCES,
   hydrated: false,
-  init: async () => {
-    if (initialized) return;
-    initialized = true;
-    const prefs = await loadPreferences();
-    set({ ...prefs, hydrated: true });
-    mirrorBgFastPath(prefs.backgroundKind, prefs.backgroundImageId);
-    void onPreferencesChange((key, value) => {
-      set({ [key]: value } as Partial<State>);
-      if (key === "backgroundKind" || key === "backgroundImageId") {
-        const s = usePreferencesStore.getState();
-        mirrorBgFastPath(s.backgroundKind, s.backgroundImageId);
-      }
-    });
+  init: () => {
+    if (initPromise) return initPromise;
+    initPromise = (async () => {
+      const prefs = await loadPreferences();
+      set({ ...prefs, hydrated: true });
+      mirrorBgFastPath(prefs.backgroundKind, prefs.backgroundImageId);
+      void onPreferencesChange((key, value) => {
+        set({ [key]: value } as Partial<State>);
+        if (key === "backgroundKind" || key === "backgroundImageId") {
+          const s = usePreferencesStore.getState();
+          mirrorBgFastPath(s.backgroundKind, s.backgroundImageId);
+        }
+      });
+    })();
+    return initPromise;
   },
 }));

--- a/src/modules/settings/preferences.ts
+++ b/src/modules/settings/preferences.ts
@@ -51,16 +51,21 @@ export const usePreferencesStore = create<State>((set) => ({
   init: () => {
     if (initPromise) return initPromise;
     initPromise = (async () => {
-      const prefs = await loadPreferences();
-      set({ ...prefs, hydrated: true });
-      mirrorBgFastPath(prefs.backgroundKind, prefs.backgroundImageId);
-      void onPreferencesChange((key, value) => {
-        set({ [key]: value } as Partial<State>);
-        if (key === "backgroundKind" || key === "backgroundImageId") {
-          const s = usePreferencesStore.getState();
-          mirrorBgFastPath(s.backgroundKind, s.backgroundImageId);
-        }
-      });
+      try {
+        const prefs = await loadPreferences();
+        set({ ...prefs, hydrated: true });
+        mirrorBgFastPath(prefs.backgroundKind, prefs.backgroundImageId);
+        void onPreferencesChange((key, value) => {
+          set({ [key]: value } as Partial<State>);
+          if (key === "backgroundKind" || key === "backgroundImageId") {
+            const s = usePreferencesStore.getState();
+            mirrorBgFastPath(s.backgroundKind, s.backgroundImageId);
+          }
+        });
+      } catch (e) {
+        initPromise = null;
+        throw e;
+      }
     })();
     return initPromise;
   },

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -155,6 +155,7 @@ export type Preferences = {
   lastWslDistro: string | null;
   zoomLevel: number;
   agentNotifications: boolean;
+  defaultWorkspaceEnv: string;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
   editorAutoSave: boolean;
   editorAutoSaveDelay: number;
@@ -207,6 +208,7 @@ const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
+const KEY_DEFAULT_WORKSPACE_ENV = "defaultWorkspaceEnv";
 const KEY_SHORTCUTS = "shortcuts";
 const KEY_EDITOR_AUTO_SAVE = "editorAutoSave";
 const KEY_EDITOR_AUTO_SAVE_DELAY = "editorAutoSaveDelay";
@@ -272,6 +274,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   lastWslDistro: null,
   zoomLevel: 1.0,
   agentNotifications: true,
+  defaultWorkspaceEnv: "local",
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
   editorAutoSave: false,
   editorAutoSaveDelay: 1000,
@@ -427,6 +430,9 @@ export async function loadPreferences(): Promise<Preferences> {
     agentNotifications:
       get<boolean>(KEY_AGENT_NOTIFICATIONS) ??
       DEFAULT_PREFERENCES.agentNotifications,
+    defaultWorkspaceEnv:
+      get<string>(KEY_DEFAULT_WORKSPACE_ENV) ??
+      DEFAULT_PREFERENCES.defaultWorkspaceEnv,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -679,6 +685,10 @@ export async function setAgentNotifications(value: boolean): Promise<void> {
   await writePref(KEY_AGENT_NOTIFICATIONS, value);
 }
 
+export async function setDefaultWorkspaceEnv(value: string): Promise<void> {
+  await writePref(KEY_DEFAULT_WORKSPACE_ENV, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {},
 ): Promise<void> {
@@ -741,6 +751,7 @@ export async function onPreferencesChange(
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
+    [KEY_DEFAULT_WORKSPACE_ENV]: "defaultWorkspaceEnv",
     [KEY_SHORTCUTS]: "shortcuts",
     [KEY_EDITOR_AUTO_SAVE]: "editorAutoSave",
     [KEY_EDITOR_AUTO_SAVE_DELAY]: "editorAutoSaveDelay",

--- a/src/modules/spaces/lib/useSpaces.ts
+++ b/src/modules/spaces/lib/useSpaces.ts
@@ -1,5 +1,9 @@
 import { create } from "zustand";
-import { LOCAL_WORKSPACE, type WorkspaceEnv } from "@/modules/workspace";
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import {
+  parseWorkspaceScopeKey,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
 import {
   deleteSpaceData,
   newSpaceId,
@@ -52,7 +56,11 @@ export const useSpaces = create<State>((set, get) => ({
       id: input.id ?? newSpaceId(),
       name: input.name,
       root: input.root,
-      env: input.env ?? LOCAL_WORKSPACE,
+      env:
+        input.env ??
+        parseWorkspaceScopeKey(
+          usePreferencesStore.getState().defaultWorkspaceEnv,
+        ),
       createdAt: now,
       updatedAt: now,
     };

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -3,7 +3,8 @@ import { native } from "@/modules/ai/lib/native";
 import type { Tab } from "@/modules/tabs";
 import { DEFAULT_SPACE_ID } from "@/modules/tabs/lib/useTabs";
 import { isLeaf, type PaneNode } from "@/modules/terminal/lib/panes";
-import type { WorkspaceEnv } from "@/modules/workspace";
+import { parseWorkspaceScopeKey, type WorkspaceEnv } from "@/modules/workspace";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { activeSpaceEnv, freshTabCwd } from "./activeSpace";
 import { freshTerminalTab, hydrateTabs } from "./serialize";
 import { loadAll, saveActiveId, saveSpacesList, type SpaceMeta } from "./store";
@@ -59,7 +60,9 @@ export function useSpacesBoot({
             id: DEFAULT_SPACE_ID,
             name: "Default",
             root,
-            env: { kind: "local" },
+            env: parseWorkspaceScopeKey(
+              usePreferencesStore.getState().defaultWorkspaceEnv,
+            ),
             createdAt: Date.now(),
             updatedAt: Date.now(),
           };

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -1,13 +1,13 @@
-import { useEffect, useRef } from "react";
 import { native } from "@/modules/ai/lib/native";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { Tab } from "@/modules/tabs";
 import { DEFAULT_SPACE_ID } from "@/modules/tabs/lib/useTabs";
 import { isLeaf, type PaneNode } from "@/modules/terminal/lib/panes";
 import { parseWorkspaceScopeKey, type WorkspaceEnv } from "@/modules/workspace";
-import { usePreferencesStore } from "@/modules/settings/preferences";
+import { useEffect, useRef } from "react";
 import { activeSpaceEnv, freshTabCwd } from "./activeSpace";
 import { freshTerminalTab, hydrateTabs } from "./serialize";
-import { loadAll, saveActiveId, saveSpacesList, type SpaceMeta } from "./store";
+import { loadAll, type SpaceMeta, saveActiveId, saveSpacesList } from "./store";
 import { useSpaces } from "./useSpaces";
 
 type Params = {
@@ -56,6 +56,11 @@ export function useSpacesBoot({
 
         if (spaces.length === 0) {
           const root = launchCwd ?? home ?? null;
+          // Hydrate prefs before reading the saved workspace env.
+          await usePreferencesStore
+            .getState()
+            .init()
+            .catch(() => {});
           const meta: SpaceMeta = {
             id: DEFAULT_SPACE_ID,
             name: "Default",

--- a/src/modules/workspace/env.ts
+++ b/src/modules/workspace/env.ts
@@ -53,6 +53,12 @@ export function workspaceScopeKey(env: WorkspaceEnv): string {
   return env.kind === "wsl" ? `wsl:${env.distro}` : "local";
 }
 
+export function parseWorkspaceScopeKey(key: string): WorkspaceEnv {
+  return key.startsWith("wsl:")
+    ? { kind: "wsl", distro: key.slice("wsl:".length) }
+    : LOCAL_WORKSPACE;
+}
+
 export function currentWorkspaceScopeKey(): string {
   return workspaceScopeKey(currentWorkspaceEnv());
 }

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -3,6 +3,7 @@ export {
   currentWorkspaceEnv,
   getWslHome,
   LOCAL_WORKSPACE,
+  parseWorkspaceScopeKey,
   useWorkspaceEnvStore,
   workspaceScopeKey,
   type WorkspaceEnv,

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -375,7 +375,7 @@ export function GeneralSection() {
             </SelectContent>
           </Select>
         </SettingRow>
-        {wslDistros.length > 0 && (
+        {(wslDistros.length > 0 || defaultWorkspaceEnv !== "local") && (
           <SettingRow
             title="Workspace environment"
             description="Where new spaces run, terminal and AI agent alike: Windows or a WSL distro. Existing spaces keep theirs; switch any from the status bar."
@@ -403,6 +403,17 @@ export function GeneralSection() {
                     WSL: {d.name}
                   </SelectItem>
                 ))}
+                {defaultWorkspaceEnv.startsWith("wsl:") &&
+                  !wslDistros.some(
+                    (d) => `wsl:${d.name}` === defaultWorkspaceEnv,
+                  ) && (
+                    <SelectItem
+                      value={defaultWorkspaceEnv}
+                      className="text-[12px]"
+                    >
+                      {defaultWorkspaceEnv.slice("wsl:".length)} (unavailable)
+                    </SelectItem>
+                  )}
               </SelectContent>
             </Select>
           </SettingRow>

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -21,6 +21,7 @@ import {
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAgentNotifications,
+  setDefaultWorkspaceEnv,
   setAutostart,
   setEditorWordWrap,
   setEditorAutoSave,
@@ -102,6 +103,10 @@ export function GeneralSection() {
   const terminalFontWeight = usePreferencesStore((s) => s.terminalFontWeight);
   const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const [shells, setShells] = useState<ShellInfo[]>([]);
+  const [wslDistros, setWslDistros] = useState<{ name: string }[]>([]);
+  const defaultWorkspaceEnv = usePreferencesStore(
+    (s) => s.defaultWorkspaceEnv,
+  );
   const terminalLetterSpacing = usePreferencesStore(
     (s) => s.terminalLetterSpacing,
   );
@@ -128,6 +133,9 @@ export function GeneralSection() {
   useEffect(() => {
     void invoke<ShellInfo[]>("pty_list_shells")
       .then(setShells)
+      .catch(() => {});
+    void invoke<{ name: string }[]>("wsl_list_distros")
+      .then(setWslDistros)
       .catch(() => {});
   }, []);
 
@@ -332,11 +340,11 @@ export function GeneralSection() {
           </Select>
         </SettingRow>
         <SettingRow
-          title="Default shell"
+          title="Integrated terminal shell"
           description={
             shells.find((s) => s.path === terminalShell)?.integrated === false
               ? "Command blocks and directory tracking are unavailable for this shell."
-              : "Shell for new terminal tabs. Existing tabs keep their shell."
+              : "Shell program for the integrated terminal on Windows. WSL spaces use the distro login shell. Existing tabs keep their shell."
           }
         >
           <Select
@@ -367,6 +375,38 @@ export function GeneralSection() {
             </SelectContent>
           </Select>
         </SettingRow>
+        {wslDistros.length > 0 && (
+          <SettingRow
+            title="Workspace environment"
+            description="Where new spaces run, terminal and AI agent alike: Windows or a WSL distro. Existing spaces keep theirs; switch any from the status bar."
+          >
+            <Select
+              value={defaultWorkspaceEnv}
+              onValueChange={(v) => void setDefaultWorkspaceEnv(v)}
+            >
+              <SelectTrigger
+                value={defaultWorkspaceEnv}
+                className="h-8 w-40 text-[12px]"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="local" className="text-[12px]">
+                  Windows
+                </SelectItem>
+                {wslDistros.map((d) => (
+                  <SelectItem
+                    key={d.name}
+                    value={`wsl:${d.name}`}
+                    className="text-[12px]"
+                  >
+                    WSL: {d.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </SettingRow>
+        )}
         <SettingRow
           title="Letter spacing"
           description="Extra horizontal space between characters (px). Use negative values to tighten Nerd Fonts."

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -1,3 +1,4 @@
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -5,7 +6,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -18,27 +18,27 @@ import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { ThemePref } from "@/modules/settings/store";
 import {
-  TERMINAL_FONT_SIZES,
-  TERMINAL_SCROLLBACK_PRESETS,
   setAgentNotifications,
-  setDefaultWorkspaceEnv,
   setAutostart,
-  setEditorWordWrap,
+  setDefaultWorkspaceEnv,
   setEditorAutoSave,
   setEditorAutoSaveDelay,
+  setEditorWordWrap,
   setExplorerGitDecorations,
   setRestoreWindowState,
   setShowHidden,
-  setTerminalFontFamily,
-  setTerminalFontWeight,
-  setTerminalShell,
-  setTerminalLetterSpacing,
-  setTerminalFontSize,
   setTerminalCursorBlink,
+  setTerminalFontFamily,
+  setTerminalFontSize,
+  setTerminalFontWeight,
+  setTerminalLetterSpacing,
   setTerminalScrollback,
+  setTerminalShell,
   setTerminalWebglEnabled,
   setVimMode,
   setZoomLevel,
+  TERMINAL_FONT_SIZES,
+  TERMINAL_SCROLLBACK_PRESETS,
 } from "@/modules/settings/store";
 import { useTheme } from "@/modules/theme";
 import {
@@ -96,17 +96,13 @@ export function GeneralSection() {
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
   );
-  const terminalCursorBlink = usePreferencesStore(
-    (s) => s.terminalCursorBlink,
-  );
+  const terminalCursorBlink = usePreferencesStore((s) => s.terminalCursorBlink);
   const terminalFontFamily = usePreferencesStore((s) => s.terminalFontFamily);
   const terminalFontWeight = usePreferencesStore((s) => s.terminalFontWeight);
   const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const [shells, setShells] = useState<ShellInfo[]>([]);
   const [wslDistros, setWslDistros] = useState<{ name: string }[]>([]);
-  const defaultWorkspaceEnv = usePreferencesStore(
-    (s) => s.defaultWorkspaceEnv,
-  );
+  const defaultWorkspaceEnv = usePreferencesStore((s) => s.defaultWorkspaceEnv);
   const terminalLetterSpacing = usePreferencesStore(
     (s) => s.terminalLetterSpacing,
   );
@@ -151,10 +147,7 @@ export function GeneralSection() {
 
   return (
     <div className="flex flex-col gap-6">
-      <SectionHeader
-        title="General"
-        description="Mode, editor, and startup."
-      />
+      <SectionHeader title="General" description="Mode, editor, and startup." />
 
       <div className="flex flex-col gap-2">
         <Label>Appearance</Label>
@@ -278,15 +271,12 @@ export function GeneralSection() {
                       ⓘ
                     </span>
                   </TooltipTrigger>
-                  <TooltipContent
-                    side="top"
-                    className="max-w-65 text-[11px]"
-                  >
-                    xterm's WebGL renderer caches glyphs in a GPU texture
-                    atlas. On some macOS setups (especially with Nerd Fonts),
-                    the atlas corrupts and terminal text becomes unreadable.
-                    Turn this off as a fallback — performance dips slightly,
-                    but text renders correctly via the DOM renderer.
+                  <TooltipContent side="top" className="max-w-65 text-[11px]">
+                    xterm's WebGL renderer caches glyphs in a GPU texture atlas.
+                    On some macOS setups (especially with Nerd Fonts), the atlas
+                    corrupts and terminal text becomes unreadable. Turn this off
+                    as a fallback — performance dips slightly, but text renders
+                    correctly via the DOM renderer.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -344,7 +334,9 @@ export function GeneralSection() {
           description={
             shells.find((s) => s.path === terminalShell)?.integrated === false
               ? "Command blocks and directory tracking are unavailable for this shell."
-              : "Shell program for the integrated terminal on Windows. WSL spaces use the distro login shell. Existing tabs keep their shell."
+              : wslDistros.length > 0
+                ? "Shell for the integrated terminal. WSL spaces use the distro login shell. Existing tabs keep their shell."
+                : "Shell for new terminal tabs. Existing tabs keep their shell."
           }
         >
           <Select
@@ -364,11 +356,7 @@ export function GeneralSection() {
                 Auto
               </SelectItem>
               {shells.map((s) => (
-                <SelectItem
-                  key={s.path}
-                  value={s.path}
-                  className="text-[12px]"
-                >
+                <SelectItem key={s.path} value={s.path} className="text-[12px]">
                   {s.name}
                 </SelectItem>
               ))}
@@ -448,7 +436,11 @@ export function GeneralSection() {
             </SelectTrigger>
             <SelectContent>
               {TERMINAL_FONT_SIZES.map((size) => (
-                <SelectItem key={size} value={String(size)} className="text-[12px]">
+                <SelectItem
+                  key={size}
+                  value={String(size)}
+                  className="text-[12px]"
+                >
                   {size} px
                 </SelectItem>
               ))}
@@ -623,4 +615,3 @@ function AutoSaveDelayInput({
     </SettingRow>
   );
 }
-


### PR DESCRIPTION
## Summary
Adds a "Workspace environment" setting (visible when WSL distros are present)
that selects where new spaces run: Windows or a specific WSL distro, for both
the terminal and the AI agent. New spaces and the first-boot default space
adopt this default via the new `parseWorkspaceScopeKey` (the inverse of
`workspaceScopeKey`); existing spaces keep their environment and can still be
switched from the status bar.

Also relabels the shell setting to "Integrated terminal shell" and clarifies
that WSL spaces use the distro login shell.

## Test plan
- `tsc` and lint clean
- Manual (WSL host): set Workspace environment to a distro, open a new space,
  confirm its terminal and agent run in that distro; existing spaces unchanged
- Manual (no WSL): the row is hidden and the default stays "local"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“workspace environment”** preference to select **Windows (local)** or a specific **WSL distro**.
  * The General settings page now includes a Workspace environment selector with unavailable options if the saved distro is no longer detected.
* **Bug Fixes**
  * Newly created spaces and the default startup space now use the saved workspace environment (including WSL) instead of always defaulting to local.
* **Style**
  * Updated integrated terminal shell label and description text for clearer guidance.
* **Refactor**
  * Improved preferences store initialization to be idempotent and retry safely after failures.
  * Added parsing/re-export for workspace environment scope keys, used for default environment selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->