### PR TITLE
feat(editor): selectable formatter with fixed format on save

### DIFF
--- a/src/modules/editor/AiDiffPane.tsx
+++ b/src/modules/editor/AiDiffPane.tsx
@@ -22,7 +22,7 @@ type Props = {
   onReject: () => void;
 };
 
-const SHARED_EXT: Extension[] = buildSharedExtensions();
+const SHARED_EXT: readonly Extension[] = buildSharedExtensions();
 const READONLY_EXT: Extension[] = [
   EditorState.readOnly.of(true),
   EditorView.editable.of(false),

--- a/src/modules/editor/EditorPane.tsx
+++ b/src/modules/editor/EditorPane.tsx
@@ -24,6 +24,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { toast } from "sonner";
 import { inlineCompletion } from "./lib/autocomplete/inlineExtension";
 import { diagnosticsReporter } from "./lib/diagnosticsReporter";
 import { useDiagnosticsStore } from "./lib/diagnosticsStore";
@@ -34,6 +35,11 @@ import {
   vimCompartment,
   wrapCompartment,
 } from "./lib/extensions";
+import {
+  applyFormattedContent,
+  readFileText,
+  runExternalFormatter,
+} from "./lib/externalFormat";
 import { type LanguageResult, resolveLanguage } from "./lib/languageResolver";
 import { useDocument } from "./lib/useDocument";
 import { useEditorThemeExt } from "./lib/useEditorThemeExt";
@@ -76,12 +82,14 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
   function EditorPane(props, ref) {
     const { path, overrideLanguage, onDirtyChange, onSaved, onClose } = props;
 
-    const { doc, onChange, save, reload } = useDocument({
+    const { doc, onChange, save, reload, markSaved } = useDocument({
       path,
       onDirtyChange,
     });
     const reloadRef = useRef(reload);
     reloadRef.current = reload;
+    const markSavedRef = useRef(markSaved);
+    markSavedRef.current = markSaved;
     const cmRef = useRef<ReactCodeMirrorRef>(null);
     const themeExt = useEditorThemeExt();
     const vimMode = usePreferencesStore((s) => s.vimMode);
@@ -142,17 +150,36 @@ export const EditorPane = forwardRef<EditorPaneHandle, Props>(
     const onCloseRef = useRef(onClose);
     onCloseRef.current = onClose;
     const lspActiveRef = useRef(false);
+    const warnedNoLspRef = useRef(false);
 
     const performSave = useCallback(async () => {
       const view = cmRef.current?.view;
-      if (
-        view &&
-        lspActiveRef.current &&
-        usePreferencesStore.getState().editorFormatOnSave
-      ) {
-        await lspFormatDocument(view).catch(() => {});
+      const prefs = usePreferencesStore.getState();
+      const formatter = prefs.editorFormatter;
+      if (prefs.editorFormatOnSave && formatter === "lsp" && view) {
+        if (lspActiveRef.current) {
+          await lspFormatDocument(view).catch(() => {});
+        } else if (!warnedNoLspRef.current) {
+          warnedNoLspRef.current = true;
+          toast.warning("Format on save skipped", {
+            description:
+              "No active language server for this file. Enable one in the statusbar, or pick Biome/Prettier in Settings.",
+          });
+        }
       }
       await saveRef.current();
+      if (prefs.editorFormatOnSave && formatter !== "lsp") {
+        const error = await runExternalFormatter(formatter, pathRef.current);
+        if (error) {
+          toast.error(`${formatter} format failed`, { description: error });
+        } else {
+          const text = await readFileText(pathRef.current);
+          if (text !== null && view) {
+            markSavedRef.current(text);
+            applyFormattedContent(view, text);
+          }
+        }
+      }
       onSavedRef.current?.();
     }, []);
     const performSaveRef = useRef(performSave);

--- a/src/modules/editor/lib/chromeTheme.ts
+++ b/src/modules/editor/lib/chromeTheme.ts
@@ -2,6 +2,7 @@ import { detectMonoFontFamily } from "@/lib/fonts";
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import {
+  AbsoluteIcon,
   BoxIcon,
   BracketsIcon,
   CodeIcon,
@@ -16,7 +17,6 @@ import {
   PackageIcon,
   PuzzleIcon,
   TextFontIcon,
-  AbsoluteIcon,
 } from "@hugeicons/core-free-icons";
 
 type IconGroup = "fn" | "val" | "type" | "iface" | "misc";
@@ -310,7 +310,11 @@ const chrome = EditorView.theme({
   ".cm-tooltip ::-webkit-scrollbar-track": { background: "transparent" },
 });
 
-const THEME: Extension = [chrome, modeTheme("light"), modeTheme("dark")];
+const THEME: Extension = Object.freeze([
+  chrome,
+  modeTheme("light"),
+  modeTheme("dark"),
+]);
 
 export function chromeTheme(): Extension {
   return THEME;

--- a/src/modules/editor/lib/extensions.ts
+++ b/src/modules/editor/lib/extensions.ts
@@ -18,7 +18,7 @@ export const lspCompartment = new Compartment();
 // bracketMatching, closeBrackets, autocompletion, highlightActiveLine,
 // highlightSelectionMatches and the search keymap.
 // Singleton: per-pane instances would inject duplicate style modules.
-const SHARED_EXTENSIONS: Extension[] = [
+const SHARED_EXTENSIONS: readonly Extension[] = Object.freeze([
   indentUnit.of("  "),
   EditorState.tabSize.of(2),
   search({ top: true }),
@@ -95,8 +95,8 @@ const SHARED_EXTENSIONS: Extension[] = [
       borderColor: "var(--border)",
     },
   }),
-];
+]);
 
-export function buildSharedExtensions(): Extension[] {
+export function buildSharedExtensions(): readonly Extension[] {
   return SHARED_EXTENSIONS;
 }

--- a/src/modules/editor/lib/externalFormat.ts
+++ b/src/modules/editor/lib/externalFormat.ts
@@ -1,0 +1,78 @@
+import { quoteShellArg } from "@/lib/shellQuote";
+import type { EditorFormatter } from "@/modules/settings/store";
+import { currentWorkspaceEnv } from "@/modules/workspace";
+import type { EditorView } from "@codemirror/view";
+import { invoke } from "@tauri-apps/api/core";
+
+type ReadResult = { kind: string; content?: string };
+
+type CommandOutput = {
+  stdout: string;
+  stderr: string;
+  exit_code: number | null;
+  timed_out: boolean;
+};
+
+const COMMANDS: Record<Exclude<EditorFormatter, "lsp">, string> = {
+  biome: "biome format --write",
+  prettier: "prettier --write",
+};
+
+function dirname(path: string): string {
+  const segs = path.split(/[\\/]/);
+  segs.pop();
+  return segs.join("/") || "/";
+}
+
+/** Returns null on success, an error message otherwise. */
+export async function runExternalFormatter(
+  formatter: Exclude<EditorFormatter, "lsp">,
+  path: string,
+): Promise<string | null> {
+  try {
+    const out = await invoke<CommandOutput>("shell_run_command", {
+      command: `${COMMANDS[formatter]} ${quoteShellArg(path)}`,
+      cwd: dirname(path),
+      timeoutSecs: 20,
+      workspace: currentWorkspaceEnv(),
+    });
+    if (out.timed_out) return `${formatter} timed out`;
+    if (out.exit_code !== 0) {
+      return out.stderr.trim().slice(-300) || `${formatter} failed`;
+    }
+    return null;
+  } catch (e) {
+    return String(e);
+  }
+}
+
+export async function readFileText(path: string): Promise<string | null> {
+  const res = await invoke<ReadResult>("fs_read_file", {
+    path,
+    workspace: currentWorkspaceEnv(),
+  }).catch(() => null);
+  return res?.kind === "text" ? (res.content ?? null) : null;
+}
+
+// Minimal change dispatch: trimming the common prefix/suffix keeps the
+// cursor in place through CodeMirror's position mapping.
+export function applyFormattedContent(view: EditorView, next: string): void {
+  const current = view.state.doc.toString();
+  if (current === next) return;
+  let start = 0;
+  const minLen = Math.min(current.length, next.length);
+  while (start < minLen && current[start] === next[start]) start += 1;
+  let endCur = current.length;
+  let endNext = next.length;
+  while (
+    endCur > start &&
+    endNext > start &&
+    current[endCur - 1] === next[endNext - 1]
+  ) {
+    endCur -= 1;
+    endNext -= 1;
+  }
+  view.dispatch({
+    changes: { from: start, to: endCur, insert: next.slice(start, endNext) },
+  });
+}

--- a/src/modules/editor/lib/useDocument.ts
+++ b/src/modules/editor/lib/useDocument.ts
@@ -136,9 +136,16 @@ export function useDocument({ path, onDirtyChange }: Options) {
 
   const save = useCallback(async () => {
     clearAutoSaveTimer();
-    if (!dirty) return;
+    if (bufferRef.current === savedRef.current) return;
     await saveNow();
-  }, [dirty, clearAutoSaveTimer, saveNow]);
+  }, [clearAutoSaveTimer, saveNow]);
+
+  // Adopt externally formatted content as the saved baseline before the
+  // matching editor dispatch lands, so the buffer never flashes dirty.
+  const markSaved = useCallback((content: string) => {
+    savedRef.current = content;
+    setDirty(bufferRef.current !== content);
+  }, []);
 
   const onChange = useCallback(
     (next: string) => {
@@ -160,5 +167,5 @@ export function useDocument({ path, onDirtyChange }: Options) {
 
   useEffect(() => clearAutoSaveTimer, [path, clearAutoSaveTimer]);
 
-  return { doc, dirty, onChange, save, reload };
+  return { doc, dirty, onChange, save, reload, markSaved };
 }

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -162,9 +162,12 @@ export type Preferences = {
   editorAutoSave: boolean;
   editorAutoSaveDelay: number;
   editorFormatOnSave: boolean;
+  editorFormatter: EditorFormatter;
   lspActivation: Record<string, LspActivation>;
   lspCustomServers: LspCustomServer[];
 };
+
+export type EditorFormatter = "lsp" | "biome" | "prettier";
 
 export type LspActivation = "enabled" | "dismissed";
 
@@ -230,6 +233,7 @@ const KEY_SHORTCUTS = "shortcuts";
 const KEY_EDITOR_AUTO_SAVE = "editorAutoSave";
 const KEY_EDITOR_AUTO_SAVE_DELAY = "editorAutoSaveDelay";
 const KEY_EDITOR_FORMAT_ON_SAVE = "editorFormatOnSave";
+const KEY_EDITOR_FORMATTER = "editorFormatter";
 const KEY_LSP_ACTIVATION = "lspActivation";
 const KEY_LSP_CUSTOM_SERVERS = "lspCustomServers";
 
@@ -299,6 +303,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   editorAutoSave: false,
   editorAutoSaveDelay: 1000,
   editorFormatOnSave: false,
+  editorFormatter: "lsp",
   lspActivation: {},
   lspCustomServers: [],
 };
@@ -467,6 +472,9 @@ export async function loadPreferences(): Promise<Preferences> {
     editorFormatOnSave:
       get<boolean>(KEY_EDITOR_FORMAT_ON_SAVE) ??
       DEFAULT_PREFERENCES.editorFormatOnSave,
+    editorFormatter:
+      get<EditorFormatter>(KEY_EDITOR_FORMATTER) ??
+      DEFAULT_PREFERENCES.editorFormatter,
     lspActivation:
       get<Record<string, LspActivation>>(KEY_LSP_ACTIVATION) ??
       DEFAULT_PREFERENCES.lspActivation,
@@ -720,9 +728,15 @@ export async function setZoomLevel(value: number): Promise<void> {
   await writePref(KEY_ZOOM_LEVEL, value);
 }
 
-function clampAutoSaveDelay(v: number): number {
+export const AUTO_SAVE_DELAY_MIN = 100;
+export const AUTO_SAVE_DELAY_MAX = 60000;
+
+export function clampAutoSaveDelay(v: number): number {
   if (!Number.isFinite(v)) return 1000;
-  return Math.min(60000, Math.max(100, Math.round(v)));
+  return Math.min(
+    AUTO_SAVE_DELAY_MAX,
+    Math.max(AUTO_SAVE_DELAY_MIN, Math.round(v)),
+  );
 }
 
 export async function setEditorAutoSave(value: boolean): Promise<void> {
@@ -735,6 +749,12 @@ export async function setEditorAutoSaveDelay(value: number): Promise<void> {
 
 export async function setEditorFormatOnSave(value: boolean): Promise<void> {
   await writePref(KEY_EDITOR_FORMAT_ON_SAVE, value);
+}
+
+export async function setEditorFormatter(
+  value: EditorFormatter,
+): Promise<void> {
+  await writePref(KEY_EDITOR_FORMATTER, value);
 }
 
 export async function setAgentNotifications(value: boolean): Promise<void> {
@@ -812,6 +832,7 @@ export async function onPreferencesChange(
     [KEY_EDITOR_AUTO_SAVE]: "editorAutoSave",
     [KEY_EDITOR_AUTO_SAVE_DELAY]: "editorAutoSaveDelay",
     [KEY_EDITOR_FORMAT_ON_SAVE]: "editorFormatOnSave",
+    [KEY_EDITOR_FORMATTER]: "editorFormatter",
     [KEY_LSP_ACTIVATION]: "lspActivation",
     [KEY_LSP_CUSTOM_SERVERS]: "lspCustomServers",
   };

--- a/src/settings/sections/EditorSection.tsx
+++ b/src/settings/sections/EditorSection.tsx
@@ -1,10 +1,22 @@
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
+  AUTO_SAVE_DELAY_MAX,
+  AUTO_SAVE_DELAY_MIN,
+  clampAutoSaveDelay,
+  type EditorFormatter,
   setEditorAutoSave,
   setEditorAutoSaveDelay,
   setEditorFormatOnSave,
+  setEditorFormatter,
   setEditorWordWrap,
   setVimMode,
 } from "@/modules/settings/store";
@@ -14,8 +26,6 @@ import { SectionHeader } from "../components/SectionHeader";
 import { SettingRow } from "../components/SettingRow";
 
 const AUTO_SAVE_STEP = 100;
-const AUTO_SAVE_MIN = 100;
-const AUTO_SAVE_MAX = 60000;
 
 export function EditorSection() {
   const vimMode = usePreferencesStore((s) => s.vimMode);
@@ -23,6 +33,7 @@ export function EditorSection() {
   const editorAutoSave = usePreferencesStore((s) => s.editorAutoSave);
   const editorAutoSaveDelay = usePreferencesStore((s) => s.editorAutoSaveDelay);
   const editorFormatOnSave = usePreferencesStore((s) => s.editorFormatOnSave);
+  const editorFormatter = usePreferencesStore((s) => s.editorFormatter);
 
   return (
     <div className="flex flex-col gap-6">
@@ -72,13 +83,35 @@ export function EditorSection() {
         )}
         <SettingRow
           title="Format on save"
-          description="Format through the language server before an explicit save. Requires an active LSP for the file."
+          description="Format the file on explicit save (Cmd+S / :w) with the formatter below."
         >
           <Switch
             checked={editorFormatOnSave}
             onCheckedChange={(v) => void setEditorFormatOnSave(v)}
           />
         </SettingRow>
+        {editorFormatOnSave && (
+          <SettingRow
+            title="Formatter"
+            description="Language server formats the buffer before writing; Biome and Prettier run on the saved file from your PATH."
+          >
+            <Select
+              value={editorFormatter}
+              onValueChange={(v) =>
+                void setEditorFormatter(v as EditorFormatter)
+              }
+            >
+              <SelectTrigger className="h-8 w-40 text-[12px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="lsp">Language server</SelectItem>
+                <SelectItem value="biome">Biome</SelectItem>
+                <SelectItem value="prettier">Prettier</SelectItem>
+              </SelectContent>
+            </Select>
+          </SettingRow>
+        )}
       </div>
 
       <LspServersGroup />
@@ -113,10 +146,7 @@ function AutoSaveDelayInput({
       setDraft(String(value));
       return;
     }
-    const clamped = Math.min(
-      AUTO_SAVE_MAX,
-      Math.max(AUTO_SAVE_MIN, Math.round(n)),
-    );
+    const clamped = clampAutoSaveDelay(n);
     setDraft(String(clamped));
     if (clamped !== value) onChange(clamped);
   };
@@ -129,8 +159,8 @@ function AutoSaveDelayInput({
       <div className="flex items-center gap-2">
         <Input
           type="number"
-          min={AUTO_SAVE_MIN}
-          max={AUTO_SAVE_MAX}
+          min={AUTO_SAVE_DELAY_MIN}
+          max={AUTO_SAVE_DELAY_MAX}
           step={AUTO_SAVE_STEP}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}


### PR DESCRIPTION
Format on save was broken two ways: the save gate read a stale React dirty flag (with autosave on, the post-format write was silently skipped), and the external-format path reloaded the whole document, resetting the cursor.

- Save now compares live buffer refs instead of component state.
- New Formatter setting (Editor tab): Language server, Biome, or Prettier. External formatters run on the saved file via the workspace-gated shell command, and the result is applied as a minimal prefix/suffix-trimmed dispatch, so the cursor and scroll stay put and the buffer never flashes dirty.
- Picking Language server with no active LSP for the file now explains itself with a one-time toast instead of doing nothing.
- Rides along: CodeRabbit follow-ups from #937 (frozen extension singletons, shared autosave clamp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Format on save” formatter choice in editor settings, with options for Language server, Biome, and Prettier.
  * Improved save behavior so formatted content is applied back into the editor after saving.

* **Bug Fixes**
  * Made save status tracking more reliable when formatting changes file contents.
  * Added a clearer warning when format-on-save is enabled but no language server is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->