### PR TITLE
fix(pty): rewrap fish prompt after config

### DIFF
--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -16,7 +16,6 @@ const ZLOGIN_SCRIPT: &str = include_str!("scripts/zlogin.zsh");
 const ZSHRC_SCRIPT: &str = include_str!("scripts/zshrc.zsh");
 #[cfg(windows)]
 const FISH_INIT_SCRIPT: &str = include_str!("scripts/init.fish");
-#[cfg(unix)]
 const FISH_REINSTALL_PROMPT: &str =
     "functions -q __terax_install_prompt; and __terax_install_prompt";
 
@@ -71,7 +70,9 @@ pub fn build_command(
 // Honor the override only if it matches an enumerated shell, so a tampered
 // setting can't spawn an arbitrary binary across the IPC boundary.
 fn sanitize_shell_override(shell: Option<String>) -> Option<String> {
-    let candidate = shell.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())?;
+    let candidate = shell
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
     let target = std::fs::canonicalize(&candidate).ok();
     let allowed = list_shells().into_iter().any(|s| {
         s.path == candidate || (target.is_some() && std::fs::canonicalize(&s.path).ok() == target)
@@ -284,7 +285,11 @@ mod unix {
         let (shell, shell_path) = Shell::resolve(shell_override);
         let mut cmd = CommandBuilder::new(&shell_path);
         super::apply_common(&mut cmd, cwd, blocks);
+        apply_shell_init(&mut cmd, &shell, &shell_path);
+        Ok(cmd)
+    }
 
+    fn apply_shell_init(cmd: &mut CommandBuilder, shell: &Shell, shell_path: &str) {
         match shell {
             Shell::Zsh => {
                 match prepare_zdotdir() {
@@ -339,7 +344,6 @@ mod unix {
                 );
             }
         }
-        Ok(cmd)
     }
 
     fn integration_root() -> Result<PathBuf, String> {
@@ -394,7 +398,7 @@ mod unix {
 
     #[cfg(test)]
     mod tests {
-        use super::Shell;
+        use super::*;
 
         #[test]
         fn classify_maps_known_shells() {
@@ -428,6 +432,26 @@ mod unix {
             let (_, fallback) = Shell::resolve(Some("   ".into()));
             let (_, detected) = Shell::detect();
             assert_eq!(fallback, detected);
+        }
+
+        #[test]
+        fn builds_unix_fish_launch_with_post_config_rewrap() {
+            let mut cmd = CommandBuilder::new("/usr/bin/fish");
+            apply_shell_init(&mut cmd, &Shell::Fish, "/usr/bin/fish");
+            let argv: Vec<_> = cmd
+                .get_argv()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect();
+            assert_eq!(
+                argv,
+                vec![
+                    "/usr/bin/fish".to_string(),
+                    "-i".to_string(),
+                    "-C".to_string(),
+                    super::super::FISH_REINSTALL_PROMPT.to_string(),
+                ]
+            );
         }
     }
 }
@@ -468,7 +492,9 @@ mod windows {
             zdotdir: String,
             user_zdotdir: Option<String>,
         },
-        Bash { rcfile: String },
+        Bash {
+            rcfile: String,
+        },
         Fish,
         None,
     }
@@ -650,6 +676,8 @@ mod windows {
                 args.push("fish_features=no-mark-prompt".to_string());
                 args.push(shell_path.to_string());
                 args.push("-i".to_string());
+                args.push("-C".to_string());
+                args.push(super::FISH_REINSTALL_PROMPT.to_string());
             }
             (ShellKind::Zsh, WslShellIntegration::None) => {
                 args.push(shell_path.to_string());
@@ -966,6 +994,8 @@ mod windows {
                     "fish_features=no-mark-prompt".to_string(),
                     "/usr/bin/fish".to_string(),
                     "-i".to_string(),
+                    "-C".to_string(),
+                    super::FISH_REINSTALL_PROMPT.to_string(),
                 ]
             );
         }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -4,9 +4,6 @@ use portable_pty::CommandBuilder;
 
 use crate::modules::workspace::{self, WorkspaceEnv};
 
-const FISH_POST_CONFIG_COMMAND: &str =
-    "functions -q __terax_install_prompt; and __terax_install_prompt";
-
 #[cfg(windows)]
 const BASHRC_SCRIPT: &str = include_str!("scripts/bashrc.bash");
 #[cfg(windows)]
@@ -185,8 +182,6 @@ mod unix {
     use std::path::{Path, PathBuf};
 
     use portable_pty::CommandBuilder;
-
-    use super::FISH_POST_CONFIG_COMMAND;
 
     const ZSHENV: &str = include_str!("scripts/zshenv.zsh");
     const ZPROFILE: &str = include_str!("scripts/zprofile.zsh");
@@ -469,8 +464,6 @@ mod windows {
 
     use crate::modules::workspace::WorkspaceEnv;
     use portable_pty::CommandBuilder;
-
-    use super::FISH_POST_CONFIG_COMMAND;
 
     const PROFILE_PS1: &str = include_str!("scripts/profile.ps1");
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -4,6 +4,9 @@ use portable_pty::CommandBuilder;
 
 use crate::modules::workspace::{self, WorkspaceEnv};
 
+const FISH_POST_CONFIG_COMMAND: &str =
+    "functions -q __terax_install_prompt; and __terax_install_prompt";
+
 #[cfg(windows)]
 const BASHRC_SCRIPT: &str = include_str!("scripts/bashrc.bash");
 #[cfg(windows)]
@@ -182,6 +185,8 @@ mod unix {
     use std::path::{Path, PathBuf};
 
     use portable_pty::CommandBuilder;
+
+    use super::FISH_POST_CONFIG_COMMAND;
 
     const ZSHENV: &str = include_str!("scripts/zshenv.zsh");
     const ZPROFILE: &str = include_str!("scripts/zprofile.zsh");
@@ -464,6 +469,8 @@ mod windows {
 
     use crate::modules::workspace::WorkspaceEnv;
     use portable_pty::CommandBuilder;
+
+    use super::FISH_POST_CONFIG_COMMAND;
 
     const PROFILE_PS1: &str = include_str!("scripts/profile.ps1");
 

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -995,7 +995,7 @@ mod windows {
                     "/usr/bin/fish".to_string(),
                     "-i".to_string(),
                     "-C".to_string(),
-                    super::FISH_REINSTALL_PROMPT.to_string(),
+                    super::super::FISH_REINSTALL_PROMPT.to_string(),
                 ]
             );
         }


### PR DESCRIPTION
## What

Fixes fish shell startup so Terax re-installs its prompt wrapper after user fish config has loaded.

Closes #819.

## Why

Fish prompt frameworks such as starship can replace Terax's wrapper after `config.fish` runs. When that happens, OSC 7 updates stop and the file explorer can stay stuck on the initial cwd.

## How

The fish launch path now runs Terax's prompt installer again via `fish -C` after config loading. The same shared post-config command is used for the regular Unix fish path and the WSL fish path.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS (targeted Rust checks); WSL/Windows compile path reviewed but not smoke-tested locally
- [x] Shells tested (if relevant): fish launch args via unit test

Ran locally:

```bash
rustfmt --edition 2021 --check src-tauri/src/modules/pty/shell_init.rs
cargo test --manifest-path src-tauri/Cargo.toml shell_init --lib --no-default-features
cargo clippy --manifest-path src-tauri/Cargo.toml --lib --no-default-features
```

Results:

```text
shell_init test: 1 passed; 0 failed
clippy: Finished dev profile successfully
```

Also attempted a Windows-target compile check with:

```bash
cargo test --manifest-path src-tauri/Cargo.toml builds_wsl_fish_launch_spec_without_init_command --lib --target x86_64-pc-windows-msvc --no-run
```

That local cross-target check is blocked on macOS before this crate compiles because `ring` needs MSVC C headers (`fatal error: 'assert.h' file not found`).

Repo-wide `cargo fmt --check` currently reports rustfmt deltas in unrelated files, so I kept this PR scoped and verified the touched file directly with `rustfmt --check` instead.

## Screenshots / GIFs

N/A; this is backend PTY shell launch behavior.

## Notes for reviewer

CodeRabbit caught that the shared fish post-config command was initially private to `mod unix` while the WSL path in `mod windows` also uses it. The latest commit hoists that constant to shared scope and imports it explicitly in both modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fish shell startup on Unix and WSL to more reliably (re)apply the terminal prompt integration at launch.
  * Prevented scenarios where prompt setup could be missed during shell initialization.
* **Refactor**
  * Streamlined shell command/launch construction for consistent fish behavior across Unix and WSL, without changing normal usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->