### PR TITLE
fix(ai): send anthropic-dangerous-direct-browser-access header

### DIFF
--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -104,7 +104,12 @@ export async function buildLanguageModel(
     }
     case "anthropic": {
       const { createAnthropic } = await import("@ai-sdk/anthropic");
-      built = createAnthropic({ apiKey: key })(resolvedModelId);
+      // Webview fetch sends an Origin header; Anthropic's API rejects such
+      // "browser" requests unless this header opts in. ponytail: required flag.
+      built = createAnthropic({
+        apiKey: key,
+        headers: { "anthropic-dangerous-direct-browser-access": "true" },
+      })(resolvedModelId);
       break;
     }
     case "google": {


### PR DESCRIPTION
## Problem

Every Claude request from the app fails with a generic **"An error occurred"** in the AI panel. The Anthropic branch in `buildLanguageModel` constructs the provider with no custom headers:

```ts
built = createAnthropic({ apiKey: key })(resolvedModelId);
```

Inside the Tauri webview, `fetch` sends an `Origin` header, so Anthropic's API treats the call as a browser request and rejects it:

```
{"type":"error","error":{"type":"authentication_error",
 "message":"CORS requests must set 'anthropic-dangerous-direct-browser-access' header"}}
```

The blocked response can't be read by the SDK, which throws — surfacing as the generic error. Key, model, billing, and network are all fine; the request never gets an answer.

Reproduced directly against `api.anthropic.com` with a valid key:
- no `Origin` → 200 OK
- `Origin` + no flag → CORS `authentication_error` (above)
- `Origin` + `anthropic-dangerous-direct-browser-access: true` → 200 OK

## Fix

Pass the opt-in header via `createAnthropic`'s `headers` option, matching what the official Anthropic SDK does under `dangerouslyAllowBrowser`.

## Notes

- Other cloud providers (OpenAI, Google, …) may need equivalent handling for webview CORS; scoped this PR to the confirmed Anthropic case.
- `pnpm check-types` clean; `src/modules/ai/config.test.ts` passes (13/13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for AI features in browser-based views, preventing requests from being rejected by the model provider.
  * Enabled successful model connections in environments that include browser-origin headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->