### PR TITLE
fix(markdown): render file previews statically

### DIFF
--- a/src/modules/markdown/MarkdownPreviewPane.test.ts
+++ b/src/modules/markdown/MarkdownPreviewPane.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(here, "MarkdownPreviewPane.tsx"), "utf8");
+const streamdownMatch = src.match(/<Streamdown[\s\S]*?<\/Streamdown>/);
+const streamdownJsx = streamdownMatch?.[0] ?? "";
+
+describe("MarkdownPreviewPane Streamdown configuration", () => {
+  it("renders complete markdown files in static mode", () => {
+    expect(streamdownJsx).toMatch(/mode="static"/);
+  });
+
+  it("does not run streaming incomplete-markdown repair for files", () => {
+    expect(streamdownJsx).toMatch(/parseIncompleteMarkdown=\{false\}/);
+  });
+});

--- a/src/modules/markdown/MarkdownPreviewPane.tsx
+++ b/src/modules/markdown/MarkdownPreviewPane.tsx
@@ -86,6 +86,8 @@ export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
             <Streamdown
               className="select-text [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
               components={components}
+              mode="static"
+              parseIncompleteMarkdown={false}
             >
               {status.content}
             </Streamdown>


### PR DESCRIPTION
## Summary
- Render file-backed Markdown previews in `static` mode instead of Streamdown's streaming/incomplete-repair path.
- Add a regression test to lock the preview configuration.
- This only changes the rendered Markdown file preview path; AI chat `Streamdown` stays streaming.

## Why
- Opening a 7,600-line Markdown file (`/Users/pigpeppa/Downloads/economy/经济学原理听课笔记.md`) made the whole editor sluggish, not just the preview.
- The preview path was treating a complete file like streaming AI output.
- Local benchmarking dropped render time from a little over 3s to about 0.xs after the change.

## Test Plan
- `pnpm test src/modules/markdown/MarkdownPreviewPane.test.ts`
- `pnpm check-types`
- `pnpm exec biome lint src/modules/markdown/MarkdownPreviewPane.tsx src/modules/markdown/MarkdownPreviewPane.test.ts`

## Manual Check
- Opened the large Markdown note above and confirmed the app-wide lag is gone after the fix.