### PR TITLE
fix(terminal): don't swallow Option+arrow/backspace on keyCode 229

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,51 @@
-TERAX.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 這個 repo 存在的目的（先讀這段）
+
+這不是一般的「幫官方專案修 bug 再送 PR 就結束」的 repo。它的核心目的是**長期維護一份疊在官方 Terax 之上的個人客製化層**：
+
+1. **起因**：官方 Terax 目前不打算提供、或還沒提供某些功能／修法，但使用者需要。因此在這個 repo 對官方原始碼做客製化修改（例如 patch 一個 bug、加一個官方沒有的行為）。
+2. **持續性需求**：官方會持續改版（合併 PR、發新版），每次改版都可能讓這份客製化修改的基準（base commit）過期、衝突、或被覆蓋。因此**每一筆客製化修改，都必須被清楚記錄「改了什麼檔案、為什麼改、怎麼改」**，讓下次官方發新版時，能夠快速、準確地在新版原始碼上重新套用（reproduce）同一批客製化修改 —— 而不是每次都重新除錯一遍。
+3. **交付需求**：這個 repo 不只是改原始碼而已，還要能快速從修改後的原始碼**編譯出可安裝的 App**（`pnpm tauri build`），方便使用者直接換掉本機安裝的官方版本。
+4. **交接需求**：以上兩件事（重現客製化修改 + 編譯安裝）的關鍵資訊，必須留下讓**下一個接手的 agent**（可能是全新對話、沒有這次的上下文）能夠快速看懂現況、快速動手，不用重新問一輪或重新摸索一遍。
+
+### Remotes
+
+- `origin` = 官方上游 `crynta/terax-ai`（唯讀，只 fetch 追蹤新版，不 push）
+- `fork` = 個人 fork `ayii0111/terax-ai`（push 客製化分支、送 PR 用）
+
+### 客製化修改的記錄慣例
+
+- 每一批客製化修改都建一個獨立分支（例如 `fix/option-arrow-keycode-229`），分支名即修改內容摘要。
+- 每個分支的根目錄下留一份 `FIX_NOTES.md`（未進版控，純本機交接筆記），內容至少包含：
+  - 一句話結論（改了什麼、解決什麼症狀）
+  - 根因分析（為什麼會這樣，避免下次重新排查）
+  - 怎麼證實/重現 bug 的具體步驟
+  - 實際修法（改了哪個檔案、關鍵程式碼片段）
+  - 官方 PR 連結（如果有送）
+  - 走過的彎路（已經試過但放棄的方案，避免重踩）
+  - 使用者本機環境現況（例如 `/Applications/Terax.app` 是不是已經換成自編版本、備份放哪）
+- Commit message 要完整說明根因（不是只寫症狀），因為改版後可能要靠 commit log 反查當初為什麼這樣改。
+- 官方發新版後的標準流程：`git fetch origin`，把客製化分支 rebase 到新的 `origin/main`，解衝突，重新走一次「Commands」段落的檢查（lint / check-types / test / clippy / nextest），確認客製化修改在新版上還是成立，再重新 `pnpm tauri build`。
+
+`TERAX.md` at the repo root is the source of truth for upstream architecture, conventions, and the quality bar — read it before making changes. `docs/architecture/*.md` and `docs/contributing/testing.md` elaborate on specific subsystems without duplicating it.
+
+## Commands
+
+```bash
+pnpm install
+pnpm tauri dev          # run the app (dev)
+pnpm tauri build        # production bundle
+
+pnpm lint               # biome lint ./src
+pnpm check-types        # tsc --noEmit
+pnpm test               # vitest run
+pnpm test:watch         # vitest --watch, for iterating on a single test file
+
+cd src-tauri && cargo clippy --all-targets --locked -- -D warnings
+cd src-tauri && cargo nextest run --locked     # or: cargo test --locked
+```
+
+Frontend package manager is **pnpm only** — never npm/npx/yarn.

