### PR TITLE
feat(ui): add search and scrollbar affordances

### DIFF
--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -72,6 +72,38 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
+type SearchOverviewMark = { id: string; top: number; active: boolean };
+
+const MAX_SEARCH_OVERVIEW_MARKS = 1000;
+
+function collectSearchOverviewMarks(
+  view: EditorView,
+  query: string,
+): SearchOverviewMark[] {
+  const needle = query.toLocaleLowerCase();
+  if (!needle) return [];
+  const doc = view.state.doc;
+  const haystack = doc.toString().toLocaleLowerCase();
+  const activeFrom = view.state.selection.main.from;
+  const activeTo = view.state.selection.main.to;
+  const marks: SearchOverviewMark[] = [];
+  let from = 0;
+  while (marks.length < MAX_SEARCH_OVERVIEW_MARKS) {
+    const index = haystack.indexOf(needle, from);
+    if (index < 0) break;
+    const to = index + needle.length;
+    const line = doc.lineAt(index).number;
+    const top = doc.lines <= 1 ? 0 : ((line - 1) / (doc.lines - 1)) * 100;
+    marks.push({
+      id: `${index}:${to}`,
+      top,
+      active: activeFrom === index && activeTo === to,
+    });
+    from = Math.max(to, index + 1);
+  }
+  return marks;
+}
+
 export const EditorPane = forwardRef<EditorPaneHandle, Props>(
   function EditorPane(props, ref) {
     const { path, overrideLanguage, onDirtyChange, onSaved, onClose } = props;
@@ -88,6 +120,10 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const editorWordWrap = usePreferencesStore((s) => s.editorWordWrap);
     const languageRef = useRef<string | null>(null);
     const [langId, setLangId] = useState<string | null>(null);
+    const [searchOverviewMarks, setSearchOverviewMarks] = useState<
+      SearchOverviewMark[]
+    >([]);
+    const searchQueryRef = useRef("");
     const apiKeyRef = useRef<string | null>(null);
 
     useEffect(() => {
@@ -182,6 +218,31 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     useEffect(() => {
       if (doc.status === "ready") applyPendingGoto();
     }, [doc.status, applyPendingGoto]);
+
+    const refreshSearchOverviewMarks = useCallback(() => {
+      const view = cmRef.current?.view;
+      if (!view || !searchQueryRef.current) {
+        setSearchOverviewMarks([]);
+        return;
+      }
+      setSearchOverviewMarks(
+        collectSearchOverviewMarks(view, searchQueryRef.current),
+      );
+    }, []);
+
+    const handleChange = useCallback(
+      (next: string) => {
+        onChange(next);
+        if (!searchQueryRef.current) return;
+        requestAnimationFrame(refreshSearchOverviewMarks);
+      },
+      [onChange, refreshSearchOverviewMarks],
+    );
+
+    useEffect(() => {
+      if (doc.status !== "ready") setSearchOverviewMarks([]);
+      else refreshSearchOverviewMarks();
+    }, [doc.status, refreshSearchOverviewMarks]);
 
     const extensions = useMemo(
       () => [
@@ -326,27 +387,39 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
         setQuery: (q: string) => {
           const view = cmRef.current?.view;
           if (!view) return;
+          searchQueryRef.current = q;
           view.dispatch({
             effects: setSearchQuery.of(
               new SearchQuery({ search: q, caseSensitive: false }),
             ),
           });
-          if (q) findNext(view);
+          if (q) {
+            findNext(view);
+            setSearchOverviewMarks(collectSearchOverviewMarks(view, q));
+          } else {
+            setSearchOverviewMarks([]);
+          }
         },
         findNext: () => {
           const view = cmRef.current?.view;
-          if (view) findNext(view);
+          if (!view) return;
+          findNext(view);
+          refreshSearchOverviewMarks();
         },
         findPrevious: () => {
           const view = cmRef.current?.view;
-          if (view) findPrevious(view);
+          if (!view) return;
+          findPrevious(view);
+          refreshSearchOverviewMarks();
         },
         clearQuery: () => {
           const view = cmRef.current?.view;
           if (!view) return;
+          searchQueryRef.current = "";
           view.dispatch({
             effects: setSearchQuery.of(new SearchQuery({ search: "" })),
           });
+          setSearchOverviewMarks([]);
         },
         focus: () => {
           cmRef.current?.view?.focus();
@@ -373,7 +446,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
           if (view) redo(view);
         },
       }),
-      [path, applyPendingGoto],
+      [path, applyPendingGoto, refreshSearchOverviewMarks],
     );
 
     if (doc.status === "loading") {
@@ -465,11 +538,11 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     }
 
     return (
-      <div className="flex h-full min-h-0 flex-col zoom-exempt">
+      <div className="relative flex h-full min-h-0 flex-col zoom-exempt">
         <CodeMirror
           ref={cmRef}
           value={doc.content}
-          onChange={onChange}
+          onChange={handleChange}
           theme={themeExt}
           extensions={extensions}
           height="100%"
@@ -486,6 +559,24 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
             searchKeymap: true,
           }}
         />
+        {searchOverviewMarks.length > 0 && (
+          <div
+            className="pointer-events-none absolute top-2 right-0 bottom-2 z-10 w-2"
+            aria-hidden="true"
+          >
+            {searchOverviewMarks.map((mark) => (
+              <span
+                key={mark.id}
+                className={
+                  mark.active
+                    ? "absolute right-0 h-1.5 w-2 rounded-full bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.75)]"
+                    : "absolute right-0 h-1 w-1.5 rounded-full bg-amber-400/70"
+                }
+                style={{ top: `${mark.top}%` }}
+              />
+            ))}
+          </div>
+        )}
       </div>
     );
   },

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -4,7 +4,12 @@ import { KEY_SEP } from "@/lib/platform";
 import type { EditorPaneHandle } from "@/modules/editor";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
