### PR TITLE
fix(terminal): stop IME-committed accents duplicating cumulatively

### DIFF
--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   terminalDeleteSequence,
+  terminalImeKeyDecision,
   terminalLineNavigationSequence,
   terminalWordNavigationSequence,
+  type TerminalImeKeyEvent,
   type TerminalKeyEvent,
 } from "./keymap";
 
@@ -76,6 +78,53 @@ describe("terminalLineNavigationSequence", () => {
         evt({ metaKey: true, altKey: true, key: "ArrowLeft", code: "ArrowLeft" }),
         { isMac: true },
       ),
+    ).toBeNull();
+  });
+});
+
+describe("terminalImeKeyDecision", () => {
+  const ime = (partial: Partial<TerminalImeKeyEvent>): TerminalImeKeyEvent => ({
+    type: "keydown",
+    isComposing: false,
+    keyCode: 0,
+    ...partial,
+  });
+
+  it("blocks keydowns fired during an active composition", () => {
+    // The Enter that commits an IME candidate arrives as a keydown with
+    // isComposing set; forwarding it would run the shell command (#158).
+    expect(
+      terminalImeKeyDecision(ime({ isComposing: true, keyCode: 13 })),
+    ).toBe("block");
+    expect(
+      terminalImeKeyDecision(ime({ isComposing: true, keyCode: 229 })),
+    ).toBe("block");
+  });
+
+  it("forwards Process (229) keydowns outside a composition to xterm", () => {
+    // IME-committed text (dead keys, ibus accents) arrives as keyCode 229
+    // with no isComposing flag. xterm's CompositionHelper must see the
+    // keydown to run its textarea-diff bookkeeping, otherwise committed
+    // accents accumulate and re-send cumulatively (#850, #927).
+    expect(terminalImeKeyDecision(ime({ keyCode: 229 }))).toBe("forward");
+  });
+
+  it("forwards IME keyups and keypresses to xterm", () => {
+    expect(
+      terminalImeKeyDecision(ime({ type: "keyup", keyCode: 229 })),
+    ).toBe("forward");
+    expect(
+      terminalImeKeyDecision(ime({ type: "keyup", isComposing: true })),
+    ).toBe("forward");
+    expect(
+      terminalImeKeyDecision(ime({ type: "keypress", isComposing: true })),
+    ).toBe("forward");
+  });
+
+  it("leaves non-IME keys to the regular shortcut handling", () => {
+    expect(terminalImeKeyDecision(ime({ keyCode: 65 }))).toBeNull();
+    expect(
+      terminalImeKeyDecision(ime({ type: "keyup", keyCode: 13 })),
     ).toBeNull();
   });
 });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -5,6 +5,36 @@ export type TerminalKeyEvent = Pick<
 
 export type PlatformOpts = { isMac: boolean };
 
