### PR TITLE
feat(source-control): show all sub-repos when the workspace root is a container

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -218,6 +218,7 @@ pub fn run() {
             fs::grep::fs_glob,
             git::commands::git_resolve_repo,
             git::commands::git_panel_snapshot,
+            git::commands::git_discover_repos,
             git::commands::git_status,
             git::commands::git_diff,
             git::commands::git_diff_content,

--- a/src-tauri/src/modules/git/commands.rs
+++ b/src-tauri/src/modules/git/commands.rs
@@ -48,6 +48,19 @@ pub async fn git_panel_snapshot(
 }
 
 #[tauri::command]
+pub async fn git_discover_repos(
+    cwd: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<Vec<String>, String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::discover_repos(r, &cwd, &workspace).map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn git_status(
     repo_root: String,
     workspace: Option<WorkspaceEnv>,

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -1284,4 +1284,88 @@ mod tests {
         )));
         assert!(!looks_like_no_head(&mk("fatal: pathspec did not match")));
     }
+
+    fn git_init(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir)
+            .status()
+            .expect("spawn git init")
+            .success();
+        assert!(ok, "git init failed for {dir:?}");
+    }
+
+    fn base_names(mut roots: Vec<String>) -> Vec<String> {
+        roots.sort();
+        roots
+            .iter()
+            .map(|r| {
+                std::path::Path::new(r)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn discover_repos_lists_child_repos_of_a_container() {
+        // container is NOT a repo; it holds two child repos + one plain dir.
+        let tmp = tempfile::tempdir().unwrap();
+        let container = tmp.path().join("workspace");
+        git_init(&container.join("repoA"));
+        git_init(&container.join("repoB"));
+        std::fs::create_dir_all(container.join("plain")).unwrap();
+
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(&container).unwrap();
+        let ws = WorkspaceEnv::default();
+
+        let roots = discover_repos(&registry, container.to_str().unwrap(), &ws).unwrap();
+        assert_eq!(base_names(roots), vec!["repoA", "repoB"]);
+    }
+
+    #[test]
+    fn discover_repos_returns_single_repo_when_cwd_is_inside_one() {
+        // cwd is inside a repo → just that repo, not a child scan.
+        let tmp = tempfile::tempdir().unwrap();
+        let container = tmp.path().join("workspace");
+        let repo = container.join("repoA");
+        git_init(&repo);
+        std::fs::create_dir_all(repo.join("sub")).unwrap();
+
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(&container).unwrap();
+        let ws = WorkspaceEnv::default();
+
+        // From the repo root and from a nested subdir, both resolve to the one repo.
+        assert_eq!(
+            base_names(discover_repos(&registry, repo.to_str().unwrap(), &ws).unwrap()),
+            vec!["repoA"],
+        );
+        assert_eq!(
+            base_names(discover_repos(&registry, repo.join("sub").to_str().unwrap(), &ws).unwrap()),
+            vec!["repoA"],
+        );
+    }
+
+    #[test]
+    fn discover_repos_rejects_unauthorized_path() {
+        // A path outside every authorized root must be denied, not scanned.
+        let tmp = tempfile::tempdir().unwrap();
+        let authorized = tmp.path().join("authorized");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&authorized).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let registry = WorkspaceRegistry::default();
+        registry.authorize(&authorized).unwrap();
+        let ws = WorkspaceEnv::default();
+
+        let err = discover_repos(&registry, outside.to_str().unwrap(), &ws)
+            .expect_err("unauthorized path must be rejected");
+        assert!(matches!(err, GitError::PathOutsideWorkspace(_)));
+    }
 }

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -81,6 +81,65 @@ fn resolve_repo_in_authorized(
     }))
 }
 
