### PR TITLE
fix(terminal): stop dropping keystrokes typed right after a terminal opens

### DIFF
--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -441,7 +441,12 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
   cancelSlotReap(slot);
   unparkSlotHost(slot);
   if (!fast) {
-    slot.host.style.visibility = "hidden";
+    // opacity, not visibility: a visibility:hidden subtree refuses focus in
+    // Chromium, and the terminal must be focusable during the two-frame
+    // anti-flash window below or the first keystrokes land on the pane
+    // container and are dropped (#857). opacity:0 hides the stale frame
+    // just the same but keeps xterm's textarea focusable.
+    slot.host.style.opacity = "0";
     if (hadWebgl) disposeSlotWebgl(slot);
   }
 
@@ -524,6 +529,18 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
     }
     if (adapter?.isLeafFocused(p.leafId)) slot.term.focus();
   } else {
+    // Focus before the two-frame unhide, not after it: rAF is throttled for
+    // occluded/activating windows on Windows, so the deferred focus can land
+    // hundreds of ms late and everything typed until then falls on <body>
+    // and is dropped (#857). Focusing here keeps that input flowing into
+    // xterm and the PTY queue (pendingInput). Blocks leaves are skipped like
+    // the mount-time focus does - at the prompt the shell editor owns focus.
+    if (
+      adapter?.isLeafFocused(p.leafId) &&
+      !adapter.isLeafBlocks(p.leafId)
+    ) {
+      slot.term.focus();
+    }
     scheduleUnhide(slot, stale || hadWebgl);
   }
 
@@ -534,7 +551,7 @@ function scheduleUnhide(slot: Slot, stale: boolean): void {
   slot.unhideRaf = requestAnimationFrame(() => {
     slot.unhideRaf = requestAnimationFrame(() => {
       slot.unhideRaf = null;
-      slot.host.style.visibility = "";
+      slot.host.style.opacity = "";
       if (stale) {
         if (!slot.webglAddon) attachWebgl(slot);
         try {
@@ -666,7 +683,7 @@ function detachSlotFromLeaf(slot: Slot, retain: boolean): void {
   slot.ptyTimer = null;
 
   cancelPendingUnhide(slot);
-  slot.host.style.visibility = "";
+  slot.host.style.opacity = "";
 
   slot.currentLeafId = null;
   slot.lastUsedAt = performance.now();


### PR DESCRIPTION
## What

Fixes keystrokes being dropped when typing into a terminal that just opened (or just got its slot rebound): the first characters — sometimes the whole line — never reach the shell.

Closes #857

## Why

Two things combine into the swallow window:

1. A freshly acquired slot is hidden with `visibility: hidden` for two animation frames to avoid flashing stale content, and `slot.term.focus()` only runs when the second rAF fires (`scheduleUnhide`). The mount-time focus that already exists (`focusSlot` in `useTerminalSession`) fires earlier — but **Chromium refuses to focus any element inside a `visibility:hidden` subtree**, so it silently no-ops. Easy to check in a console: a textarea under `visibility:hidden` rejects `.focus()`; under `opacity:0` it accepts it.
2. On Windows, WebView2 throttles/suspends rAF for occluded, freshly shown, or still-activating windows — exactly the "newly opened terminal / app window just became active" conditions in the report. The two-frame unhide can then take hundreds of milliseconds, and everything typed in that window targets `document.body` and is dropped. (The report's suspicion about the frontend focus race was right — the PTY write path is fine, `pendingInput` queues input typed before the PTY attaches.)

## How

- Hide the acquired slot with `opacity: 0` instead of `visibility: hidden`. Same anti-flash effect and identical layout/IntersectionObserver behavior, but the subtree stays focusable.
- Focus the terminal synchronously in `acquireSlot` for the focused leaf (skipping blocks leaves, same as the existing mount-time focus — at the prompt the shell editor owns focus). The rAF-deferred focus in `scheduleUnhide` stays as a safety net.

Keystrokes typed while the slot is still transparent now land in xterm and flow into the PTY input queue instead of vanishing.

## Testing

To make the race measurable I drove the real frontend (vite dev) in a headless Chromium over CDP: trusted `Ctrl+T` + immediately typing `echo hi`, with a capture-phase keydown logger and a 5 ms `activeElement`/slot-style sampler, and rAF delayed by 700 ms to model the throttled-window condition.

- **Before**: all 7 keys hit `document.body` (dropped); the new slot sits at `visibility:hidden`; focus only reaches its textarea ~1.4 s later when the starved rAFs finally fire. With healthy rAF the same script happens to win the race — which is why this reproduces intermittently in real use, mostly on Windows.
- **After**: focus reaches the new terminal's textarea at ~28 ms (at acquire, before the first key); all 7 keys are delivered to it; the slot stays `opacity:0` until the same two-frame unhide clears it, so the anti-flash behavior is unchanged.
- Also reproduced the loss in the real app on Windows 11 (`pnpm tauri dev`, driving `Ctrl+T` + immediate typing via OS-level key injection): commands typed right after opening a tab never reached any shell pre-fix.

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature (typed commands execute; new tabs, tab switches, splits behave as before)
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows 11 (WebView2) + headless Chromium harness
- [x] Shells tested (if relevant): pwsh

No test added: the behavior lives in DOM focus/rAF timing, which the node test environment can't exercise — happy to add one if you have a preferred harness for this layer.

## Notes for reviewer

- `opacity:0` differs from `visibility:hidden` in two ways that seemed acceptable: the transparent slot can receive pointer events during the two frames (a click just focuses the terminal, which is what the click intends), and it stays in the a11y tree for those two frames.
- The new focus call mirrors the fast-rebind path one branch above, with the extra `isLeafBlocks` guard so a blocks-mode prompt can't leak keystrokes to the PTY behind the shell editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal focus behavior when panels are rebound, helping keep the terminal focusable in more cases.
  * Reduced visual flashing during terminal slot transitions by changing how hidden terminal frames are shown and restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->