### PR TITLE
feat(ai): add current frontier models and provider errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "knip": "knip"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.85",
+    "@ai-sdk/anthropic": "^3.0.94",
     "@ai-sdk/cerebras": "^2.0.57",
     "@ai-sdk/google": "^3.0.83",
     "@ai-sdk/groq": "^3.0.42",
-    "@ai-sdk/openai": "^3.0.73",
+    "@ai-sdk/openai": "^3.0.81",
     "@ai-sdk/openai-compatible": "^2.0.51",
     "@ai-sdk/react": "^3.0.209",
-    "@ai-sdk/xai": "^3.0.96",
+    "@ai-sdk/xai": "^3.0.103",
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-css": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.85
-        version: 3.0.85(zod@4.4.3)
+        specifier: ^3.0.94
+        version: 3.0.94(zod@4.4.3)
       '@ai-sdk/cerebras':
         specifier: ^2.0.57
         version: 2.0.57(zod@4.4.3)
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.0.42
         version: 3.0.42(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.73
-        version: 3.0.73(zod@4.4.3)
+        specifier: ^3.0.81
+        version: 3.0.81(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.51
         version: 2.0.51(zod@4.4.3)
@@ -30,8 +30,8 @@ importers:
         specifier: ^3.0.209
         version: 3.0.209(react@19.2.7)(zod@4.4.3)
       '@ai-sdk/xai':
-        specifier: ^3.0.96
-        version: 3.0.96(zod@4.4.3)
+        specifier: ^3.0.103
+        version: 3.0.103(zod@4.4.3)
       '@codemirror/autocomplete':
         specifier: ^6.20.3
         version: 6.20.3
@@ -315,8 +315,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@3.0.85':
-    resolution: {integrity: sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==}
+  '@ai-sdk/anthropic@3.0.94':
+    resolution: {integrity: sha512-sRENM4zDL4Cd/TBifbZ/X88Vv9vK8r7G5f2DDMi69+89QjXOVtASWj7y2d3kYBPGPEGHWHkSKq/nQ+pSYWY14w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -351,8 +351,14 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.73':
-    resolution: {integrity: sha512-+3x9oxHv9Xp33Iv2L8D+e5hqmZi64jofBKig/9611JKyfV59NdkaDDajtwc0CxOEfARgCVq1BW7dP+526gKOKw==}
+  '@ai-sdk/openai-compatible@2.0.57':
+    resolution: {integrity: sha512-Qt4GfVxKT70YxlDHJeHQ72pO4+Dj8lPGB76+4dENHOrTZp7L24eRIo9mljOLXU8WFZf0uv49bF6CfLnefHMPiw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.81':
+    resolution: {integrity: sha512-VarNyiLU5nSbyVQw3M8HUzw/UlnWfGA5LpZsA35rq2oC/lD4Oqg2VC+qgV3w39hhTwpqfouYO59pKF4yaFVlYg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -363,8 +369,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.36':
+    resolution: {integrity: sha512-hy0V+eyKcYyjmIxdcSh1jvy4+zNC7DbP0/V45jkRmfVnz+lI6GslT0qsd0V/bfJKo/A+P2t1tYFypTQJdOH1Sg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.13':
+    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.209':
@@ -373,8 +389,8 @@ packages:
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
-  '@ai-sdk/xai@3.0.96':
-    resolution: {integrity: sha512-a24jD29cQ3YocP7B4NUvNTb9s5CYR1ao2yU/QncT7QDwwOp4x/lq+6W+BdXGf1VucG7A0dx9jtyIOm6PE4JPyg==}
+  '@ai-sdk/xai@3.0.103':
+    resolution: {integrity: sha512-QNaDqJXJCMbRZtHn//rmGRZjvkFdu6Ku6iPHIuNFpXEp8zfuj3AMiUkmAWYnWFj5bdY2+cBR+SMdJlozvSl5Qw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -662,20 +678,11 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
-
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1182,18 +1189,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@oxc-resolver/binding-android-arm-eabi@11.22.0':
-    resolution: {integrity: sha512-il+0FB7BBUfuQaE0Lgd9zlgSjzu88ErN8vr4hintuTt1qRDcPtmzLyurail1gJZpJ1ljo7zA0cid/a/PaWMyZg==}
-    cpu: [arm]
-    os: [android]
-
   '@oxc-resolver/binding-android-arm64@11.20.0':
     resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-resolver/binding-android-arm64@11.22.0':
-    resolution: {integrity: sha512-rWCyvcoiMxb5JRsGMXI22DFAlsddZHOTBWp/zz48E85Yh/KWQRFko18Gf5xsRdcN0pz65VFnJoisz/B2LWoaGg==}
     cpu: [arm64]
     os: [android]
 
@@ -1202,18 +1199,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-resolver/binding-darwin-arm64@11.22.0':
-    resolution: {integrity: sha512-eDx1up8xhb6OH58RfcADHAKWQY3yatNAbrOF2QEqDN2ml0DsOlHBNgj7E5NB3kU62yam2VEYnFTMO8meOYEe1w==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@oxc-resolver/binding-darwin-x64@11.20.0':
     resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-resolver/binding-darwin-x64@11.22.0':
-    resolution: {integrity: sha512-4YUMAsVqqQGzkq7eDWEZXUvzm1L7eZFd4jghnoDv76fPF2IisedcBjkJY3iwcAlWQNtZLgc5Od/cL0Z2ogEwaQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -1222,18 +1209,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-resolver/binding-freebsd-x64@11.22.0':
-    resolution: {integrity: sha512-I7qjjmCzrqPme94B9b9deHID6YiggKQRy3s9mTjnUuYlpgDx5YgC1G00W2S/Cchrjz5I8VOik17/3uO4joPULw==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
     resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.22.0':
-    resolution: {integrity: sha512-VsI6Vnsyg9O5jLv+bkYP15yHv924i63fLbROZAZfwAAUJ611FF8OE4aCX2KzsG70yRlcn4n7Zh0fyHT5L4myGA==}
     cpu: [arm]
     os: [linux]
 
@@ -1242,19 +1219,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.22.0':
-    resolution: {integrity: sha512-Imedx3sbderR0w8HHZ+vH7PqrY7eL3H7cj666Yrg+erelaRCVzXlJjQD5w0vNk+RtGDqhmnP5R18WIowFCI+uA==}
-    cpu: [arm]
-    os: [linux]
-
   '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-resolver/binding-linux-arm64-gnu@11.22.0':
-    resolution: {integrity: sha512-a9L5IxPBpiSXcvEPGNWOpD5pKbcE0VgC5smcaYn0t/oMaJxHwejrJ1qRoXZLj767HAo+nq9FNEpZ9WFW91lP8g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1265,20 +1231,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.22.0':
-    resolution: {integrity: sha512-4AFo9hX0AbA/o7qWrsrAHbRGsZpthcUEZiuMHlxqZsR4JNgvFmeuLtMXUV+KPHWo+gfefFmiQ0UdUx8GPBCrXQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.22.0':
-    resolution: {integrity: sha512-QVPpxFDkLxWAnfAqN0DA1TH4agOPL1bxg7dwUZ7goQKU5IfaPoL/ZcPClMol4+Dwb30g2nPNxbr0BPyFmcVV3A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1289,20 +1243,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.22.0':
-    resolution: {integrity: sha512-saQJeKGMCrtW5DH8uY9N9pPE4/8Hs+DpZ4hJg1+SzvISSKhTf3V6/jOROxluU14ftz5KNd8G/NXRgj9vTS0Emg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-resolver/binding-linux-riscv64-musl@11.22.0':
-    resolution: {integrity: sha512-/p6aCGRKot+Je44l+WoL+zkizRXY4ApQcvRXlLw8lRM305tmmEqNtAyekDLMCzn8DUt81lS3ZsiUpdn0bL533A==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -1313,20 +1255,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.22.0':
-    resolution: {integrity: sha512-ZYfI5CG/W1C+HXDWkJ5+JPjiuwVQw6HBD1jUTneAzJVWImRDjstQPKmixCa1fTkthCM1OCkn2D8fdX+q37kMXQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-resolver/binding-linux-x64-gnu@11.22.0':
-    resolution: {integrity: sha512-IR2juRKWbR6TmFZTn6plHFm5iXWD8Szw/fGeKhaGWzwTPN/Oq4CCV6ZVp8Bq8ih2easVh7Mwom2A5CGkB+QVxg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1337,19 +1267,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-x64-musl@11.22.0':
-    resolution: {integrity: sha512-TCE/wgDr3EaxQrwQrU9MbRK35cFsYAVwMT2Du0lbyjmlaXV03uPLnCKIDDmxUPyQUdPgZirM+k26GDR3LNs+hw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-resolver/binding-openharmony-arm64@11.22.0':
-    resolution: {integrity: sha512-uhNpwQzWnYVBZ6ZZomIQN2X/jUDLp3HYjLSVbdsZqA4hNpYSFENSF8JV6I6gdvvV9TLQr1rC/viDsxhvE/5/Ww==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -1358,28 +1277,13 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-resolver/binding-wasm32-wasi@11.22.0':
-    resolution: {integrity: sha512-nn8NCiQhh3rgwrGMf8msky7MjPd0W8Vwmo7oZr5cs7TOJby2IRMZYPPgb+NTz8vVG6VjjjcLPriIMxHE1aAx1A==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
   '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
     resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.22.0':
-    resolution: {integrity: sha512-kHx9KiAKQKeSW/yVmt5tUa7oAHUd9OsoB5fdpQjSBDaKtHSQpPIXxNJ1E9q8cnaxS9NNWANR6w3osEHBD+5lSg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
     resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-resolver/binding-win32-x64-msvc@11.22.0':
-    resolution: {integrity: sha512-gZKq7BTQBdAmvFYGQfqkuz3zeoytmAkluFjajToSkWUTed0DsJ3GdCoXpPdpGSElBLLIeAgKM3ju6XdPvKOr0A==}
     cpu: [x64]
     os: [win32]
 
@@ -2399,8 +2303,8 @@ packages:
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
-  '@react-grab/cli@0.1.47':
-    resolution: {integrity: sha512-Cc7d8mSwvoV8gpeTQbE8dMPdeXIyO6w+yIhzgi3jY06i03WLNhb/6jIxNBNF1cVRI7ujnFQXZA66BbnBNTpBSw==}
+  '@react-grab/cli@0.1.48':
+    resolution: {integrity: sha512-KXRZFN0b78BeVa4Tq1FC9kiXPpC5lS4pQp/mvQ1azy9dZUJ3zfc7Ei84+yvGh+WoYdceMCFxXfBp6qhU/G056g==}
     hasBin: true
 
   '@replit/codemirror-vim@6.3.0':
@@ -3214,6 +3118,11 @@ packages:
     peerDependencies:
       react: '>=17.0.1'
 
+  bippy@0.5.43:
+    resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
+    peerDependencies:
+      react: '>=17.0.1'
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -3665,8 +3574,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.5.8:
-    resolution: {integrity: sha512-Vq9D2x4dAIW24zcH55DTrl3/vi13UNKfXgw0yj7ULTssZ6KOdw/oyBHtlvE94KFC9yYEhgFTrGjaqqZKvV9pwA==}
+  deslop-js@0.7.1:
+    resolution: {integrity: sha512-HsEoRI/bzuD0o2OVczYz42SXTCl5of3ax6eiojZbC/7gJsPNxxjPRvBysP88LXsHujYrIGJnGtFRnHwCmKWuxQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4760,8 +4669,8 @@ packages:
   oxc-resolver@11.22.0:
     resolution: {integrity: sha512-F3VuQRlu5uaMN9ffo2ufEa8D/SKykx1a2KaLtBa2JEmbtulRaTZKwQrrLsNLGfvBeLW8M/J0CE47KN3s0VdcmQ==}
 
-  oxlint-plugin-react-doctor@0.5.8:
-    resolution: {integrity: sha512-L0jveKAMbqF1qAqA2Ksu8aH0/Q8FDQxLwXmHYgALa2XlsxEUuamJ+1Da2MhPWJ2ahn+ekFbnWK20qixxD+fw6A==}
+  oxlint-plugin-react-doctor@0.7.1:
+    resolution: {integrity: sha512-fvARsCESDZYvDIlhuB/JlDeUhTOLHYstoDJCKm0pzh4HQQJVVV6gcrQajBjYo/hdHC1ukl7btKTK3rk4uZwuew==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -4929,8 +4838,8 @@ packages:
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     hasBin: true
 
-  react-doctor@0.5.8:
-    resolution: {integrity: sha512-gDXDQ+48KeFq2jkVgsUhQ67oQ+kUMdnIaA+YeS9VXXZFXSg9wxY5dDxurEpILSh8RwO06W8p6uCnTR+wn5B/GA==}
+  react-doctor@0.7.1:
+    resolution: {integrity: sha512-Gmty7Enyrh6GPlz6Paq+UoL2O7YkTzNeHdflbqdp6fspX1UbUem5ejPyIUgo1jf77D6kB+INqsi2K+Mk/K8uBQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -4939,8 +4848,8 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
-  react-grab@0.1.47:
-    resolution: {integrity: sha512-1GNy24KMJ4CY1IxorYO9mydItGi0L1HkQB19uYU3t0BMsJB0K+D/QYiaBz+rugRynyY8LzmXIuOcon1TykLlCg==}
+  react-grab@0.1.48:
+    resolution: {integrity: sha512-p3WnmK9LLvXE/c4ITPLlXcP1fkXo2VFEQqK94tIfcHIWKNdqdhYYFyNVioO50HR+uyHIwT63Z4txZDqJlVcD/Q==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -5392,6 +5301,11 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -5770,10 +5684,10 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@3.0.85(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.94(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/cerebras@2.0.57(zod@4.4.3)':
@@ -5808,10 +5722,16 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.73(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.57(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@3.0.81(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
@@ -5821,7 +5741,18 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.36(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.13':
     dependencies:
       json-schema: 0.4.0
 
@@ -5835,11 +5766,11 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/xai@3.0.96(zod@4.4.3)':
+  '@ai-sdk/xai@3.0.103(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.51(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 2.0.57(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@4.4.3)
       zod: 4.4.3
 
   '@antfu/install-pkg@1.1.0':
@@ -6270,28 +6201,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.2.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6511,13 +6426,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.9.7':
@@ -6710,97 +6618,49 @@ snapshots:
   '@oxc-resolver/binding-android-arm-eabi@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-android-arm-eabi@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-android-arm64@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-android-arm64@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-darwin-arm64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-darwin-arm64@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-darwin-x64@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-darwin-x64@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-freebsd-x64@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-freebsd-x64@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm64-gnu@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-riscv64-musl@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-x64-gnu@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-linux-x64-musl@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-openharmony-arm64@11.22.0':
     optional: true
 
   '@oxc-resolver/binding-wasm32-wasi@11.20.0':
@@ -6810,23 +6670,10 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.22.0':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    optional: true
-
   '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
     optional: true
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.22.0':
-    optional: true
-
   '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
-    optional: true
-
-  '@oxc-resolver/binding-win32-x64-msvc@11.22.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.66.0':
@@ -7798,7 +7645,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@react-grab/cli@0.1.47':
+  '@react-grab/cli@0.1.48':
     dependencies:
       agent-install: 0.0.6
       commander: 14.0.3
@@ -8575,6 +8422,10 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  bippy@0.5.43(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   birpc@4.0.0: {}
 
   bl@4.1.0:
@@ -9031,14 +8882,14 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.5.8:
+  deslop-js@0.7.1:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
       minimatch: 10.2.5
       oxc-parser: 0.132.0
       oxc-resolver: 11.22.0
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   detect-libc@2.1.2: {}
 
@@ -10418,29 +10269,9 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
 
-  oxc-resolver@11.22.0:
-    optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.22.0
-      '@oxc-resolver/binding-android-arm64': 11.22.0
-      '@oxc-resolver/binding-darwin-arm64': 11.22.0
-      '@oxc-resolver/binding-darwin-x64': 11.22.0
-      '@oxc-resolver/binding-freebsd-x64': 11.22.0
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.22.0
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.22.0
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.22.0
-      '@oxc-resolver/binding-linux-arm64-musl': 11.22.0
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.22.0
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.22.0
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.22.0
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.22.0
-      '@oxc-resolver/binding-linux-x64-gnu': 11.22.0
-      '@oxc-resolver/binding-linux-x64-musl': 11.22.0
-      '@oxc-resolver/binding-openharmony-arm64': 11.22.0
-      '@oxc-resolver/binding-wasm32-wasi': 11.22.0
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.22.0
-      '@oxc-resolver/binding-win32-x64-msvc': 11.22.0
+  oxc-resolver@11.22.0: {}
 
-  oxlint-plugin-react-doctor@0.5.8:
+  oxlint-plugin-react-doctor@0.7.1:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-scope: 9.1.2
@@ -10667,24 +10498,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.5.8(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0)):
+  react-doctor@0.7.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.5.8
+      deslop-js: 0.7.1
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.5.8
+      oxlint-plugin-react-doctor: 0.7.1
       prompts: 2.4.2
-      typescript: 6.0.3
+      typescript: 5.9.3
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
@@ -10697,10 +10529,10 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-grab@0.1.47(react@19.2.7):
+  react-grab@0.1.48(react@19.2.7):
     dependencies:
-      '@react-grab/cli': 0.1.47
-      bippy: 0.5.41(react@19.2.7)
+      '@react-grab/cli': 0.1.48
+      bippy: 0.5.43(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
 
@@ -10740,9 +10572,9 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.5.8(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0))
+      react-doctor: 0.7.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
-      react-grab: 0.1.47(react@19.2.7)
+      react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:
       unplugin: 3.0.0
     transitivePeerDependencies:
@@ -11239,6 +11071,8 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 

--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -252,7 +252,7 @@ export function AiChatView({
         )}
         {error && (
           <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-            <div className="font-medium">Something went wrong.</div>
+            <div className="font-medium">Request failed.</div>
             <div className="mt-0.5 leading-relaxed opacity-90">
               {error.message}
             </div>

--- a/src/modules/ai/config.test.ts
+++ b/src/modules/ai/config.test.ts
@@ -6,6 +6,9 @@ import {
   isCompatModelId,
   migrateLegacyCompatEndpoint,
   modelKeepsReasoning,
+  modelSupportsTemperature,
+  modelUsesReasoningTokens,
+  MODEL_PRICING,
   resolveModel,
   type CustomEndpoint,
 } from "./config";
@@ -49,6 +52,17 @@ describe("resolveModel", () => {
     expect(resolveModel("gpt-5.4-mini").provider).toBe("openai");
   });
 
+  it.each([
+    ["gpt-5.6", "openai"],
+    ["gpt-5.6-terra", "openai"],
+    ["gpt-5.6-luna", "openai"],
+    ["claude-fable-5", "anthropic"],
+    ["claude-sonnet-5", "anthropic"],
+    ["grok-4.5", "xai"],
+  ] as const)("resolves current model %s through %s", (modelId, provider) => {
+    expect(resolveModel(modelId).provider).toBe(provider);
+  });
+
   it("throws on an unknown static model id", () => {
     expect(() => resolveModel("nope-not-real")).toThrow();
   });
@@ -61,7 +75,31 @@ describe("getModelContextLimit", () => {
   });
 
   it("reads the static table for known models", () => {
-    expect(getModelContextLimit("claude-opus-4-7")).toBe(200_000);
+    expect(getModelContextLimit("claude-opus-4-7")).toBe(1_000_000);
+  });
+
+  it.each([
+    ["gpt-5.6", 1_050_000],
+    ["gpt-5.6-terra", 1_050_000],
+    ["gpt-5.6-luna", 1_050_000],
+    ["claude-fable-5", 1_000_000],
+    ["claude-sonnet-5", 1_000_000],
+    ["grok-4.5", 500_000],
+  ] as const)("uses the published context limit for %s", (modelId, limit) => {
+    expect(getModelContextLimit(modelId)).toBe(limit);
+  });
+});
+
+describe("current model pricing", () => {
+  it.each([
+    ["gpt-5.6", 5, 30, 0.5],
+    ["gpt-5.6-terra", 2.5, 15, 0.25],
+    ["gpt-5.6-luna", 1, 6, 0.1],
+    ["claude-fable-5", 10, 50, 1],
+    ["claude-sonnet-5", 3, 15, 0.3],
+    ["grok-4.5", 2, 6, 0.5],
+  ] as const)("uses the published token pricing for %s", (modelId, input, output, cacheRead) => {
+    expect(MODEL_PRICING[modelId]).toEqual({ input, output, cacheRead });
   });
 });
 
@@ -77,6 +115,38 @@ describe("modelKeepsReasoning", () => {
 
   it("keeps reasoning for tagged reasoning models", () => {
     expect(modelKeepsReasoning(resolveModel("claude-opus-4-7"))).toBe(true);
+  });
+});
+
+describe("model sampling capabilities", () => {
+  it.each([
+    ["openai", "gpt-5.4-nano"],
+    ["openai", "gpt-5.6"],
+    ["anthropic", "claude-fable-5"],
+    ["anthropic", "claude-sonnet-5"],
+  ] as const)("omits temperature for %s/%s", (provider, modelId) => {
+    expect(modelSupportsTemperature(provider, modelId)).toBe(false);
+  });
+
+  it("keeps temperature for models that accept sampling parameters", () => {
+    expect(modelSupportsTemperature("openai", "gpt-4.1-mini")).toBe(true);
+    expect(modelSupportsTemperature("xai", "grok-4.5")).toBe(true);
+  });
+
+  it("defaults unknown provider models to temperature support", () => {
+    expect(modelSupportsTemperature("openai-compatible", "custom-model")).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    ["openai", "gpt-5.4-nano"],
+    ["openai", "gpt-5.6-luna"],
+    ["anthropic", "claude-sonnet-5"],
+    ["xai", "grok-4.5"],
+    ["groq", "openai/gpt-oss-20b"],
+  ] as const)("allocates a reasoning output budget for %s/%s", (provider, modelId) => {
+    expect(modelUsesReasoningTokens(provider, modelId)).toBe(true);
   });
 });
 

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -184,10 +184,41 @@ export type ModelInfo = {
   description: string;
   capabilities: ModelCapabilities;
   tags?: readonly ModelTag[];
+  supportsTemperature?: boolean;
 };
 
 export const MODELS = [
   // ── OpenAI ────────────────────────────────────────────────────────────────
+  {
+    id: "gpt-5.6",
+    provider: "openai",
+    label: "GPT-5.6 Sol",
+    hint: "Flagship",
+    description: "Frontier model for complex professional and agentic work.",
+    capabilities: { intelligence: 5, speed: 4, cost: 1 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
+  },
+  {
+    id: "gpt-5.6-terra",
+    provider: "openai",
+    label: "GPT-5.6 Terra",
+    hint: "Balanced",
+    description: "Strong intelligence with lower cost and latency.",
+    capabilities: { intelligence: 5, speed: 4, cost: 2 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
+  },
+  {
+    id: "gpt-5.6-luna",
+    provider: "openai",
+    label: "GPT-5.6 Luna",
+    hint: "Fast",
+    description: "Fast, affordable reasoning for high-volume work.",
+    capabilities: { intelligence: 4, speed: 5, cost: 3 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
+  },
   {
     id: "gpt-5.5",
     provider: "openai",
@@ -196,15 +227,18 @@ export const MODELS = [
     description: "Frontier reasoning and code.",
     capabilities: { intelligence: 5, speed: 3, cost: 1 },
     tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
   },
   {
     id: "gpt-5.5-pro",
     provider: "openai",
     label: "GPT-5.5 Pro",
     hint: "Max",
-    description: "Highest-accuracy version for the hardest professional and agentic tasks.",
+    description:
+      "Highest-accuracy version for the hardest professional and agentic tasks.",
     capabilities: { intelligence: 5, speed: 2, cost: 1 },
     tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
   },
   {
     id: "gpt-5.4-mini",
@@ -214,6 +248,7 @@ export const MODELS = [
     description: "Snappy default at low cost.",
     capabilities: { intelligence: 4, speed: 4, cost: 4 },
     tags: ["vision", "tools"],
+    supportsTemperature: false,
   },
   {
     id: "gpt-5.4-nano",
@@ -223,6 +258,7 @@ export const MODELS = [
     description: "Tiny and instant — great for autocomplete.",
     capabilities: { intelligence: 3, speed: 5, cost: 5 },
     tags: ["tools"],
+    supportsTemperature: false,
   },
   {
     id: "gpt-5.3-codex",
@@ -232,6 +268,7 @@ export const MODELS = [
     description: "Tuned for code and tool use.",
     capabilities: { intelligence: 4, speed: 4, cost: 3 },
     tags: ["tools", "coding"],
+    supportsTemperature: false,
   },
   {
     id: "gpt-4.1-mini",
@@ -245,13 +282,36 @@ export const MODELS = [
 
   // ── Anthropic ─────────────────────────────────────────────────────────────
   {
+    id: "claude-fable-5",
+    provider: "anthropic",
+    label: "Claude Fable 5",
+    hint: "Frontier",
+    description:
+      "Most capable Claude for demanding reasoning and long-horizon agentic work.",
+    capabilities: { intelligence: 5, speed: 2, cost: 1 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
+  },
+  {
+    id: "claude-sonnet-5",
+    provider: "anthropic",
+    label: "Claude Sonnet 5",
+    hint: "Balanced",
+    description: "Best combination of Claude intelligence and speed.",
+    capabilities: { intelligence: 5, speed: 4, cost: 3 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
+  },
+  {
     id: "claude-opus-4-8",
     provider: "anthropic",
     label: "Claude Opus 4.8",
     hint: "Best",
-    description: "Anthropic's most capable model for complex reasoning and long-horizon agentic coding.",
+    description:
+      "Anthropic's most capable model for complex reasoning and long-horizon agentic coding.",
     capabilities: { intelligence: 5, speed: 2, cost: 1 },
     tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
   },
   {
     id: "claude-opus-4-7",
@@ -261,6 +321,7 @@ export const MODELS = [
     description: "Previous-gen flagship for long reasoning.",
     capabilities: { intelligence: 5, speed: 2, cost: 1 },
     tags: ["vision", "reasoning", "tools", "coding"],
+    supportsTemperature: false,
   },
   {
     id: "claude-sonnet-4-6",
@@ -348,6 +409,15 @@ export const MODELS = [
 
   // ── xAI ───────────────────────────────────────────────────────────────────
   {
+    id: "grok-4.5",
+    provider: "xai",
+    label: "Grok 4.5",
+    hint: "Frontier",
+    description: "Frontier coding, agentic, and knowledge-work model.",
+    capabilities: { intelligence: 5, speed: 4, cost: 2 },
+    tags: ["vision", "reasoning", "tools", "coding"],
+  },
+  {
     id: "grok-4.20-reasoning",
     provider: "xai",
     label: "Grok 4.20 Reasoning",
@@ -379,7 +449,8 @@ export const MODELS = [
     provider: "xai",
     label: "Grok 4.3",
     hint: "Flagship",
-    description: "Most intelligent and fastest Grok. Strong agentic tool use and 1M context.",
+    description:
+      "Most intelligent and fastest Grok. Strong agentic tool use and 1M context.",
     capabilities: { intelligence: 5, speed: 4, cost: 2 },
     tags: ["vision", "reasoning", "tools", "coding"],
   },
@@ -388,7 +459,8 @@ export const MODELS = [
     provider: "xai",
     label: "Grok Build 0.1",
     hint: "Coding",
-    description: "Specialized fast coding model for agentic workflows (powers Grok Build CLI).",
+    description:
+      "Specialized fast coding model for agentic workflows (powers Grok Build CLI).",
     capabilities: { intelligence: 4, speed: 5, cost: 4 },
     tags: ["tools", "coding"],
   },
@@ -574,7 +646,9 @@ export function getCompatModelInfo(
     provider: "openai-compatible",
     label: ep?.modelId || name,
     hint: name,
-    description: ep ? `${name} — ${ep.baseURL}` : "Custom OpenAI-compatible endpoint",
+    description: ep
+      ? `${name} — ${ep.baseURL}`
+      : "Custom OpenAI-compatible endpoint",
     capabilities: { intelligence: 3, speed: 3, cost: 3 },
   };
 }
@@ -609,7 +683,34 @@ const FREEFORM_PROVIDERS: ReadonlySet<ProviderId> = new Set([
 
 // Reasoning models reject tool-call turns whose reasoning was stripped; keep it.
 export function modelKeepsReasoning(m: ModelInfo): boolean {
-  return (m.tags?.includes("reasoning") ?? false) || FREEFORM_PROVIDERS.has(m.provider);
+  return (
+    (m.tags?.includes("reasoning") ?? false) ||
+    FREEFORM_PROVIDERS.has(m.provider)
+  );
+}
+
+export function modelSupportsTemperature(
+  provider: ProviderId,
+  modelId: string,
+): boolean {
+  const model: ModelInfo | undefined = MODELS.find(
+    (m) => m.provider === provider && m.id === modelId,
+  );
+  return model?.supportsTemperature !== false;
+}
+
+export function modelUsesReasoningTokens(
+  provider: ProviderId,
+  modelId: string,
+): boolean {
+  const model: ModelInfo | undefined = MODELS.find(
+    (m) => m.provider === provider && m.id === modelId,
+  );
+  return (
+    (model?.tags?.includes("reasoning") ?? false) ||
+    (provider === "openai" && /^gpt-5(?:[.-]|$)/.test(modelId)) ||
+    /\bgpt-oss\b/i.test(modelId)
+  );
 }
 
 export const DEFAULT_MODEL_ID: ModelId = "gpt-5.4-mini";
@@ -618,23 +719,29 @@ export const DEFAULT_MODEL_ID: ModelId = "gpt-5.4-mini";
  *  context-usage indicator in the AI mini-window header. Conservative
  *  estimates — actual provider limits may shift. */
 export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  "gpt-5.6": 1_050_000,
+  "gpt-5.6-terra": 1_050_000,
+  "gpt-5.6-luna": 1_050_000,
   "gpt-5.5": 1_050_000,
   "gpt-5.5-pro": 1_050_000,
   "gpt-5.4-mini": 400_000,
   "gpt-5.4-nano": 400_000,
   "gpt-5.3-codex": 400_000,
   "gpt-4.1-mini": 128_000,
-  "claude-opus-4-7": 200_000,
+  "claude-fable-5": 1_000_000,
+  "claude-sonnet-5": 1_000_000,
+  "claude-opus-4-7": 1_000_000,
   "claude-opus-4-8": 1_000_000,
-  "claude-sonnet-4-6": 200_000,
+  "claude-sonnet-4-6": 1_000_000,
   "claude-haiku-4-5": 200_000,
-  "claude-opus-4-6": 200_000,
+  "claude-opus-4-6": 1_000_000,
   "gemini-3.5-flash": 1_000_000,
   "gemini-3.1-flash-lite": 1_000_000,
   "gemini-3.1-pro-preview": 1_000_000,
   "gemini-3-flash-preview": 1_000_000,
   "gemini-2.5-pro": 1_000_000,
   "gemini-2.5-flash": 1_000_000,
+  "grok-4.5": 500_000,
   "grok-4.20-reasoning": 2_000_000,
   "grok-4.20-non-reasoning": 2_000_000,
   "grok-4-fast-reasoning": 2_000_000,
@@ -677,12 +784,17 @@ export type ModelPricing = {
 };
 
 export const MODEL_PRICING: Record<string, ModelPricing> = {
-  "gpt-5.5": { input: 5, output: 15, cacheRead: 0.5 },
+  "gpt-5.6": { input: 5, output: 30, cacheRead: 0.5 },
+  "gpt-5.6-terra": { input: 2.5, output: 15, cacheRead: 0.25 },
+  "gpt-5.6-luna": { input: 1, output: 6, cacheRead: 0.1 },
+  "gpt-5.5": { input: 5, output: 30, cacheRead: 0.5 },
   "gpt-5.5-pro": { input: 30, output: 180 },
-  "gpt-5.4-mini": { input: 0.4, output: 1.6, cacheRead: 0.04 },
-  "gpt-5.4-nano": { input: 0.1, output: 0.4, cacheRead: 0.01 },
+  "gpt-5.4-mini": { input: 0.75, output: 4.5, cacheRead: 0.075 },
+  "gpt-5.4-nano": { input: 0.2, output: 1.25, cacheRead: 0.02 },
   "gpt-5.3-codex": { input: 1.5, output: 6, cacheRead: 0.15 },
   "gpt-4.1-mini": { input: 0.4, output: 1.6, cacheRead: 0.1 },
+  "claude-fable-5": { input: 10, output: 50, cacheRead: 1 },
+  "claude-sonnet-5": { input: 3, output: 15, cacheRead: 0.3 },
   "claude-opus-4-7": { input: 15, output: 75, cacheRead: 1.5 },
   "claude-opus-4-8": { input: 5, output: 25, cacheRead: 0.5 },
   "claude-opus-4-6": { input: 15, output: 75, cacheRead: 1.5 },
@@ -694,6 +806,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "gemini-3-flash-preview": { input: 0.3, output: 2.5, cacheRead: 0.075 },
   "gemini-2.5-pro": { input: 1.25, output: 10, cacheRead: 0.31 },
   "gemini-2.5-flash": { input: 0.3, output: 2.5, cacheRead: 0.075 },
+  "grok-4.5": { input: 2, output: 6, cacheRead: 0.5 },
   "grok-4.20-reasoning": { input: 3, output: 15 },
   "grok-4.20-non-reasoning": { input: 1, output: 5 },
   "grok-4-fast-reasoning": { input: 0.2, output: 0.5 },
@@ -706,7 +819,11 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
 
 export function estimateCost(
   modelId: string | undefined,
-  usage: { inputTokens: number; outputTokens: number; cachedInputTokens: number },
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cachedInputTokens: number;
+  },
 ): number | null {
   if (!modelId) return null;
   const p = MODEL_PRICING[modelId];
@@ -714,7 +831,9 @@ export function estimateCost(
   const fresh = Math.max(0, usage.inputTokens - usage.cachedInputTokens);
   const cached = usage.cachedInputTokens;
   return (
-    (fresh * p.input + cached * (p.cacheRead ?? p.input) + usage.outputTokens * p.output) /
+    (fresh * p.input +
+      cached * (p.cacheRead ?? p.input) +
+      usage.outputTokens * p.output) /
     1_000_000
   );
 }

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -4,7 +4,6 @@ import {
   stepCountIs,
   streamText,
   type LanguageModel,
-  type ModelMessage,
   type UIMessage,
 } from "ai";
 import {
@@ -26,6 +25,7 @@ import {
 import { buildTools, type ToolContext } from "../tools/tools";
 import { compactModelMessagesDetailed } from "./compact";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
+import { prepareAgentPrompt } from "./prompt";
 import { createProxyFetch } from "./proxyFetch";
 
 const localProxyFetch = createProxyFetch({ allowPrivateNetwork: true });
@@ -321,28 +321,6 @@ function buildStableSystem(
   return `${base}${memoryBlock}${personaBlock}${customBlock}`;
 }
 
-// OpenAI / Gemini / DeepSeek apply prefix caching automatically; only
-// Anthropic needs explicit breakpoints. Mark the stable system prefix and
-// the rotating conversation tail.
-function applyCacheBreakpoints(
-  messages: ModelMessage[],
-  provider: ProviderId,
-): ModelMessage[] {
-  if (provider !== "anthropic" || messages.length === 0) return messages;
-  const marker = {
-    anthropic: { cacheControl: { type: "ephemeral" as const } },
-  };
-  const withMarker = (m: ModelMessage): ModelMessage => ({
-    ...m,
-    providerOptions: { ...(m.providerOptions ?? {}), ...marker },
-  });
-  const out = messages.slice();
-  out[0] = withMarker(out[0]);
-  const lastIdx = out.length - 1;
-  if (lastIdx > 0) out[lastIdx] = withMarker(out[lastIdx]);
-  return out;
-}
-
 export type AgentUsage = {
   inputTokens: number;
   outputTokens: number;
@@ -434,18 +412,19 @@ export async function runAgentStream(opts: RunAgentOptions) {
     opts.onCompact?.({ droppedCount: compact.droppedCount });
   }
 
-  const messages: ModelMessage[] = [{ role: "system", content: stableSystem }];
-  if (opts.planMode) {
-    messages.push({ role: "system", content: PLAN_MODE_PROMPT });
-  }
-  messages.push(...compactedHistory);
-
-  const finalMessages = applyCacheBreakpoints(messages, provider);
+  const prompt = prepareAgentPrompt(
+    stableSystem,
+    opts.planMode ? PLAN_MODE_PROMPT : null,
+    compactedHistory,
+    provider,
+  );
 
   let stepsSeen = 0;
   return streamText({
     model,
-    messages: finalMessages,
+    system: prompt.system,
+    messages: prompt.messages,
+    allowSystemInMessages: false,
     tools: buildTools(opts.toolContext),
     stopWhen: stepCountIs(MAX_AGENT_STEPS),
     abortSignal: opts.abortSignal,

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -285,7 +285,7 @@ export function buildConfiguredLanguageModel(
   } else if (m.id === "openrouter-custom") {
     if (!local.openrouterModelId?.trim()) {
       throw new Error(
-        "OpenRouter: no model id set. Open Settings → Models and enter an OpenRouter model id (e.g. anthropic/claude-sonnet-4-6).",
+        "OpenRouter: no model id set. Open Settings → Models and enter an OpenRouter model id (e.g. anthropic/claude-sonnet-5).",
       );
     }
     resolvedId = local.openrouterModelId.trim();

--- a/src/modules/ai/lib/errors.test.ts
+++ b/src/modules/ai/lib/errors.test.ts
@@ -1,0 +1,100 @@
+import { streamText } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, it } from "vitest";
+import { formatAiError } from "./errors";
+
+describe("formatAiError", () => {
+  it("surfaces nested provider model errors", () => {
+    expect(
+      formatAiError({
+        type: "error",
+        sequence_number: 2,
+        error: {
+          code: "model_not_found",
+          message:
+            "The model `gpt-5.6-luna` is in limited preview and is not available on this account.",
+          type: "invalid_request_error",
+        },
+      }),
+    ).toBe(
+      "Model unavailable: The model `gpt-5.6-luna` is in limited preview and is not available on this account.",
+    );
+  });
+
+  it("extracts structured response bodies from SDK errors", () => {
+    expect(
+      formatAiError({
+        message: "Bad Request",
+        responseBody: JSON.stringify({
+          error: {
+            code: "rate_limit_exceeded",
+            message: "Please retry after 10 seconds.",
+          },
+        }),
+      }),
+    ).toBe("Rate limit reached: Please retry after 10 seconds.");
+  });
+
+  it("preserves useful local errors", () => {
+    expect(formatAiError(new Error("No API key configured for OpenAI."))).toBe(
+      "No API key configured for OpenAI.",
+    );
+  });
+
+  it("redacts credential-like values", () => {
+    expect(
+      formatAiError(
+        new Error(
+          "Authorization Bearer secret-token-value and key sk-ant-abcdefghijklmnop were rejected.",
+        ),
+      ),
+    ).toBe("Authorization Bearer [redacted] and key [redacted] were rejected.");
+  });
+
+  it("uses an actionable fallback for unknown error shapes", () => {
+    expect(formatAiError({ unexpected: true })).toBe(
+      "The AI provider rejected the request. Check the selected model and provider settings, then try again.",
+    );
+  });
+
+  it("preserves provider details through the AI SDK UI stream", async () => {
+    const providerError = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "invalid_request_error",
+        code: "model_not_found",
+        message:
+          "The model `gpt-5.6-luna` is in limited preview and is not available on this account.",
+      },
+    };
+    const model = new MockLanguageModelV3({
+      doStream: {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "error", error: providerError });
+            controller.close();
+          },
+        }),
+      },
+    });
+    const result = streamText({
+      model,
+      prompt: "hello",
+      onError: () => {},
+    });
+    const chunks = [];
+    for await (const chunk of result.toUIMessageStream({
+      onError: formatAiError,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toContainEqual({
+      type: "error",
+      errorText:
+        "Model unavailable: The model `gpt-5.6-luna` is in limited preview and is not available on this account.",
+    });
+  });
+});

--- a/src/modules/ai/lib/errors.ts
+++ b/src/modules/ai/lib/errors.ts
@@ -1,0 +1,91 @@
+type ErrorDetails = {
+  code: string | null;
+  message: string;
+};
+
+const MAX_ERROR_LENGTH = 800;
+const FALLBACK_ERROR =
+  "The AI provider rejected the request. Check the selected model and provider settings, then try again.";
+
+export function formatAiError(error: unknown): string {
+  const details = extractErrorDetails(error);
+  if (!details) return FALLBACK_ERROR;
+  const message = sanitizeErrorMessage(details.message);
+  if (!message) return FALLBACK_ERROR;
+  const prefix = errorPrefix(details.code, message);
+  return prefix ? `${prefix}: ${message}` : message;
+}
+
+function extractErrorDetails(
+  value: unknown,
+  depth = 0,
+  seen = new Set<unknown>(),
+): ErrorDetails | null {
+  if (depth > 5 || value == null || seen.has(value)) return null;
+  if (typeof value === "string") {
+    const parsed = parseJson(value);
+    if (parsed !== null) return extractErrorDetails(parsed, depth + 1, seen);
+    return { code: null, message: value };
+  }
+  if (typeof value !== "object") return null;
+  seen.add(value);
+
+  const record = value as Record<string, unknown>;
+  const code = stringValue(record.code);
+  for (const key of ["error", "responseBody", "body", "data", "cause"]) {
+    const nested = extractErrorDetails(record[key], depth + 1, seen);
+    if (nested) return { code: nested.code ?? code, message: nested.message };
+  }
+  const message = stringValue(record.message);
+  return message ? { code, message } : null;
+}
+
+function parseJson(value: string): unknown | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function sanitizeErrorMessage(message: string): string {
+  const redacted = message
+    .replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
+    .replace(
+      /\b(?:sk-(?:ant-|proj-)?|xai-|gsk_)[A-Za-z0-9_-]{8,}\b/g,
+      "[redacted]",
+    )
+    .replace(/\bAIza[A-Za-z0-9_-]{20,}\b/g, "[redacted]")
+    .replace(/\s+/g, " ")
+    .trim();
+  return redacted.length <= MAX_ERROR_LENGTH
+    ? redacted
+    : `${redacted.slice(0, MAX_ERROR_LENGTH - 3)}...`;
+}
+
+function errorPrefix(code: string | null, message: string): string | null {
+  switch (code?.toLowerCase()) {
+    case "model_not_found":
+    case "not_found_error":
+      return "Model unavailable";
+    case "invalid_api_key":
+    case "authentication_error":
+      return "Authentication failed";
+    case "insufficient_quota":
+      return "Quota exceeded";
+    case "rate_limit_exceeded":
+    case "rate_limit_error":
+      return "Rate limit reached";
+  }
+  return /\bmodel\b.*\b(?:limited preview|not available|not found)\b/i.test(
+    message,
+  )
+    ? "Model unavailable"
+    : null;
+}

--- a/src/modules/ai/lib/prompt.test.ts
+++ b/src/modules/ai/lib/prompt.test.ts
@@ -1,0 +1,86 @@
+import { streamText, type ModelMessage } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+import { prepareAgentPrompt } from "./prompt";
+
+const history: ModelMessage[] = [
+  { role: "user", content: "Fix the issue" },
+  { role: "assistant", content: "I will inspect it." },
+];
+
+describe("prepareAgentPrompt", () => {
+  it("keeps trusted instructions outside conversation messages", () => {
+    const prompt = prepareAgentPrompt(
+      "Stable instructions",
+      "Plan instructions",
+      history,
+      "openai",
+    );
+
+    expect(prompt.system).toEqual([
+      { role: "system", content: "Stable instructions" },
+      { role: "system", content: "Plan instructions" },
+    ]);
+    expect(prompt.messages).toEqual(history);
+    expect(prompt.messages.every((message) => message.role !== "system")).toBe(
+      true,
+    );
+  });
+
+  it("keeps Anthropic cache markers on the stable prefix and rotating tail", () => {
+    const prompt = prepareAgentPrompt(
+      "Stable instructions",
+      "Plan instructions",
+      history,
+      "anthropic",
+    );
+
+    expect(prompt.system[0].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+    expect(prompt.system[1].providerOptions).toBeUndefined();
+    expect(prompt.messages[0].providerOptions).toBeUndefined();
+    expect(prompt.messages[1].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+    expect(history.every((message) => message.providerOptions == null)).toBe(
+      true,
+    );
+  });
+
+  it("does not trigger the SDK system-message warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const model = new MockLanguageModelV3({
+      doStream: {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.close();
+          },
+        }),
+      },
+    });
+    const prompt = prepareAgentPrompt(
+      "Stable instructions",
+      "Plan instructions",
+      history,
+      "openai",
+    );
+
+    try {
+      const result = streamText({
+        model,
+        system: prompt.system,
+        messages: prompt.messages,
+        allowSystemInMessages: false,
+        onError: () => {},
+      });
+      await result.consumeStream();
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("System messages in the prompt"),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/src/modules/ai/lib/prompt.ts
+++ b/src/modules/ai/lib/prompt.ts
@@ -1,0 +1,40 @@
+import type { ModelMessage, SystemModelMessage } from "ai";
+import type { ProviderId } from "@/modules/ai/config";
+
+export type PreparedAgentPrompt = {
+  system: SystemModelMessage[];
+  messages: ModelMessage[];
+};
+
+export function prepareAgentPrompt(
+  stableSystem: string,
+  planInstructions: string | null,
+  history: readonly ModelMessage[],
+  provider: ProviderId,
+): PreparedAgentPrompt {
+  const system: SystemModelMessage[] = [
+    { role: "system", content: stableSystem },
+  ];
+  if (planInstructions) {
+    system.push({ role: "system", content: planInstructions });
+  }
+  const messages = history.slice();
+  if (provider !== "anthropic") return { system, messages };
+
+  system[0] = withAnthropicCacheMarker(system[0]);
+  const lastIdx = messages.length - 1;
+  if (lastIdx >= 0) {
+    messages[lastIdx] = withAnthropicCacheMarker(messages[lastIdx]);
+  }
+  return { system, messages };
+}
+
+function withAnthropicCacheMarker<T extends ModelMessage>(message: T): T {
+  return {
+    ...message,
+    providerOptions: {
+      ...(message.providerOptions ?? {}),
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    },
+  };
+}

--- a/src/modules/ai/lib/transport.ts
+++ b/src/modules/ai/lib/transport.ts
@@ -2,6 +2,7 @@ import type { UIMessage } from "@ai-sdk/react";
 import type { CustomEndpoint } from "../config";
 import { runAgentStream, type AgentUsageDelta } from "./agent";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
+import { formatAiError } from "./errors";
 import { native } from "./native";
 import type { ToolContext } from "../tools/tools";
 
@@ -108,6 +109,7 @@ export function createContextAwareTransport(deps: Deps) {
     });
     return result.toUIMessageStream({
       originalMessages: options.messages,
+      onError: formatAiError,
     });
   };
 

--- a/src/modules/editor/lib/autocomplete/provider.ts
+++ b/src/modules/editor/lib/autocomplete/provider.ts
@@ -2,6 +2,8 @@ import {
   type AutocompleteProviderId,
   DEFAULT_AUTOCOMPLETE_MODEL,
   LMSTUDIO_DEFAULT_BASE_URL,
+  modelSupportsTemperature,
+  modelUsesReasoningTokens,
 } from "@/modules/ai/config";
 import { buildLanguageModel } from "@/modules/ai/lib/agent";
 import { EMPTY_PROVIDER_KEYS } from "@/modules/ai/lib/keyring";
@@ -46,12 +48,14 @@ export async function requestCompletion(
     openaiCompatibleBaseURL: deps.openaiCompatibleBaseURL,
   });
 
-  const isReasoning = /\bgpt-oss\b/i.test(modelId);
+  const isReasoning = modelUsesReasoningTokens(deps.provider, modelId);
   const providerOptions = isReasoning
     ? {
+        anthropic: { effort: "low" },
         cerebras: { reasoningEffort: "low" },
         groq: { reasoningEffort: "low" },
         openai: { reasoningEffort: "low" },
+        xai: { reasoningEffort: "low" },
       }
     : undefined;
 
@@ -64,7 +68,9 @@ export async function requestCompletion(
       : MAX_OUTPUT_TOKENS_DEFAULT,
     maxRetries: 0,
     abortSignal: signal,
-    temperature: 0.1,
+    ...(modelSupportsTemperature(deps.provider, modelId)
+      ? { temperature: 0.1 }
+      : {}),
     ...(providerOptions ? { providerOptions } : {}),
   });
 

--- a/src/modules/source-control/useSourceControlPanel.ts
+++ b/src/modules/source-control/useSourceControlPanel.ts
@@ -6,7 +6,11 @@ import {
   type GitStatusSnapshot,
 } from "@/modules/ai/lib/native";
 import { useChatStore } from "@/modules/ai/store/chatStore";
-import { providerNeedsKey, resolveModel } from "@/modules/ai/config";
+import {
+  modelSupportsTemperature,
+  providerNeedsKey,
+  resolveModel,
+} from "@/modules/ai/config";
 import {
   invalidateDiff,
   invalidateRepoDiffs,
@@ -463,6 +467,10 @@ export function useSourceControlPanel(
   const allClean = stagedEntries.length === 0 && unstagedEntries.length === 0;
   const canPush = !!status?.upstream && status.behind === 0;
   const selectedModel = resolveModel(selectedModelId);
+  const selectedModelSupportsTemperature = modelSupportsTemperature(
+    selectedModel.provider,
+    selectedModel.id,
+  );
   const aiBusy = agentStatus !== "idle" && agentStatus !== "error";
   const anyActionBusy = localActionBusy !== null || summary.busyAction !== null;
   const aiUnavailableReason = useMemo(() => {
@@ -890,7 +898,7 @@ export function useSourceControlPanel(
         system: COMMIT_MESSAGE_SYSTEM_PROMPT,
         prompt: buildCommitMessagePrompt(stagedEntries, diffText, truncated),
         maxOutputTokens: COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
-        temperature: 0.2,
+        ...(selectedModelSupportsTemperature ? { temperature: 0.2 } : {}),
       });
       let message = cleanCommitMessage(result.text);
       if (!isValidCommitMessage(message)) {
@@ -899,7 +907,7 @@ export function useSourceControlPanel(
           system: COMMIT_MESSAGE_SYSTEM_PROMPT,
           prompt: buildRepairCommitMessagePrompt(message, stagedEntries),
           maxOutputTokens: COMMIT_MESSAGE_MAX_OUTPUT_TOKENS,
-          temperature: 0,
+          ...(selectedModelSupportsTemperature ? { temperature: 0 } : {}),
         });
         message = cleanCommitMessage(repair.text);
       }
@@ -926,6 +934,7 @@ export function useSourceControlPanel(
     openrouterModelId,
     repo,
     selectedModelId,
+    selectedModelSupportsTemperature,
     stagedEntries,
   ]);
 

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -138,7 +138,7 @@ const LOCAL_META: Partial<Record<ProviderId, LocalMeta>> = {
   },
   openrouter: {
     urlPlaceholder: "",
-    modelPlaceholder: "anthropic/claude-sonnet-4-6, openai/gpt-5.5, …",
+    modelPlaceholder: "anthropic/claude-sonnet-5, openai/gpt-5.6, …",
     description: "Any model on OpenRouter — type its full provider/model id.",
     modelHint: (
       <>


### PR DESCRIPTION
## Summary

- add GPT-5.6 family, Claude Fable 5, Claude Sonnet 5, and Grok 4.5
- omit unsupported temperature settings and budget autocomplete reasoning
- surface sanitized provider errors and move trusted instructions to the SDK system field

## Verification

- pnpm test
- pnpm check-types
- pnpm lint
- pnpm build
- pnpm analyze:eager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for newer AI models, including updated context limits and pricing information.
  - Improved model capability handling for reasoning tokens and temperature settings.
  - Enhanced Anthropic prompt caching for more efficient requests.
  - Added clearer, safer AI error messages with sensitive information redacted.
  - Updated model examples shown for local OpenRouter configuration.

- **Bug Fixes**
  - Improved compatibility across providers by avoiding unsupported request settings.
  - Updated the chat error message to “Request failed.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->