### PR TITLE
feat(editor): add find and replace to the search bar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -676,6 +676,7 @@ export default function App() {
       "blocks.prev": () => navigateFocusedBlocks(-1),
       "blocks.next": () => navigateFocusedBlocks(1),
       "search.focus": () => searchInlineRef.current?.focus(),
+      "search.replace": () => searchInlineRef.current?.focusReplace(),
       "ai.toggle": togglePanelAndFocus,
       "ai.askSelection": askFromSelection,
       "agent.focusAttention": () => {
@@ -721,6 +722,11 @@ export default function App() {
   const shortcutsDisabled = useCallback(
     (id: ShortcutId, e: KeyboardEvent) => {
       if (id === "editor.undo" || id === "editor.redo") {
+        return activeTab?.kind !== "editor";
+      }
+      if (id === "search.replace") {
+        // Replace only applies to the editor; elsewhere let Ctrl+H fall through
+        // (in a terminal it must remain backspace / ^H).
         return activeTab?.kind !== "editor";
       }
       if (id === "ai.askSelection") {
@@ -864,6 +870,8 @@ export default function App() {
         kind: "terminal",
         addon: activeSearchAddon,
         focus: () => terminalRefs.current.get(activeLeafId)?.focus(),
+        getSelection: () =>
+          terminalRefs.current.get(activeLeafId)?.getSelection() ?? null,
       };
     if (isEditorTab && activeEditorHandle)
       return {

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -6,6 +6,8 @@ import { redo, undo } from "@codemirror/commands";
 import {
   findNext,
   findPrevious,
+  replaceAll,
+  replaceNext,
   SearchQuery,
   setSearchQuery,
 } from "@codemirror/search";
@@ -36,10 +38,20 @@ import { inlineCompletion } from "./lib/autocomplete/inlineExtension";
 
 initVimGlobals();
 
+/** Options carried alongside the search term into CodeMirror's search state. */
+export type EditorSearchOptions = {
+  replace?: string;
+  caseSensitive?: boolean;
+  regexp?: boolean;
+  wholeWord?: boolean;
+};
+
 export type EditorPaneHandle = {
-  setQuery: (q: string) => void;
+  setQuery: (q: string, opts?: EditorSearchOptions) => void;
   findNext: () => void;
   findPrevious: () => void;
+  replaceNext: () => void;
+  replaceAll: () => void;
   clearQuery: () => void;
   focus: () => void;
   getSelection: () => string | null;
@@ -78,6 +90,9 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const reloadRef = useRef(reload);
     reloadRef.current = reload;
     const cmRef = useRef<ReactCodeMirrorRef>(null);
+    // Track the last search criteria so typing in the replace field (which
+    // re-issues setQuery) doesn't keep jumping the selection to the next match.
+    const lastFindKeyRef = useRef("");
     const themeExt = useEditorThemeExt();
     const vimMode = usePreferencesStore((s) => s.vimMode);
     const editorWordWrap = usePreferencesStore((s) => s.editorWordWrap);
@@ -285,15 +300,27 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     useImperativeHandle(
       ref,
       () => ({
-        setQuery: (q: string) => {
+        setQuery: (q: string, opts?: EditorSearchOptions) => {
           const view = cmRef.current?.view;
           if (!view) return;
           view.dispatch({
             effects: setSearchQuery.of(
-              new SearchQuery({ search: q, caseSensitive: false }),
+              new SearchQuery({
+                search: q,
+                replace: opts?.replace ?? "",
+                caseSensitive: opts?.caseSensitive ?? false,
+                regexp: opts?.regexp ?? false,
+                wholeWord: opts?.wholeWord ?? false,
+              }),
             ),
           });
-          if (q) findNext(view);
+          // Only advance the selection when the match criteria changed — not
+          // when only the replacement text changed.
+          const findKey = `${q} ${opts?.caseSensitive ? 1 : 0}${
+            opts?.regexp ? 1 : 0
+          }${opts?.wholeWord ? 1 : 0}`;
+          if (q && findKey !== lastFindKeyRef.current) findNext(view);
+          lastFindKeyRef.current = findKey;
         },
         findNext: () => {
           const view = cmRef.current?.view;
@@ -303,7 +330,16 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
           const view = cmRef.current?.view;
           if (view) findPrevious(view);
         },
+        replaceNext: () => {
+          const view = cmRef.current?.view;
+          if (view) replaceNext(view);
+        },
+        replaceAll: () => {
+          const view = cmRef.current?.view;
+          if (view) replaceAll(view);
+        },
         clearQuery: () => {
+          lastFindKeyRef.current = "";
           const view = cmRef.current?.view;
           if (!view) return;
           view.dispatch({
@@ -436,7 +472,11 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
             autocompletion: true,
             highlightActiveLine: true,
             highlightSelectionMatches: true,
-            searchKeymap: true,
+            // The unified header search bar (SearchInline) is the single
+            // find/replace surface and drives the search state directly, so
+            // CodeMirror's built-in panel keymap (Cmd/Ctrl+F etc.) is disabled
+            // to avoid a competing second surface.
+            searchKeymap: false,
           }}
         />
       </div>

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -4,7 +4,11 @@ import { KEY_SEP } from "@/lib/platform";
 import type { EditorPaneHandle } from "@/modules/editor";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
-import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowDown01Icon,
+  Cancel01Icon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
 import {
@@ -25,7 +29,12 @@ const TERM_DECORATIONS = {
 };
 
 export type SearchTarget =
-  | { kind: "terminal"; addon: SearchAddon; focus: () => void }
+  | {
+      kind: "terminal";
+      addon: SearchAddon;
+      focus: () => void;
+      getSelection: () => string | null;
+    }
   | { kind: "editor"; handle: EditorPaneHandle; focus: () => void }
   | {
       kind: "git-history";
@@ -34,7 +43,11 @@ export type SearchTarget =
     }
   | null;
 
-export type SearchInlineHandle = { focus: () => void };
+export type SearchInlineHandle = {
+  focus: () => void;
+  /** Reveal the replace row (editor only) and focus the search field. */
+  focusReplace: () => void;
+};
 
 type Props = {
   target: SearchTarget;
@@ -42,9 +55,43 @@ type Props = {
   compact?: boolean;
 };
 
+/** Small square toggle chip used for the editor search modifiers. */
+function SearchToggle({
+  active,
+  onClick,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={`flex h-5 min-w-5 items-center justify-center rounded px-1 text-[11px] font-medium leading-none transition-colors ${
+        active
+          ? "bg-primary/85 text-primary-foreground"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
 export const SearchInline = forwardRef<SearchInlineHandle, Props>(
   function SearchInline({ target, compact }, ref) {
     const [q, setQ] = useState("");
+    const [replaceVal, setReplaceVal] = useState("");
+    const [replaceOpen, setReplaceOpen] = useState(false);
+    const [caseSensitive, setCaseSensitive] = useState(false);
+    const [regexp, setRegexp] = useState(false);
+    const [wholeWord, setWholeWord] = useState(false);
     // In compact mode the field is hidden behind an icon until activated.
     // In normal mode the field is always present.
     const [openInCompact, setOpenInCompact] = useState(false);
@@ -58,6 +105,8 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     }, []);
 
     const userShortcuts = usePreferencesStore((s) => s.shortcuts);
+
+    const isEditor = target?.kind === "editor";
 
     const shortcutText = useMemo(() => {
       const s = SHORTCUTS.find((s) => s.id === "search.focus");
@@ -80,14 +129,39 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
 
     const expanded = !compact || openInCompact;
 
-    const focus = useCallback(() => {
+    const focusInput = useCallback(() => {
       pendingFocusRef.current = true;
       if (compact) setOpenInCompact(true);
       else inputRef.current?.focus();
       if (inputRef.current) pendingFocusRef.current = false;
     }, [compact]);
 
-    useImperativeHandle(ref, () => ({ focus }), [focus]);
+    // Seed the query from the active selection so "select text → Cmd+F/Cmd+H"
+    // starts searching that text. Single-line selections only — a multi-line
+    // block isn't a sensible search term.
+    const prefillFromSelection = useCallback(() => {
+      let sel: string | null = null;
+      if (target?.kind === "editor") sel = target.handle.getSelection();
+      else if (target?.kind === "terminal") sel = target.getSelection();
+      if (sel && sel.length > 0 && !sel.includes("\n")) setQ(sel);
+    }, [target]);
+
+    const openSearch = useCallback(
+      (replace: boolean) => {
+        prefillFromSelection();
+        if (replace) setReplaceOpen(true);
+        focusInput();
+      },
+      [prefillFromSelection, focusInput],
+    );
+
+    const focus = useCallback(() => openSearch(false), [openSearch]);
+    const focusReplace = useCallback(() => openSearch(true), [openSearch]);
+
+    useImperativeHandle(ref, () => ({ focus, focusReplace }), [
+      focus,
+      focusReplace,
+    ]);
 
     const clearTarget = useCallback(() => {
       if (!target) return;
@@ -103,21 +177,31 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
     // Target switched (terminal ↔ editor) or removed → drop highlights.
     useEffect(() => clearTarget, [clearTarget]);
 
-    const applyIncremental = (next: string) => {
+    // Single place that pushes the current query + modifiers into the active
+    // target. Editor targets carry the replacement text and modifiers; the
+    // terminal keeps its original incremental behaviour untouched.
+    useEffect(() => {
       if (!target) return;
       if (target.kind === "terminal") {
-        if (next) {
-          target.addon.findNext(next, {
+        if (q) {
+          target.addon.findNext(q, {
             incremental: true,
             decorations: TERM_DECORATIONS,
           });
         } else {
           target.addon.clearDecorations();
         }
+      } else if (target.kind === "editor") {
+        target.handle.setQuery(q, {
+          replace: replaceVal,
+          caseSensitive,
+          regexp,
+          wholeWord,
+        });
       } else {
-        target.handle.setQuery(next);
+        target.handle.setQuery(q);
       }
-    };
+    }, [q, replaceVal, caseSensitive, regexp, wholeWord, target]);
 
     const findDirection = (forward: boolean) => {
       if (!target || !q) return;
@@ -132,60 +216,134 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
       // git-history: the list filters live; Enter has no next/prev semantics.
     };
 
+    const doReplaceNext = () => {
+      if (target?.kind !== "editor" || !q) return;
+      // Make sure the latest replacement text is in the query before replacing.
+      target.handle.setQuery(q, {
+        replace: replaceVal,
+        caseSensitive,
+        regexp,
+        wholeWord,
+      });
+      target.handle.replaceNext();
+    };
+
+    const doReplaceAll = () => {
+      if (target?.kind !== "editor" || !q) return;
+      target.handle.setQuery(q, {
+        replace: replaceVal,
+        caseSensitive,
+        regexp,
+        wholeWord,
+      });
+      target.handle.replaceAll();
+    };
+
+    const dismiss = () => {
+      clearTarget();
+      setQ("");
+      setReplaceOpen(false);
+      if (compact) setOpenInCompact(false);
+      restoreTargetFocus();
+    };
+
     return (
       <div
         className="relative h-7 shrink-0 transition-[width] duration-200 ease-out"
-        style={{ width: expanded ? 192 : 28 }}
+        style={{ width: expanded ? (isEditor ? 264 : 192) : 28 }}
       >
         {expanded ? (
-          <div className="absolute inset-0 animate-in fade-in-0 duration-150">
-            <HugeiconsIcon
-              icon={Search01Icon}
-              size={13}
-              strokeWidth={1.75}
-              className="pointer-events-none absolute top-1/2 left-2 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              ref={setInputRef}
-              value={q}
-              placeholder={placeholder}
-              className="h-7 w-full bg-muted/80 pr-7 pl-7 text-[13px]! placeholder:text-muted-foreground/70 focus-visible:ring-0"
-              onChange={(e) => {
-                const next = e.target.value;
-                setQ(next);
-                applyIncremental(next);
-              }}
-              onBlur={() => {
-                if (compact && !q) setOpenInCompact(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  findDirection(!e.shiftKey);
-                } else if (e.key === "Escape") {
-                  e.preventDefault();
-                  clearTarget();
-                  setQ("");
-                  if (compact) {
-                    setOpenInCompact(false);
-                  }
-                  restoreTargetFocus();
-                }
-              }}
-            />
-            {q && (
-              <button
-                type="button"
-                onClick={() => {
-                  setQ("");
-                  clearTarget();
-                  inputRef.current?.focus();
+          <div className="flex h-full items-center gap-1 animate-in fade-in-0 duration-150">
+            <div className="relative min-w-0 flex-1">
+              <HugeiconsIcon
+                icon={Search01Icon}
+                size={13}
+                strokeWidth={1.75}
+                className="pointer-events-none absolute top-1/2 left-2 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                ref={setInputRef}
+                value={q}
+                placeholder={placeholder}
+                className="h-7 w-full bg-muted/80 pr-7 pl-7 text-[13px]! placeholder:text-muted-foreground/70 focus-visible:ring-0"
+                onChange={(e) => setQ(e.target.value)}
+                onBlur={() => {
+                  if (compact && !q) setOpenInCompact(false);
                 }}
-                className="absolute top-1/2 right-1.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-                aria-label="Clear search"
-              >
-                <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
-              </button>
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    findDirection(!e.shiftKey);
+                  } else if (e.key === "Escape") {
+                    e.preventDefault();
+                    dismiss();
+                  }
+                }}
+              />
+              {q && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setQ("");
+                    clearTarget();
+                    inputRef.current?.focus();
+                  }}
+                  className="absolute top-1/2 right-1.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  aria-label="Clear search"
+                >
+                  <HugeiconsIcon
+                    icon={Cancel01Icon}
+                    size={11}
+                    strokeWidth={2}
+                  />
+                </button>
+              )}
+            </div>
+
+            {isEditor && (
+              <div className="flex shrink-0 items-center gap-0.5">
+                <SearchToggle
+                  active={caseSensitive}
+                  onClick={() => setCaseSensitive((v) => !v)}
+                  title="Match case"
+                >
+                  Aa
+                </SearchToggle>
+                <SearchToggle
+                  active={wholeWord}
+                  onClick={() => setWholeWord((v) => !v)}
+                  title="Match whole word"
+                >
+                  W
+                </SearchToggle>
+                <SearchToggle
+                  active={regexp}
+                  onClick={() => setRegexp((v) => !v)}
+                  title="Use regular expression"
+                >
+                  .*
+                </SearchToggle>
+                <button
+                  type="button"
+                  onClick={() => setReplaceOpen((v) => !v)}
+                  aria-pressed={replaceOpen}
+                  title="Toggle replace"
+                  className={`flex h-5 w-5 items-center justify-center rounded transition-colors ${
+                    replaceOpen
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  }`}
+                >
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
+                    size={13}
+                    strokeWidth={2}
+                    className={`transition-transform ${
+                      replaceOpen ? "rotate-180" : ""
+                    }`}
+                  />
+                </button>
+              </div>
             )}
           </div>
         ) : (
@@ -199,6 +357,44 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
             >
               <HugeiconsIcon icon={Search01Icon} size={15} strokeWidth={1.75} />
             </Button>
+          </div>
+        )}
+
+        {isEditor && expanded && replaceOpen && (
+          <div className="absolute top-[calc(100%+4px)] right-0 z-50 w-[264px] rounded-md border border-border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95 duration-100">
+            <div className="flex items-center gap-1">
+              <input
+                value={replaceVal}
+                placeholder="Replace"
+                onChange={(e) => setReplaceVal(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    doReplaceNext();
+                  } else if (e.key === "Escape") {
+                    e.preventDefault();
+                    dismiss();
+                  }
+                }}
+                className="h-6 min-w-0 flex-1 rounded bg-muted/70 px-2 text-[13px] text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={doReplaceNext}
+                title="Replace next match (Enter)"
+                className="h-6 shrink-0 rounded px-2 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                Replace
+              </button>
+              <button
+                type="button"
+                onClick={doReplaceAll}
+                title="Replace all matches"
+                className="h-6 shrink-0 rounded px-2 text-[11px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                All
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -232,7 +232,7 @@ export const SHORTCUTS: Shortcut[] = [
   },
   {
     id: "search.focus",
-    label: "Find in terminal",
+    label: "Find",
     group: "Search",
     defaultBindings: [{ [MOD_PROP]: true, key: "f" }],
   },

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -29,6 +29,7 @@ export type ShortcutId =
   | "blocks.prev"
   | "blocks.next"
   | "search.focus"
+  | "search.replace"
   | "explorer.search"
   | "explorer.focus"
   | "view.zoomIn"
@@ -234,6 +235,14 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Find in terminal",
     group: "Search",
     defaultBindings: [{ [MOD_PROP]: true, key: "f" }],
+  },
+  {
+    id: "search.replace",
+    label: "Find & replace in editor",
+    group: "Search",
+    // Only claimed while an editor is focused (see shortcutsDisabled); in a
+    // terminal Ctrl+H must stay backspace (^H).
+    defaultBindings: [{ [MOD_PROP]: true, key: "h" }],
   },
   {
     id: "ai.toggle",


### PR DESCRIPTION
## What

Adds find & replace to the editor's search bar. For editor tabs the bar now has case-sensitive, whole-word, and regex toggles plus an expandable replace row (Replace / Replace All). `Cmd/Ctrl+H` opens it directly, and selecting text before `Cmd/Ctrl+F` or `Cmd/Ctrl+H` prefills the query. Terminal and git-history search are unchanged.

## Why

The search bar could only *find* in the editor — there was no way to replace text without leaving the app. The project-wide search work (#688, closes #128) shipped read-only and explicitly listed find-and-replace as out of scope, leaving the single-file editor case unaddressed.

Reuses CodeMirror's existing `@codemirror/search` state, so it adds **no new dependency**. Scope is deliberately single-file editor find/replace — not IDE-scale project-wide search.

## How

- `SearchInline` renders modifier toggles + an expandable replace row for `editor` targets only; `terminal` / `git-history` paths are untouched. Search application is centralized in one effect.
- `EditorPaneHandle.setQuery(q, opts)` carries the modifiers + replacement into the CodeMirror `SearchQuery`, and adds `replaceNext` / `replaceAll`. A small dedup ref stops the selection jumping while you type in the replace field.
- New `search.replace` shortcut = `Cmd/Ctrl+H`, gated in `shortcutsDisabled` to editor focus so `Ctrl+H` stays backspace (`^H`) in the terminal.
- Selection prefill uses the existing `getSelection()` (editor + terminal).
- `basicSetup.searchKeymap` is disabled so CodeMirror's built-in panel no longer competes with the header bar — one find/replace surface.
- Relabels the `Cmd/Ctrl+F` shortcut from "Find in terminal" to "Find" — it already focused search for the editor and git-history views too, so the old label was inaccurate even before this change.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) — N/A, no Rust changes
- [x] (If you changed a `#[tauri::command]` signature) — N/A
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [x] Shells tested (if relevant): N/A

Manual flows exercised in `pnpm tauri dev`:
- `Ctrl+F` / `Ctrl+H` focus the bar; toggles (case / word / regex) update matches live; `Enter` / `Shift+Enter` cycle.
- Replace and Replace All modify the buffer; typing in the replace field does not jump the selection.
- `Ctrl+H` inside a focused terminal still deletes a character (backspace) — the binding is not hijacked there.
- Select text, then `Ctrl+F` / `Ctrl+H` → the query is prefilled from the selection.

`pnpm test`: 438 pass. (Two pre-existing `eager-budget.test.ts` failures on `main` are a parse error unrelated to this change.)

## Screenshots

<img width="1284" height="535" alt="image" src="https://github.com/user-attachments/assets/3f722fc9-a6b1-4d45-bf2a-ab97ca4f0fec" />

## Notes for reviewer

- **Default-behavior change:** in an editor, `Ctrl+F` now always routes to the header search bar; CodeMirror's built-in search panel keymap is disabled. Flagging since it changes an existing interaction.
- No new dependencies — reuses `@codemirror/search`.
- Opened as a **draft** for direction/alignment feedback before polishing (per CONTRIBUTING's "open a draft PR early"). Happy to adjust scope.