+/// Resolve every git repository reachable from `cwd` for the source-control panel.
+/// If `cwd` is itself inside a repo, returns that single repo root. Otherwise treats
+/// `cwd` as a multi-repo container and returns each immediate child that is its own
+/// repository (dir or worktree), sorted. Enables one panel to show all sub-repos when
+/// the opened workspace root is just a container (e.g. a git-worktree workspace).
+pub fn discover_repos(
+    registry: &WorkspaceRegistry,
+    cwd: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<Vec<String>> {
+    let cwd = canonical_dir(registry, cwd, workspace)?;
+    if !registry.is_authorized(&cwd.local_path) {
+        return Err(GitError::PathOutsideWorkspace(cwd.local_path));
+    }
+    ensure_git_available(&cwd.workspace)?;
+
+    // Directory itself inside a repo → that single repo is the whole result.
+    if let Some(root_line) = git_stdout_line_opt(
+        &cwd.workspace,
+        &cwd.git_path,
+        ["rev-parse", "--show-toplevel"],
+    )? {
+        let canonical_root = canonical_dir(registry, &root_line, &cwd.workspace)?;
+        let _ = registry.authorize(&canonical_root.local_path);
+        return Ok(vec![canonical_root.git_path]);
+    }
+
+    // Otherwise scan immediate children; each holding a `.git` (dir or worktree file)
+    // is its own repository.
+    // ponytail: one level deep, local FS only — matches the worktree workspace layout;
+    // recurse or honor a config depth if a deeper container ever shows up.
+    let mut roots: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(&cwd.local_path)
+        .map_err(GitError::Io)?
+        .flatten()
+    {
+        let path = entry.path();
+        if !path.is_dir() || !path.join(".git").exists() {
+            continue;
+        }
+        let Some(child_str) = path.to_str() else {
+            continue;
+        };
+        let child = canonical_dir(registry, child_str, &cwd.workspace)?;
+        if let Some(root_line) = git_stdout_line_opt(
+            &child.workspace,
+            &child.git_path,
+            ["rev-parse", "--show-toplevel"],
+        )? {
+            let canonical_root = canonical_dir(registry, &root_line, &child.workspace)?;
+            let _ = registry.authorize(&canonical_root.local_path);
+            roots.push(canonical_root.git_path);
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    Ok(roots)
+}
+
 pub fn panel_snapshot(
     registry: &WorkspaceRegistry,
     cwd: &str,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -579,8 +579,12 @@ export default function App() {
     activeTab?.kind === "editor" || activeTab?.kind === "markdown"
       ? activeTab.path
       : null;
-  const { sourceControl, toggleSourceControl, openGitGraphFromContext } =
-    useSourceControlContext({
+  const {
+    sourceControl,
+    sourceControlPath,
+    toggleSourceControl,
+    openGitGraphFromContext,
+  } = useSourceControlContext({
       activeTab,
       tabs,
       activeTerminalLeafCwd,
@@ -1131,6 +1135,7 @@ export default function App() {
                     ) : (
                       <SourceControlPanel
                         open
+                        scanPath={sourceControlPath}
                         sourceControl={sourceControl}
                         onOpenDiff={openGitDiffTab}
                         onOpenGitGraph={openGitGraphFromContext}

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -268,6 +268,11 @@ export const native = {
       cwd,
       workspace: currentWorkspaceEnv(),
     }),
+  gitDiscoverRepos: (cwd: string) =>
+    invoke<string[]>("git_discover_repos", {
+      cwd,
+      workspace: currentWorkspaceEnv(),
+    }),
   gitStatus: (repoRoot: string) =>
     invoke<GitStatusSnapshot>("git_status", {
       repoRoot,

--- a/src/modules/source-control/SourceControlMultiPanel.tsx
+++ b/src/modules/source-control/SourceControlMultiPanel.tsx
@@ -1,0 +1,122 @@
+import { type ComponentProps, memo, useEffect, useMemo, useState } from "react";
+import { native } from "@/modules/ai/lib/native";
+import { SourceControlPanel } from "./SourceControlPanel";
+import { useSourceControl } from "./useSourceControl";
+
+type PanelProps = ComponentProps<typeof SourceControlPanel>;
+type SharedPanelProps = Omit<PanelProps, "open" | "sourceControl">;
+
+type Props = PanelProps & {
+  /** Directory the panel is probing; scanned for sub-repos when it is not itself a repo. */
+  scanPath: string | null;
+};
+
+/**
+ * Wraps the single-repo SourceControlPanel with multi-root support: when the active
+ * workspace directory is not itself a git repo but contains child repositories (e.g. a
+ * git-worktree workspace), render one collapsible SourceControlPanel per child repo so
+ * every sub-repo's changes show on one screen. Falls back to the original single panel
+ * when the cwd is inside a repo, or when no child repos are found.
+ */
+export const SourceControlMultiPanel = memo(function SourceControlMultiPanel({
+  scanPath,
+  sourceControl,
+  open,
+  ...shared
+}: Props) {
+  // null = discovery for the current scanPath hasn't resolved yet.
+  const [roots, setRoots] = useState<string[] | null>(null);
+
+  // Re-discover on every scanPath change — NOT gated on the parent summary, whose
+  // hasRepo lags behind tab switches and would otherwise keep the panel stuck on a
+  // closed tab's single repo.
+  useEffect(() => {
+    let cancelled = false;
+    if (!scanPath) {
+      setRoots([]);
+      return;
+    }
+    native
+      .gitDiscoverRepos(scanPath)
+      .then((r) => {
+        if (!cancelled) setRoots(r);
+      })
+      .catch(() => {
+        if (!cancelled) setRoots([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [scanPath]);
+
+  // Multiple sibling repos under the directory → one collapsible section each.
+  if (roots && roots.length > 1) {
+    return (
+      <div className="flex h-full min-w-0 flex-col overflow-y-auto bg-card/80 backdrop-blur">
+        {roots.map((root) => (
+          <RepoSection key={root} repoRoot={root} shared={shared} />
+        ))}
+      </div>
+    );
+  }
+
+  // 0 or 1 repo, or discovery still loading → original single-repo panel.
+  return (
+    <SourceControlPanel open={open} sourceControl={sourceControl} {...shared} />
+  );
+});
+
+const RepoSection = memo(function RepoSection({
+  repoRoot,
+  shared,
+}: {
+  repoRoot: string;
+  shared: SharedPanelProps;
+}) {
+  const [open, setOpen] = useState(true);
+  // Keep enabled even when collapsed so the header still shows the changed count.
+  const sc = useSourceControl(repoRoot, true);
+  const name = useMemo(
+    () => repoRoot.replace(/\/+$/, "").split("/").pop() || repoRoot,
+    [repoRoot],
+  );
+
+  return (
+    <div className="flex shrink-0 flex-col border-b border-border/40">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex shrink-0 items-center gap-2 px-3 py-2 text-left hover:bg-foreground/[0.04]"
+      >
+        <span className="text-[10px] text-muted-foreground/70">
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="truncate text-[12px] font-semibold text-foreground/90">
+          {name}
+        </span>
+        {sc.status?.branch ? (
+          <span className="truncate text-[11px] font-normal text-muted-foreground">
+            {sc.status.isDetached ? "detached" : sc.status.branch}
+          </span>
+        ) : null}
+        {sc.changedCount > 0 ? (
+          <span className="ml-auto rounded-full bg-foreground/10 px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground">
+            {sc.changedCount}
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        // ponytail: fixed section height keeps each embedded panel's internal scroll
+        // working; make it resizable if users want to grow one repo.
+        <div className="h-[22rem] shrink-0 border-t border-border/30">
+          <SourceControlPanel
+            open
+            sourceControl={sc}
+            {...shared}
+            onOpenGitGraph={undefined}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/src/modules/source-control/SourceControlPanelLazy.tsx
+++ b/src/modules/source-control/SourceControlPanelLazy.tsx
@@ -1,10 +1,10 @@
 import { lazy, Suspense } from "react";
 import type { ComponentProps } from "react";
-import type { SourceControlPanel as SourceControlPanelType } from "./SourceControlPanel";
+import type { SourceControlMultiPanel as SourceControlPanelType } from "./SourceControlMultiPanel";
 
 const SourceControlPanelInner = lazy(() =>
-  import("./SourceControlPanel").then((m) => ({
-    default: m.SourceControlPanel,
+  import("./SourceControlMultiPanel").then((m) => ({
+    default: m.SourceControlMultiPanel,
   })),
 );
 

--- a/src/modules/source-control/useSourceControlContext.ts
+++ b/src/modules/source-control/useSourceControlContext.ts
@@ -107,5 +107,10 @@ export function useSourceControlContext({
     sourceControlContextPath,
   ]);
 
-  return { sourceControl, toggleSourceControl, openGitGraphFromContext };
+  return {
+    sourceControl,
+    sourceControlPath,
+    toggleSourceControl,
+    openGitGraphFromContext,
+  };
 }


### PR DESCRIPTION
> **Draft — overlaps with #639.** Opening for discussion, not asking for a merge over that PR. See "Relationship to #639" below; happy to close this and fold the idea into #639 if you prefer.

## What
When the active workspace directory is **not itself** a git repo but **contains** child repositories (e.g. a git-worktree workspace holding several repos), render one collapsible Source Control section **per child repo, all on one screen** — instead of showing "No repository".

## Why
Multi-repo / worktree workspaces open at a container directory that has no `.git` of its own, so the panel shows "No repository" even though every subfolder is a repo. This surfaces all of them at once.

## Relationship to #639
#639 also adds multi-repo support, with a **repo-switcher dropdown** (one repo visible at a time, auto-switching on editor focus) and a depth-3 recursive scan. This PR takes a different UX: **all sub-repos shown simultaneously** as stacked collapsible sections (VS Code multi-root style), with a **one-level** scan of the container. Different enough that I wanted to show it; if #639 is the chosen direction I'll close this.

## How
- Backend `git::operations::discover_repos` + `git_discover_repos` command: if cwd is inside a repo → that single repo; else scan immediate children for `.git` (handles worktree `.git` files) → sorted repo roots. Authorization reuses the existing prefix-based `is_authorized`.
- Frontend `SourceControlMultiPanel` wraps the existing single-repo `SourceControlPanel`, rendering one per discovered repo. Discovery re-runs on every `scanPath` change so tab switches don't leave the panel stuck on a closed tab's single repo. Single-repo behavior is unchanged.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test: opened a worktree workspace containing 4 repos → 4 collapsible sections, each with its own changes/stage/commit/push; opening inside a single repo → unchanged single panel.
- [ ] **`cargo test` for the git command layer — not yet added.** CONTRIBUTING requires a test for changes to the git command layer (repo-root resolution / discovery). I'd add one for `discover_repos` (container-with-children, cwd-inside-repo, deny path) before this leaves draft.
- [x] Platforms tested: macOS

## Screenshots / GIFs
_Container workspace: Source Control shows one collapsible section per sub-repo (account / community / …), each with its own file list and actions._

## Notes for reviewer
Main open questions: (1) is the "show all at once" UX wanted at all vs. #639's switcher; (2) one-level scan vs. #639's depth-3. Will add the required Rust test once there's a signal this direction is worth pursuing — didn't want to invest the test before confirming it's not just duplicating #639.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source control can now detect multiple Git repositories inside a selected folder and show them as separate sections.
  * The source control view now uses the current scan location to surface repository roots more accurately.

* **Bug Fixes**
  * Improved repository detection for nested folders and repo worktrees.
  * Unauthorized locations are now rejected more reliably when scanning for repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->