-import { Cancel01Icon, Search01Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowDown01Icon,
+  ArrowUp01Icon,
+  Cancel01Icon,
+  Search01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { SearchAddon } from "@xterm/addon-search";
 import {
@@ -132,10 +137,12 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
       // git-history: the list filters live; Enter has no next/prev semantics.
     };
 
+    const canNavigate = !!q && target?.kind !== "git-history";
+
     return (
       <div
         className="relative h-7 shrink-0 transition-[width] duration-200 ease-out"
-        style={{ width: expanded ? 192 : 28 }}
+        style={{ width: expanded ? 244 : 28 }}
       >
         {expanded ? (
           <div className="absolute inset-0 animate-in fade-in-0 duration-150">
@@ -149,7 +156,7 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
               ref={setInputRef}
               value={q}
               placeholder={placeholder}
-              className="h-7 w-full bg-muted/80 pr-7 pl-7 text-[13px]! placeholder:text-muted-foreground/70 focus-visible:ring-0"
+              className="h-7 w-full bg-muted/80 pr-20 pl-7 text-[13px]! placeholder:text-muted-foreground/70 focus-visible:ring-0"
               onChange={(e) => {
                 const next = e.target.value;
                 setQ(next);
@@ -173,20 +180,59 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
                 }
               }}
             />
-            {q && (
+            <div className="absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center gap-0.5">
               <button
                 type="button"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={() => {
-                  setQ("");
-                  clearTarget();
+                  findDirection(false);
                   inputRef.current?.focus();
                 }}
-                className="absolute top-1/2 right-1.5 -translate-y-1/2 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-                aria-label="Clear search"
+                disabled={!canNavigate}
+                className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
+                aria-label="Previous search match"
+                title="Previous match"
               >
-                <HugeiconsIcon icon={Cancel01Icon} size={11} strokeWidth={2} />
+                <HugeiconsIcon icon={ArrowUp01Icon} size={11} strokeWidth={2} />
               </button>
-            )}
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  findDirection(true);
+                  inputRef.current?.focus();
+                }}
+                disabled={!canNavigate}
+                className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
+                aria-label="Next search match"
+                title="Next match"
+              >
+                <HugeiconsIcon
+                  icon={ArrowDown01Icon}
+                  size={11}
+                  strokeWidth={2}
+                />
+              </button>
+              {q && (
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    setQ("");
+                    clearTarget();
+                    inputRef.current?.focus();
+                  }}
+                  className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  aria-label="Clear search"
+                >
+                  <HugeiconsIcon
+                    icon={Cancel01Icon}
+                    size={11}
+                    strokeWidth={2}
+                  />
+                </button>
+              )}
+            </div>
           </div>
         ) : (
           <div className="absolute inset-0 flex items-center justify-end animate-in fade-in-0 duration-150">

--- a/src/modules/terminal/TerminalPane.tsx
+++ b/src/modules/terminal/TerminalPane.tsx
@@ -67,6 +67,7 @@ export const TerminalPane = memo(
       onCwd: (c) => onCwd?.(leafId, c),
     });
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies: theme tokens intentionally trigger terminal repaint
     useEffect(() => {
       // Defer one frame so CSS-variable token resolution sees the new class.
       const id = requestAnimationFrame(() => session.applyTheme());
@@ -94,7 +95,7 @@ export const TerminalPane = memo(
     if (blocks) {
       return (
         <div
-          className="zoom-exempt flex h-full w-full flex-col"
+          className="terminal-pane-scrollbar zoom-exempt flex h-full w-full flex-col"
           style={hideStyle}
         >
           <div className="relative min-h-0 flex-1">
@@ -139,7 +140,7 @@ export const TerminalPane = memo(
     return (
       <div
         ref={containerRef}
-        className="zoom-exempt h-full w-full"
+        className="terminal-pane-scrollbar zoom-exempt h-full w-full"
         style={hideStyle}
       />
     );

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -183,6 +183,7 @@ function termOptions() {
     cursorInactiveStyle: "outline" as const,
     scrollback: prefs.terminalScrollback,
     allowProposedApi: true,
+    overviewRuler: { width: 10 },
     minimumContrastRatio: bgActive(prefs) ? MCR_BG_ACTIVE : MCR_BG_INACTIVE,
   };
 }
@@ -290,7 +291,8 @@ function createSlot(): Slot {
       if (event.type === "keydown") {
         const targetLeafId = slot.currentLeafId;
         void readTerminalClipboard().then((text) => {
-          if (text && slot.currentLeafId === targetLeafId) slot.term.paste(text);
+          if (text && slot.currentLeafId === targetLeafId)
+            slot.term.paste(text);
         });
       }
       event.preventDefault();
@@ -366,7 +368,8 @@ function pickSlotFor(leafId: number): PickResult {
       best = s;
     }
   }
-  const chosen = best!;
+  if (!best) return { slot: createSlot(), previousLeafId: null };
+  const chosen = best;
   return { slot: chosen, previousLeafId: chosen.currentLeafId };
 }
 

--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -21,15 +21,44 @@ import { ModelsSection } from "./sections/ModelsSection";
 import { ShortcutsSection } from "./sections/ShortcutsSection";
 import { ThemesSection } from "./sections/ThemesSection";
 
-const TABS: { id: SettingsTab; label: string; icon: typeof Settings01Icon, component: () => JSX.Element }[] =
-  [
-    { id: "general", label: "General", icon: Settings01Icon, component: GeneralSection },
-    { id: "themes", label: "Themes", icon: PaintBoardIcon, component: ThemesSection },
-    { id: "shortcuts", label: "Shortcuts", icon: KeyboardIcon, component: ShortcutsSection },
-    { id: "models", label: "Models", icon: AiScanIcon, component: ModelsSection },
-    { id: "agents", label: "Agents", icon: UserMultiple02Icon, component: AgentsSection },
-    { id: "about", label: "About", icon: InformationCircleIcon, component: AboutSection },
-  ];
+const TABS: {
+  id: SettingsTab;
+  label: string;
+  icon: typeof Settings01Icon;
+  component: () => JSX.Element;
+}[] = [
+  {
+    id: "general",
+    label: "General",
+    icon: Settings01Icon,
+    component: GeneralSection,
+  },
+  {
+    id: "themes",
+    label: "Themes",
+    icon: PaintBoardIcon,
+    component: ThemesSection,
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: KeyboardIcon,
+    component: ShortcutsSection,
+  },
+  { id: "models", label: "Models", icon: AiScanIcon, component: ModelsSection },
+  {
+    id: "agents",
+    label: "Agents",
+    icon: UserMultiple02Icon,
+    component: AgentsSection,
+  },
+  {
+    id: "about",
+    label: "About",
+    icon: InformationCircleIcon,
+    component: AboutSection,
+  },
+];
 
 const VALID_TABS: SettingsTab[] = [
   "general",
@@ -53,7 +82,7 @@ function readInitialTab(): SettingsTab {
 export function SettingsApp() {
   const [active, setActive] = useState<SettingsTab>(readInitialTab);
   const init = usePreferencesStore((s) => s.init);
-  const ActiveSection = TABS.find(t => t.id === active)?.component;
+  const ActiveSection = TABS.find((t) => t.id === active)?.component;
 
   useEffect(() => {
     void init();
@@ -82,8 +111,9 @@ export function SettingsApp() {
     <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground select-none">
       <header
         data-tauri-drag-region
-        className={`flex h-11 shrink-0 items-center border-b border-border/60 bg-card/60 ${IS_MAC ? "pr-3 pl-22" : "pr-0 pl-3"
-          }`}
+        className={`flex h-11 shrink-0 items-center border-b border-border/60 bg-card/60 ${
+          IS_MAC ? "pr-3 pl-22" : "pr-0 pl-3"
+        }`}
       >
         <Tabs
           value={active}
@@ -108,7 +138,7 @@ export function SettingsApp() {
         {USE_CUSTOM_WINDOW_CONTROLS && <WindowControls closeOnly />}
       </header>
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-8 pt-6 pb-7 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <main className="terax-scrollbar min-h-0 flex-1 overflow-y-auto px-8 pt-6 pb-7">
         <div className="mx-auto w-full max-w-160">
           {ActiveSection && <ActiveSection />}
         </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -163,6 +163,16 @@
 
 :root {
   --app-zoom: 1;
+  --scrollbar-thumb: color-mix(
+    in srgb,
+    var(--muted-foreground) 42%,
+    transparent
+  );
+  --scrollbar-thumb-hover: color-mix(
+    in srgb,
+    var(--muted-foreground) 62%,
+    transparent
+  );
 }
 
 html[data-chrome="borderless"] .terax-bg-surface {
@@ -228,14 +238,35 @@ html[data-chrome="borderless"] #settings-root {
 
 .cm-editor,
 .cm-scroller {
-  scrollbar-width: none !important;
-  -ms-overflow-style: none !important;
+  scrollbar-width: thin !important;
+  scrollbar-color: var(--scrollbar-thumb) transparent !important;
+  -ms-overflow-style: auto !important;
 }
 .cm-editor::-webkit-scrollbar,
 .cm-scroller::-webkit-scrollbar {
-  width: 0 !important;
-  height: 0 !important;
-  display: none !important;
+  width: 10px !important;
+  height: 10px !important;
+  display: block !important;
+}
+.cm-editor::-webkit-scrollbar-track,
+.cm-scroller::-webkit-scrollbar-track {
+  background: transparent !important;
+}
+.cm-editor::-webkit-scrollbar-thumb,
+.cm-scroller::-webkit-scrollbar-thumb {
+  min-height: 28px !important;
+  border: 2px solid transparent !important;
+  border-radius: 999px !important;
+  background-clip: content-box !important;
+  background-color: var(--scrollbar-thumb) !important;
+}
+.cm-editor::-webkit-scrollbar-thumb:hover,
+.cm-scroller::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover) !important;
+}
+.cm-editor::-webkit-scrollbar-corner,
+.cm-scroller::-webkit-scrollbar-corner {
+  background: transparent !important;
 }
 
 body {
@@ -298,11 +329,6 @@ textarea,
   display: none !important;
 }
 
-/* Kill native scrollbars everywhere by default — Linux/Windows ship chunky
- * Chromium bars that break the chrome, and macOS WKWebView flashes its overlay
- * scrollbar briefly during layout transitions (AI panel open, pane split,
- * window resize) which looks like a glitch. Visible scroll affordances are
- * provided per-region via shadcn <ScrollArea>. */
 html,
 html *,
 html *::before,
@@ -314,6 +340,88 @@ html *::-webkit-scrollbar {
   width: 0;
   height: 0;
   display: none;
+}
+
+.terax-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
+  -ms-overflow-style: auto;
+}
+
+.terax-scrollbar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+  display: block;
+}
+
+.terax-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.terax-scrollbar::-webkit-scrollbar-thumb {
+  min-height: 28px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: content-box;
+  background-color: var(--scrollbar-thumb);
+}
+
+.terax-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
+.terax-scrollbar::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.terminal-pane-scrollbar .xterm .xterm-viewport,
+.terminal-pane-scrollbar .xterm-viewport {
+  scrollbar-width: thin !important;
+  scrollbar-color: var(--scrollbar-thumb) transparent !important;
+  -ms-overflow-style: auto !important;
+}
+
+.terminal-pane-scrollbar .xterm .xterm-viewport::-webkit-scrollbar,
+.terminal-pane-scrollbar .xterm-viewport::-webkit-scrollbar {
+  width: 10px !important;
+  height: 10px !important;
+  display: block !important;
+}
+
+.terminal-pane-scrollbar .xterm .xterm-viewport::-webkit-scrollbar-track,
+.terminal-pane-scrollbar .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent !important;
+}
+
+.terminal-pane-scrollbar .xterm .xterm-viewport::-webkit-scrollbar-thumb,
+.terminal-pane-scrollbar .xterm-viewport::-webkit-scrollbar-thumb {
+  min-height: 28px !important;
+  border: 2px solid transparent !important;
+  border-radius: 999px !important;
+  background-clip: content-box !important;
+  background-color: var(--scrollbar-thumb) !important;
+}
+
+.terminal-pane-scrollbar .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover,
+.terminal-pane-scrollbar .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover) !important;
+}
+
+.terminal-pane-scrollbar .xterm .xterm-viewport::-webkit-scrollbar-corner,
+.terminal-pane-scrollbar .xterm-viewport::-webkit-scrollbar-corner {
+  background: transparent !important;
+}
+
+.terminal-pane-scrollbar .xterm .scrollbar.vertical {
+  display: block !important;
+  visibility: visible !important;
+  width: 10px !important;
+  height: auto !important;
+  pointer-events: auto !important;
+}
+
+.terminal-pane-scrollbar .xterm .scrollbar.horizontal {
+  display: none !important;
 }
 
 /* Motion tokens. Reduced-motion zeroes the durations as a global snap. */


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits — it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own —
     describe the actual flows you exercised. -->

- [ ] `pnpm exec tsc --noEmit` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo test --locked` and `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: <!-- macOS / Linux / Windows -->
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search result markers in the editor to show where matches occur and highlight the active one.
  * Expanded search controls with previous/next navigation and a clear search button.

* **Bug Fixes**
  * Improved search behavior so markers update as content, query, and navigation change.
  * Made terminal slot selection safer when no reuse candidate is available.

* **Style**
  * Updated scrollbar styling across the app for clearer, themed, visible scrollbars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->