### PR TITLE
fix(ui): blur background image behind dialog overlays

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,10 +1,13 @@
 import * as React from "react"
+import { useEffect } from "react"
 import { Dialog as DialogPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Cancel01Icon } from "@hugeicons/core-free-icons"
+
+let dialogCount = 0
 
 function Dialog({
   ...props
@@ -34,6 +37,14 @@ function DialogOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  useEffect(() => {
+    dialogCount++
+    document.body.dataset.dialogOpen = ""
+    return () => {
+      dialogCount--
+      if (dialogCount <= 0) delete document.body.dataset.dialogOpen
+    }
+  }, [])
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -168,6 +168,9 @@
 html[data-chrome="borderless"] .terax-bg-surface {
   border-radius: 12px;
 }
+body[data-dialog-open] .terax-bg-surface {
+  z-index: 40 !important;
+}
 .zoom-content {
   zoom: var(--app-zoom);
 }


### PR DESCRIPTION
## What
When a dialog (command palette, settings, etc.) opens, the background image now properly blurs and dims behind the overlay. 

## Why
Closes #863. Dialog overlay renders with `z-index: 50`. The background image renders with `z-index: 2147483646`. The blur effect never reach it. 

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows


## Screenshots / GIFs

Before: 
<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/cee34f5c-5962-477e-b194-4f258bee5888" />

After:
<img width="1918" height="1017" alt="image" src="https://github.com/user-attachments/assets/82a5f152-bbc7-4709-8c39-db94541e19fb" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog layering so overlays display correctly above other page elements.
  * Kept background surfaces in the right stacking order while dialogs are open, helping prevent visual overlap issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->