### PR TITLE
feat(sidebar): persist collapsed state across sessions

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -262,7 +262,9 @@ export default function App() {
     sidebarRef,
     sidebarWidthRef,
     sidebarView,
+    initialSidebarCollapsed,
     persistSidebarView,
+    persistSidebarCollapsed,
     toggleSidebar,
     cycleSidebarView,
     persistSidebarWidth,
@@ -1098,13 +1100,16 @@ export default function App() {
               <ResizablePanel
                 id="sidebar"
                 panelRef={sidebarRef}
-                defaultSize={`${sidebarWidthRef.current}px`}
+                defaultSize={
+                  initialSidebarCollapsed ? "0px" : `${sidebarWidthRef.current}px`
+                }
                 minSize={`${SIDEBAR_MIN_WIDTH}px`}
                 maxSize={`${SIDEBAR_MAX_WIDTH}px`}
                 collapsible
                 collapsedSize={0}
                 onResize={(size) => {
                   if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
+                  persistSidebarCollapsed(size.inPixels <= 0);
                 }}
               >
                 <div className="flex h-full min-h-0 flex-col border-r border-border/60 bg-card">

--- a/src/modules/sidebar/useSidebarPanel.ts
+++ b/src/modules/sidebar/useSidebarPanel.ts
@@ -13,6 +13,7 @@ export const SIDEBAR_MIN_WIDTH = 220;
 export const SIDEBAR_MAX_WIDTH = 480;
 const SIDEBAR_WIDTH_STORAGE_KEY = "terax.sidebar.width";
 const SIDEBAR_VIEW_STORAGE_KEY = "terax.sidebar.view";
+const SIDEBAR_COLLAPSED_STORAGE_KEY = "terax.sidebar.collapsed";
 
 function clampSidebarWidth(width: number): number {
   return Math.min(
@@ -43,6 +44,14 @@ function readSidebarView(): SidebarViewId {
   return "explorer";
 }
 
+function readSidebarCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 type FocusableExplorer = {
   focus: () => void;
   isFocused: () => boolean;
@@ -57,6 +66,8 @@ export function useSidebarPanel(
   const explorerReturnFocusRef = useRef<HTMLElement | null>(null);
   const [sidebarView, setSidebarViewState] =
     useState<SidebarViewId>(readSidebarView);
+  const [initialSidebarCollapsed] = useState(readSidebarCollapsed);
+  const collapsedRef = useRef(initialSidebarCollapsed);
 
   const persistSidebarView = useCallback((view: SidebarViewId) => {
     setSidebarViewState(view);
@@ -67,10 +78,23 @@ export function useSidebarPanel(
     }
   }, []);
 
+  const persistSidebarCollapsed = useCallback((collapsed: boolean) => {
+    if (collapsedRef.current === collapsed) return;
+    collapsedRef.current = collapsed;
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_COLLAPSED_STORAGE_KEY,
+        collapsed ? "1" : "0",
+      );
+    } catch {
+      // storage may fail in private mode
+    }
+  }, []);
+
   const toggleSidebar = useCallback(() => {
     const p = sidebarRef.current;
     if (!p) return;
-    if (p.getSize().asPercentage <= 0) p.expand();
+    if (p.getSize().asPercentage <= 0) p.resize(`${sidebarWidthRef.current}px`);
     else p.collapse();
   }, []);
 
@@ -151,7 +175,9 @@ export function useSidebarPanel(
     sidebarRef,
     sidebarWidthRef,
     sidebarView,
+    initialSidebarCollapsed,
     persistSidebarView,
+    persistSidebarCollapsed,
     toggleSidebar,
     cycleSidebarView,
     persistSidebarWidth,


### PR DESCRIPTION
Sidebar open/closed state was session-only; now persisted to localStorage (`terax.sidebar.collapsed`) like width and view already are.

- `onResize` is the single persist path (covers toggle, view-cycle, focus-expand, drag-to-collapse)
- restores via `defaultSize=0px` when last collapsed (collapsible panel mounts collapsed natively, no flash)
- `toggleSidebar` expands via `resize(savedWidth)` instead of `expand()` so width is correct after a collapsed boot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar collapsed/expanded state now persists between sessions.
  * The sidebar restores its last collapsed state on load.

* **Bug Fixes**
  * Improved sidebar toggle behavior so a collapsed panel reopens to its previous width instead of resetting unexpectedly.
  * Resizing now correctly saves both the panel width and collapsed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->