### PR TITLE
feat(tabs): show terminal agent status on tabs

### DIFF
--- a/src/modules/tabs/AgentTabBadge.tsx
+++ b/src/modules/tabs/AgentTabBadge.tsx
@@ -1,0 +1,65 @@
+import { Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { cn } from "@/lib/utils";
+import {
+  aggregateAgentPhases,
+  useAgentActivityStore,
+} from "@/modules/terminal/lib/agentActivity";
+import { leafIds } from "@/modules/terminal/lib/panes";
+import { ptyIdForLeaf } from "@/modules/terminal/lib/useTerminalSession";
+import type { Tab } from "./lib/useTabs";
+
+const DOT_CLASS: Record<"working" | "attention", string> = {
+  working: "bg-sky-400",
+  attention: "bg-amber-400",
+};
+
+export function AgentTabBadge({ tab }: { tab: Tab }) {
+  const phases = useAgentActivityStore((s) => s.phases);
+  if (tab.kind !== "terminal") return null;
+
+  const ptyIds: number[] = [];
+  for (const leaf of leafIds(tab.paneTree)) {
+    const id = ptyIdForLeaf(leaf);
+    if (id !== null) ptyIds.push(id);
+  }
+
+  const { top, count } = aggregateAgentPhases(phases, ptyIds);
+  if (!top) return null;
+
+  return (
+    <span
+      data-no-drag
+      role="img"
+      className="flex shrink-0 items-center gap-0.5"
+      aria-label={`Agent ${top}${count > 1 ? ` (${count})` : ""}`}
+      title={`${count || 1} agent${(count || 1) === 1 ? "" : "s"} · ${top}`}
+    >
+      {top === "finished" ? (
+        <HugeiconsIcon
+          icon={Tick02Icon}
+          size={11}
+          strokeWidth={2.5}
+          className="text-emerald-400"
+        />
+      ) : (
+        <span className="relative flex size-2">
+          <span
+            className={cn(
+              "absolute inline-flex size-full animate-ping rounded-full opacity-70",
+              DOT_CLASS[top],
+            )}
+          />
+          <span
+            className={cn("relative inline-flex size-2 rounded-full", DOT_CLASS[top])}
+          />
+        </span>
+      )}
+      {count > 1 ? (
+        <span className="text-[9px] font-semibold tabular-nums text-foreground/70">
+          {count}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -43,6 +43,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { AgentTabBadge } from "./AgentTabBadge";
 import { labelFor } from "./lib/tabLabel";
 import type { EditorTab, Tab } from "./lib/useTabs";
 
@@ -454,6 +455,7 @@ export function TabBar({
                       />
                     ) : null}
                   </span>
+                  <AgentTabBadge tab={t} />
                   {tabs.length > 1 && (
                     <span
                       role="button"

--- a/src/modules/terminal/lib/agentActivity.ts
+++ b/src/modules/terminal/lib/agentActivity.ts
@@ -1,13 +1,48 @@
 import { listen } from "@tauri-apps/api/event";
+import { create } from "zustand";
+
+export type AgentPhase = "working" | "attention" | "finished" | "idle";
 
 type AgentSignal = { id: number; kind: string };
 
-const active = new Set<number>();
+type AgentActivityStore = {
+  phases: Record<number, AgentPhase>;
+  setPhase: (id: number, phase: AgentPhase) => void;
+  clear: (id: number) => void;
+};
+
+export const useAgentActivityStore = create<AgentActivityStore>((set) => ({
+  phases: {},
+  setPhase: (id, phase) =>
+    set((s) => {
+      if (s.phases[id] === phase) return s;
+      return { phases: { ...s.phases, [id]: phase } };
+    }),
+  clear: (id) =>
+    set((s) => {
+      if (!(id in s.phases)) return s;
+      const next = { ...s.phases };
+      delete next[id];
+      return { phases: next };
+    }),
+}));
+
+const FINISHED_TTL_MS = 6000;
+const finishedTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+function clearFinishedTimer(id: number): void {
+  const t = finishedTimers.get(id);
+  if (t) {
+    clearTimeout(t);
+    finishedTimers.delete(id);
+  }
+}
+
 let onExited: ((ptyId: number) => void) | null = null;
 let bound = false;
 
-// Covers shells without an OSC 133 C preexec hook (pwsh): the Rust detector
-// arms via the Claude Code OSC 777 marker and reports per-pty lifecycle.
+// The Rust detector arms via the Claude Code / Codex / Gemini OSC 777 marker and
+// reports per-pty lifecycle: started, working, attention, finished, exited.
 export function ensureAgentActivityListener(
   exited: (ptyId: number) => void,
 ): void {
@@ -15,15 +50,70 @@ export function ensureAgentActivityListener(
   if (bound || typeof window === "undefined") return;
   bound = true;
   void listen<AgentSignal>("terax:agent-signal", (e) => {
-    if (e.payload.kind === "started") {
-      active.add(e.payload.id);
-    } else if (e.payload.kind === "exited") {
-      active.delete(e.payload.id);
-      onExited?.(e.payload.id);
+    const { id, kind } = e.payload;
+    const store = useAgentActivityStore.getState();
+    switch (kind) {
+      case "started":
+      case "working":
+        clearFinishedTimer(id);
+        store.setPhase(id, "working");
+        break;
+      case "attention":
+        clearFinishedTimer(id);
+        store.setPhase(id, "attention");
+        break;
+      case "finished":
+        clearFinishedTimer(id);
+        store.setPhase(id, "finished");
+        finishedTimers.set(
+          id,
+          setTimeout(() => {
+            finishedTimers.delete(id);
+            const s = useAgentActivityStore.getState();
+            if (s.phases[id] === "finished") s.setPhase(id, "idle");
+          }, FINISHED_TTL_MS),
+        );
+        break;
+      case "exited":
+        clearFinishedTimer(id);
+        store.clear(id);
+        onExited?.(id);
+        break;
     }
   });
 }
 
 export function isAgentActivePty(ptyId: number): boolean {
-  return active.has(ptyId);
+  return ptyId in useAgentActivityStore.getState().phases;
+}
+
+export type AgentTabStatus = {
+  top: "attention" | "working" | "finished" | null;
+  count: number;
+};
+
+const PRIORITY: Record<Exclude<AgentPhase, "idle">, number> = {
+  attention: 3,
+  working: 2,
+  finished: 1,
+};
+
+export function aggregateAgentPhases(
+  phases: Record<number, AgentPhase>,
+  ptyIds: readonly number[],
+): AgentTabStatus {
+  let top: AgentTabStatus["top"] = null;
+  let topRank = 0;
+  let count = 0;
+  for (const id of ptyIds) {
+    const phase = phases[id];
+    if (!phase || phase === "idle") continue;
+    if (phase === "working" || phase === "attention") count++;
+    const rank = PRIORITY[phase];
+    if (rank > topRank) {
+      topRank = rank;
+      top = phase;
+    }
+  }
+  return { top, count };
 }

--- a/src/modules/terminal/lib/useTerminalSession.ts
+++ b/src/modules/terminal/lib/useTerminalSession.ts
@@ -288,6 +288,10 @@ export function leafIdForPty(ptyId: number): number | null {
   return null;
 }
 
+export function ptyIdForLeaf(leafId: number): number | null {
+  return sessions.get(leafId)?.pty?.id ?? null;
+}
+
 function leafBusy(s: Session): boolean {
   return s.commandRunning || (s.pty !== null && isAgentActivePty(s.pty.id));
 }


### PR DESCRIPTION
## What
Surfaces running terminal AI agents (Claude Code, Codex, Gemini) on the **tab bar**: a small colored dot per tab shows whether an agent is **working**, **waiting for you**, or **just finished** — visible even when the tab isn't focused, and aggregated across multiple agent sessions split into one tab's panes.

## Why
When you run coding agents inside the terminal, you often have several going at once across tabs/splits. Today there's no way to tell from the tab bar which one needs you or is still working — you have to click into each. This adds an at-a-glance status so you know where to look (especially the "waiting for you" state).

## How
The detection already exists — `agent_detect.rs` watches the OSC 777 marker our agent hooks emit and reports per-pty lifecycle (`started` / `working` / `attention` / `finished` / `exited` via `terax:agent-signal`). The frontend previously **collapsed all of that to a binary active/inactive** flag. This PR keeps the richer states:

- **`agentActivity`** → reactive store of per-pty phase (`working` / `attention` / `finished` / `idle`); `finished` auto-fades to `idle` after a few seconds so the check is brief.
- **Aggregation** → for a terminal tab, walk its pane leaves → their ptys → reduce by priority (`attention` > `working` > `finished`) plus a count of actively-running agents.
- **`AgentTabBadge`** → pulsing dot (working = blue, attention = amber, finished = green check) with the count when > 1.
- **`ptyIdForLeaf()`** → maps a pane leaf to its pty for the aggregation.

No Rust changes — this is purely the frontend consuming signals the backend already sends.

## Testing
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 258 passed
- [x] `pnpm lint` — no new warnings
- [x] (Rust) untouched — no backend changes
- [x] (`#[tauri::command]` signatures) none changed
- [ ] (UI) manual: run Claude Code in a tab → dot pulses blue (working) → amber when it asks for permission/input → green check when the turn ends; split the pane and run a second agent → count shows `2`
- [x] Platforms tested: macOS (Apple Silicon)

## Notes for reviewer
- Priority + count was the chosen aggregation: a tab with `[working][working][attention][idle]` shows an amber dot with `3`.
- `isAgentActivePty` keeps its previous "active until exit" semantics (idle stays in the map until `exited`), so the existing session-activity behavior is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status badges to terminal tabs to show agent activity at a glance.
  * Tabs can now display live indicators for working, attention, finished, and multiple active agents.

* **Bug Fixes**
  * Improved agent status tracking so finished states persist briefly before clearing, giving users a more reliable view.
  * Updated tab status handling to better reflect activity across nested terminal panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->