### PR TITLE
feat(ai): bypass-approvals (YOLO) toggle

### DIFF
--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -60,6 +60,7 @@ import { ACCEPTED_FILES, useComposer } from "../lib/composer";
 import { toggleFavoriteModel } from "../lib/modelPrefs";
 import { useChatStore } from "../store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setAiBypassPermissions } from "@/modules/settings/store";
 
 const PROVIDER_ICON = {
   openai: ChatGptIcon,
@@ -155,6 +156,8 @@ export function AiStatusBarControls() {
       )}
 
       <ModelDropdown />
+
+      <YoloToggle />
 
       <span className="mx-1 h-8 w-px bg-border" aria-hidden />
       <Button
@@ -684,6 +687,26 @@ function CapBar({
         ))}
       </span>
     </span>
+  );
+}
+
+function YoloToggle() {
+  const bypass = usePreferencesStore((s) => s.aiBypassPermissions);
+  return (
+    <IconBtn
+      title={
+        bypass
+          ? "Bypass approvals ON. Edits and commands auto-run (click to require approval)"
+          : "Approvals required (click to bypass)"
+      }
+      onClick={() => void setAiBypassPermissions(!bypass)}
+      className={cn(
+        bypass &&
+          "bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive",
+      )}
+    >
+      <HugeiconsIcon icon={FlashIcon} size={13} strokeWidth={1.75} />
+    </IconBtn>
   );
 }
 

--- a/src/modules/ai/tools/agent.ts
+++ b/src/modules/ai/tools/agent.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { useManagedAgentsStore } from "@/modules/agents/store/managedAgentsStore";
 import { writeToSession } from "@/modules/terminal";
-import type { ToolContext } from "./context";
+import { gateApproval, type ToolContext } from "./context";
 
 // Claude Code's TUI treats a trailing CR in the same write chunk as the text
 // as a literal newline, not a submit. Send the Enter as a separate chunk once
@@ -35,7 +35,7 @@ export function buildManagedAgentTools(ctx: ToolContext) {
             "The full, self-contained task prompt for the Claude Code agent.",
           ),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ prompt }) => {
         const sessionId = ctx.getSessionId();
         if (!sessionId) return { error: "no active chat session" };
@@ -67,7 +67,7 @@ export function buildManagedAgentTools(ctx: ToolContext) {
             "One clear, self-contained instruction for the agent. No control characters.",
           ),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ instruction }) => {
         const sessionId = ctx.getSessionId();
         const store = useManagedAgentsStore.getState();

--- a/src/modules/ai/tools/agent.ts
+++ b/src/modules/ai/tools/agent.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { useManagedAgentsStore } from "@/modules/agents/store/managedAgentsStore";
 import { writeToSession } from "@/modules/terminal";
-import { gateApproval, type ToolContext } from "./context";
+import type { ToolContext } from "./context";
 
 // Claude Code's TUI treats a trailing CR in the same write chunk as the text
 // as a literal newline, not a submit. Send the Enter as a separate chunk once
@@ -35,7 +35,9 @@ export function buildManagedAgentTools(ctx: ToolContext) {
             "The full, self-contained task prompt for the Claude Code agent.",
           ),
       }),
-      needsApproval: gateApproval,
+      // Always require approval, even under bypass: spawning an autonomous
+      // agent has no in-execute deny-list, so the prompt is the only gate.
+      needsApproval: true,
       execute: async ({ prompt }) => {
         const sessionId = ctx.getSessionId();
         if (!sessionId) return { error: "no active chat session" };
@@ -67,7 +69,8 @@ export function buildManagedAgentTools(ctx: ToolContext) {
             "One clear, self-contained instruction for the agent. No control characters.",
           ),
       }),