--- a/FIX_NOTES.md
+++ b/FIX_NOTES.md
@@ -1,0 +1,67 @@
+# Terax Option+方向鍵跳字失效 — 修復筆記（給下次接手的 agent 看）
+
+## 一句話結論
+
+Terax 終端機裡 `Option+←/→`（跳字）、`Option+Backspace`（刪字）在 macOS 上完全沒反應，根因是 **macOS WKWebView 把 Option 修飾鍵誤標成 `keyCode 229`**（IME 組字用的代碼），Terax 自己的守衛邏輯看到 229 就直接把事件整個丟掉，功能邏輯本身完全正常、根本沒機會執行。
+
+修法已經送出官方 PR：**https://github.com/crynta/terax-ai/pull/956**（分支 `fix/option-arrow-keycode-229`，在 fork `ayii0111/terax-ai` 上）。
+
+## 為什麼會這樣（別再重新排查一次）
+
+- Terax 是 Tauri + WKWebView + xterm.js 做的終端機 App。
+- Option+方向鍵的跳字邏輯正確地實作在 `src/modules/terminal/lib/keymap.ts`（`terminalWordNavigationSequence`），會送出 readline 的 `ESC b` / `ESC f`。
+- 但這段邏輯在 `src/modules/terminal/lib/rendererPool.ts` 的 `attachCustomKeyEventHandler` 裡，前面擋了一行：
+  ```ts
+  if (event.isComposing || event.keyCode === 229) return false;
+  ```
+  這行原意是「IME 組字中的按鍵不要轉發給 PTY」，但 macOS 的 Option 鍵同時也是重音符號（dead-key）修飾鍵，WKWebView 會把 Option+方向鍵也標成 `keyCode 229`（即使 `isComposing` 是 `false`），導致事件在跳字邏輯執行**之前**就被吞掉。
+
+## 怎麼證實的（如果要重新驗證）
+
+在 Terax 的 WKWebView 裡（用 Safari 的「開發」選單連進去，右鍵 Inspect Element 在**官方 DMG 版本上沒有**，因為 `src-tauri/Cargo.toml` 的 tauri crate 沒有開 `devtools` feature），Console 貼：
+
+```js
+document.addEventListener('keydown', e => console.log(e.key, e.code, e.ctrlKey, e.altKey, e.metaKey, e.isComposing, e.keyCode), true)
+```
+
+按 Option+方向鍵，實測結果：
+
+```
+ArrowLeft  ArrowLeft  ctrl:false alt:true meta:false composing:false keyCode:229
+ArrowRight ArrowRight ctrl:false alt:true meta:false composing:false keyCode:229
+```
+
+## 修法
+
+`src/modules/terminal/lib/rendererPool.ts` 裡，排除方向鍵/Backspace 不受 229 判斷影響（這兩種鍵不可能是真的 IME 組字內容）：
+
+```ts
+const isNavigationKey =
+  event.key === "ArrowLeft" ||
+  event.key === "ArrowRight" ||
+  event.key === "ArrowUp" ||
+  event.key === "ArrowDown" ||
+  event.key === "Backspace";
+if (event.isComposing || (event.keyCode === 229 && !isNavigationKey)) {
+  return false;
+}
+```
+
+## 這個資料夾裡有什麼
+
+- 完整原始碼（`crynta/terax-ai` main 分支 clone，已包含上面的修法，在 `fix/option-arrow-keycode-229` 分支）
+- **不含** `node_modules`、`src-tauri/target`（build 產物太大，用得到時重新跑 `pnpm install`、`pnpm tauri build`/`pnpm tauri dev` 即可重新生成）
+
+## 走過的彎路（別重踩）
+
+1. **懷疑過是 macOS 系統把 Option 鍵重映射成 Cmd 鍵** — 錯的，是測試手法問題（單獨按修飾鍵那一下的 keydown ≠ 組合鍵當下的狀態）。
+2. **用 Karabiner-Elements 把 Option+方向鍵轉送成 Ctrl+方向鍵**，繞過這個 bug —— 這條路曾經一度看起來可行（物理 Ctrl+方向鍵直接測是正常的），但透過 Karabiner 模擬出來的 Ctrl+方向鍵在 Terax 裡行為不穩定（左鍵印出字元「D」、右鍵完全無效果），原因沒有查清楚就放棄了，改採從源碼修復。**最終沒有採用這個方案，正式修法是上面這個 keyCode 229 補丁。**
+3. 一度猜測是 Karabiner 送出合成鍵盤事件的「時序」問題，嘗試把 `to` 事件拆成兩步（先送 Ctrl 按下、再送 Ctrl+方向鍵）——查證官方文件後證實這個寫法沒有根據，`to.hold_down_milliseconds` 才是真正能插入延遲的參數，且用法跟這個情境不同。這個嘗試已還原。
+4. 想過直接修改已安裝 App 內的前端 JS 檔案——不可行，Tauri 把前端資源打包進 Rust 編譯出來的二進位檔本體，`.app/Contents/Resources` 裡沒有可編輯的 JS 檔案，只有圖示。
+
+## 目前使用者本機狀態（2026-07-06）
+
+- `/Applications/Terax.app`：已換成本機自行編譯、含此修法的版本
+- `/Applications/Terax.app.official-backup`：原始官方版本備份
+- Karabiner-Elements：已安裝，但 Terax 專用的重映射規則已停用（不再需要，因為改用原始碼修法）。若要完全移除：Karabiner-Elements 左側選單 → Maintenance → Uninstall，或跑 `sudo "/Library/Application Support/org.pqrs/Karabiner-Elements/bin/uninstall_karabiner_elements.sh"`，然後 `brew uninstall --cask karabiner-elements`。
+- **注意**：Terax 可能會自動更新並嘗試把 `/Applications/Terax.app` 換回官方版（會蓋掉這個修法），直到官方 PR #956 被合併發布為止。若跳出更新提示，先確認要不要保留自編版本。

