### PR TITLE
feat(source-control): commit history panel in sidebar with undo last commit

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,6 +231,7 @@ pub fn run() {
             git::commands::git_unstage,
             git::commands::git_discard,
             git::commands::git_commit,
+            git::commands::git_undo_commit,
             git::commands::git_fetch,
             git::commands::git_pull_ff_only,
             git::commands::git_push,

--- a/src-tauri/src/modules/git/commands.rs
+++ b/src-tauri/src/modules/git/commands.rs
@@ -156,6 +156,21 @@ pub async fn git_commit(
 }
 
 #[tauri::command]
+pub async fn git_undo_commit(
+    repo_root: String,
+    expected_head_sha: String,
+    workspace: Option<WorkspaceEnv>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let workspace = WorkspaceEnv::from_option(workspace);
+    blocking(app, move |r| {
+        operations::undo_last_commit(r, &repo_root, &expected_head_sha, &workspace)
+            .map_err(Into::into)
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn git_fetch(
     repo_root: String,
     workspace: Option<WorkspaceEnv>,

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -445,38 +445,51 @@ pub fn undo_last_commit(
     let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
     ensure_git_available(&repo_root.workspace)?;
 
-    let head = git_stdout_line_opt(&repo_root.workspace, &repo_root.git_path, ["rev-parse", "HEAD"])?
-        .ok_or(GitError::CommandFailed {
-            context: "failed to resolve HEAD",
-            detail: String::new(),
-        })?;
-    if head != expected_head_sha {
+    if expected_head_sha.len() != 40
+        || !expected_head_sha.bytes().all(|b| b.is_ascii_hexdigit())
+    {
         return Err(GitError::command(
-            "git reset",
-            "HEAD changed since the commit list was loaded; refresh and try again",
+            "git update-ref",
+            "expected a full commit sha",
         ));
     }
 
-    let has_parent = git_stdout_line_opt(
+    // Derive the parent from the expected sha, not from HEAD, so a racing
+    // commit cannot redirect which commit gets undone.
+    let parent = git_stdout_line_opt(
         &repo_root.workspace,
         &repo_root.git_path,
-        ["rev-parse", "--verify", "--quiet", "HEAD~1"],
+        [
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{expected_head_sha}^"),
+        ],
     )?
-    .is_some();
-    if !has_parent {
-        return Err(GitError::command(
-            "git reset",
-            "cannot undo the initial commit",
-        ));
-    }
+    .ok_or_else(|| GitError::command("git update-ref", "cannot undo the initial commit"))?;
 
+    // A soft reset is just a ref move; update-ref with an old-value check makes
+    // it an atomic compare-and-swap, so HEAD moving after the commit list was
+    // loaded fails the update instead of discarding the wrong commit.
     let output = run_git(
         &repo_root.workspace,
         Some(&repo_root.git_path),
-        ["reset", "--soft", "HEAD~1"],
+        [
+            "update-ref",
+            "-m",
+            "reset: moving to HEAD~1 (undo last commit)",
+            "HEAD",
+            &parent,
+            expected_head_sha,
+        ],
         DEFAULT_TIMEOUT_SECS,
     )?;
-    ensure_success(&output, "git reset failed")?;
+    if output.exit_code != Some(0) {
+        return Err(GitError::command(
+            "git update-ref",
+            "HEAD changed since the commit list was loaded; refresh and try again",
+        ));
+    }
     Ok(())
 }
 

--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -436,6 +436,50 @@ pub fn commit(
     })
 }
 
+pub fn undo_last_commit(
+    registry: &WorkspaceRegistry,
+    repo_root: &str,
+    expected_head_sha: &str,
+    workspace: &WorkspaceEnv,
+) -> Result<()> {
+    let repo_root = authorized_repo_root(registry, repo_root, workspace)?;
+    ensure_git_available(&repo_root.workspace)?;
+
+    let head = git_stdout_line_opt(&repo_root.workspace, &repo_root.git_path, ["rev-parse", "HEAD"])?
+        .ok_or(GitError::CommandFailed {
+            context: "failed to resolve HEAD",
+            detail: String::new(),
+        })?;
+    if head != expected_head_sha {
+        return Err(GitError::command(
+            "git reset",
+            "HEAD changed since the commit list was loaded; refresh and try again",
+        ));
+    }
+
+    let has_parent = git_stdout_line_opt(
+        &repo_root.workspace,
+        &repo_root.git_path,
+        ["rev-parse", "--verify", "--quiet", "HEAD~1"],
+    )?
+    .is_some();
+    if !has_parent {
+        return Err(GitError::command(
+            "git reset",
+            "cannot undo the initial commit",
+        ));
+    }
+
+    let output = run_git(
+        &repo_root.workspace,
+        Some(&repo_root.git_path),
+        ["reset", "--soft", "HEAD~1"],
+        DEFAULT_TIMEOUT_SECS,
+    )?;
+    ensure_success(&output, "git reset failed")?;
+    Ok(())
+}
+
 pub fn push(
     registry: &WorkspaceRegistry,
     repo_root: &str,

--- a/src-tauri/tests/git_operations.rs
+++ b/src-tauri/tests/git_operations.rs
@@ -564,3 +564,88 @@ fn list_branches_keeps_current_branch_local_and_surfaces_worktrees() {
     assert!(!feature[0].is_head);
     assert!(feature[0].worktree_path.is_some());
 }
+
+#[test]
+fn undo_last_commit_moves_changes_back_to_index() {
+    if skip_if_no_git() {
+        return;
+    }
+    let fx = GitRepoFixture::new();
+    fx.write_file("a.txt", "alpha\n");
+    fx.run_git(&["add", "a.txt"]);
+    fx.run_git(&["commit", "-q", "-m", "first"]);
+    fx.write_file("b.txt", "beta\n");
+    fx.run_git(&["add", "b.txt"]);
+    fx.run_git(&["commit", "-q", "-m", "second"]);
+
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
+        .expect("log");
+    assert_eq!(entries.len(), 2);
+    let head_sha = entries[0].sha.clone();
+
+    operations::undo_last_commit(&fx.registry, &fx.repo_str(), &head_sha, &fx.workspace)
+        .expect("undo");
+
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
+        .expect("log after undo");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].subject, "first");
+
+    let snap = operations::status(&fx.registry, &fx.repo_str(), &fx.workspace).unwrap();
+    let entry = snap
+        .changed_files
+        .iter()
+        .find(|f| f.path == "b.txt")
+        .expect("b.txt back in index");
+    assert!(entry.staged);
+}
+
+#[test]
+fn undo_last_commit_rejects_stale_head_sha() {
+    if skip_if_no_git() {
+        return;
+    }
+    let fx = GitRepoFixture::new();
+    fx.write_file("a.txt", "alpha\n");
+    fx.run_git(&["add", "a.txt"]);
+    fx.run_git(&["commit", "-q", "-m", "first"]);
+    fx.write_file("b.txt", "beta\n");
+    fx.run_git(&["add", "b.txt"]);
+    fx.run_git(&["commit", "-q", "-m", "second"]);
+
+    let err = operations::undo_last_commit(
+        &fx.registry,
+        &fx.repo_str(),
+        "0000000000000000000000000000000000000000",
+        &fx.workspace,
+    )
+    .expect_err("stale sha must be rejected");
+    assert!(matches!(err, GitError::CommandFailed { .. }));
+
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
+        .expect("log");
+    assert_eq!(entries.len(), 2, "history must be untouched");
+}
+
+#[test]
+fn undo_last_commit_rejects_initial_commit() {
+    if skip_if_no_git() {
+        return;
+    }
+    let fx = GitRepoFixture::new();
+    fx.write_file("a.txt", "alpha\n");
+    fx.run_git(&["add", "a.txt"]);
+    fx.run_git(&["commit", "-q", "-m", "first"]);
+
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
+        .expect("log");
+    let head_sha = entries[0].sha.clone();
+
+    let err = operations::undo_last_commit(&fx.registry, &fx.repo_str(), &head_sha, &fx.workspace)
+        .expect_err("initial commit cannot be undone");
+    assert!(matches!(err, GitError::CommandFailed { .. }));
+
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
+        .expect("log");
+    assert_eq!(entries.len(), 1, "history must be untouched");
+}

--- a/src-tauri/tests/git_operations.rs
+++ b/src-tauri/tests/git_operations.rs
@@ -613,13 +613,23 @@ fn undo_last_commit_rejects_stale_head_sha() {
     fx.run_git(&["add", "b.txt"]);
     fx.run_git(&["commit", "-q", "-m", "second"]);
 
+    // A sha that exists and has a parent but is no longer HEAD: the atomic
+    // compare-and-swap must refuse to move the ref.
+    let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)
+        .expect("log");
+    let stale_sha = entries[1].sha.clone();
+    let err =
+        operations::undo_last_commit(&fx.registry, &fx.repo_str(), &stale_sha, &fx.workspace)
+            .expect_err("stale sha must be rejected");
+    assert!(matches!(err, GitError::CommandFailed { .. }));
+
     let err = operations::undo_last_commit(
         &fx.registry,
         &fx.repo_str(),
-        "0000000000000000000000000000000000000000",
+        "not-a-sha",
         &fx.workspace,
     )
-    .expect_err("stale sha must be rejected");
+    .expect_err("malformed sha must be rejected");
     assert!(matches!(err, GitError::CommandFailed { .. }));
 
     let entries = operations::log(&fx.registry, &fx.repo_str(), 10, None, &fx.workspace)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1136,6 +1136,7 @@ export default function App() {
                         onOpenGitGraph={openGitGraphFromContext}
                         onOpenFile={handleOpenFile}
                         onNavigateToPath={cdInNewTab}
+                        onOpenCommitFile={openCommitFileDiffTab}
                       />
                     )}
                   </div>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -595,6 +595,9 @@ export default function App() {
   const explorerGitDecorations = usePreferencesStore(
     (s) => s.explorerGitDecorations,
   );
+  const sourceControlUndoCommit = usePreferencesStore(
+    (s) => s.sourceControlUndoCommit,
+  );
 
   const openPreviewTab = useCallback(
     (url: string) => {
@@ -1137,6 +1140,7 @@ export default function App() {
                         onOpenFile={handleOpenFile}
                         onNavigateToPath={cdInNewTab}
                         onOpenCommitFile={openCommitFileDiffTab}
+                        showUndoCommit={sourceControlUndoCommit}
                       />
                     )}
                   </div>

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -317,6 +317,12 @@ export const native = {
       message,
       workspace: currentWorkspaceEnv(),
     }),
+  gitUndoCommit: (repoRoot: string, expectedHeadSha: string) =>
+    invoke<void>("git_undo_commit", {
+      repoRoot,
+      expectedHeadSha,
+      workspace: currentWorkspaceEnv(),
+    }),
   gitFetch: (repoRoot: string) =>
     invoke<void>("git_fetch", {
       repoRoot,

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -146,6 +146,7 @@ export type Preferences = {
   editorWordWrap: boolean;
   showHidden: boolean;
   explorerGitDecorations: boolean;
+  sourceControlUndoCommit: boolean;
   terminalWebglEnabled: boolean;
   terminalCursorBlink: boolean;
   terminalFontFamily: string;
@@ -213,6 +214,7 @@ const KEY_EDITOR_WORD_WRAP = "editorWordWrap";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_EXPLORER_GIT_DECORATIONS = "explorerGitDecorations";
+const KEY_SOURCE_CONTROL_UNDO_COMMIT = "sourceControlUndoCommit";
 const KEY_TERMINAL_WEBGL_ENABLED = "terminalWebglEnabled";
 const KEY_TERMINAL_CURSOR_BLINK = "terminalCursorBlink";
 const KEY_TERMINAL_FONT_FAMILY = "terminalFontFamily";
@@ -281,6 +283,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   editorWordWrap: false,
   showHidden: false,
   explorerGitDecorations: true,
+  sourceControlUndoCommit: true,
   terminalWebglEnabled: true,
   terminalCursorBlink: false,
   terminalFontFamily: "",
@@ -417,6 +420,9 @@ export async function loadPreferences(): Promise<Preferences> {
     explorerGitDecorations:
       get<boolean>(KEY_EXPLORER_GIT_DECORATIONS) ??
       DEFAULT_PREFERENCES.explorerGitDecorations,
+    sourceControlUndoCommit:
+      get<boolean>(KEY_SOURCE_CONTROL_UNDO_COMMIT) ??
+      DEFAULT_PREFERENCES.sourceControlUndoCommit,
     terminalWebglEnabled:
       get<boolean>(KEY_TERMINAL_WEBGL_ENABLED) ??
       DEFAULT_PREFERENCES.terminalWebglEnabled,
@@ -650,6 +656,12 @@ export async function setExplorerGitDecorations(value: boolean): Promise<void> {
   await writePref(KEY_EXPLORER_GIT_DECORATIONS, value);
 }
 
+export async function setSourceControlUndoCommit(
+  value: boolean,
+): Promise<void> {
+  await writePref(KEY_SOURCE_CONTROL_UNDO_COMMIT, value);
+}
+
 export async function setTerminalWebglEnabled(value: boolean): Promise<void> {
   await writePref(KEY_TERMINAL_WEBGL_ENABLED, value);
 }
@@ -786,6 +798,7 @@ export async function onPreferencesChange(
     [KEY_EDITOR_WORD_WRAP]: "editorWordWrap",
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_EXPLORER_GIT_DECORATIONS]: "explorerGitDecorations",
+    [KEY_SOURCE_CONTROL_UNDO_COMMIT]: "sourceControlUndoCommit",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",
     [KEY_TERMINAL_CURSOR_BLINK]: "terminalCursorBlink",
     [KEY_TERMINAL_FONT_FAMILY]: "terminalFontFamily",

--- a/src/modules/source-control/CommitHistorySection.tsx
+++ b/src/modules/source-control/CommitHistorySection.tsx
@@ -1,0 +1,501 @@
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import {
+  native,
+  type GitCommitFileChange,
+  type GitLogEntry,
+} from "@/modules/ai/lib/native";
+import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  GitBranchIcon,
+  Refresh01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+
+export const HISTORY_HEADER_PX = 29;
+
+const PAGE_SIZE = 30;
+const NEAR_BOTTOM_PX = 160;
+const FILES_CACHE_LIMIT = 16;
+
+type CommitFileDiffOpenInput = {
+  repoRoot: string;
+  sha: string;
+  shortSha: string;
+  subject: string;
+  path: string;
+  originalPath: string | null;
+};
+
+type Props = {
+  repoRoot: string | null;
+  refreshKey: unknown;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  onOpenCommitFile: (input: CommitFileDiffOpenInput) => void;
+  onOpenGitGraph?: () => void;
+};
+
+type LoadStatus = "idle" | "initial" | "more" | "error";
+
+type FilesEntry =
+  | { state: "loading" }
+  | { state: "loaded"; files: GitCommitFileChange[] }
+  | { state: "error"; error: string };
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : path;
+}
+
+function normalizeError(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "Unknown error";
+}
+
+export function relativeTime(secs: number, nowMs: number): string {
+  if (!secs) return "";
+  const diff = Math.max(0, Math.floor(nowMs / 1000) - secs);
+  if (diff < 60) return "now";
+  const mins = Math.floor(diff / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.floor(months / 12)}y`;
+}
+
+function statusTone(code: string): string {
+  switch (code.toUpperCase()) {
+    case "A":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "M":
+      return "text-amber-600 dark:text-amber-300";
+    case "D":
+      return "text-rose-600 dark:text-rose-400";
+    case "R":
+    case "C":
+      return "text-sky-600 dark:text-sky-300";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+export function CommitHistorySection({
+  repoRoot,
+  refreshKey,
+  collapsed,
+  onToggleCollapsed,
+  onOpenCommitFile,
+  onOpenGitGraph,
+}: Props) {
+  const [commits, setCommits] = useState<GitLogEntry[]>([]);
+  const [loadStatus, setLoadStatus] = useState<LoadStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [endReached, setEndReached] = useState(false);
+  const [expandedSha, setExpandedSha] = useState<string | null>(null);
+  const [filesTick, setFilesTick] = useState(0);
+
+  const requestIdRef = useRef(0);
+  const inflightMoreRef = useRef(false);
+  const filesInflightRef = useRef(new Set<string>());
+  const filesCacheRef = useRef(new Map<string, FilesEntry>());
+  const commitsRef = useRef<GitLogEntry[]>([]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const bumpFiles = useCallback(() => setFilesTick((n) => n + 1), []);
+
+  const replaceCommits = useCallback((entries: GitLogEntry[]) => {
+    commitsRef.current = entries;
+    setCommits(entries);
+  }, []);
+
+  const loadInitial = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (!repoRoot) {
+      replaceCommits([]);
+      setLoadStatus("idle");
+      setError(null);
+      setEndReached(true);
+      return;
+    }
+    setLoadStatus("initial");
+    setError(null);
+    try {
+      const entries = await native.gitLog(repoRoot, { limit: PAGE_SIZE });
+      if (requestId !== requestIdRef.current) return;
+      const prev = commitsRef.current;
+      const unchanged =
+        prev.length >= entries.length &&
+        entries.every((e, i) => prev[i]?.sha === e.sha);
+      if (!unchanged) {
+        filesInflightRef.current.clear();
+        filesCacheRef.current.clear();
+        bumpFiles();
+        setExpandedSha(null);
+        replaceCommits(entries);
+        setEndReached(entries.length < PAGE_SIZE);
+      }
+      setLoadStatus("idle");
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      setError(normalizeError(err));
+      setLoadStatus("error");
+    }
+  }, [bumpFiles, repoRoot, replaceCommits]);
+
+  const loadMore = useCallback(async () => {
+    if (!repoRoot) return;
+    if (inflightMoreRef.current || endReached) return;
+    if (loadStatus !== "idle") return;
+    const last = commitsRef.current[commitsRef.current.length - 1];
+    if (!last) return;
+    inflightMoreRef.current = true;
+    setLoadStatus("more");
+    try {
+      const entries = await native.gitLog(repoRoot, {
+        limit: PAGE_SIZE,
+        beforeSha: last.sha,
+      });
+      const seen = new Set(commitsRef.current.map((c) => c.sha));
+      const merged = [...commitsRef.current];
+      for (const e of entries) if (!seen.has(e.sha)) merged.push(e);
+      replaceCommits(merged);
+      if (entries.length < PAGE_SIZE) setEndReached(true);
+      setLoadStatus("idle");
+    } catch (err) {
+      setError(normalizeError(err));
+      setLoadStatus("error");
+    } finally {
+      inflightMoreRef.current = false;
+    }
+  }, [endReached, loadStatus, repoRoot, replaceCommits]);
+
+  const lastRepoRef = useRef<string | null | undefined>(undefined);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey re-runs the initial load after commit/push/refresh
+  useEffect(() => {
+    if (lastRepoRef.current !== repoRoot) {
+      lastRepoRef.current = repoRoot;
+      filesInflightRef.current.clear();
+      filesCacheRef.current.clear();
+      bumpFiles();
+      setExpandedSha(null);
+      replaceCommits([]);
+    }
+    void loadInitial();
+  }, [bumpFiles, loadInitial, refreshKey, repoRoot, replaceCommits]);
+
+  const fetchFiles = useCallback(
+    async (sha: string) => {
+      if (!repoRoot) return;
+      if (filesInflightRef.current.has(sha)) return;
+      const cache = filesCacheRef.current;
+      const existing = cache.get(sha);
+      if (existing && existing.state !== "error") return;
+      filesInflightRef.current.add(sha);
+      cache.set(sha, { state: "loading" });
+      bumpFiles();
+      try {
+        const files = await native.gitCommitFiles(repoRoot, sha);
+        cache.set(sha, { state: "loaded", files });
+        while (cache.size > FILES_CACHE_LIMIT) {
+          const oldest = cache.keys().next().value;
+          if (oldest === undefined || oldest === sha) break;
+          cache.delete(oldest);
+        }
+        bumpFiles();
+      } catch (err) {
+        cache.set(sha, { state: "error", error: normalizeError(err) });
+        bumpFiles();
+      } finally {
+        filesInflightRef.current.delete(sha);
+      }
+    },
+    [bumpFiles, repoRoot],
+  );
+
+  const toggleCommit = useCallback(
+    (sha: string) => {
+      setExpandedSha((prev) => (prev === sha ? null : sha));
+      void fetchFiles(sha);
+    },
+    [fetchFiles],
+  );
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const remaining = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (remaining < NEAR_BOTTOM_PX) void loadMore();
+  }, [loadMore]);
+
+  useEffect(() => {
+    if (collapsed) return;
+    if (loadStatus !== "idle" || endReached || commits.length === 0) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    if (el.scrollHeight - el.clientHeight > NEAR_BOTTOM_PX) return;
+    const id = window.setTimeout(() => void loadMore(), 0);
+    return () => window.clearTimeout(id);
+  }, [collapsed, commits.length, endReached, loadMore, loadStatus]);
+
+  const handleRefresh = useCallback(() => {
+    void loadInitial();
+  }, [loadInitial]);
+
+  const nowMs = Date.now();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col border-t border-border/50">
+      <div
+        className="group flex shrink-0 items-center gap-1 px-2"
+        style={{ height: HISTORY_HEADER_PX }}
+      >
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-left text-muted-foreground transition-colors hover:text-foreground"
+          aria-expanded={!collapsed}
+        >
+          <HugeiconsIcon
+            icon={collapsed ? ArrowRight01Icon : ArrowDown01Icon}
+            size={11}
+            strokeWidth={2.2}
+            className="shrink-0"
+          />
+          <span className="truncate text-[10.5px] font-semibold uppercase tracking-wider">
+            Commits
+          </span>
+        </button>
+        <div
+          className={cn(
+            "flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100",
+            !collapsed && "opacity-100",
+          )}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                aria-label="Refresh commits"
+                className="size-5 cursor-pointer rounded text-muted-foreground hover:text-foreground"
+                onClick={handleRefresh}
+              >
+                <HugeiconsIcon icon={Refresh01Icon} size={11.5} strokeWidth={1.9} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-[10.5px]">
+              Refresh commits
+            </TooltipContent>
+          </Tooltip>
+          {onOpenGitGraph ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="Open commit graph"
+                  className="size-5 cursor-pointer rounded text-muted-foreground hover:text-foreground"
+                  onClick={onOpenGitGraph}
+                >
+                  <HugeiconsIcon
+                    icon={GitBranchIcon}
+                    size={11.5}
+                    strokeWidth={1.9}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-[10.5px]">
+                Open commit graph
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+      </div>
+
+      {collapsed ? null : (
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]"
+        >
+          {loadStatus === "initial" && commits.length === 0 ? (
+            <div className="flex items-center justify-center py-6">
+              <Spinner className="size-3.5" />
+            </div>
+          ) : loadStatus === "error" && commits.length === 0 ? (
+            <div className="space-y-2 px-3 py-4 text-[11px] text-muted-foreground">
+              <p className="break-words">{error}</p>
+              <Button size="xs" variant="secondary" onClick={handleRefresh}>
+                Retry
+              </Button>
+            </div>
+          ) : commits.length === 0 ? (
+            <p className="px-3 py-4 text-[11px] text-muted-foreground">
+              No commits yet.
+            </p>
+          ) : (
+            <div data-files-tick={filesTick}>
+              {commits.map((commit) => (
+                <CommitRow
+                  key={commit.sha}
+                  commit={commit}
+                  nowMs={nowMs}
+                  expanded={expandedSha === commit.sha}
+                  filesEntry={
+                    expandedSha === commit.sha
+                      ? (filesCacheRef.current.get(commit.sha) ?? null)
+                      : null
+                  }
+                  repoRoot={repoRoot}
+                  onToggle={toggleCommit}
+                  onRetryFiles={fetchFiles}
+                  onOpenCommitFile={onOpenCommitFile}
+                />
+              ))}
+              {loadStatus === "more" ? (
+                <div className="flex items-center justify-center py-2">
+                  <Spinner className="size-3" />
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const CommitRow = memo(function CommitRow({
+  commit,
+  nowMs,
+  expanded,
+  filesEntry,
+  repoRoot,
+  onToggle,
+  onRetryFiles,
+  onOpenCommitFile,
+}: {
+  commit: GitLogEntry;
+  nowMs: number;
+  expanded: boolean;
+  filesEntry: FilesEntry | null;
+  repoRoot: string | null;
+  onToggle: (sha: string) => void;
+  onRetryFiles: (sha: string) => void;
+  onOpenCommitFile: (input: CommitFileDiffOpenInput) => void;
+}) {
+  const isMerge = commit.parents.length > 1;
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => onToggle(commit.sha)}
+        title={`${commit.subject}\n${commit.shortSha} by ${commit.author}`}
+        className={cn(
+          "flex w-full cursor-pointer items-center gap-1.5 px-2 py-[5px] text-left transition-colors hover:bg-foreground/[0.05]",
+          expanded && "bg-foreground/[0.04]",
+        )}
+      >
+        <HugeiconsIcon
+          icon={expanded ? ArrowDown01Icon : ArrowRight01Icon}
+          size={10}
+          strokeWidth={2.2}
+          className="shrink-0 text-muted-foreground/70"
+        />
+        <span
+          className={cn(
+            "size-1.5 shrink-0 rounded-full",
+            isMerge ? "bg-muted-foreground/50" : "bg-primary/70",
+          )}
+        />
+        <span className="min-w-0 flex-1 truncate text-[11.5px] leading-tight text-foreground/90">
+          {commit.subject}
+        </span>
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+          {relativeTime(commit.timestampSecs, nowMs)}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div className="border-b border-border/30 pb-1">
+          <div className="flex items-center gap-1.5 px-6 pb-1 pt-0.5 text-[10px] text-muted-foreground/75">
+            <span className="font-mono">{commit.shortSha}</span>
+            <span className="truncate">{commit.author}</span>
+            <span className="ml-auto shrink-0 tabular-nums">
+              {commit.filesChanged}{" "}
+              {commit.filesChanged === 1 ? "file" : "files"}
+            </span>
+          </div>
+          {!filesEntry || filesEntry.state === "loading" ? (
+            <div className="flex items-center gap-1.5 px-6 py-1 text-[10.5px] text-muted-foreground">
+              <Spinner className="size-2.5" /> Loading files
+            </div>
+          ) : filesEntry.state === "error" ? (
+            <div className="space-y-1 px-6 py-1 text-[10.5px] text-muted-foreground">
+              <p className="break-words">{filesEntry.error}</p>
+              <button
+                type="button"
+                className="cursor-pointer underline underline-offset-2 hover:text-foreground"
+                onClick={() => onRetryFiles(commit.sha)}
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            filesEntry.files.map((file) => (
+              <button
+                key={`${file.path}:${file.status}`}
+                type="button"
+                title={file.path}
+                onClick={() => {
+                  if (!repoRoot) return;
+                  onOpenCommitFile({
+                    repoRoot,
+                    sha: commit.sha,
+                    shortSha: commit.shortSha,
+                    subject: commit.subject,
+                    path: file.path,
+                    originalPath: file.originalPath,
+                  });
+                }}
+                className="flex w-full cursor-pointer items-center gap-1.5 py-[3px] pl-6 pr-2 text-left transition-colors hover:bg-foreground/[0.05]"
+              >
+                <img
+                  src={fileIconUrl(basename(file.path))}
+                  alt=""
+                  className="size-3.5 shrink-0"
+                  draggable={false}
+                />
+                <span className="min-w-0 flex-1 truncate text-[11px] text-foreground/85">
+                  {basename(file.path)}
+                </span>
+                <span
+                  className={cn(
+                    "shrink-0 font-mono text-[9.5px] font-semibold",
+                    statusTone(file.status),
+                  )}
+                >
+                  {file.status.toUpperCase()}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+});

--- a/src/modules/source-control/CommitHistorySection.tsx
+++ b/src/modules/source-control/CommitHistorySection.tsx
@@ -49,6 +49,7 @@ type Props = {
   refreshKey: unknown;
   collapsed: boolean;
   topCommitPushed: boolean;
+  showUndoCommit: boolean;
   onToggleCollapsed: () => void;
   onOpenCommitFile: (input: CommitFileDiffOpenInput) => void;
   onOpenGitGraph?: () => void;
@@ -112,6 +113,7 @@ export function CommitHistorySection({
   refreshKey,
   collapsed,
   topCommitPushed,
+  showUndoCommit,
   onToggleCollapsed,
   onOpenCommitFile,
   onOpenGitGraph,
@@ -397,7 +399,9 @@ export function CommitHistorySection({
                       : null
                   }
                   repoRoot={repoRoot}
-                  canUndo={index === 0 && commit.parents.length > 0}
+                  canUndo={
+                    showUndoCommit && index === 0 && commit.parents.length > 0
+                  }
                   onRequestUndo={setPendingUndo}
                   onToggle={toggleCommit}
                   onRetryFiles={fetchFiles}

--- a/src/modules/source-control/CommitHistorySection.tsx
+++ b/src/modules/source-control/CommitHistorySection.tsx
@@ -1,3 +1,13 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -11,11 +21,13 @@ import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
 import {
   ArrowDown01Icon,
   ArrowRight01Icon,
+  ArrowTurnBackwardIcon,
   GitBranchIcon,
   Refresh01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 export const HISTORY_HEADER_PX = 29;
 
@@ -36,9 +48,11 @@ type Props = {
   repoRoot: string | null;
   refreshKey: unknown;
   collapsed: boolean;
+  topCommitPushed: boolean;
   onToggleCollapsed: () => void;
   onOpenCommitFile: (input: CommitFileDiffOpenInput) => void;
   onOpenGitGraph?: () => void;
+  onDidUndoCommit?: () => void;
 };
 
 type LoadStatus = "idle" | "initial" | "more" | "error";
@@ -97,9 +111,11 @@ export function CommitHistorySection({
   repoRoot,
   refreshKey,
   collapsed,
+  topCommitPushed,
   onToggleCollapsed,
   onOpenCommitFile,
   onOpenGitGraph,
+  onDidUndoCommit,
 }: Props) {
   const [commits, setCommits] = useState<GitLogEntry[]>([]);
   const [loadStatus, setLoadStatus] = useState<LoadStatus>("idle");
@@ -255,6 +271,26 @@ export function CommitHistorySection({
     void loadInitial();
   }, [loadInitial]);
 
+  const [pendingUndo, setPendingUndo] = useState<GitLogEntry | null>(null);
+  const [undoBusy, setUndoBusy] = useState(false);
+
+  const confirmUndo = useCallback(async () => {
+    const commit = pendingUndo;
+    if (!commit || !repoRoot || undoBusy) return;
+    setUndoBusy(true);
+    try {
+      await native.gitUndoCommit(repoRoot, commit.sha);
+      setPendingUndo(null);
+      void loadInitial();
+      onDidUndoCommit?.();
+    } catch (err) {
+      setPendingUndo(null);
+      toast.error(`Undo commit failed: ${normalizeError(err)}`);
+    } finally {
+      setUndoBusy(false);
+    }
+  }, [loadInitial, onDidUndoCommit, pendingUndo, repoRoot, undoBusy]);
+
   const nowMs = Date.now();
 
   return (
@@ -349,7 +385,7 @@ export function CommitHistorySection({
             </p>
           ) : (
             <div data-files-tick={filesTick}>
-              {commits.map((commit) => (
+              {commits.map((commit, index) => (
                 <CommitRow
                   key={commit.sha}
                   commit={commit}
@@ -361,6 +397,8 @@ export function CommitHistorySection({
                       : null
                   }
                   repoRoot={repoRoot}
+                  canUndo={index === 0 && commit.parents.length > 0}
+                  onRequestUndo={setPendingUndo}
                   onToggle={toggleCommit}
                   onRetryFiles={fetchFiles}
                   onOpenCommitFile={onOpenCommitFile}
@@ -375,6 +413,40 @@ export function CommitHistorySection({
           )}
         </div>
       )}
+
+      <AlertDialog
+        open={pendingUndo !== null}
+        onOpenChange={(o) => {
+          if (!o && !undoBusy) setPendingUndo(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Undo last commit?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingUndo
+                ? `"${pendingUndo.subject}" will be removed from history and its changes returned to the staged area.${
+                    topCommitPushed
+                      ? " This commit looks already pushed; undoing it rewrites history and the branch will diverge from its upstream."
+                      : ""
+                  }`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={undoBusy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={undoBusy}
+              onClick={(event) => {
+                event.preventDefault();
+                void confirmUndo();
+              }}
+            >
+              {undoBusy ? "Undoing" : "Undo Commit"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -385,6 +457,8 @@ const CommitRow = memo(function CommitRow({
   expanded,
   filesEntry,
   repoRoot,
+  canUndo,
+  onRequestUndo,
   onToggle,
   onRetryFiles,
   onOpenCommitFile,
@@ -394,6 +468,8 @@ const CommitRow = memo(function CommitRow({
   expanded: boolean;
   filesEntry: FilesEntry | null;
   repoRoot: string | null;
+  canUndo: boolean;
+  onRequestUndo: (commit: GitLogEntry) => void;
   onToggle: (sha: string) => void;
   onRetryFiles: (sha: string) => void;
   onOpenCommitFile: (input: CommitFileDiffOpenInput) => void;
@@ -401,34 +477,57 @@ const CommitRow = memo(function CommitRow({
   const isMerge = commit.parents.length > 1;
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => onToggle(commit.sha)}
-        title={`${commit.subject}\n${commit.shortSha} by ${commit.author}`}
-        className={cn(
-          "flex w-full cursor-pointer items-center gap-1.5 px-2 py-[5px] text-left transition-colors hover:bg-foreground/[0.05]",
-          expanded && "bg-foreground/[0.04]",
-        )}
-      >
-        <HugeiconsIcon
-          icon={expanded ? ArrowDown01Icon : ArrowRight01Icon}
-          size={10}
-          strokeWidth={2.2}
-          className="shrink-0 text-muted-foreground/70"
-        />
-        <span
+      <div className="group relative">
+        <button
+          type="button"
+          onClick={() => onToggle(commit.sha)}
+          title={`${commit.subject}\n${commit.shortSha} by ${commit.author}`}
           className={cn(
-            "size-1.5 shrink-0 rounded-full",
-            isMerge ? "bg-muted-foreground/50" : "bg-primary/70",
+            "flex w-full cursor-pointer items-center gap-1.5 px-2 py-[5px] text-left transition-colors hover:bg-foreground/[0.05]",
+            expanded && "bg-foreground/[0.04]",
           )}
-        />
-        <span className="min-w-0 flex-1 truncate text-[11.5px] leading-tight text-foreground/90">
-          {commit.subject}
-        </span>
-        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
-          {relativeTime(commit.timestampSecs, nowMs)}
-        </span>
-      </button>
+        >
+          <HugeiconsIcon
+            icon={expanded ? ArrowDown01Icon : ArrowRight01Icon}
+            size={10}
+            strokeWidth={2.2}
+            className="shrink-0 text-muted-foreground/70"
+          />
+          <span
+            className={cn(
+              "size-1.5 shrink-0 rounded-full",
+              isMerge ? "bg-muted-foreground/50" : "bg-primary/70",
+            )}
+          />
+          <span className="min-w-0 flex-1 truncate text-[11.5px] leading-tight text-foreground/90">
+            {commit.subject}
+          </span>
+          <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+            {relativeTime(commit.timestampSecs, nowMs)}
+          </span>
+        </button>
+        {canUndo ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Undo last commit"
+                onClick={() => onRequestUndo(commit)}
+                className="absolute right-1 top-1/2 hidden -translate-y-1/2 cursor-pointer items-center justify-center rounded bg-card p-1 text-muted-foreground shadow-sm transition-colors hover:text-foreground group-hover:flex"
+              >
+                <HugeiconsIcon
+                  icon={ArrowTurnBackwardIcon}
+                  size={12}
+                  strokeWidth={1.9}
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left" className="text-[10.5px]">
+              Undo last commit
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+      </div>
 
       {expanded ? (
         <div className="border-b border-border/30 pb-1">

--- a/src/modules/source-control/CommitHistorySection.tsx
+++ b/src/modules/source-control/CommitHistorySection.tsx
@@ -179,6 +179,7 @@ export function CommitHistorySection({
     if (loadStatus !== "idle") return;
     const last = commitsRef.current[commitsRef.current.length - 1];
     if (!last) return;
+    const requestId = requestIdRef.current;
     inflightMoreRef.current = true;
     setLoadStatus("more");
     try {
@@ -186,6 +187,7 @@ export function CommitHistorySection({
         limit: PAGE_SIZE,
         beforeSha: last.sha,
       });
+      if (requestId !== requestIdRef.current) return;
       const seen = new Set(commitsRef.current.map((c) => c.sha));
       const merged = [...commitsRef.current];
       for (const e of entries) if (!seen.has(e.sha)) merged.push(e);
@@ -193,8 +195,9 @@ export function CommitHistorySection({
       if (entries.length < PAGE_SIZE) setEndReached(true);
       setLoadStatus("idle");
     } catch (err) {
-      setError(normalizeError(err));
-      setLoadStatus("error");
+      if (requestId !== requestIdRef.current) return;
+      toast.error(`Failed to load older commits: ${normalizeError(err)}`);
+      setLoadStatus("idle");
     } finally {
       inflightMoreRef.current = false;
     }
@@ -517,7 +520,7 @@ const CommitRow = memo(function CommitRow({
                 type="button"
                 aria-label="Undo last commit"
                 onClick={() => onRequestUndo(commit)}
-                className="absolute right-1 top-1/2 hidden -translate-y-1/2 cursor-pointer items-center justify-center rounded bg-card p-1 text-muted-foreground shadow-sm transition-colors hover:text-foreground group-hover:flex"
+                className="absolute right-1 top-1/2 flex -translate-y-1/2 cursor-pointer items-center justify-center rounded bg-card p-1 text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40 group-hover:opacity-100"
               >
                 <HugeiconsIcon
                   icon={ArrowTurnBackwardIcon}

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -11,6 +11,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
@@ -52,14 +57,12 @@ import {
   AiContentGenerator02Icon,
   Alert02Icon,
   ArrowDown01Icon,
-  ArrowRight01Icon,
   ArrowUp01Icon,
   CheckmarkCircle01Icon,
   Download01Icon,
   Folder01Icon,
   FolderCloudIcon,
   FolderGitTwoIcon,
-  GitBranchIcon,
   Refresh01Icon,
   RemoveSquareIcon,
   Tick02Icon,
@@ -76,6 +79,11 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import type { PanelImperativeHandle } from "react-resizable-panels";
+import {
+  CommitHistorySection,
+  HISTORY_HEADER_PX,
+} from "./CommitHistorySection";
 import type { SourceControlSummary } from "./useSourceControl";
 import {
   useSourceControlPanel,
@@ -96,7 +104,50 @@ type Props = {
   }) => void;
   onOpenFile?: (absolutePath: string) => void;
   onNavigateToPath?: (path: string) => void;
+  onOpenCommitFile?: (input: {
+    repoRoot: string;
+    sha: string;
+    shortSha: string;
+    subject: string;
+    path: string;
+    originalPath: string | null;
+  }) => void;
 };
+
+const HISTORY_HEIGHT_STORAGE_KEY = "terax.sourceControl.history.height";
+const HISTORY_COLLAPSED_STORAGE_KEY = "terax.sourceControl.history.collapsed";
+const HISTORY_DEFAULT_HEIGHT = 220;
+const HISTORY_MIN_HEIGHT = 100;
+const HISTORY_MAX_HEIGHT = 600;
+
+function clampHistoryHeight(height: number): number {
+  return Math.min(
+    HISTORY_MAX_HEIGHT,
+    Math.max(HISTORY_MIN_HEIGHT, Math.round(height)),
+  );
+}
+
+function readHistoryHeight(): number {
+  try {
+    const stored = window.localStorage.getItem(HISTORY_HEIGHT_STORAGE_KEY);
+    const parsed = stored ? Number.parseInt(stored, 10) : NaN;
+    return Number.isFinite(parsed)
+      ? clampHistoryHeight(parsed)
+      : HISTORY_DEFAULT_HEIGHT;
+  } catch {
+    return HISTORY_DEFAULT_HEIGHT;
+  }
+}
+
+function readHistoryCollapsed(): boolean {
+  try {
+    return (
+      window.localStorage.getItem(HISTORY_COLLAPSED_STORAGE_KEY) === "1"
+    );
+  } catch {
+    return false;
+  }
+}
 
 const SOURCE_CONTROL_TOOLTIP_CLASS =
   "border border-border/70 bg-zinc-950 text-zinc-100 shadow-lg shadow-black/30 dark:border-border/60 dark:bg-zinc-950 dark:text-zinc-100";
@@ -348,6 +399,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   onOpenDiff,
   onOpenFile,
   onNavigateToPath,
+  onOpenCommitFile,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
   const refreshAnimationRef = useRef<number | null>(null);
@@ -355,13 +407,61 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   const scrollRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [focusedRowKey, setFocusedRowKey] = useState<string | null>(null);
+  const historyPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const historyHeightRef = useRef(readHistoryHeight());
+  const historyWriteTimerRef = useRef(0);
+  const [historyCollapsed, setHistoryCollapsed] =
+    useState(readHistoryCollapsed);
 
   useEffect(() => {
     return () => {
       if (refreshAnimationRef.current) {
         window.clearTimeout(refreshAnimationRef.current);
       }
+      if (historyWriteTimerRef.current) {
+        window.clearTimeout(historyWriteTimerRef.current);
+      }
     };
+  }, []);
+
+  const persistHistoryHeight = useCallback((next: number) => {
+    historyHeightRef.current = next;
+    if (historyWriteTimerRef.current) {
+      window.clearTimeout(historyWriteTimerRef.current);
+    }
+    historyWriteTimerRef.current = window.setTimeout(() => {
+      historyWriteTimerRef.current = 0;
+      try {
+        window.localStorage.setItem(HISTORY_HEIGHT_STORAGE_KEY, String(next));
+      } catch {
+        // storage may fail in private mode
+      }
+    }, 200);
+  }, []);
+
+  const persistHistoryCollapsed = useCallback((collapsed: boolean) => {
+    setHistoryCollapsed((prev) => {
+      if (prev === collapsed) return prev;
+      try {
+        window.localStorage.setItem(
+          HISTORY_COLLAPSED_STORAGE_KEY,
+          collapsed ? "1" : "0",
+        );
+      } catch {
+        // storage may fail in private mode
+      }
+      return collapsed;
+    });
+  }, []);
+
+  const toggleHistoryCollapsed = useCallback(() => {
+    const panel = historyPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) {
+      panel.resize(`${clampHistoryHeight(historyHeightRef.current)}px`);
+    } else {
+      panel.collapse();
+    }
   }, []);
 
   const isRefreshing = scm.panelState === "loading";
@@ -717,28 +817,6 @@ export const SourceControlPanel = memo(function SourceControlPanel({
           </div>
         </header>
 
-        {onOpenGitGraph ? (
-          <button
-            type="button"
-            onClick={() => onOpenGitGraph()}
-            className="group flex shrink-0 cursor-pointer items-center gap-2 border-b border-border/40 px-3 py-2 text-left text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
-          >
-            <HugeiconsIcon
-              icon={GitBranchIcon}
-              size={13}
-              strokeWidth={1.85}
-              className="shrink-0"
-            />
-            <span className="flex-1 text-[12px] font-medium">Commit Graph</span>
-            <HugeiconsIcon
-              icon={ArrowRight01Icon}
-              size={12}
-              strokeWidth={2}
-              className="shrink-0 opacity-50 transition-transform group-hover:translate-x-0.5"
-            />
-          </button>
-        ) : null}
-
         {scm.panelState === "loading" ? (
           <PanelCenter title="Loading repository" />
         ) : null}
@@ -763,7 +841,15 @@ export const SourceControlPanel = memo(function SourceControlPanel({
         ) : null}
 
         {scm.panelState === "ready" && scm.status ? (
-          <>
+          <ResizablePanelGroup
+            orientation="vertical"
+            className="min-h-0 flex-1"
+          >
+            <ResizablePanel
+              id="scm-changes"
+              minSize="160px"
+              className="flex min-h-0 flex-col"
+            >
             <div className="relative shrink-0 space-y-2 border-b border-border/40 bg-gradient-to-b from-card/65 to-card/30 px-2.5 pb-2.5 pt-2.5">
               <div
                 className={cn(
@@ -962,7 +1048,35 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 </div>
               </div>
             )}
-          </>
+            </ResizablePanel>
+            <ResizableHandle />
+            <ResizablePanel
+              id="scm-history"
+              panelRef={historyPanelRef}
+              defaultSize={
+                historyCollapsed
+                  ? `${HISTORY_HEADER_PX}px`
+                  : `${historyHeightRef.current}px`
+              }
+              minSize={`${HISTORY_MIN_HEIGHT}px`}
+              collapsible
+              collapsedSize={`${HISTORY_HEADER_PX}px`}
+              onResize={(size) => {
+                const collapsed = size.inPixels <= HISTORY_HEADER_PX;
+                if (!collapsed) persistHistoryHeight(size.inPixels);
+                persistHistoryCollapsed(collapsed);
+              }}
+            >
+              <CommitHistorySection
+                repoRoot={scm.repo?.repoRoot ?? null}
+                refreshKey={`${scm.status.branch}:${scm.status.ahead}:${scm.status.behind}:${scm.status.changedFiles.length}`}
+                collapsed={historyCollapsed}
+                onToggleCollapsed={toggleHistoryCollapsed}
+                onOpenCommitFile={onOpenCommitFile ?? (() => {})}
+                onOpenGitGraph={onOpenGitGraph}
+              />
+            </ResizablePanel>
+          </ResizablePanelGroup>
         ) : null}
       </aside>
 

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -112,6 +112,7 @@ type Props = {
     path: string;
     originalPath: string | null;
   }) => void;
+  showUndoCommit?: boolean;
 };
 
 const HISTORY_HEIGHT_STORAGE_KEY = "terax.sourceControl.history.height";
@@ -400,6 +401,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   onOpenFile,
   onNavigateToPath,
   onOpenCommitFile,
+  showUndoCommit = true,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
   const refreshAnimationRef = useRef<number | null>(null);
@@ -1076,6 +1078,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 onOpenCommitFile={onOpenCommitFile ?? (() => {})}
                 onOpenGitGraph={onOpenGitGraph}
                 onDidUndoCommit={() => void scm.refresh()}
+                showUndoCommit={showUndoCommit}
               />
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -1071,9 +1071,11 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                 repoRoot={scm.repo?.repoRoot ?? null}
                 refreshKey={`${scm.status.branch}:${scm.status.ahead}:${scm.status.behind}:${scm.status.changedFiles.length}`}
                 collapsed={historyCollapsed}
+                topCommitPushed={!!scm.status.upstream && scm.status.ahead === 0}
                 onToggleCollapsed={toggleHistoryCollapsed}
                 onOpenCommitFile={onOpenCommitFile ?? (() => {})}
                 onOpenGitGraph={onOpenGitGraph}
+                onDidUndoCommit={() => void scm.refresh()}
               />
             </ResizablePanel>
           </ResizablePanelGroup>

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -27,6 +27,7 @@ import {
   setExplorerGitDecorations,
   setRestoreWindowState,
   setShowHidden,
+  setSourceControlUndoCommit,
   setTerminalCursorBlink,
   setTerminalFontFamily,
   setTerminalFontSize,
@@ -93,6 +94,9 @@ export function GeneralSection() {
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const explorerGitDecorations = usePreferencesStore(
     (s) => s.explorerGitDecorations,
+  );
+  const sourceControlUndoCommit = usePreferencesStore(
+    (s) => s.sourceControlUndoCommit,
   );
   const terminalWebglEnabled = usePreferencesStore(
     (s) => s.terminalWebglEnabled,
@@ -254,6 +258,15 @@ export function GeneralSection() {
           <Switch
             checked={explorerGitDecorations}
             onCheckedChange={(v) => void setExplorerGitDecorations(v)}
+          />
+        </SettingRow>
+        <SettingRow
+          title="Undo last commit"
+          description="Show the undo action on the newest commit in Source Control."
+        >
+          <Switch
+            checked={sourceControlUndoCommit}
+            onCheckedChange={(v) => void setSourceControlUndoCommit(v)}
           />
         </SettingRow>
       </div>


### PR DESCRIPTION
## What

Adds a resizable, collapsible Commits section to the bottom of the Source Control sidebar: recent commits with expandable changed-file lists that open per-file diffs, infinite scroll pagination, and an undo action on the newest commit (git reset --soft HEAD~1) behind a confirm dialog. A settings toggle (General > Undo last commit) can hide the undo action.

## Why

Commit history currently only exists as the full-page Commit Graph tab. The common loop of "what did I just commit, let me undo and fix it" requires leaving the current tab. This brings a GitLens-style history view into the sidebar next to the changes list.

## How

- The commit list reuses the existing backend surface: git_log with beforeSha pagination, git_commit_files for expanded rows, and the existing git-commit-file diff tab for file clicks. No new list-side backend.
- One new Rust command, git_undo_commit, gated through the workspace registry like the other git commands. It verifies HEAD still matches the sha the user clicked before resetting (guards against a racing commit) and refuses to undo the initial commit.
- The section refetch is keyed on branch/ahead/behind/changed-file count rather than the raw status snapshot, and reloads keep the current rows on screen until the top of history actually changes, so idle status polls do not flicker the list.
- Split uses the react-resizable-panels group already in the app; height and collapsed state persist in localStorage. The old "Commit Graph" sidebar button moved into the section header as an icon.

## Testing

Exercised manually in pnpm tauri dev on a real repo: commit from the panel and watch it appear at the top of the section, expand commits and open per-file diffs, scroll to page in older commits, drag the divider and restart to confirm persisted height, collapse/expand the section, undo the last commit and confirm its changes return to the staged list, confirm the undo icon is absent on the initial commit and hidden when the new setting is off, and confirm a non-repo workspace shows the empty state.

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS
- [ ] Shells tested (if relevant): n/a

New command: `git_undo_commit(repo_root, expected_head_sha)`; its frontend caller (native.gitUndoCommit) lands in the same PR. Three new integration tests in tests/git_operations.rs cover the undo path, the stale-HEAD rejection, and the initial-commit rejection; 254 frontend tests and pnpm lint pass with no new warnings.

## Screenshots / GIFs

Screenshots to follow in a comment.

## Notes for reviewer

Undo is soft: the commit's changes return to the index, nothing is lost. If the newest commit appears pushed (upstream exists and ahead is 0), the confirm dialog adds an explicit history-rewrite warning instead of blocking. The undo action defaults to visible; the new sourceControlUndoCommit preference hides it for people who consider reset too sharp a tool for a sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full Commit History view in source control with infinite scroll, expandable commit details, and a refresh action.
  * Added an “Undo last commit” capability (optional in the UI) that reverts the latest commit and opens commit file diffs from history.
  * Added a preference to enable/disable “Undo last commit” (default: on) and wired it into the Source Control panel.
  * Commit history panel layout now remembers its size and collapsed state.
* **Bug Fixes**
  * Undo now validates the expected HEAD SHA and prevents undo when the repo has changed (including malformed or initial commits), keeping history unchanged.
* **Tests**
  * Added coverage for undo success, stale/malformed SHA handling, and initial-commit rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->