### PR TITLE
fix(terminal): eliminate 1-frame WebGL input/rendering desync with preserveDrawingBuffer

### DIFF
--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -775,7 +775,9 @@ function attachWebgl(slot: Slot): void {
     elem.querySelectorAll<HTMLCanvasElement>("canvas"),
   );
   try {
-    const webgl = new WebglAddon();
+    // preserveDrawingBuffer: true forces single-buffering so draw calls
+    // are visible in the same frame, eliminating WebGL's default 1-frame lag.
+    const webgl = new WebglAddon(true);
     webgl.onContextLoss(() => {
       const cur = slot.webglAddon;
       if (cur === webgl) {


### PR DESCRIPTION
## Problem

When WebGL rendering is enabled, terminal input and rendering are
consistently 1 frame out of sync:

```
user types:     a     b     c     d     e
screen shows:   -     a     ab    abc   abcd
^ first keystroke completely invisible
```

This affects all input — keyboard typing, mouse clicks, cursor movement,
selection. Disabling WebGL makes the problem disappear instantly.

## Root Cause

With the default WebGL context attribute `preserveDrawingBuffer: false`, the browser maintains a swap chain (typically 2–3 buffers):

```
Frame N:   gl.drawElementsInstanced() → back buffer
compositor displays front buffer (frame N−1 content)
buffers swap → frame N becomes front buffer

Frame N+1: gl.drawElementsInstanced() → back buffer
compositor displays front buffer (frame N content)
```

## Tadeoff

`preserveDrawingBuffer: true` disables swap-chain optimizations at the GPU driver level. I am new to webGL, maybe there is a better fix?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering responsiveness by reducing visible frame lag in WebGL-backed output.
  * Terminal display should now feel more immediate and better synced during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->