### PR TITLE
fix(terminal): register configured font as a local() @font-face for the WebGL renderer (#898)

### DIFF
--- a/src/lib/fonts.test.ts
+++ b/src/lib/fonts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveFontFamily } from "./fonts";
 
 const FALLBACK = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
@@ -31,5 +31,112 @@ describe("resolveFontFamily", () => {
   it("falls back to the mono chain for empty input", () => {
     expect(resolveFontFamily("")).toBe(FALLBACK);
     expect(resolveFontFamily("   ")).toBe(FALLBACK);
+  });
+});
+
+type FakeStyle = {
+  id: string;
+  textContent: string;
+  appendChild: (node: { text: string }) => void;
+};
+
+// vitest runs in the node environment (no DOM), so stub a minimal document to
+// observe what registerLocalFont injects into the FontFaceSet.
+function installFakeDocument() {
+  const children: FakeStyle[] = [];
+  const loaded: string[] = [];
+  const doc = {
+    head: {
+      appendChild(el: FakeStyle) {
+        children.push(el);
+      },
+    },
+    fonts: {
+      load(spec: string) {
+        loaded.push(spec);
+        return Promise.resolve([]);
+      },
+    },
+    getElementById(id: string): FakeStyle | null {
+      return children.find((c) => c.id === id) ?? null;
+    },
+    createElement(_tag: string): FakeStyle {
+      const style: FakeStyle = {
+        id: "",
+        textContent: "",
+        appendChild(node) {
+          style.textContent += node.text;
+        },
+      };
+      return style;
+    },
+    createTextNode(text: string) {
+      return { text };
+    },
+  };
+  vi.stubGlobal("document", doc);
+  return { children, loaded };
+}
+
+describe("registerLocalFont", () => {
+  // Reset modules between tests so the module-level dedup Set starts empty.
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("injects a local() @font-face for weights 400/700 and loads the family", async () => {
+    const { children, loaded } = installFakeDocument();
+    const { registerLocalFont } = await import("./fonts");
+
+    await registerLocalFont("ComicShannsMono Nerd Font Mono");
+
+    expect(children).toHaveLength(1);
+    const style = children[0];
+    expect(style.id).toBe("terax-local-fonts");
+    expect(style.textContent).toContain(
+      'src:local("ComicShannsMono Nerd Font Mono")',
+    );
+    expect(style.textContent).toContain("font-weight:400");
+    expect(style.textContent).toContain("font-weight:700");
+    expect(loaded).toEqual([
+      '400 14px "ComicShannsMono Nerd Font Mono"',
+      '700 14px "ComicShannsMono Nerd Font Mono"',
+    ]);
+  });
+
+  it("is a no-op for blank input", async () => {
+    const { children, loaded } = installFakeDocument();
+    const { registerLocalFont } = await import("./fonts");
+
+    await registerLocalFont("   ");
+
+    expect(children).toHaveLength(0);
+    expect(loaded).toHaveLength(0);
+  });
+
+  it("is a no-op for a comma-separated stack", async () => {
+    const { children, loaded } = installFakeDocument();
+    const { registerLocalFont } = await import("./fonts");
+
+    await registerLocalFont("Foo, Bar");
+
+    expect(children).toHaveLength(0);
+    expect(loaded).toHaveLength(0);
+  });
+
+  it("strips surrounding quotes and registers each family only once", async () => {
+    const { children, loaded } = installFakeDocument();
+    const { registerLocalFont } = await import("./fonts");
+
+    await registerLocalFont('"Fira Code"');
+    await registerLocalFont("Fira Code"); // same family — already registered
+
+    expect(children).toHaveLength(1);
+    const style = children[0];
+    expect(style.textContent.match(/@font-face/g)).toHaveLength(2);
+    expect(style.textContent).toContain('local("Fira Code")');
+    // load() still runs for both invocations (a no-op once cached).
+    expect(loaded).toHaveLength(4);
   });
 });

--- a/src/lib/fonts.test.ts
+++ b/src/lib/fonts.test.ts
@@ -34,11 +34,7 @@ describe("resolveFontFamily", () => {
   });
 });
 
-type FakeStyle = {
-  id: string;
-  textContent: string;
-  appendChild: (node: { text: string }) => void;
-};
+type FakeStyle = { id: string; textContent: string };
 
 // vitest runs in the node environment (no DOM), so stub a minimal document to
 // observe what registerLocalFont injects into the FontFaceSet.
