### PR TITLE
asd

### DIFF
--- a/.claude/skills/terax-pr-workflow/SKILL.md
+++ b/.claude/skills/terax-pr-workflow/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: terax-pr-workflow
+description: Use this skill whenever making ANY change to this repository — features, fixes, shortcuts, refactors, anything. It enforces the mandatory branch → commit → dual-PR (fork + upstream) → merge-fork → back-to-main workflow. Trigger on phrases like "create a PR", "add a feature", "fix this", "push this", "open a pull request", or any task that involves committing and shipping code changes.
+user-invocable: true
+---
+
+# Terax PR Workflow
+
+Every change to this repo MUST follow this exact workflow. No exceptions.
+
+## Remotes
+
+- `origin` → `https://github.com/roberto-fernandino/terax-ai-fork.git` (the fork — you have write access)
+- `upstream` → `https://github.com/crynta/terax-ai.git` (the original — NO push access, use cross-fork PRs)
+
+## Step-by-step
+
+### 1. Create a branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/<descriptive-name>
+# or fix/<name>, chore/<name>, etc.
+```
+
+Branch name must be kebab-case and describe the change.
+
+### 2. Make the changes
+
+Implement the feature/fix. Type-check before committing:
+
+```bash
+npx tsc --noEmit
+```
+
+### 3. Commit
+
+Stage only the relevant files (never `git add -A` blindly):
+
+```bash
+git add <specific files>
+git commit -m "$(cat <<'EOF'
+feat/fix/chore(scope): short imperative description
+
+Longer explanation if needed.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 4. Push to fork
+
+```bash
+git push origin <branch-name>
+```
+
+### 5. Create PR on the fork (roberto-fernandino/terax-ai-fork)
+
+```bash
+gh pr create \
+  --repo roberto-fernandino/terax-ai-fork \
+  --base main \
+  --head <branch-name> \
+  --title "<same as commit title>" \
+  --body "$(cat <<'EOF'
+## Summary
+- bullet points
+
+## Test plan
+- [ ] item
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 6. Create cross-fork PR on the upstream (crynta/terax-ai)
+
+Push access is denied to upstream, so use the fork branch as head:
+
+```bash
+gh pr create \
+  --repo crynta/terax-ai \
+  --base main \
+  --head roberto-fernandino:<branch-name> \
+  --title "<same as commit title>" \
+  --body "..."
+```
+
+### 7. Merge the fork PR
+
+```bash
+gh pr merge <pr-number> --repo roberto-fernandino/terax-ai-fork --merge --auto
+```
+
+### 8. Return to main and pull
+
+```bash
+git checkout main
+git pull origin main
+```
+
+## Rules
+
+- ALWAYS create a branch — never commit directly to main.
+- ALWAYS open TWO PRs: one on the fork, one on the upstream (cross-fork).
+- ALWAYS merge the fork PR and return to main at the end.
+- NEVER push directly to upstream (no access); always use `--head roberto-fernandino:<branch>` for the upstream PR.
+- Type-check (`npx tsc --noEmit`) before committing.
+- Use conventional commit prefixes: `feat`, `fix`, `chore`, `refactor`, `docs`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.8.2",
   "license": "Apache-2.0",
   "type": "module",
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "engines": {
     "node": ">=22"
   },

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -995,6 +995,12 @@ export default function App() {
             openSpacesOverview: () => setSwitcherOpen(true),
             newSpace: () => void handleNewSpace(),
             switchSpace: (id) => useSpaces.getState().setActive(id),
+            terminalTabs: tabs.filter(
+              (t) =>
+                t.kind === "terminal" &&
+                t.spaceId === (activeSpaceId ?? DEFAULT_SPACE_ID),
+            ),
+            switchTab: (id) => setActiveId(id),
           })
         : [],
     [

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -639,7 +639,11 @@ export default function App() {
       "tab.close": handleCloseTabOrPane,
       "tab.next": () => stepSwitcher(1),
       "tab.prev": () => stepSwitcher(-1),
-      "tab.selectByIndex": (e) => selectByIndex(parseInt(e.key, 10) - 1),
+      "tab.selectByIndex": (e) =>
+        selectByIndex(
+          parseInt(e.key, 10) - 1,
+          activeSpaceId ?? DEFAULT_SPACE_ID,
+        ),
       "space.next": () => cycleSpace(1),
       "space.prev": () => cycleSpace(-1),
       "space.overview": () => setSwitcherOpen(true),

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -653,6 +653,7 @@ export default function App() {
       "pane.focusNext": () => focusNextPaneInTab(activeId, 1),
       "pane.focusPrev": () => focusNextPaneInTab(activeId, -1),
       "pane.source": toggleSourceControl,
+      "sidebar.files": () => cycleSidebarView("explorer"),
       "terminal.clear": () => {
         clearFocusedTerminal();
       },
@@ -980,6 +981,7 @@ export default function App() {
             openNewPreview: () => openPreviewTab(""),
             openGitGraph: openGitGraphFromContext,
             toggleSourceControl,
+            toggleFilesExplorer: () => cycleSidebarView("explorer"),
             closeActiveTabOrPane: handleCloseTabOrPane,
             splitPaneRight: () => splitActivePaneInActiveTab("row"),
             splitPaneDown: () => splitActivePaneInActiveTab("col"),
@@ -1016,6 +1018,7 @@ export default function App() {
       openPreviewTab,
       openGitGraphFromContext,
       toggleSourceControl,
+      cycleSidebarView,
       handleCloseTabOrPane,
       splitActivePaneInActiveTab,
       toggleSidebar,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -284,6 +284,7 @@ export default function App() {
   const miniOpen = useChatStore((s) => s.mini.open);
   const miniPresence = usePresence(miniOpen, 200);
   const openMini = useChatStore((s) => s.openMini);
+  const toggleMini = useChatStore((s) => s.toggleMini);
   const focusInput = useChatStore((s) => s.focusInput);
   const openPanel = useChatStore((s) => s.openPanel);
   const panelOpen = useChatStore((s) => s.panelOpen);
@@ -661,6 +662,13 @@ export default function App() {
       "blocks.next": () => navigateFocusedBlocks(1),
       "search.focus": () => searchInlineRef.current?.focus(),
       "ai.toggle": togglePanelAndFocus,
+      "ai.toggleMini": () => {
+        if (!hasComposer) {
+          void openSettingsWindow("models");
+          return;
+        }
+        toggleMini();
+      },
       "ai.askSelection": askFromSelection,
       "settings.open": () => void openSettingsWindow(),
       "sidebar.toggle": toggleSidebar,
@@ -686,7 +694,9 @@ export default function App() {
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
       toggleSourceControl,
+      hasComposer,
       togglePanelAndFocus,
+      toggleMini,
       askFromSelection,
       toggleSidebar,
       toggleExplorerFocus,

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -170,9 +170,8 @@ export function AiStatusBarControls() {
         </Kbd>
       </Button>
       <IconBtn
-        title={miniOpen ? "Mini-window open" : "Open conversation"}
+        title={`${miniOpen ? "Close" : "Open"} AI chat window (${fmtShortcut("⇧", MOD_KEY, "I")})`}
         onClick={openMini}
-        disabled={miniOpen}
       >
         <HugeiconsIcon icon={Message01Icon} size={13} strokeWidth={1.75} />
       </IconBtn>

--- a/src/modules/command-palette/commands.ts
+++ b/src/modules/command-palette/commands.ts
@@ -24,6 +24,7 @@ import type { PaletteItem } from "./types";
 export const COMMAND_GROUPS = [
   "General",
   "Spaces",
+  "Terminals",
   "Tabs",
   "Panes",
   "Git",
@@ -60,6 +61,8 @@ export type CommandPaletteActionContext = {
   openSpacesOverview: () => void;
   newSpace: () => void;
   switchSpace: (id: string) => void;
+  terminalTabs: { id: number; title: string; customTitle?: string }[];
+  switchTab: (id: number) => void;
 };
 
 const noop = () => {};
@@ -133,6 +136,15 @@ export function createCommandItems(
       disabledReason:
         sp.id === ctx.activeSpaceId ? "Current space" : undefined,
       run: () => ctx.switchSpace(sp.id),
+    })),
+    ...ctx.terminalTabs.map((tab) => ({
+      id: `terminals.switch.${tab.id}`,
+      title: tab.customTitle || tab.title,
+      group: "Terminals" as const,
+      keywords: ["terminal", "switch", "tab", tab.customTitle ?? "", tab.title],
+      icon: TerminalIcon,
+      disabledReason: tab.id === ctx.activeId ? "Current tab" : undefined,
+      run: () => ctx.switchTab(tab.id),
     })),
     {
       id: "tab.new",

--- a/src/modules/command-palette/commands.ts
+++ b/src/modules/command-palette/commands.ts
@@ -46,6 +46,7 @@ export type CommandPaletteActionContext = {
   openNewPreview: () => void;
   openGitGraph: () => void;
   toggleSourceControl: () => void;
+  toggleFilesExplorer: () => void;
   closeActiveTabOrPane: () => void;
   splitPaneRight: () => void;
   splitPaneDown: () => void;
@@ -237,6 +238,15 @@ export function createCommandItems(
       icon: SourceCodeIcon,
       shortcutId: "pane.source",
       run: ctx.toggleSourceControl,
+    },
+    {
+      id: "sidebar.files",
+      title: "Show Files sidebar",
+      group: "View",
+      keywords: ["files", "explorer", "sidebar", "file tree"],
+      icon: SidebarLeftIcon,
+      shortcutId: "sidebar.files",
+      run: ctx.toggleFilesExplorer,
     },
     {
       id: "search.content",

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -40,6 +40,7 @@ export type ShortcutId =
   | "ai.askSelection"
   | "settings.open"
   | "sidebar.toggle"
+  | "sidebar.files"
   | "editor.undo"
   | "editor.redo";
 
@@ -252,6 +253,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Ask AI about selection",
     group: "AI",
     defaultBindings: [{ [MOD_PROP]: true, key: "j" }],
+  },
+  {
+    id: "sidebar.files",
+    label: "Show Files sidebar",
+    group: "View",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "g" }],
   },
   {
     id: "sidebar.toggle",

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -36,6 +36,7 @@ export type ShortcutId =
   | "view.zoomReset"
   | "view.zenMode"
   | "ai.toggle"
+  | "ai.toggleMini"
   | "ai.askSelection"
   | "settings.open"
   | "sidebar.toggle"
@@ -239,6 +240,12 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Toggle AI agent",
     group: "AI",
     defaultBindings: [{ [MOD_PROP]: true, key: "i" }],
+  },
+  {
+    id: "ai.toggleMini",
+    label: "Toggle AI chat window",
+    group: "AI",
+    defaultBindings: [{ [MOD_PROP]: true, shift: true, key: "i" }],
   },
   {
     id: "ai.askSelection",

--- a/src/modules/tabs/lib/pickTabBySpaceIndex.test.ts
+++ b/src/modules/tabs/lib/pickTabBySpaceIndex.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { pickTabBySpaceIndex, type Tab } from "./useTabs";
+
+function term(id: number, spaceId: string): Tab {
+  return {
+    id,
+    kind: "terminal",
+    spaceId,
+    title: "shell",
+    paneTree: { kind: "leaf", id: id * 10 },
+    activeLeafId: id * 10,
+  } as Tab;
+}
+
+describe("pickTabBySpaceIndex", () => {
+  const tabs = [term(1, "a"), term(2, "b"), term(3, "b")];
+
+  it("Cmd+1 in space B returns B's first tab, not A's", () => {
+    expect(pickTabBySpaceIndex(tabs, 0, "b")?.id).toBe(2);
+  });
+
+  it("Cmd+2 in space B returns B's second tab", () => {
+    expect(pickTabBySpaceIndex(tabs, 1, "b")?.id).toBe(3);
+  });
+
+  it("Cmd+3 in space B returns undefined (does nothing)", () => {
+    expect(pickTabBySpaceIndex(tabs, 2, "b")).toBeUndefined();
+  });
+
+  it("Cmd+1 in space A returns A's only tab", () => {
+    expect(pickTabBySpaceIndex(tabs, 0, "a")?.id).toBe(1);
+  });
+
+  it("returns undefined for an empty space", () => {
+    expect(pickTabBySpaceIndex(tabs, 0, "c")).toBeUndefined();
+  });
+});

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -148,6 +148,17 @@ function titleFromUrl(url: string): string {
 
 export const DEFAULT_SPACE_ID = "default";
 
+// Returns the tab at position `idx` within the given space, or undefined when
+// idx is out of range or no matching space tab exists.
+export function pickTabBySpaceIndex(
+  tabs: Tab[],
+  idx: number,
+  spaceId: string,
+): Tab | undefined {
+  const pool = tabs.filter((t) => t.spaceId === spaceId);
+  return pool[idx];
+}
+
 // Next active after close, scoped to the closing tab's space. null = last tab of
 // its space, which callers treat as "refuse to close".
 export function nextActiveInSpace(
@@ -951,8 +962,10 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   }, []);
 
   const selectByIndex = useCallback(
-    (idx: number) => {
-      const t = tabs[idx];
+    (idx: number, spaceId?: string) => {
+      const t = spaceId
+        ? pickTabBySpaceIndex(tabs, idx, spaceId)
+        : tabs[idx];
       if (t) setActiveId(t.id);
     },
     [tabs],


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: <!-- macOS / Linux / Windows -->
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shortcut and command-palette option to open the AI mini chat window.
  * Added a shortcut and command-palette option to open the Files sidebar.
  * Added terminal switching commands in the command palette.

* **Bug Fixes**
  * Tab switching now respects the current workspace/space.
  * The AI mini chat toggle now works more consistently from the status bar and shortcuts.

* **Tests**
  * Added coverage for selecting tabs within the correct workspace/space.

* **Chores**
  * Updated the pinned package manager version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->