### PR TITLE
feat(editor): optional side-by-side diff view

### DIFF
--- a/src/modules/editor/GitDiffPane.tsx
+++ b/src/modules/editor/GitDiffPane.tsx
@@ -3,8 +3,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { unifiedMergeView } from "@codemirror/merge";
-import { EditorState } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -14,7 +12,12 @@ import {
   getCachedDiff,
   workingDiffKey,
 } from "./lib/diffCache";
-import { buildSharedExtensions, languageCompartment } from "./lib/extensions";
+import { UNIFIED_DIFF_THEME } from "./lib/diffTheme";
+import {
+  buildSharedExtensions,
+  languageCompartment,
+  READONLY_EXTENSIONS,
+} from "./lib/extensions";
 import { resolveLanguage, resolveLanguageSync } from "./lib/languageResolver";
 import { useEditorThemeExt } from "./lib/useEditorThemeExt";
 import { SplitDiffView } from "./SplitDiffView";
@@ -44,47 +47,6 @@ type Props = {
 const LARGE_FILE_THRESHOLD = 256 * 1024;
 
 const SHARED_EXT = buildSharedExtensions();
-const READONLY_EXT = [
-  EditorState.readOnly.of(true),
-  EditorView.editable.of(false),
-];
-const DIFF_THEME = EditorView.theme({
-  "&.cm-merge-b .cm-changedText, .cm-changedText": {
-    background: "rgba(110, 200, 120, 0.20) !important",
-    borderRadius: "3px",
-    padding: "0 1px",
-  },
-  ".cm-deletedChunk .cm-deletedText, &.cm-merge-b .cm-deletedText": {
-    background: "rgba(220, 90, 90, 0.22) !important",
-    borderRadius: "3px",
-    padding: "0 1px",
-  },
-  "&.cm-merge-b .cm-changedLine, .cm-changedLine, .cm-inlineChangedLine": {
-    backgroundColor: "rgba(110, 200, 120, 0.05) !important",
-  },
-  ".cm-deletedChunk": {
-    backgroundColor: "rgba(220, 90, 90, 0.05) !important",
-    paddingTop: "1px",
-    paddingBottom: "1px",
-  },
-  "&.cm-merge-b .cm-changedLineGutter, .cm-changedLineGutter": {
-    background: "rgba(110, 200, 120, 0.55) !important",
-  },
-  ".cm-deletedLineGutter, &.cm-merge-a .cm-changedLineGutter": {
-    background: "rgba(220, 90, 90, 0.5) !important",
-  },
-  ".cm-changeGutter": {
-    width: "2px !important",
-    paddingLeft: "0 !important",
-  },
-  ".cm-collapsedLines": {
-    backgroundColor: "transparent",
-    color: "var(--muted-foreground, #9ca3af)",
-    fontSize: "10.5px",
-    padding: "2px 8px",
-    opacity: 0.7,
-  },
-});
 
 function countDiffLines(patch: string): { added: number; removed: number } {
   let added = 0;
@@ -204,22 +166,27 @@ export function GitDiffPane({ source, chipLabel, active }: Props) {
   const useFallback = isBinary || isTooLarge;
 
   const initialLang = useMemo(() => resolveLanguageSync(path), [path]);
+  // Only the inline <CodeMirror> consumes these; skip building them in split
+  // mode where SplitDiffView owns its own editor setup.
   const extensions = useMemo(
-    () => [
-      ...SHARED_EXT,
-      languageCompartment.of(initialLang?.ext ?? []),
-      ...READONLY_EXT,
-      unifiedMergeView({
-        original: originalContent,
-        mergeControls: false,
-        highlightChanges: true,
-        gutter: true,
-        syntaxHighlightDeletions: true,
-        collapseUnchanged: { margin: 3, minSize: 6 },
-      }),
-      DIFF_THEME,
-    ],
-    [originalContent, initialLang],
+    () =>
+      diffViewMode === "split"
+        ? []
+        : [
+            ...SHARED_EXT,
+            languageCompartment.of(initialLang?.ext ?? []),
+            ...READONLY_EXTENSIONS,
+            unifiedMergeView({
+              original: originalContent,
+              mergeControls: false,
+              highlightChanges: true,
+              gutter: true,
+              syntaxHighlightDeletions: true,
+              collapseUnchanged: { margin: 3, minSize: 6 },
+            }),
+            UNIFIED_DIFF_THEME,
+          ],
+    [originalContent, initialLang, diffViewMode],
   );
 
   // Resolve and apply syntax highlighting asynchronously when the language pack

--- a/src/modules/editor/GitDiffPane.tsx
+++ b/src/modules/editor/GitDiffPane.tsx
@@ -1,21 +1,23 @@
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { unifiedMergeView } from "@codemirror/merge";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { buildSharedExtensions, languageCompartment } from "./lib/extensions";
 import {
+  commitDiffKey,
   fetchCommitDiff,
   fetchWorkingDiff,
   getCachedDiff,
   workingDiffKey,
-  commitDiffKey,
 } from "./lib/diffCache";
+import { buildSharedExtensions, languageCompartment } from "./lib/extensions";
 import { resolveLanguage, resolveLanguageSync } from "./lib/languageResolver";
 import { useEditorThemeExt } from "./lib/useEditorThemeExt";
+import { SplitDiffView } from "./SplitDiffView";
 
 type WorkingSource = {
   kind: "working";
@@ -101,7 +103,13 @@ function countDiffLines(patch: string): { added: number; removed: number } {
 type LoadState =
   | { kind: "idle" }
   | { kind: "loading" }
-  | { kind: "loaded"; originalContent: string; modifiedContent: string; isBinary: boolean; fallbackPatch: string }
+  | {
+      kind: "loaded";
+      originalContent: string;
+      modifiedContent: string;
+      isBinary: boolean;
+      fallbackPatch: string;
+    }
   | { kind: "error"; message: string };
 
 function cacheKey(source: WorkingSource | CommitSource): string {
@@ -110,9 +118,7 @@ function cacheKey(source: WorkingSource | CommitSource): string {
     : commitDiffKey(source.repoRoot, source.sha, source.path);
 }
 
-function loadStateFromCache(
-  source: WorkingSource | CommitSource,
-): LoadState {
+function loadStateFromCache(source: WorkingSource | CommitSource): LoadState {
   const hit = getCachedDiff(cacheKey(source));
   if (!hit) return { kind: "idle" };
   return {
@@ -127,6 +133,7 @@ function loadStateFromCache(
 export function GitDiffPane({ source, chipLabel, active }: Props) {
   const cmRef = useRef<ReactCodeMirrorRef>(null);
   const themeExt = useEditorThemeExt();
+  const diffViewMode = usePreferencesStore((s) => s.diffViewMode);
   const [state, setState] = useState<LoadState>(() =>
     active ? loadStateFromCache(source) : { kind: "idle" },
   );
@@ -224,6 +231,7 @@ export function GitDiffPane({ source, chipLabel, active }: Props) {
   useEffect(() => {
     if (useFallback || initialLang) return;
     if (state.kind !== "loaded") return;
+    if (diffViewMode === "split") return;
     let cancelled = false;
     resolveLanguage(path).then((res) => {
       if (cancelled) return;
@@ -236,10 +244,11 @@ export function GitDiffPane({ source, chipLabel, active }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [useFallback, path, initialLang, state.kind]);
+  }, [useFallback, path, initialLang, state.kind, diffViewMode]);
 
   const stats = useMemo(
-    () => (useFallback ? countDiffLines(fallbackPatch) : { added: 0, removed: 0 }),
+    () =>
+      useFallback ? countDiffLines(fallbackPatch) : { added: 0, removed: 0 },
     [useFallback, fallbackPatch],
   );
 
@@ -300,6 +309,12 @@ export function GitDiffPane({ source, chipLabel, active }: Props) {
               {fallbackPatch || "Diff preview is not available for this file."}
             </pre>
           </ScrollArea>
+        ) : diffViewMode === "split" ? (
+          <SplitDiffView
+            original={originalContent}
+            modified={modifiedContent}
+            path={path}
+          />
         ) : (
           <CodeMirror
             ref={cmRef}

--- a/src/modules/editor/SplitDiffView.tsx
+++ b/src/modules/editor/SplitDiffView.tsx
@@ -1,8 +1,22 @@
+import { defaultKeymap } from "@codemirror/commands";
+import { foldGutter } from "@codemirror/language";
 import { MergeView } from "@codemirror/merge";
-import { EditorState, type Extension } from "@codemirror/state";
-import { EditorView, lineNumbers } from "@codemirror/view";
-import { useEffect, useMemo, useRef } from "react";
-import { buildSharedExtensions, languageCompartment } from "./lib/extensions";
+import { searchKeymap } from "@codemirror/search";
+import { Compartment, type Extension } from "@codemirror/state";
+import {
+  drawSelection,
+  type EditorView,
+  highlightSpecialChars,
+  keymap,
+  lineNumbers,
+} from "@codemirror/view";
+import { useEffect, useRef } from "react";
+import { SPLIT_DIFF_THEME } from "./lib/diffTheme";
+import {
+  buildSharedExtensions,
+  languageCompartment,
+  READONLY_EXTENSIONS,
+} from "./lib/extensions";
 import { resolveLanguage, resolveLanguageSync } from "./lib/languageResolver";
 import { useEditorThemeExt } from "./lib/useEditorThemeExt";
 
@@ -13,94 +27,92 @@ type Props = {
 };
 
 const SHARED_EXT = buildSharedExtensions();
-const READONLY_EXT = [
-  EditorState.readOnly.of(true),
-  EditorView.editable.of(false),
-];
+const themeCompartment = new Compartment();
 
-// Editor A holds the original (deletions, red); editor B the modified
-// (insertions, green). Scoped by the .cm-merge-a/.cm-merge-b root classes
-// MergeView puts on each side.
-const SPLIT_DIFF_THEME = EditorView.theme({
-  "&.cm-merge-a .cm-changedText": {
-    background: "rgba(220, 90, 90, 0.22) !important",
-    borderRadius: "3px",
-    padding: "0 1px",
-  },
-  "&.cm-merge-a .cm-changedLine": {
-    backgroundColor: "rgba(220, 90, 90, 0.05) !important",
-  },
-  "&.cm-merge-a .cm-changedLineGutter": {
-    background: "rgba(220, 90, 90, 0.5) !important",
-  },
-  "&.cm-merge-b .cm-changedText": {
-    background: "rgba(110, 200, 120, 0.20) !important",
-    borderRadius: "3px",
-    padding: "0 1px",
-  },
-  "&.cm-merge-b .cm-changedLine": {
-    backgroundColor: "rgba(110, 200, 120, 0.05) !important",
-  },
-  "&.cm-merge-b .cm-changedLineGutter": {
-    background: "rgba(110, 200, 120, 0.55) !important",
-  },
-  ".cm-changeGutter": {
-    width: "2px !important",
-    paddingLeft: "0 !important",
-  },
-  ".cm-collapsedLines": {
-    backgroundColor: "transparent",
-    color: "var(--muted-foreground, #9ca3af)",
-    fontSize: "10.5px",
-    padding: "2px 8px",
-    opacity: 0.7,
-  },
-});
+function replaceDoc(view: EditorView, doc: string): void {
+  if (view.state.doc.toString() === doc) return;
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: doc },
+  });
+}
 
 export function SplitDiffView({ original, modified, path }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<MergeView | null>(null);
   const themeExt = useEditorThemeExt();
-  const initialLang = useMemo(() => resolveLanguageSync(path), [path]);
+
+  // Effects read initial values through refs so the MergeView is only
+  // rebuilt on a path change; content and theme update in place below.
+  const originalRef = useRef(original);
+  originalRef.current = original;
+  const modifiedRef = useRef(modified);
+  modifiedRef.current = modified;
+  const themeRef = useRef(themeExt);
+  themeRef.current = themeExt;
 
   // MergeView is a plain class managing two EditorViews, not a CodeMirror
-  // extension, so it cannot go through <CodeMirror>. Rebuild on any input
-  // change; diff panes are read-only so there is no editor state to preserve.
+  // extension, so it cannot render through <CodeMirror>.
   useEffect(() => {
     const parent = containerRef.current;
     if (!parent) return;
+    const lang = resolveLanguageSync(path);
     const sideExtensions: Extension[] = [
       ...SHARED_EXT,
       lineNumbers(),
-      languageCompartment.of(initialLang?.ext ?? []),
-      ...READONLY_EXT,
-      themeExt,
+      foldGutter(),
+      highlightSpecialChars(),
+      drawSelection(),
+      keymap.of([...defaultKeymap, ...searchKeymap]),
+      languageCompartment.of(lang?.ext ?? []),
+      themeCompartment.of(themeRef.current),
+      ...READONLY_EXTENSIONS,
       SPLIT_DIFF_THEME,
     ];
     const view = new MergeView({
-      a: { doc: original, extensions: sideExtensions },
-      b: { doc: modified, extensions: sideExtensions },
+      a: { doc: originalRef.current, extensions: sideExtensions },
+      b: { doc: modifiedRef.current, extensions: sideExtensions },
       parent,
       gutter: true,
       highlightChanges: true,
       collapseUnchanged: { margin: 3, minSize: 6 },
     });
+    viewRef.current = view;
     let cancelled = false;
-    if (!initialLang) {
-      void resolveLanguage(path).then((res) => {
-        if (cancelled || !res) return;
-        view.a.dispatch({
-          effects: languageCompartment.reconfigure(res.ext),
-        });
-        view.b.dispatch({
-          effects: languageCompartment.reconfigure(res.ext),
-        });
-      });
+    if (!lang) {
+      resolveLanguage(path)
+        .then((res) => {
+          if (cancelled) return;
+          for (const side of [view.a, view.b]) {
+            side.dispatch({
+              effects: languageCompartment.reconfigure(res?.ext ?? []),
+            });
+          }
+        })
+        .catch(() => undefined);
     }
     return () => {
       cancelled = true;
+      viewRef.current = null;
       view.destroy();
     };
-  }, [original, modified, path, initialLang, themeExt]);
+  }, [path]);
+
+  // Working diffs refetch on file save; replacing the docs in place keeps
+  // scroll position and expanded regions, unlike a destroy/recreate.
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    replaceDoc(view.a, original);
+    replaceDoc(view.b, modified);
+  }, [original, modified]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    for (const side of [view.a, view.b]) {
+      side.dispatch({ effects: themeCompartment.reconfigure(themeExt) });
+    }
+  }, [themeExt]);
 
   return (
     <div

--- a/src/modules/editor/SplitDiffView.tsx
+++ b/src/modules/editor/SplitDiffView.tsx
@@ -1,0 +1,111 @@
+import { MergeView } from "@codemirror/merge";
+import { EditorState, type Extension } from "@codemirror/state";
+import { EditorView, lineNumbers } from "@codemirror/view";
+import { useEffect, useMemo, useRef } from "react";
+import { buildSharedExtensions, languageCompartment } from "./lib/extensions";
+import { resolveLanguage, resolveLanguageSync } from "./lib/languageResolver";
+import { useEditorThemeExt } from "./lib/useEditorThemeExt";
+
+type Props = {
+  original: string;
+  modified: string;
+  path: string;
+};
+
+const SHARED_EXT = buildSharedExtensions();
+const READONLY_EXT = [
+  EditorState.readOnly.of(true),
+  EditorView.editable.of(false),
+];
+
+// Editor A holds the original (deletions, red); editor B the modified
+// (insertions, green). Scoped by the .cm-merge-a/.cm-merge-b root classes
+// MergeView puts on each side.
+const SPLIT_DIFF_THEME = EditorView.theme({
+  "&.cm-merge-a .cm-changedText": {
+    background: "rgba(220, 90, 90, 0.22) !important",
+    borderRadius: "3px",
+    padding: "0 1px",
+  },
+  "&.cm-merge-a .cm-changedLine": {
+    backgroundColor: "rgba(220, 90, 90, 0.05) !important",
+  },
+  "&.cm-merge-a .cm-changedLineGutter": {
+    background: "rgba(220, 90, 90, 0.5) !important",
+  },
+  "&.cm-merge-b .cm-changedText": {
+    background: "rgba(110, 200, 120, 0.20) !important",
+    borderRadius: "3px",
+    padding: "0 1px",
+  },
+  "&.cm-merge-b .cm-changedLine": {
+    backgroundColor: "rgba(110, 200, 120, 0.05) !important",
+  },
+  "&.cm-merge-b .cm-changedLineGutter": {
+    background: "rgba(110, 200, 120, 0.55) !important",
+  },
+  ".cm-changeGutter": {
+    width: "2px !important",
+    paddingLeft: "0 !important",
+  },
+  ".cm-collapsedLines": {
+    backgroundColor: "transparent",
+    color: "var(--muted-foreground, #9ca3af)",
+    fontSize: "10.5px",
+    padding: "2px 8px",
+    opacity: 0.7,
+  },
+});
+
+export function SplitDiffView({ original, modified, path }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const themeExt = useEditorThemeExt();
+  const initialLang = useMemo(() => resolveLanguageSync(path), [path]);
+
+  // MergeView is a plain class managing two EditorViews, not a CodeMirror
+  // extension, so it cannot go through <CodeMirror>. Rebuild on any input
+  // change; diff panes are read-only so there is no editor state to preserve.
+  useEffect(() => {
+    const parent = containerRef.current;
+    if (!parent) return;
+    const sideExtensions: Extension[] = [
+      ...SHARED_EXT,
+      lineNumbers(),
+      languageCompartment.of(initialLang?.ext ?? []),
+      ...READONLY_EXT,
+      themeExt,
+      SPLIT_DIFF_THEME,
+    ];
+    const view = new MergeView({
+      a: { doc: original, extensions: sideExtensions },
+      b: { doc: modified, extensions: sideExtensions },
+      parent,
+      gutter: true,
+      highlightChanges: true,
+      collapseUnchanged: { margin: 3, minSize: 6 },
+    });
+    let cancelled = false;
+    if (!initialLang) {
+      void resolveLanguage(path).then((res) => {
+        if (cancelled || !res) return;
+        view.a.dispatch({
+          effects: languageCompartment.reconfigure(res.ext),
+        });
+        view.b.dispatch({
+          effects: languageCompartment.reconfigure(res.ext),
+        });
+      });
+    }
+    return () => {
+      cancelled = true;
+      view.destroy();
+    };
+  }, [original, modified, path, initialLang, themeExt]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full [&>.cm-mergeView]:h-full [&>.cm-mergeView]:overflow-auto"
+    />
+  );
+}

--- a/src/modules/editor/lib/diffTheme.ts
+++ b/src/modules/editor/lib/diffTheme.ts
@@ -1,0 +1,81 @@
+import { EditorView } from "@codemirror/view";
+
+// Single source for the diff palette so the unified and split views cannot
+// drift apart when colors are tuned.
+const ADDED_TEXT = "rgba(110, 200, 120, 0.20) !important";
+const ADDED_LINE = "rgba(110, 200, 120, 0.05) !important";
+const ADDED_GUTTER = "rgba(110, 200, 120, 0.55) !important";
+const REMOVED_TEXT = "rgba(220, 90, 90, 0.22) !important";
+const REMOVED_LINE = "rgba(220, 90, 90, 0.05) !important";
+const REMOVED_GUTTER = "rgba(220, 90, 90, 0.5) !important";
+
+const CHANGED_TEXT_SHAPE = {
+  borderRadius: "3px",
+  padding: "0 1px",
+};
+
+const SHARED_RULES = {
+  ".cm-changeGutter": {
+    width: "2px !important",
+    paddingLeft: "0 !important",
+  },
+  ".cm-collapsedLines": {
+    backgroundColor: "transparent",
+    color: "var(--muted-foreground, #9ca3af)",
+    fontSize: "10.5px",
+    padding: "2px 8px",
+    opacity: 0.7,
+  },
+};
+
+export const UNIFIED_DIFF_THEME = EditorView.theme({
+  "&.cm-merge-b .cm-changedText, .cm-changedText": {
+    background: ADDED_TEXT,
+    ...CHANGED_TEXT_SHAPE,
+  },
+  ".cm-deletedChunk .cm-deletedText, &.cm-merge-b .cm-deletedText": {
+    background: REMOVED_TEXT,
+    ...CHANGED_TEXT_SHAPE,
+  },
+  "&.cm-merge-b .cm-changedLine, .cm-changedLine, .cm-inlineChangedLine": {
+    backgroundColor: ADDED_LINE,
+  },
+  ".cm-deletedChunk": {
+    backgroundColor: REMOVED_LINE,
+    paddingTop: "1px",
+    paddingBottom: "1px",
+  },
+  "&.cm-merge-b .cm-changedLineGutter, .cm-changedLineGutter": {
+    background: ADDED_GUTTER,
+  },
+  ".cm-deletedLineGutter, &.cm-merge-a .cm-changedLineGutter": {
+    background: REMOVED_GUTTER,
+  },
+  ...SHARED_RULES,
+});
+
+// MergeView roots carry .cm-merge-a (original) and .cm-merge-b (modified),
+// so deletions read red on the left and insertions green on the right.
+export const SPLIT_DIFF_THEME = EditorView.theme({
+  "&.cm-merge-a .cm-changedText": {
+    background: REMOVED_TEXT,
+    ...CHANGED_TEXT_SHAPE,
+  },
+  "&.cm-merge-a .cm-changedLine": {
+    backgroundColor: REMOVED_LINE,
+  },
+  "&.cm-merge-a .cm-changedLineGutter": {
+    background: REMOVED_GUTTER,
+  },
+  "&.cm-merge-b .cm-changedText": {
+    background: ADDED_TEXT,
+    ...CHANGED_TEXT_SHAPE,
+  },
+  "&.cm-merge-b .cm-changedLine": {
+    backgroundColor: ADDED_LINE,
+  },
+  "&.cm-merge-b .cm-changedLineGutter": {
+    background: ADDED_GUTTER,
+  },
+  ...SHARED_RULES,
+});

--- a/src/modules/editor/lib/extensions.ts
+++ b/src/modules/editor/lib/extensions.ts
@@ -7,6 +7,11 @@ import { EditorView } from "@codemirror/view";
 
 // Compartments allow runtime reconfiguration without rebuilding state.
 export const languageCompartment = new Compartment();
+
+export const READONLY_EXTENSIONS: Extension[] = [
+  EditorState.readOnly.of(true),
+  EditorView.editable.of(false),
+];
 export const readOnlyCompartment = new Compartment();
 export const wrapCompartment = new Compartment();
 export const vimCompartment = new Compartment();

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -111,6 +111,8 @@ export const EDITOR_THEME_LABELS: Record<EditorThemeId, string> = {
   "xcode-light": "Xcode Light",
 };
 
+export type DiffViewMode = "inline" | "split";
+
 export type Preferences = {
   theme: ThemePref;
   themeId: string;
@@ -144,6 +146,7 @@ export type Preferences = {
   recentModelIds: string[];
   vimMode: boolean;
   editorWordWrap: boolean;
+  diffViewMode: DiffViewMode;
   showHidden: boolean;
   explorerGitDecorations: boolean;
   terminalWebglEnabled: boolean;
@@ -210,6 +213,7 @@ const KEY_FAVORITE_MODELS = "favoriteModelIds";
 const KEY_RECENT_MODELS = "recentModelIds";
 const KEY_VIM_MODE = "vimMode";
 const KEY_EDITOR_WORD_WRAP = "editorWordWrap";
+const KEY_DIFF_VIEW_MODE = "diffViewMode";
 const KEY_SHOW_HIDDEN = "showHidden";
 const LEGACY_KEY_SHOW_HIDDEN_DIRS = "showHiddenDirectories";
 const KEY_EXPLORER_GIT_DECORATIONS = "explorerGitDecorations";
@@ -279,6 +283,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   recentModelIds: [],
   vimMode: false,
   editorWordWrap: false,
+  diffViewMode: "inline",
   showHidden: false,
   explorerGitDecorations: true,
   terminalWebglEnabled: true,
@@ -410,6 +415,8 @@ export async function loadPreferences(): Promise<Preferences> {
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
     editorWordWrap:
       get<boolean>(KEY_EDITOR_WORD_WRAP) ?? DEFAULT_PREFERENCES.editorWordWrap,
+    diffViewMode:
+      get<DiffViewMode>(KEY_DIFF_VIEW_MODE) === "split" ? "split" : "inline",
     showHidden:
       get<boolean>(KEY_SHOW_HIDDEN) ??
       get<boolean>(LEGACY_KEY_SHOW_HIDDEN_DIRS) ??
@@ -642,6 +649,10 @@ export async function setEditorWordWrap(value: boolean): Promise<void> {
   await writePref(KEY_EDITOR_WORD_WRAP, value);
 }
 
+export async function setDiffViewMode(value: DiffViewMode): Promise<void> {
+  await writePref(KEY_DIFF_VIEW_MODE, value);
+}
+
 export async function setShowHidden(value: boolean): Promise<void> {
   await writePref(KEY_SHOW_HIDDEN, value);
 }
@@ -784,6 +795,7 @@ export async function onPreferencesChange(
     [KEY_RECENT_MODELS]: "recentModelIds",
     [KEY_VIM_MODE]: "vimMode",
     [KEY_EDITOR_WORD_WRAP]: "editorWordWrap",
+    [KEY_DIFF_VIEW_MODE]: "diffViewMode",
     [KEY_SHOW_HIDDEN]: "showHidden",
     [KEY_EXPLORER_GIT_DECORATIONS]: "explorerGitDecorations",
     [KEY_TERMINAL_WEBGL_ENABLED]: "terminalWebglEnabled",

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -415,8 +415,11 @@ export async function loadPreferences(): Promise<Preferences> {
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
     editorWordWrap:
       get<boolean>(KEY_EDITOR_WORD_WRAP) ?? DEFAULT_PREFERENCES.editorWordWrap,
-    diffViewMode:
-      get<DiffViewMode>(KEY_DIFF_VIEW_MODE) === "split" ? "split" : "inline",
+    diffViewMode: ((): DiffViewMode => {
+      const stored = get<string>(KEY_DIFF_VIEW_MODE);
+      if (stored === "inline" || stored === "split") return stored;
+      return DEFAULT_PREFERENCES.diffViewMode;
+    })(),
     showHidden:
       get<boolean>(KEY_SHOW_HIDDEN) ??
       get<boolean>(LEGACY_KEY_SHOW_HIDDEN_DIRS) ??

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -221,16 +221,13 @@ export function GeneralSection() {
         </SettingRow>
         <SettingRow
           title="Diff view"
-          description="How file diffs are laid out: inline in a single column, or side by side like VS Code."
+          description="How git diffs are laid out: inline in a single column, or side by side like VS Code."
         >
           <Select
             value={diffViewMode}
             onValueChange={(v) => void setDiffViewMode(v as DiffViewMode)}
           >
-            <SelectTrigger
-              value={diffViewMode}
-              className="h-8 w-36 text-[12px]"
-            >
+            <SelectTrigger className="h-8 w-36 text-[12px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -16,11 +16,12 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import type { ThemePref } from "@/modules/settings/store";
+import type { DiffViewMode, ThemePref } from "@/modules/settings/store";
 import {
   setAgentNotifications,
   setAutostart,
   setDefaultWorkspaceEnv,
+  setDiffViewMode,
   setEditorAutoSave,
   setEditorAutoSaveDelay,
   setEditorWordWrap,
@@ -89,6 +90,7 @@ export function GeneralSection() {
   const vimMode = usePreferencesStore((s) => s.vimMode);
   const editorWordWrap = usePreferencesStore((s) => s.editorWordWrap);
   const editorAutoSave = usePreferencesStore((s) => s.editorAutoSave);
+  const diffViewMode = usePreferencesStore((s) => s.diffViewMode);
   const editorAutoSaveDelay = usePreferencesStore((s) => s.editorAutoSaveDelay);
   const showHidden = usePreferencesStore((s) => s.showHidden);
   const explorerGitDecorations = usePreferencesStore(
@@ -216,6 +218,30 @@ export function GeneralSection() {
             checked={editorWordWrap}
             onCheckedChange={(v) => void setEditorWordWrap(v)}
           />
+        </SettingRow>
+        <SettingRow
+          title="Diff view"
+          description="How file diffs are laid out: inline in a single column, or side by side like VS Code."
+        >
+          <Select
+            value={diffViewMode}
+            onValueChange={(v) => void setDiffViewMode(v as DiffViewMode)}
+          >
+            <SelectTrigger
+              value={diffViewMode}
+              className="h-8 w-36 text-[12px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="inline" className="text-[12px]">
+                Inline
+              </SelectItem>
+              <SelectItem value="split" className="text-[12px]">
+                Side by side
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </SettingRow>
         <SettingRow
           title="Auto save"


### PR DESCRIPTION
## What

Adds a "Diff view" setting so git diffs can render side by side (original left, modified right, aligned line by line) instead of the current inline view. Inline stays the default.

## Why

On files with dense changes the inline view gets hard to follow, since deletions and insertions are interleaved in one column. VS Code's side-by-side layout reads much better there. I wanted the same in Terax without forcing it on anyone, so it's a preference.

## How

- New `diffViewMode` preference (`"inline" | "split"`), exposed as a Select row under Settings > General > Editor. Follows the existing pref pattern in `settings/store.ts`, syncs across windows like the rest.
- New `SplitDiffView` component wrapping `MergeView` from `@codemirror/merge` (already a dependency, the inline view uses `unifiedMergeView` from the same package). `MergeView` is a class managing two editors rather than an extension, so it can't go through `<CodeMirror>`. The wrapper builds it once per file and then updates in place: content changes land as doc-replacing dispatches and theme changes go through a compartment, so scroll position and expanded regions survive file saves and theme switches.
- `GitDiffPane` picks the view from the pref, which covers both working-tree diffs and commit-file diffs. The binary/large-file patch fallback is unchanged.
- The red/green diff palette moved to a shared `lib/diffTheme.ts` so the inline and split views can't drift apart when colors get tuned.
- The AI diff pane is left alone on purpose (it has its own review flow); the setting copy says "git diffs".

No Rust changes. `git_diff_content` already returns both full sides of the file, so the split view had everything it needed.

## Testing

- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) not applicable, frontend only
- [ ] (If you changed a `#[tauri::command]` signature) not applicable
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS

Manual flows exercised: toggled the setting with diff tabs open (open tabs switch layout live), working-tree diff and commit diff both render split, saving the file while its split diff is open keeps scroll position, Cmd+F opens search inside the split view, switching editor theme keeps scroll, binary files still fall back to the patch view. `pnpm test` passes (254 tests), biome clean on touched files.

## Screenshots / GIFs

<img width="1510" height="857" alt="side-by-side-view" src="https://github.com/user-attachments/assets/a85ddc9e-6ddf-43a8-8b4a-808d7ed56a56" />

## Notes for reviewer

- Both sides live in one scroll container (`.cm-mergeView` with `overflow: auto`), which is how `MergeView` keeps the panes aligned. There is no per-pane scrolling.
- The split view doesn't go through `@uiw/react-codemirror`'s `basicSetup`, so the keymaps and gutters the inline view gets for free (`searchKeymap`, `defaultKeymap`, fold gutter, special-char highlighting) are added explicitly. If a parity gap shows up later, that extension list is the place to look.
- Possible follow-up: apply the same mode to the AI diff pane.