+export type TerminalImeKeyEvent = Pick<
+  KeyboardEvent,
+  "type" | "isComposing" | "keyCode"
+>;
+
+export type ImeKeyDecision = "block" | "forward" | null;
+
+/** How the custom key handler should treat IME-related events.
+ *
+ * "block"   — drop the event entirely. Only raw keydowns fired during an
+ *             active composition: the Enter that commits an IME candidate
+ *             must not reach the PTY as a real Enter, and xterm's own
+ *             pipeline would finalize-then-forward it.
+ * "forward" — hand the event straight to xterm and skip Terax shortcuts.
+ *             keyCode 229 ("Process") keydowns must reach xterm's
+ *             CompositionHelper: it never forwards them raw, and its
+ *             textarea-diff bookkeeping is what emits IME-committed text
+ *             (dead keys, ibus accents like ñ/ö) exactly once. Blocking
+ *             them starves that bookkeeping, so each committed accent
+ *             re-sends the whole accumulated textarea value.
+ * null      — not IME-related; continue with Terax's shortcut handling.
+ */
+export function terminalImeKeyDecision(
+  event: TerminalImeKeyEvent,
+): ImeKeyDecision {
+  if (event.type === "keydown" && event.isComposing) return "block";
+  if (event.isComposing || event.keyCode === 229) return "forward";
+  return null;
+}
+
 export function terminalWordNavigationSequence(event: TerminalKeyEvent): string | null {
   if (!event.altKey || event.ctrlKey || event.metaKey) return null;
   if (event.key === "ArrowLeft" || event.code === "ArrowLeft") return "\x1bb";

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -15,6 +15,7 @@ import {
 } from "./terminalClipboard";
 import {
   terminalDeleteSequence,
+  terminalImeKeyDecision,
   terminalLineNavigationSequence,
   terminalWordNavigationSequence,
 } from "./keymap";
@@ -241,13 +242,14 @@ function createSlot(): Slot {
 
   term.attachCustomKeyEventHandler((event) => {
     // During IME composition the browser is assembling a multi-keystroke
-    // character (Chinese pinyin → hanzi, Korean jamo → syllable, etc.).
-    // Raw keydown events — including the Enter that commits a candidate —
-    // must NOT be forwarded to the PTY; xterm will receive the final
-    // composed string through its own compositionend handler instead.
-    // keyCode 229 ("Process") is what Chromium reports for every key
-    // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // character (Chinese pinyin → hanzi, Korean jamo → syllable, dead-key
+    // accents). Raw keydowns fired mid-composition — including the Enter
+    // that commits a candidate — must NOT be forwarded to the PTY. All
+    // other IME events (keyCode 229 "Process") must still reach xterm's
+    // own pipeline: its CompositionHelper is what turns committed text
+    // into exactly one data event (#850, #927).
+    const imeDecision = terminalImeKeyDecision(event);
+    if (imeDecision) return imeDecision === "forward";
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;
@@ -298,6 +300,27 @@ function createSlot(): Slot {
     }
     return true;
   });
+
+  // WebKitGTK can commit IME text (dead keys, ibus accents like ñ/ö)
+  // without a compositionstart, so xterm's composition offset stays at 0
+  // and every commit re-sends the hidden textarea's accumulated value —
+  // one ñ, then ññ, then ñññ (#850, #927). xterm only clears that textarea
+  // on blur or Enter. Clear it once the commit has been consumed: xterm
+  // reads the value in a 0ms timer scheduled by its own compositionend
+  // listener, which registered first and therefore runs before this one.
+  const textarea = term.textarea;
+  if (textarea) {
+    let composing = false;
+    textarea.addEventListener("compositionstart", () => {
+      composing = true;
+    });
+    textarea.addEventListener("compositionend", () => {
+      composing = false;
+      window.setTimeout(() => {
+        if (!composing) textarea.value = "";
+      }, 0);
+    });
+  }
 
   term.onData((data) => {
     const leafId = slot.currentLeafId;


### PR DESCRIPTION
## What

Fixes composed/IME-committed characters (ñ, ö, ä, …) duplicating cumulatively in the terminal: one keystroke printed `ñ`, the next printed `ññ`, the next `ñññ`.

Closes #850
Closes #927

## Why

Both issues are on Linux (WebKitGTK). When an input method commits a character there, the commit can arrive **without a `compositionstart`** — just a `keyCode 229` keydown, the textarea mutation, and a `compositionend`. Two things then go wrong in the current code:

1. `attachCustomKeyEventHandler` in `rendererPool.ts` returns `false` for *every* event with `keyCode === 229`, so xterm's `CompositionHelper.keydown()` never runs. That helper never forwards raw keys — its job is the textarea-diff bookkeeping (`_handleAnyTextareaChanges`, `_dataAlreadySent`) that emits IME-committed text exactly once. Starved of it, xterm falls back to reading the textarea from a stale composition offset.
2. xterm only clears its hidden textarea on blur or Enter, and with no `compositionstart` the composition offset stays at 0. So the textarea accumulates `ñ`, `ññ`, `ñññ` … and each `compositionend` re-sends the whole accumulated value. That is exactly the 1 → 2 → 3 pattern in both issue reports.

## How

- `terminalImeKeyDecision()` (new, in `keymap.ts`): only **keydowns fired during an active composition** are dropped — that keeps the #196 guard intact (the Enter that commits a Chinese IME candidate must not run the shell command, #158, and raw jamo keydowns must not race the composed string, #147). Everything else IME-related (`keyCode 229`) is handed back to xterm, which processes it through `CompositionHelper` and never writes it to the PTY raw.
- `rendererPool.ts`: after a `compositionend` has been consumed (xterm reads the textarea in a 0 ms timer scheduled by its own listener, which registered first and runs before ours), clear the hidden textarea unless a new composition already started. This removes the accumulation source on every engine, matching what xterm itself does on blur/Enter.

To validate the mechanism without a Linux box, I ported xterm 6.0.0's `CompositionHelper` + `_keyDown`/`_keyUp` gating verbatim into a small harness and replayed six plausible engine event orderings (Chromium full sequence, WebKitGTK commit-without-compositionstart, commit-as-`insertText`, composition-events-before-keydown, 229 keyups, fast-typing overlap). The commit-without-compositionstart sequences reproduce the exact reported 1 → 2 → 3 pattern under the current code; with this PR every sequence emits exactly one character per keystroke and the healthy sequences are unchanged. Happy to share the harness if useful.

## Testing

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (new `terminalImeKeyDecision` cases in `keymap.test.ts` lock the contract: mid-composition keydowns blocked, 229 events forwarded, plain keys untouched)
- [x] Manual smoke-test of the affected feature
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows 11 (WebView2). I don't have a Linux machine at hand — @nachosag / @mosenturm, would you mind confirming on Ubuntu?
- [x] Shells tested (if relevant): pwsh

Manual testing on Windows in `pnpm tauri dev`: regular typing, Enter, and command execution work as before (typed commands run and their output/redirection lands where expected). I don't have an IME or dead-key layout installed on this machine, so the composition scenarios themselves are covered by the harness above plus the unit tests — that's why a confirmation from the Linux reporters would be valuable.

## Notes for reviewer

- The `event.isComposing` keydown block is deliberately kept — dropping it would regress #158/#147.
- The textarea clear runs only when no composition is active and always after xterm's own `compositionend` timer, so multi-keystroke IMEs (pinyin, Hangul) are unaffected; the fast-typing overlap case was covered in the harness.
- No behavior change for non-IME keys: the shortcut chain (word/line nav, delete, copy/paste, Shift+Enter) is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input handling for IME users, so composing text is treated more reliably.
  * Fixed Enter/commit behavior during IME input and reduced duplicate character input in certain browser environments.
  * Kept non-IME shortcut handling unchanged while ensuring IME-related key events are routed appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->