-      needsApproval: gateApproval,
+      // Always require approval, even under bypass (steers an autonomous agent).
+      needsApproval: true,
       execute: async ({ instruction }) => {
         const sessionId = ctx.getSessionId();
         const store = useManagedAgentsStore.getState();

--- a/src/modules/ai/tools/approval.test.ts
+++ b/src/modules/ai/tools/approval.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { usePreferencesStore } from "@/modules/settings/preferences";
+import { gateApproval, type ToolContext } from "./context";
+import { buildShellTools } from "./shell";
+
+const ctxStub: ToolContext = {
+  getCwd: () => null,
+  getWorkspaceRoot: () => null,
+  getTerminalContext: () => null,
+  isActiveTerminalPrivate: () => false,
+  injectIntoActivePty: () => false,
+  openPreview: () => false,
+  spawnAgent: () => null,
+  readAgentOutput: () => null,
+  readCache: new Map(),
+  getSessionId: () => "session-1",
+};
+
+// The AI SDK's tool() execute takes (input, options); our impls ignore options.
+const run = (
+  fn: unknown,
+  input: unknown,
+): Promise<{ error?: string }> =>
+  (fn as (i: unknown, o: unknown) => Promise<{ error?: string }>)(input, {});
+
+beforeEach(() => {
+  usePreferencesStore.setState({ aiBypassPermissions: false });
+});
+
+describe("gateApproval", () => {
+  it("requires approval by default (bypass off)", () => {
+    expect(gateApproval()).toBe(true);
+  });
+
+  it("skips approval when bypass is enabled", () => {
+    usePreferencesStore.setState({ aiBypassPermissions: true });
+    expect(gateApproval()).toBe(false);
+  });
+});
+
+// The security invariant: bypass only drops the approval prompt. The deny-list
+// in each tool's execute must still reject, otherwise a destructive command
+// would auto-run. If the guard were skipped, execute would fall through to
+// native (which throws under test) and the error would NOT name the deny reason.
+describe("bypass never weakens the shell deny-list", () => {
+  it("bash_run still refuses 'rm -rf /' with bypass ON", async () => {
+    usePreferencesStore.setState({ aiBypassPermissions: true });
+    const tools = buildShellTools(ctxStub);
+    const res = await run(tools.bash_run.execute, { command: "rm -rf /" });
+    expect(res.error).toContain("filesystem root");
+  });
+
+  it("bash_background still refuses a fork bomb with bypass ON", async () => {
+    usePreferencesStore.setState({ aiBypassPermissions: true });
+    const tools = buildShellTools(ctxStub);
+    const res = await run(tools.bash_background.execute, {
+      command: ":(){ :|:& };:",
+    });
+    expect(res.error).toContain("fork-bomb");
+  });
+});

--- a/src/modules/ai/tools/context.ts
+++ b/src/modules/ai/tools/context.ts
@@ -26,7 +26,8 @@ export type ToolContext = {
 
 // Skips the approval card (auto-executes) when bypass mode is on. The fs/shell
 // deny-lists in execute (checkWritableCanonical / checkShellCommand) still run;
-// bypass drops the prompt, not the guards. Agent spawn/steer have no deny-list.
+// bypass drops the prompt, not the guards. Agent spawn/steer have no deny-list,
+// so they stay always-approved even under bypass (see agent.ts).
 export function gateApproval(): boolean {
   return !usePreferencesStore.getState().aiBypassPermissions;
 }

--- a/src/modules/ai/tools/context.ts
+++ b/src/modules/ai/tools/context.ts
@@ -1,3 +1,5 @@
+import { usePreferencesStore } from "@/modules/settings/preferences";
+
 export type ToolContext = {
   /** Active terminal tab cwd, used to resolve relative paths. Null = home. */
   getCwd: () => string | null;
@@ -21,6 +23,13 @@ export type ToolContext = {
   /** Active chat session id — used by tools that persist per-session state (todos). */
   getSessionId: () => string | null;
 };
+
+// Skips the approval card (auto-executes) when bypass mode is on. The fs/shell
+// deny-lists in execute (checkWritableCanonical / checkShellCommand) still run;
+// bypass drops the prompt, not the guards. Agent spawn/steer have no deny-list.
+export function gateApproval(): boolean {
+  return !usePreferencesStore.getState().aiBypassPermissions;
+}
 
 export function resolvePath(rawPath: string, cwd: string | null): string {
   if (rawPath.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(rawPath))

--- a/src/modules/ai/tools/edit.ts
+++ b/src/modules/ai/tools/edit.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { native } from "../lib/native";
 import { checkWritableCanonical } from "../lib/security";
 import { newQueuedEditId, usePlanStore } from "../store/planStore";
-import { resolvePath, type ToolContext } from "./context";
+import { gateApproval, resolvePath, type ToolContext } from "./context";
 
 type EditResult =
   | { ok: true; replacements: number; bytesWritten: number; path: string }
@@ -130,7 +130,7 @@ export function buildEditTools(ctx: ToolContext) {
         new_string: z.string().describe("Replacement substring."),
         replace_all: z.boolean().optional(),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ path, old_string, new_string, replace_all }) => {
         const reqPath = resolvePath(path, ctx.getCwd());
         const safety = await checkWritableCanonical(reqPath, native.canonicalize);
@@ -167,7 +167,7 @@ export function buildEditTools(ctx: ToolContext) {
           )
           .min(1),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ path, edits }) => {
         const reqPath = resolvePath(path, ctx.getCwd());
         const safety = await checkWritableCanonical(reqPath, native.canonicalize);

--- a/src/modules/ai/tools/fs.ts
+++ b/src/modules/ai/tools/fs.ts
@@ -6,7 +6,7 @@ import {
   checkWritableCanonical,
 } from "../lib/security";
 import { newQueuedEditId, usePlanStore } from "../store/planStore";
-import { resolvePath, type ToolContext } from "./context";
+import { gateApproval, resolvePath, type ToolContext } from "./context";
 
 const READ_BYTE_CAP = 25 * 1024;
 const READ_LINE_CAP = 2000;
@@ -140,7 +140,7 @@ export function buildFsTools(ctx: ToolContext) {
         path: z.string(),
         content: z.string(),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ path, content }) => {
         const reqPath = resolvePath(path, ctx.getCwd());
         const safety = await checkWritableCanonical(reqPath, native.canonicalize);
@@ -187,7 +187,7 @@ export function buildFsTools(ctx: ToolContext) {
       inputSchema: z.object({
         path: z.string(),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ path }) => {
         const reqPath = resolvePath(path, ctx.getCwd());
         const safety = await checkWritableCanonical(reqPath, native.canonicalize);

--- a/src/modules/ai/tools/shell.ts
+++ b/src/modules/ai/tools/shell.ts
@@ -2,7 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { native } from "../lib/native";
 import { checkShellCommand } from "../lib/security";
-import type { ToolContext } from "./context";
+import { gateApproval, type ToolContext } from "./context";
 import { currentWorkspaceEnv, workspaceScopeKey } from "@/modules/workspace";
 
 /**
@@ -36,7 +36,7 @@ export function buildShellTools(ctx: ToolContext) {
         command: z.string(),
         timeout_secs: z.number().int().min(1).max(300).optional(),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ command, timeout_secs }) => {
         const safety = checkShellCommand(command);
         if (!safety.ok) return { error: safety.reason };
@@ -73,7 +73,7 @@ export function buildShellTools(ctx: ToolContext) {
         command: z.string(),
         cwd: z.string().nullable().optional(),
       }),
-      needsApproval: true,
+      needsApproval: gateApproval,
       execute: async ({ command, cwd }) => {
         const safety = checkShellCommand(command);
         if (!safety.ok) return { error: safety.reason };

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -160,6 +160,7 @@ export type Preferences = {
   zoomLevel: number;
   agentNotifications: boolean;
   defaultWorkspaceEnv: string;
+  aiBypassPermissions: boolean;
   shortcuts: Record<ShortcutId, KeyBinding[]>;
   editorAutoSave: boolean;
   editorAutoSaveDelay: number;
@@ -249,6 +250,7 @@ const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
 const KEY_AGENT_NOTIFICATIONS = "agentNotifications";
 const KEY_DEFAULT_WORKSPACE_ENV = "defaultWorkspaceEnv";
+const KEY_AI_BYPASS_PERMISSIONS = "aiBypassPermissions";
 const KEY_SHORTCUTS = "shortcuts";
 const KEY_EDITOR_AUTO_SAVE = "editorAutoSave";
 const KEY_EDITOR_AUTO_SAVE_DELAY = "editorAutoSaveDelay";
@@ -330,6 +332,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   zoomLevel: 1.0,
   agentNotifications: true,
   defaultWorkspaceEnv: "local",
+  aiBypassPermissions: false,
   shortcuts: {} as Record<ShortcutId, KeyBinding[]>,
   editorAutoSave: false,
   editorAutoSaveDelay: 1000,
@@ -499,6 +502,9 @@ export async function loadPreferences(): Promise<Preferences> {
     defaultWorkspaceEnv:
       get<string>(KEY_DEFAULT_WORKSPACE_ENV) ??
       DEFAULT_PREFERENCES.defaultWorkspaceEnv,
+    aiBypassPermissions:
+      get<boolean>(KEY_AI_BYPASS_PERMISSIONS) ??
+      DEFAULT_PREFERENCES.aiBypassPermissions,
     shortcuts:
       get<Record<ShortcutId, KeyBinding[]>>(KEY_SHORTCUTS) ??
       DEFAULT_PREFERENCES.shortcuts,
@@ -840,6 +846,10 @@ export async function setDefaultWorkspaceEnv(value: string): Promise<void> {
   await writePref(KEY_DEFAULT_WORKSPACE_ENV, value);
 }
 
+export async function setAiBypassPermissions(value: boolean): Promise<void> {
+  await writePref(KEY_AI_BYPASS_PERMISSIONS, value);
+}
+
 export async function setShortcuts(
   value: Record<ShortcutId, KeyBinding[]> | {},
 ): Promise<void> {
@@ -905,6 +915,7 @@ export async function onPreferencesChange(
     [KEY_ZOOM_LEVEL]: "zoomLevel",
     [KEY_AGENT_NOTIFICATIONS]: "agentNotifications",
     [KEY_DEFAULT_WORKSPACE_ENV]: "defaultWorkspaceEnv",
+    [KEY_AI_BYPASS_PERMISSIONS]: "aiBypassPermissions",
     [KEY_SHORTCUTS]: "shortcuts",
     [KEY_EDITOR_AUTO_SAVE]: "editorAutoSave",
     [KEY_EDITOR_AUTO_SAVE_DELAY]: "editorAutoSaveDelay",

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -18,6 +18,7 @@ import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { ThemePref } from "@/modules/settings/store";
 import {
   setAgentNotifications,
+  setAiBypassPermissions,
   setAutostart,
   setDefaultWorkspaceEnv,
   setExplorerGitDecorations,
@@ -98,6 +99,9 @@ export function GeneralSection() {
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
   const zoomLevel = usePreferencesStore((s) => s.zoomLevel);
   const agentNotifications = usePreferencesStore((s) => s.agentNotifications);
+  const aiBypassPermissions = usePreferencesStore(
+    (s) => s.aiBypassPermissions,
+  );
 
   useEffect(() => {
     let alive = true;
@@ -436,6 +440,15 @@ export function GeneralSection() {
           <Switch
             checked={agentNotifications}
             onCheckedChange={(v) => void setAgentNotifications(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Bypass approvals (YOLO)"
+          description="Let the AI agent run edits and shell commands without per-action approval. Convenient but risky: the agent can modify files and run commands unprompted. Also toggleable from the AI bar."
+        >
+          <Switch
+            checked={aiBypassPermissions}
+            onCheckedChange={(v) => void setAiBypassPermissions(v)}
           />
         </SettingRow>
       </div>


### PR DESCRIPTION
Related to #189

## Summary
Adds an opt-in "Bypass approvals (YOLO)" mode (default off) that lets the AI
agent run edits and shell commands without the per-action approval card. Each
tool's `needsApproval` becomes a function (`gateApproval`) that reads the live
preference, so the gate is evaluated per call. Toggleable from Settings and
from the AI status bar (with a destructive-styled indicator when on).

Bypass only removes the human approval prompt. The deny-lists in each tool's
`execute` (`checkShellCommand` for shell, `checkWritableCanonical` for fs/edit)
still run, so a destructive command is refused even with bypass on. The agent
spawn/steer tools have no such deny-list, noted in the code.

## Test plan
- `pnpm test`: new `approval.test.ts` locks the invariant. `gateApproval` flips
  with the pref, and with bypass ON `bash_run` still refuses `rm -rf /` and
  `bash_background` still refuses a fork bomb
- `tsc` and lint clean
- Manual: enable bypass, confirm edits/commands auto-run; confirm a denied
  command (e.g. `rm -rf /`) is still blocked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI “Bypass approvals (YOLO)” toggle in AI settings (Agents section) and AI status bar controls.
  * Users can enable or disable approval bypass via the new preference-backed switches.
* **Bug Fixes**
  * Approval gating now consistently follows the bypass setting across edit, file, and shell actions, while keeping existing command safety protections intact.
* **Tests**
  * Added automated coverage to confirm bypass only suppresses the approval prompt and does not weaken per-tool deny-list checks for shell commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->