### PR TITLE
feat(source-control): add hover button to open a changed file for editing

### DIFF
--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -56,6 +56,7 @@ import {
   ArrowUp01Icon,
   CheckmarkCircle01Icon,
   Download01Icon,
+  File01Icon,
   Folder01Icon,
   FolderCloudIcon,
   FolderGitTwoIcon,
@@ -1208,6 +1209,18 @@ const EntryRow = memo(function EntryRow({
               ) : null}
             </div>
           </button>
+
+          {!isDeleted && onOpenFile && absolutePath ? (
+            <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 data-[focused=true]:opacity-100 data-[selected=true]:opacity-100">
+              <IconActionButton
+                label="Open file for editing"
+                side="top"
+                onClick={() => onOpenFile(absolutePath)}
+              >
+                <HugeiconsIcon icon={File01Icon} size={11} strokeWidth={1.9} />
+              </IconActionButton>
+            </div>
+          ) : null}
 
           {showDiscard ? (
             <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 data-[focused=true]:opacity-100 data-[selected=true]:opacity-100">


### PR DESCRIPTION
## What
Add a one-click hover button on each changed-file row in the Source Control panel that opens the **editable** file (not the read-only diff).

## Why
Clicking a changed file opens the read-only diff view. Opening the actual editable file was only reachable via the right-click → "Open File" context-menu item, which is easy to miss. This surfaces that same action as a visible hover control.

## How
Reuses the existing `onOpenFile` handler already wired to the panel. The button renders on row hover next to the stage/discard controls (only for non-deleted files, matching the existing "Open File" menu-item guard). No change to the diff-click behavior or the context menu.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test: hovered a modified file, clicked the button, file opened in an editable editor tab; edited and saved with ⌘S. Deleted files correctly show no button. Diff-on-click and the context-menu "Open File" both still work.
- [x] Platforms tested: macOS

## Screenshots / GIFs
_Hover a changed file row → a file icon button appears beside the stage checkbox; clicking it opens the editable file._

## Notes for reviewer
Tiny, focused change (one file, +13 lines). Pure discoverability win for an action that already existed in the context menu. Happy to adjust the icon or placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline “Open file for editing” action to changed file entries in source control.
  * The action appears only when a file can be opened and is hidden for deleted items.
  * The new control is integrated into each row with hover/focus visibility for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->