### PR TITLE
feat(updater): update-notifications toggle

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -843,6 +843,8 @@ export async function setAgentNotifications(value: boolean): Promise<void> {
 
 export async function setDefaultWorkspaceEnv(value: string): Promise<void> {
   await writePref(KEY_DEFAULT_WORKSPACE_ENV, value);
+}
+
 export async function setNotifyUpdates(value: boolean): Promise<void> {
   await writePref(KEY_NOTIFY_UPDATES, value);
 }

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -160,6 +160,7 @@ export type Preferences = {
   zoomLevel: number;
   agentNotifications: boolean;
   defaultWorkspaceEnv: string;
+  notifyUpdates: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
   editorAutoSave: boolean;
   editorAutoSaveDelay: number;
@@ -249,6 +250,7 @@ const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
 const KEY_DEFAULT_WORKSPACE_ENV = "defaultWorkspaceEnv";
+const KEY_NOTIFY_UPDATES = "notifyUpdates";
 const KEY_SHORTCUTS = "shortcuts";
 const KEY_EDITOR_AUTO_SAVE = "editorAutoSave";
 const KEY_EDITOR_AUTO_SAVE_DELAY = "editorAutoSaveDelay";
@@ -330,6 +332,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   zoomLevel: 1.0,
   agentNotifications: true,
   defaultWorkspaceEnv: "local",
+  notifyUpdates: true,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
   editorAutoSave: false,
   editorAutoSaveDelay: 1000,
@@ -499,6 +502,8 @@ export async function loadPreferences(): Promise<Preferences> {
     defaultWorkspaceEnv:
       get<string>(KEY_DEFAULT_WORKSPACE_ENV) ??
       DEFAULT_PREFERENCES.defaultWorkspaceEnv,
+    notifyUpdates:
+      get<boolean>(KEY_NOTIFY_UPDATES) ?? DEFAULT_PREFERENCES.notifyUpdates,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -838,6 +843,8 @@ export async function setAgentNotifications(value: boolean): Promise<void> {
 
 export async function setDefaultWorkspaceEnv(value: string): Promise<void> {
   await writePref(KEY_DEFAULT_WORKSPACE_ENV, value);
+export async function setNotifyUpdates(value: boolean): Promise<void> {
+  await writePref(KEY_NOTIFY_UPDATES, value);
 }
 
 export async function setShortcuts(
@@ -905,6 +912,7 @@ export async function onPreferencesChange(
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
     [KEY_DEFAULT_WORKSPACE_ENV]: "defaultWorkspaceEnv",
+    [KEY_NOTIFY_UPDATES]: "notifyUpdates",
     [KEY_SHORTCUTS]: "shortcuts",
     [KEY_EDITOR_AUTO_SAVE]: "editorAutoSave",
     [KEY_EDITOR_AUTO_SAVE_DELAY]: "editorAutoSaveDelay",

--- a/src/modules/updater/UpdaterDialog.tsx
+++ b/src/modules/updater/UpdaterDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
 import { useUpdater } from "./useUpdater";
@@ -38,7 +39,10 @@ function formatBytes(n: number): string {
 }
 
 export function UpdaterDialog() {
-  const { status, install, dismiss } = useUpdater();
+  // Off suppresses the auto-check, so status stays idle and this dialog never
+  // opens. Manual checks live in About (its own updater instance).
+  const notifyUpdates = usePreferencesStore((s) => s.notifyUpdates);
+  const { status, install, dismiss } = useUpdater({ autoCheck: notifyUpdates });
   const [copied, setCopied] = useState(false);
   const [distro, setDistro] = useState<DistroKey>("arch");
   const manualVersion =

--- a/src/modules/updater/UpdaterDialog.tsx
+++ b/src/modules/updater/UpdaterDialog.tsx
@@ -42,7 +42,12 @@ export function UpdaterDialog() {
   // Off suppresses the auto-check, so status stays idle and this dialog never
   // opens. Manual checks live in About (its own updater instance).
   const notifyUpdates = usePreferencesStore((s) => s.notifyUpdates);
-  const { status, install, dismiss } = useUpdater({ autoCheck: notifyUpdates });
+  const hydrated = usePreferencesStore((s) => s.hydrated);
+  // Gate on hydration: notifyUpdates defaults to true, so without this the
+  // mount check could fire before a persisted off-state loads.
+  const { status, install, dismiss } = useUpdater({
+    autoCheck: hydrated && notifyUpdates,
+  });
   const [copied, setCopied] = useState(false);
   const [distro, setDistro] = useState<DistroKey>("arch");
   const manualVersion =

--- a/src/settings/sections/AboutSection.tsx
+++ b/src/settings/sections/AboutSection.tsx
@@ -48,6 +48,9 @@ export function AboutSection() {
                   : "Check for updates";
   const onUpdateClick = () => {
     if (available) void install();
+    // No in-app installer on this platform (Linux): open the release page for
+    // the package/command instead of re-checking in place.
+    else if (manualAvailable) void openUrl(`${REPO_URL}/releases/latest`);
     else void check({ manual: true });
   };
 

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -18,6 +18,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { ThemePref } from "@/modules/settings/store";
 import {
   setAgentNotifications,
+  setNotifyUpdates,
   setAutostart,
   setDefaultWorkspaceEnv,
   setExplorerGitDecorations,
@@ -98,6 +99,7 @@ export function GeneralSection() {
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
   const agentNotifications = usePreferencesStore((s) => s.agentNotifications);
+  const notifyUpdates = usePreferencesStore((s) => s.notifyUpdates);
 
   useEffect(() => {
     let alive = true;
@@ -438,6 +440,21 @@ export function GeneralSection() {
             onCheckedChange={(v) => void setAgentNotifications(v)}
           />
         </SettingRow>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label>Confirmations</Label>
+        <div className="flex flex-col gap-2">
+          <SettingRow
+            title="Update notifications"
+            description="Automatically check for updates and show the update dialog when one is available. You can still check manually under About."
+          >
+            <Switch
+              checked={notifyUpdates}
+              onCheckedChange={(v) => void setNotifyUpdates(v)}
+            />
+          </SettingRow>
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
Adds an "Update notifications" setting (default on). When off, the updater's
auto-check is disabled so the update dialog never opens; manual checks under
About still work.

On platforms without an in-app installer (Linux), the About "Update to vX"
button now opens the latest release page instead of re-checking in place, so
the manual path actually reaches the package/command.

## Test plan
- `tsc` and lint clean
- Manual: toggle off and confirm no auto update dialog appears; open About,
  check for updates, confirm it still reports the update (and, on Linux, the
  button opens the release page)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Confirmations** section with an **Update notifications** switch to control whether update notifications are enabled.
  * Automatic update checks now wait until settings are loaded and only run when update notifications are enabled.
* **Bug Fixes**
  * Improved consistency of update notification preference changes across multiple app windows.
  * Updated the “manual update available” action to open the latest releases page directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->