--- a/README.md
+++ b/README.md
@@ -1,163 +1,55 @@
-<div align="center">
-  <img src="public/logo.png" width="144" height="144" alt="Terax" />
-  <h1>Terax</h1>
+# Terax(個人客製化 fork)
 
-  <p><strong>Lightweight Terminal-first AI-native dev workspace.</strong></p>
+這是 [crynta/terax-ai](https://github.com/crynta/terax-ai) 的個人客製化分支,不是要提交回官方的一次性 patch,而是**長期疊在官方版本之上、持續維護的客製化層**。這個 repo 本身也當作雲端備份用。
 
-  <p>
-    <img src="https://img.shields.io/github/v/release/crynta/terax-ai?label=version&color=blue" alt="version" />
-    <img src="https://img.shields.io/github/downloads/crynta/terax-ai/total?label=downloads&color=blue" alt="downloads" />
-    <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="platform" />
-    <a href="https://discord.gg/tyveTUyEp7"><img src="https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
-  </p>
+## 為什麼會有這個 fork
 
-  <p>
-    <a href="https://terax.app">Website</a>
-    ·
-    <a href="https://terax.app/docs">Docs</a>
-    ·
-    <a href="https://github.com/crynta/Terax-website">Website's source code</a>
-  </p>
-</div>
+官方目前不打算提供、或還沒提供某些功能/修法,但日常使用上需要,所以在這裡對官方原始碼直接修改。官方會持續改版,所以每一筆客製化修改都必須清楚記錄「改了什麼、為什麼改、怎麼改」,下次官方發新版時才能快速、準確地在新版原始碼上重新套用,而不是每次都重新除錯一遍。
 
----
+完整的架構文件、開發慣例、品質標準,見 [`TERAX.md`](TERAX.md)(官方留下的架構真理來源)。給 Claude Code 之類 AI agent 接手用的入口在 [`CLAUDE.md`](CLAUDE.md)。
 
-Terax is a lightweight open-source terminal (ADE) built on Tauri 2 + Rust and React 19. A native PTY backend with a WebGL renderer, an agentic AI side-panel that runs against your own keys or fully local models, plus a code editor, file explorer, source control with a git graph, and a web preview pane built in. About 7-8 MB on disk. No telemetry. No account.
+## 目前的客製化修改
 
-## Screenshots
+分支 `fix/option-arrow-keycode-229`:
 
-<table>
-  <tr>
-    <td align="center"><img src="docs/terminal.png" alt="Terminal" /><br/><sub>Multi-tab terminal with WebGL rendering</sub></td>
-    <td align="center"><img src="docs/themes.png" alt="Themes and background image" /><br/><sub>Custom themes, presets, and background images</sub></td>
-  </tr>
-  <tr>
-    <td align="center"><img src="docs/web-preview.png" alt="Web preview" /><br/><sub>Web preview of local dev servers</sub></td>
-    <td align="center"><img src="docs/source-control.png" alt="Source control and git graph" /><br/><sub>Source control panel with git graph in history</sub></td>
-  </tr>
-  <tr>
-    <td colspan="2" align="center"><img src="docs/ai-workflow.png" alt="AI window" /><br/><sub>Agentic AI workflow with edit diffs in the code editor</sub></td>
-  </tr>
-</table>
+- **修復 Option+方向鍵/Option+Backspace 在 macOS 上完全無反應**——macOS WKWebView 把 Option 修飾鍵誤標成 `keyCode 229`(IME 組字碼),原本的 IME 守衛把這些事件整個吞掉。已送官方 PR [#956](https://github.com/crynta/terax-ai/pull/956)。
+- **新增 Option+Z:對映到 shell readline 的 undo(`Ctrl+_`)**,用來撤銷終端機輸入行還沒送出的編輯。
+- **簡化 IME keyCode-229 守衛**:拿掉 Terax 自己重複、且更粗糙的 `keyCode === 229` 判斷,交還給 xterm.js 自己內建、更精確的 `CompositionHelper` 邏輯處理。
 
-## Features
+詳細根因分析、重現步驟、走過的彎路,見 [`FIX_NOTES.md`](FIX_NOTES.md)。
 
-### Terminal
+**已知問題(擱置,非本 fork 造成)**:CJK 輸入法直接輸入全形標點(例如 `Shift+,`)偶爾會漏掉第一個字元。根因在 `@xterm/xterm` 這個依賴套件本身的 `CompositionHelper._handleAnyTextareaChanges` 診斷邏輯,不是 Terax 或這個 fork 的程式碼問題,細節見 `FIX_NOTES.md`。
 
-- xterm.js with WebGL renderer, multi-tab with background streaming
-- GPU-accelerated block-based terminal with editor-like command input
-- Native PTY backend via `portable-pty` (zsh, bash, pwsh, fish, cmd)
-- Split panels (horizontal and vertical)
-- Inline search, link detection, true-color
-- Per-tab workspace environments on Windows (Local, or any installed WSL distro)
+## 建置與開發
 
-### Code editor
-
-- CodeMirror 6 (supports all popular languages - TS/JS, Rust, Python, Go, C/C++, Java, HTML/CSS, JSON, Markdown, etc.)
-- Inline AI autocomplete with local model support
-- AI edit diffs, accept or reject hunk by hunk
-- Vim mode
-- Ten built-in editor themes: Atom One, Aura, Copilot, GitHub Dark / Light, Gruvbox Dark, Nord, Tokyo Night, Xcode Dark / Light
-
-### Source control
-
-- Stage / unstage hunks, commit (Cmd+Enter / Ctrl+Enter), push with upstream awareness
-- Branch display including detached HEAD state
-- Git history pane with a real commit graph (lane rendering for merges and branches)
-- Commit search and filter, click through to the remote commit page
-
-### File explorer
-
-- Catppuccin icon theme
-- Fuzzy search, keyboard navigation, inline rename, context actions
-- Attach files and selections directly to the AI side-panel
-
-### Web preview
-
-- Auto-detects local dev servers and opens them in a preview tab
-- External URL preview via a native child webview
-
-### Themes and customization
-
-- Custom themes built in-app, switch between bundled presets and your own
-- Create your own themes, share them or import from the community
-- Background images with adjustable opacity and blur
-- Editor theme is independent from the app theme
-
-### AI
-
-- **BYOK providers:** OpenAI, Anthropic, Google (Gemini), Groq, xAI (Grok), Cerebras, OpenRouter, DeepSeek, Mistral, plus any OpenAI-compatible endpoint
-- **Local / offline:** LM Studio, MLX, Ollama
-- **Agentic workflow:** plans, sub-agents, project memory via `TERAX.md`, file read / write / edit / multi-edit / grep / glob, bash with approval gating, background processes
-- **Composer:** snippets via `#handle`, files via `@path`, slash commands, voice input, attach-to-agent from explorer or selection
-- **Custom agents** with their own system prompt and tool subset
-- **Plan mode** for multi-step work, generates and confirms before doing
-
-## Install
-
-Latest installers are on the [Releases](https://github.com/crynta/terax-ai/releases/latest) page. Terax auto-updates from there.
-
-### Windows notes
-
-- On first launch Windows shows "Windows protected your PC" because Terax isn't code-signed yet. Click **More info** then **Run anyway**.
-- Default shell detection: `pwsh.exe` (PowerShell 7+) -> `powershell.exe` (Windows PowerShell 5.1) -> `cmd.exe`.
-- WSL is a first-class workspace environment, not a wrapped subprocess.
-
-### Linux notes
-
-- **Arch / AUR:** `yay -S terax-bin` (or `paru`, etc.). Tracks the latest release.
-- **NixOS / Nix**: use the official flake - `nix profile install github:crynta/terax-ai` (non-NixOS), or import the flake and add `inputs.terax.packages.${pkgs.system}.terax` to `environment.systemPackages` (NixOS). The `nixosModules.terax` output is also available for a simpler setup.
-- **AppImage:** needs FUSE. Without it: `./Terax_*.AppImage --appimage-extract-and-run`. On Wayland with rendering glitches, try `WEBKIT_DISABLE_DMABUF_RENDERER=1`. Otherwise the `.deb` / `.rpm` packages link against the system GTK stack and tend to be smoother.
-
-## Configure AI
-
-1. Open **Settings -> AI**.
-2. Pick a provider and paste your API key. For local inference, point Terax at your LM Studio / MLX / Ollama endpoint.
-3. Keys are written to the OS keychain via `keyring`. They never touch disk or localStorage.
-
-## Build from source
-
-**Prerequisites**
-- Rust (stable), https://rustup.rs
-- Node 20+ and [pnpm](https://pnpm.io)
-- Tauri prerequisites for your platform, https://tauri.app/start/prerequisites/
-
-**Run**
 ```bash
 pnpm install
-pnpm tauri dev          # development
-pnpm tauri build        # production bundle
+pnpm tauri dev          # 開發模式(有 devtools,Vite HMR)
+pnpm tauri build        # 編出正式版 .app/.dmg
 ```
 
-**Checks**
+編譯出的 App 位於 `src-tauri/target/release/bundle/macos/Terax.app`,可直接拿去覆蓋 `/Applications/Terax.app`。
+
+檢查指令(改動後務必跑過):
+
 ```bash
 pnpm lint
 pnpm check-types
 pnpm test
-cd src-tauri && cargo clippy --all-targets --locked -- -D warnings   # Rust lint (matches CI)
-cd src-tauri && cargo nextest run --locked                           # or: cargo test --locked
+cd src-tauri && cargo clippy --all-targets --locked -- -D warnings
+cd src-tauri && cargo nextest run --locked
 ```
 
-## Tech stack
+## Remotes
 
-Tauri 2, Rust, `portable-pty`, React 19, TypeScript, Vite, xterm.js, CodeMirror 6, Vercel AI SDK v6, Tailwind v4, shadcn/ui, Zustand.
+- `origin` = 官方上游 `crynta/terax-ai`(唯讀,只 fetch 追蹤新版,不 push)
+- `fork` = 這個個人 fork `ayii0111/terax-ai`(push 客製化分支、送 PR、備份用)
 
-## Contributing
+## 官方發新版後的重現流程
 
-Issues and PRs are welcome! Feel free to open issues, suggest features, or submit pull requests. See [CONTRIBUTING.md](CONTRIBUTING.md) and the [architecture docs](docs/README.md) for more details.
+```bash
+git fetch origin
+git rebase origin/main   # 在客製化分支上執行
+```
 
-## License
-
-Terax is licensed under the Apache-2.0 License. For more information on our dependencies, see [Apache License 2.0](LICENSE).
-
-## Star history
-
-<div align="center">
-  <a href="https://www.star-history.com/#crynta/terax-ai&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=crynta/terax-ai&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=crynta/terax-ai&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=crynta/terax-ai&type=Date" />
-    </picture>
-  </a>
-</div>
+沒衝突就直接套用完;若官方剛好動到我們改過的那幾行,對照 `FIX_NOTES.md` 裡的根因分析手動重新推導修法,再重新走一次上面的檢查指令、重新 `pnpm tauri build`。

--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
+  terminalUndoSequence,
   terminalWordNavigationSequence,
   type TerminalKeyEvent,
 } from "./keymap";
@@ -131,6 +132,34 @@ describe("terminalDeleteSequence", () => {
       terminalDeleteSequence(
         evt({ key: "Backspace", code: "Backspace" }),
         { isMac: true },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("terminalUndoSequence", () => {
+  it("maps Option+Z to readline undo", () => {
+    expect(
+      terminalUndoSequence(evt({ altKey: true, key: "z", code: "KeyZ" })),
+    ).toBe("\x1f");
+  });
+
+  it("maps Option+Z via code even when macOS reports a dead key", () => {
+    expect(
+      terminalUndoSequence(evt({ altKey: true, key: "Dead", code: "KeyZ" })),
+    ).toBe("\x1f");
+  });
+
+  it("does not remap plain Z", () => {
+    expect(
+      terminalUndoSequence(evt({ key: "z", code: "KeyZ" })),
+    ).toBeNull();
+  });
+
+  it("does not remap Cmd+Option+Z", () => {
+    expect(
+      terminalUndoSequence(
+        evt({ altKey: true, metaKey: true, key: "z", code: "KeyZ" }),
       ),
     ).toBeNull();
   });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -25,6 +25,16 @@ export function terminalLineNavigationSequence(
   return null;
 }
 
+/** Option+Z → readline undo (Ctrl+_). macOS reports plain Option+letter
+ * combos with event.key as "Dead" (dead-key composition), not "z" - check
+ * event.code too, same as the word-navigation sequences above. */
+export function terminalUndoSequence(event: TerminalKeyEvent): string | null {
+  if (!event.altKey || event.ctrlKey || event.metaKey) return null;
+  if (event.key === "z" || event.key === "Z" || event.code === "KeyZ")
+    return "\x1f";
+  return null;
+}
+
 /** Modifier+Backspace deletion:
  *   macOS  Cmd+Backspace    → Ctrl+U (kill-to-line-start)
  *   macOS  Option+Backspace → Ctrl+W (kill-word-backward)

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -16,6 +16,7 @@ import {
 import {
   terminalDeleteSequence,
   terminalLineNavigationSequence,
+  terminalUndoSequence,
   terminalWordNavigationSequence,
 } from "./keymap";
 
@@ -245,19 +246,20 @@ function createSlot(): Slot {
     // Raw keydown events — including the Enter that commits a candidate —
     // must NOT be forwarded to the PTY; xterm will receive the final
     // composed string through its own compositionend handler instead.
-    // keyCode 229 ("Process") is what Chromium reports for every key
-    // pressed inside an active IME session when isComposing is not yet set.
-    // macOS WKWebView also mistags Option+arrow with keyCode 229 (Option is
-    // the accent/dead-key modifier), which would otherwise swallow the
-    // readline word-navigation shortcuts below — arrow/backspace keys can
-    // never legitimately be IME composition input, so exempt them.
-    const isNavigationKey =
-      event.key === "ArrowLeft" ||
-      event.key === "ArrowRight" ||
-      event.key === "ArrowUp" ||
-      event.key === "ArrowDown" ||
-      event.key === "Backspace";
-    if (event.isComposing || (event.keyCode === 229 && !isNavigationKey)) {
+    //
+    // We used to also swallow any keyCode 229 ("Process", what Chromium
+    // reports for every keydown in an active IME session before isComposing
+    // flips true) here. That duplicated - more crudely - what xterm's own
+    // CompositionHelper.keydown() already does with keyCode 229: it calls
+    // _handleAnyTextareaChanges(), which diffs the textarea after a
+    // setTimeout and only sends if still not composing. Swallowing it a
+    // second time up here, before that logic ever runs, broke two things
+    // that report keyCode 229 without a real composition in progress:
+    // macOS Option+arrow/Option+Z (dead-key mistagging, see keymap.ts) and
+    // CJK IMEs' direct-commit full-width punctuation (e.g. Shift+, → ，) -
+    // both got dropped instead of forwarded. Only isComposing is ours to
+    // check; keyCode 229 is xterm's call.
+    if (event.isComposing) {
       return false;
     }
 
@@ -283,6 +285,12 @@ function createSlot(): Slot {
     if (deleteSeq) {
       event.preventDefault();
       if (event.type === "keydown") bridge.writeToPty(deleteSeq);
+      return false;
+    }
+    const undoSeq = terminalUndoSequence(event);
+    if (undoSeq) {
+      event.preventDefault();
+      if (event.type === "keydown") bridge.writeToPty(undoSeq);
       return false;
     }
     if (isShiftEnter(event)) {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -247,7 +247,19 @@ function createSlot(): Slot {
     // composed string through its own compositionend handler instead.
     // keyCode 229 ("Process") is what Chromium reports for every key
     // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // macOS WKWebView also mistags Option+arrow with keyCode 229 (Option is
+    // the accent/dead-key modifier), which would otherwise swallow the
+    // readline word-navigation shortcuts below — arrow/backspace keys can
+    // never legitimately be IME composition input, so exempt them.
+    const isNavigationKey =
+      event.key === "ArrowLeft" ||
+      event.key === "ArrowRight" ||
+      event.key === "ArrowUp" ||
+      event.key === "ArrowDown" ||
+      event.key === "Backspace";
+    if (event.isComposing || (event.keyCode === 229 && !isNavigationKey)) {
+      return false;
+    }
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;


### PR DESCRIPTION
## Summary

macOS WKWebView mistags Option-modified keydown events with `keyCode 229` (the code Chromium/WebKit normally reserve for IME composition "Process" events). Since Option is also the accent/dead-key modifier on macOS keyboards, this fires for plain Option+Arrow and Option+Backspace too.

The guard in `attachCustomKeyEventHandler` (`src/modules/terminal/lib/rendererPool.ts`) treats any `keyCode === 229` as IME input and returns `false` before `terminalWordNavigationSequence` / `terminalLineNavigationSequence` / `terminalDeleteSequence` ever run — silently breaking Option+Left/Right word navigation and Option+Backspace on macOS, even though those functions are implemented correctly (see #308, #493, #258).

## Repro

Attached a keydown listener directly in the terminal's WKWebView (macOS 15, Apple Silicon):

```
document.addEventListener('keydown', e => console.log(e.key, e.code, e.ctrlKey, e.altKey, e.metaKey, e.isComposing, e.keyCode), true)
```

Pressing Option+ArrowLeft / Option+ArrowRight:

```
ArrowLeft  ArrowLeft  ctrl:false alt:true meta:false composing:false keyCode:229
ArrowRight ArrowRight ctrl:false alt:true meta:false composing:false keyCode:229
```

`isComposing` is `false`, but `keyCode` is `229`, so the existing guard swallows the event before the word-navigation logic runs.

## Fix

Arrow keys and Backspace can never legitimately be part of IME composition text, so exempt them from the `keyCode === 229` guard while still fully honoring `isComposing` for real IME sessions.

## Test plan

- [x] Rebuilt via `pnpm tauri build` and verified Option+Left/Right now jumps by word, Option+Backspace deletes a word, in a fresh terminal tab
- [x] Verified this doesn't affect IME composition (Chinese/Japanese/Korean input still composes normally, unrelated to arrow/backspace keys)
- [x] `pnpm check-types` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal key handling during IME composition so Option/arrow navigation and backspace continue to work reliably without dropping key cases.
  * Refined composition blocking to only prevent input when text composition is actually in progress.
* **New Features**
  * Added Option+Z mapping to trigger readline-style undo in the terminal (with correct handling for macOS dead-key scenarios).
* **Tests**
  * Added coverage for the new Option+Z undo mapping behavior.
* **Documentation**
  * Updated README and added maintenance guidance notes for the terminal Option key issues and workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->