### PR TITLE
feat(terminal): confirm closing a running terminal

### DIFF
--- a/src/app/hooks/useAppCloseGuard.ts
+++ b/src/app/hooks/useAppCloseGuard.ts
@@ -1,5 +1,6 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { Tab } from "@/modules/tabs";
 import { leafHasForegroundProcess, leafIds } from "@/modules/terminal";
 
@@ -23,7 +24,10 @@ export function useAppCloseGuard(tabsRef: RefObject<Tab[]>) {
       .onCloseRequested(async (event) => {
         if (forceClose.current) return;
         event.preventDefault();
-        if (await anyTerminalBusy(tabsRef.current)) {
+        if (
+          usePreferencesStore.getState().confirmCloseTerminal &&
+          (await anyTerminalBusy(tabsRef.current))
+        ) {
           setPendingAppClose(true);
         } else {
           forceClose.current = true;

--- a/src/app/hooks/useTabCloseGuards.ts
+++ b/src/app/hooks/useTabCloseGuards.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { leafHasForegroundProcess, leafIds } from "@/modules/terminal";
 import { nextActiveInSpace, type Tab } from "@/modules/tabs";
 
@@ -31,7 +32,7 @@ export function useTabCloseGuards({ tabs, disposeTab }: Params) {
         setPendingCloseTab(id);
         return;
       }
-      if (t?.kind === "terminal") {
+      if (t?.kind === "terminal" && usePreferencesStore.getState().confirmCloseTerminal) {
         const leaves = leafIds(t.paneTree);
         const checks = await Promise.all(leaves.map(leafHasForegroundProcess));
         if (checks.some(Boolean)) {

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -155,6 +155,7 @@ export type Preferences = {
   lastWslDistro: string | null;
   zoomLevel: number;
   agentNotifications: boolean;
+  confirmCloseTerminal: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
   editorAutoSave: boolean;
   editorAutoSaveDelay: number;
@@ -207,6 +208,7 @@ const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
+const KEY_CONFIRM_CLOSE_TERMINAL = "confirmCloseTerminal";
 const KEY_SHORTCUTS = "shortcuts";
 const KEY_EDITOR_AUTO_SAVE = "editorAutoSave";
 const KEY_EDITOR_AUTO_SAVE_DELAY = "editorAutoSaveDelay";
@@ -272,6 +274,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   lastWslDistro: null,
   zoomLevel: 1.0,
   agentNotifications: true,
+  confirmCloseTerminal: true,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
   editorAutoSave: false,
   editorAutoSaveDelay: 1000,
@@ -427,6 +430,9 @@ export async function loadPreferences(): Promise<Preferences> {
     agentNotifications:
       get<boolean>(KEY_AGENT_NOTIFICATIONS) ??
       DEFAULT_PREFERENCES.agentNotifications,
+    confirmCloseTerminal:
+      get<boolean>(KEY_CONFIRM_CLOSE_TERMINAL) ??
+      DEFAULT_PREFERENCES.confirmCloseTerminal,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -679,6 +685,10 @@ export async function setAgentNotifications(value: boolean): Promise<void> {
   await writePref(KEY_AGENT_NOTIFICATIONS, value);
 }
 
+export async function setConfirmCloseTerminal(value: boolean): Promise<void> {
+  await writePref(KEY_CONFIRM_CLOSE_TERMINAL, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {},
 ): Promise<void> {
@@ -741,6 +751,7 @@ export async function onPreferencesChange(
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
+    [KEY_CONFIRM_CLOSE_TERMINAL]: "confirmCloseTerminal",
     [KEY_SHORTCUTS]: "shortcuts",
     [KEY_EDITOR_AUTO_SAVE]: "editorAutoSave",
     [KEY_EDITOR_AUTO_SAVE_DELAY]: "editorAutoSaveDelay",

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -21,6 +21,7 @@ import {
   TERMINAL_FONT_SIZES,
   TERMINAL_SCROLLBACK_PRESETS,
   setAgentNotifications,
+  setConfirmCloseTerminal,
   setAutostart,
   setEditorWordWrap,
   setEditorAutoSave,
@@ -109,6 +110,9 @@ export function GeneralSection() {
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
   const agentNotifications = usePreferencesStore((s) => s.agentNotifications);
+  const confirmCloseTerminal = usePreferencesStore(
+    (s) => s.confirmCloseTerminal,
+  );
 
   useEffect(() => {
     let alive = true;
@@ -441,6 +445,21 @@ export function GeneralSection() {
             onCheckedChange={(v) => void setAgentNotifications(v)}
           />
         </SettingRow>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label>Confirmations</Label>
+        <div className="flex flex-col gap-2">
+          <SettingRow
+            title="Confirm closing a running terminal"
+            description="Ask before closing a terminal tab or quitting while a foreground process is still running."
+          >
+            <Switch
+              checked={confirmCloseTerminal}
+              onCheckedChange={(v) => void setConfirmCloseTerminal(v)}
+            />
+          </SettingRow>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
Adds a "Confirm closing a running terminal" setting (new Confirmations group,
default on). When enabled, closing a terminal tab or quitting while a
foreground process is still running asks first; when disabled, the busy check
is skipped and the terminal closes immediately.

## Test plan
- `tsc` and lint clean
- Manual: run a long process (e.g. `sleep 100`), close the tab and confirm the
  prompt appears; toggle the setting off, close again and confirm no prompt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new confirmation setting for closing running terminals.
  * Users can now toggle terminal-close confirmations in Settings.

* **Bug Fixes**
  * Closing a terminal tab or the app now follows the new confirmation preference, avoiding unnecessary prompts when disabled.
  * Preference changes are applied consistently across open windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->