@@ -61,17 +57,7 @@ function installFakeDocument() {
       return children.find((c) => c.id === id) ?? null;
     },
     createElement(_tag: string): FakeStyle {
-      const style: FakeStyle = {
-        id: "",
-        textContent: "",
-        appendChild(node) {
-          style.textContent += node.text;
-        },
-      };
-      return style;
-    },
-    createTextNode(text: string) {
-      return { text };
+      return { id: "", textContent: "" };
     },
   };
   vi.stubGlobal("document", doc);
@@ -79,7 +65,8 @@ function installFakeDocument() {
 }
 
 describe("registerLocalFont", () => {
-  // Reset modules between tests so the module-level dedup Set starts empty.
+  // Reset modules between tests so the module-level registration cache starts
+  // empty.
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetModules();
@@ -136,7 +123,7 @@ describe("registerLocalFont", () => {
     const style = children[0];
     expect(style.textContent.match(/@font-face/g)).toHaveLength(2);
     expect(style.textContent).toContain('local("Fira Code")');
-    // load() still runs for both invocations (a no-op once cached).
-    expect(loaded).toHaveLength(4);
+    // The second invocation returns the cached load promise.
+    expect(loaded).toHaveLength(2);
   });
 });

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -34,6 +34,48 @@ export function ensureMonoFontsLoaded(): Promise<void> {
   return monoReady;
 }
 
+const registeredLocal = new Set<string>();
+
+// macOS WKWebView won't expose a system-installed font to the canvas/WebGL
+// glyph-atlas rasterizer unless it's a registered FontFace — only the DOM
+// renderer can reach raw system fonts (see #820). Declaring an @font-face that
+// points at the installed font via local() registers it in the FontFaceSet
+// without bundling any file, so the WebGL renderer resolves it the same way it
+// already resolves the bundled JetBrains Mono. Resolves once the faces have
+// loaded, so callers can rebuild stale glyph atlases afterwards.
+export function registerLocalFont(userInput: string): Promise<void> {
+  const name = userInput.trim();
+  // Blank = auto-detected font; a comma = a full stack — neither is a single
+  // local family we can register.
+  if (!name || name.includes(",")) return Promise.resolve();
+  if (typeof document === "undefined" || !document.fonts?.load) {
+    return Promise.resolve();
+  }
+  const family = name.replace(/['"]/g, "");
+  if (!registeredLocal.has(family)) {
+    registeredLocal.add(family);
+    const STYLE_ID = "terax-local-fonts";
+    let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+    if (!style) {
+      style = document.createElement("style");
+      style.id = STYLE_ID;
+      document.head.appendChild(style);
+    }
+    style.appendChild(
+      document.createTextNode(
+        `@font-face{font-family:"${family}";font-weight:400;src:local("${family}");}` +
+          `@font-face{font-family:"${family}";font-weight:700;src:local("${family}");}`,
+      ),
+    );
+  }
+  // With an @font-face now backing the family, these actually load it into the
+  // FontFaceSet (a no-op once cached).
+  return Promise.allSettled([
+    document.fonts.load(`400 14px "${family}"`),
+    document.fonts.load(`700 14px "${family}"`),
+  ]).then(() => undefined);
+}
+
 export function resolveFontFamily(userInput: string): string {
   const name = userInput.trim();
   if (!name) return detectMonoFontFamily();

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -17,24 +17,39 @@ const NERD_FONT_CANDIDATES = [
 ];
 
 const FALLBACK_CHAIN = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
+const WEIGHTS = [400, 700] as const;
 
 let detected: string | null = null;
 let monoReady: Promise<void> | null = null;
 
+function canLoadFonts(): boolean {
+  return typeof document !== "undefined" && !!document.fonts?.load;
+}
+
+function loadFamilyWeights(family: string): Promise<void> {
+  return Promise.allSettled(
+    WEIGHTS.map((w) => document.fonts.load(`${w} 14px "${family}"`)),
+  ).then(() => undefined);
+}
+
+// Blank = auto-detected font; a comma = a full stack — neither is a single
+// local family. Otherwise strip quotes so a stray quote can't produce a
+// malformed token.
+function parseSingleFamily(userInput: string): string | null {
+  const name = userInput.trim();
+  if (!name || name.includes(",")) return null;
+  return name.replace(/['"]/g, "");
+}
+
 export function ensureMonoFontsLoaded(): Promise<void> {
   if (monoReady) return monoReady;
-  if (typeof document === "undefined" || !document.fonts?.load) {
-    monoReady = Promise.resolve();
-    return monoReady;
-  }
-  monoReady = Promise.allSettled([
-    document.fonts.load('400 14px "JetBrains Mono"'),
-    document.fonts.load('700 14px "JetBrains Mono"'),
-  ]).then(() => undefined);
+  monoReady = canLoadFonts()
+    ? loadFamilyWeights("JetBrains Mono")
+    : Promise.resolve();
   return monoReady;
 }
 
-const registeredLocal = new Set<string>();
+const registeredLocal = new Map<string, Promise<void>>();
 
 // macOS WKWebView won't expose a system-installed font to the canvas/WebGL
 // glyph-atlas rasterizer unless it's a registered FontFace — only the DOM
@@ -44,16 +59,10 @@ const registeredLocal = new Set<string>();
 // already resolves the bundled JetBrains Mono. Resolves once the faces have
 // loaded, so callers can rebuild stale glyph atlases afterwards.
 export function registerLocalFont(userInput: string): Promise<void> {
-  const name = userInput.trim();
-  // Blank = auto-detected font; a comma = a full stack — neither is a single
-  // local family we can register.
-  if (!name || name.includes(",")) return Promise.resolve();
-  if (typeof document === "undefined" || !document.fonts?.load) {
-    return Promise.resolve();
-  }
-  const family = name.replace(/['"]/g, "");
-  if (!registeredLocal.has(family)) {
-    registeredLocal.add(family);
+  const family = parseSingleFamily(userInput);
+  if (!family || !canLoadFonts()) return Promise.resolve();
+  let ready = registeredLocal.get(family);
+  if (!ready) {
     const STYLE_ID = "terax-local-fonts";
     let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
     if (!style) {
@@ -61,29 +70,23 @@ export function registerLocalFont(userInput: string): Promise<void> {
       style.id = STYLE_ID;
       document.head.appendChild(style);
     }
-    style.appendChild(
-      document.createTextNode(
-        `@font-face{font-family:"${family}";font-weight:400;src:local("${family}");}` +
-          `@font-face{font-family:"${family}";font-weight:700;src:local("${family}");}`,
-      ),
-    );
+    style.textContent += WEIGHTS.map(
+      (w) =>
+        `@font-face{font-family:"${family}";font-weight:${w};src:local("${family}");}`,
+    ).join("");
+    // With an @font-face now backing the family, this actually loads it into
+    // the FontFaceSet.
+    ready = loadFamilyWeights(family);
+    registeredLocal.set(family, ready);
   }
-  // With an @font-face now backing the family, these actually load it into the
-  // FontFaceSet (a no-op once cached).
-  return Promise.allSettled([
-    document.fonts.load(`400 14px "${family}"`),
-    document.fonts.load(`700 14px "${family}"`),
-  ]).then(() => undefined);
+  return ready;
 }
 
 export function resolveFontFamily(userInput: string): string {
   const name = userInput.trim();
   if (!name) return detectMonoFontFamily();
-  // A comma means the user gave a full stack; otherwise quote the single family.
-  // Strip any quotes first so a stray quote can't produce a malformed token.
-  const head = name.includes(",")
-    ? name
-    : `"${name.replace(/['"]/g, "")}"`;
+  const single = parseSingleFamily(name);
+  const head = single ? `"${single}"` : name;
   return `${head}, ${FALLBACK_CHAIN}`;
 }
 

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -817,12 +817,11 @@ function attachWebgl(slot: Slot): void {
 
 // Rebuild a slot's GPU glyph atlas so any fallback glyphs baked in before the
 // configured font was resident get re-rasterized in the correct font.
+// Terminal.clearTextureAtlas (xterm 6.0.0) drops the active renderer's atlas;
+// the refresh then repaints it against the now-registered font.
 function clearWebglAtlas(slot: Slot): void {
-  const addon = slot.webglAddon as unknown as {
-    clearTextureAtlas?: () => void;
-  } | null;
   try {
-    addon?.clearTextureAtlas?.();
+    slot.term.clearTextureAtlas();
   } catch {}
   try {
     slot.term.refresh(0, slot.term.rows - 1);

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -944,6 +944,14 @@ export function applyTerminalFont(font: RendererFont): void {
     }
     if (refit) refitSlot(slot);
   }
+  // Register the new family as a local FontFace so the WebGL atlas can resolve
+  // it (WKWebView won't otherwise), then rebuild any stale atlases so glyphs
+  // baked in the old/fallback font get re-rasterized (#898). Use the raw
+  // pre-resolution family: registerLocalFont skips stacks, and the resolved
+  // value is always a stack.
+  void registerLocalFont(font.fontFamily).then(() => {
+    for (const slot of slots) clearWebglAtlas(slot);
+  });
 }
 
 export function applyScrollback(value: number): void {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -72,17 +72,18 @@ export type Slot = {
 const slots: Slot[] = [];
 let recyclerEl: HTMLDivElement | null = null;
 let adapter: SlotAdapter | null = null;
-let configuredFont: RendererFont | null = null;
-// Raw (pre-resolution) family behind configuredFont, kept for local()
-// FontFace registration: registerLocalFont needs a single family name, and
-// configuredFont.fontFamily is already resolved into a stack.
-let configuredRawFamily: string | null = null;
+let configuredFont: ConfiguredFont | null = null;
 
 type RendererFont = {
   fontFamily: string;
   fontWeight: string;
   fontSize: number;
 };
+
+// rawFamily keeps the pre-resolution family for local() FontFace
+// registration: registerLocalFont needs a single family name, and fontFamily
+// is already resolved into a stack.
+type ConfiguredFont = RendererFont & { rawFamily: string };
 
 let windowActive =
   typeof document === "undefined" || (!document.hidden && document.hasFocus());
@@ -812,7 +813,8 @@ function attachWebgl(slot: Slot): void {
     // via applyTerminalFont wins over the preference), then rebuild the atlas
     // so it re-rasterizes in the correct font.
     const fam =
-      configuredRawFamily ?? usePreferencesStore.getState().terminalFontFamily;
+      configuredFont?.rawFamily ??
+      usePreferencesStore.getState().terminalFontFamily;
     void registerLocalFont(fam).then(() => {
       if (slot.webglAddon === webgl) clearWebglAtlas(slot);
     });
@@ -828,8 +830,6 @@ function attachWebgl(slot: Slot): void {
 function clearWebglAtlas(slot: Slot): void {
   try {
     slot.term.clearTextureAtlas();
-  } catch {}
-  try {
     slot.term.refresh(0, slot.term.rows - 1);
   } catch {}
 }
@@ -928,13 +928,14 @@ export function applyLetterSpacing(spacing: number): void {
 }
 
 export function applyTerminalFont(font: RendererFont): void {
-  const next = {
+  const next: ConfiguredFont = {
     fontFamily: resolveFontFamily(font.fontFamily),
     fontWeight: font.fontWeight,
     fontSize: font.fontSize,
+    rawFamily: font.fontFamily,
   };
+  const familyChanged = configuredFont?.rawFamily !== next.rawFamily;
   configuredFont = next;
-  configuredRawFamily = font.fontFamily;
   for (const slot of slots) {
     let refit = false;
     if (slot.term.options.fontFamily !== next.fontFamily) {
@@ -955,9 +956,11 @@ export function applyTerminalFont(font: RendererFont): void {
   // baked in the old/fallback font get re-rasterized (#898). Use the raw
   // pre-resolution family: registerLocalFont skips stacks, and the resolved
   // value is always a stack.
-  void registerLocalFont(font.fontFamily).then(() => {
-    for (const slot of slots) clearWebglAtlas(slot);
-  });
+  if (familyChanged) {
+    void registerLocalFont(next.rawFamily).then(() => {
+      for (const slot of slots) clearWebglAtlas(slot);
+    });
+  }
 }
 
 export function applyScrollback(value: number): void {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,4 +1,4 @@
-import { resolveFontFamily } from "@/lib/fonts";
+import { registerLocalFont, resolveFontFamily } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -802,9 +802,31 @@ function attachWebgl(slot: Slot): void {
     for (const c of after) if (!before.has(c)) added.push(c);
     slot.webglAddon = webgl;
     slot.webglCanvases = added;
+    // WKWebView hides system fonts from the WebGL atlas rasterizer unless they
+    // are registered FontFaces, so some cells bake as the fallback font — the
+    // "two fonts" effect (#898). Register the configured font, then rebuild the
+    // atlas so it re-rasterizes in the correct font.
+    const fam = usePreferencesStore.getState().terminalFontFamily;
+    void registerLocalFont(fam).then(() => {
+      if (slot.webglAddon === webgl) clearWebglAtlas(slot);
+    });
   } catch (e) {
     console.warn("[terax-webgl] unavailable:", e);
   }
+}
+
+// Rebuild a slot's GPU glyph atlas so any fallback glyphs baked in before the
+// configured font was resident get re-rasterized in the correct font.
+function clearWebglAtlas(slot: Slot): void {
+  const addon = slot.webglAddon as unknown as {
+    clearTextureAtlas?: () => void;
+  } | null;
+  try {
+    addon?.clearTextureAtlas?.();
+  } catch {}
+  try {
+    slot.term.refresh(0, slot.term.rows - 1);
+  } catch {}
 }
 
 function disposeSlotWebgl(slot: Slot): void {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -73,6 +73,10 @@ const slots: Slot[] = [];
 let recyclerEl: HTMLDivElement | null = null;
 let adapter: SlotAdapter | null = null;
 let configuredFont: RendererFont | null = null;
+// Raw (pre-resolution) family behind configuredFont, kept for local()
+// FontFace registration: registerLocalFont needs a single family name, and
+// configuredFont.fontFamily is already resolved into a stack.
+let configuredRawFamily: string | null = null;
 
 type RendererFont = {
   fontFamily: string;
@@ -804,9 +808,11 @@ function attachWebgl(slot: Slot): void {
     slot.webglCanvases = added;
     // WKWebView hides system fonts from the WebGL atlas rasterizer unless they
     // are registered FontFaces, so some cells bake as the fallback font — the
-    // "two fonts" effect (#898). Register the configured font, then rebuild the
-    // atlas so it re-rasterizes in the correct font.
-    const fam = usePreferencesStore.getState().terminalFontFamily;
+    // "two fonts" effect (#898). Register the effective font (theme override
+    // via applyTerminalFont wins over the preference), then rebuild the atlas
+    // so it re-rasterizes in the correct font.
+    const fam =
+      configuredRawFamily ?? usePreferencesStore.getState().terminalFontFamily;
     void registerLocalFont(fam).then(() => {
       if (slot.webglAddon === webgl) clearWebglAtlas(slot);
     });
@@ -928,6 +934,7 @@ export function applyTerminalFont(font: RendererFont): void {
     fontSize: font.fontSize,
   };
   configuredFont = next;
+  configuredRawFamily = font.fontFamily;
   for (const slot of slots) {
     let refit = false;
     if (slot.term.options.fontFamily !== next.fontFamily) {


### PR DESCRIPTION
Closes #898

Register the configured terminal font as a `local()` `@font-face` so the macOS WKWebView WebGL glyph-atlas rasterizer can resolve it, then rebuild the atlas. Fixes the "two fonts at once" mismatch where a subset of glyphs fell back to bundled JetBrains Mono under the WebGL renderer while the DOM renderer was fine (same mechanism as #820).

<!-- michi:plan -->
- [x] T1 <!--m:f0a1--> Add `registerLocalFont()` to `src/lib/fonts.ts` — inject a `local()` `@font-face` for the configured family and load it into the FontFaceSet, no-op on blank/comma-stack input
- [x] T2 <!--m:b2c3--> Wire it into the WebGL renderer (`rendererPool.ts`): add a `clearWebglAtlas()` helper and register the font + rebuild the atlas on `attachWebgl`
- [x] T3 <!--m:d4e5--> Register + rebuild atlases in `applyFontFamily` so live font-family changes re-resolve under WebGL
- [x] T4 <!--m:a6b7--> Add `registerLocalFont` unit tests to `src/lib/fonts.test.ts` (guards, `@font-face` injection, dedup)
- [x] T5 <!--m:c8d9--> Address review (#918): simplify `clearWebglAtlas` to call `slot.term.clearTextureAtlas()`, dropping the `webglAddon` cast
- [x] T6 <!--m:e0f1--> Rebase onto main after #1011: move the atlas hook into `applyTerminalFont` and register the effective (theme-overridden) family, tracked via `configuredRawFamily`
<!-- /michi:plan -->






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `registerLocalFont` to dynamically register user-provided local font families, including quoted names.
  * The terminal now refreshes its WebGL glyph atlas when the effective font family changes to apply updates immediately.
* **Bug Fixes**
  * Avoided duplicate local font injections and redundant font-face loading via caching.
  * Improved input handling by trimming, ignoring empty/stack inputs, and loading only when browser font APIs are available.
* **Tests**
  * Expanded font registration coverage with Node-friendly document/font mocking and additional edge-case assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


