### PR TITLE
feat: add directional pane swapping shortcuts

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -81,6 +81,7 @@ import {
   hasLeaf,
   leafIds,
   navigateFocusedBlocks,
+  type PaneBounds,
   type TerminalPaneHandle,
   useTerminalFileDrop,
   writeToSession,
@@ -627,6 +628,28 @@ export default function App() {
     [activeId, splitActivePane],
   );
 
+  const livePaneBounds = useCallback((tabId: number): PaneBounds[] => {
+    const tab = document.querySelector<HTMLElement>(
+      `[data-terminal-tab="${tabId}"]`,
+    );
+    if (!tab) return [];
+    return [...tab.querySelectorAll<HTMLElement>("[data-pane-leaf]")].flatMap(
+      (element) => {
+        const id = Number(element.dataset.paneLeaf);
+        if (!Number.isFinite(id)) return [];
+        const { left, right, top, bottom } = element.getBoundingClientRect();
+        return [{ id, left, right, top, bottom }];
+      },
+    );
+  }, []);
+
+  const swapActivePane = useCallback(
+    (direction: "left" | "right" | "up" | "down") => {
+      swapActivePaneInDirection(activeId, direction, livePaneBounds(activeId));
+    },
+    [activeId, livePaneBounds, swapActivePaneInDirection],
+  );
+
   const handleCloseTabOrPane = useCallback(() => {
     const t = tabsRef.current.find((x) => x.id === activeId);
     if (t?.kind === "terminal" && leafIds(t.paneTree).length > 1) {
@@ -676,10 +699,10 @@ export default function App() {
       "pane.splitDown": () => splitActivePaneInActiveTab("col"),
       "pane.focusNext": () => focusNextPaneInTab(activeId, 1),
       "pane.focusPrev": () => focusNextPaneInTab(activeId, -1),
-      "pane.swapLeft": () => swapActivePaneInDirection(activeId, "left"),
-      "pane.swapRight": () => swapActivePaneInDirection(activeId, "right"),
-      "pane.swapUp": () => swapActivePaneInDirection(activeId, "up"),
-      "pane.swapDown": () => swapActivePaneInDirection(activeId, "down"),
+      "pane.swapLeft": () => swapActivePane("left"),
+      "pane.swapRight": () => swapActivePane("right"),
+      "pane.swapUp": () => swapActivePane("up"),
+      "pane.swapDown": () => swapActivePane("down"),
       "pane.source": toggleSourceControl,
       "terminal.clear": () => {
         clearFocusedTerminal();
@@ -734,7 +757,7 @@ export default function App() {
       selectByIndex,
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
-      swapActivePaneInDirection,
+      swapActivePane,
       toggleSourceControl,
       hasComposer,
       togglePanelAndFocus,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -136,6 +136,7 @@ export default function App() {
     setLeafCwd,
     focusPane,
     focusNextPaneInTab,
+    swapActivePaneInDirection,
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,
@@ -675,6 +676,10 @@ export default function App() {
       "pane.splitDown": () => splitActivePaneInActiveTab("col"),
       "pane.focusNext": () => focusNextPaneInTab(activeId, 1),
       "pane.focusPrev": () => focusNextPaneInTab(activeId, -1),
+      "pane.swapLeft": () => swapActivePaneInDirection(activeId, "left"),
+      "pane.swapRight": () => swapActivePaneInDirection(activeId, "right"),
+      "pane.swapUp": () => swapActivePaneInDirection(activeId, "up"),
+      "pane.swapDown": () => swapActivePaneInDirection(activeId, "down"),
       "pane.source": toggleSourceControl,
       "terminal.clear": () => {
         clearFocusedTerminal();
@@ -729,6 +734,7 @@ export default function App() {
       selectByIndex,
       splitActivePaneInActiveTab,
       focusNextPaneInTab,
+      swapActivePaneInDirection,
       toggleSourceControl,
       hasComposer,
       togglePanelAndFocus,

--- a/src/modules/shortcuts/shortcuts.ts
+++ b/src/modules/shortcuts/shortcuts.ts
@@ -23,6 +23,10 @@ export type ShortcutId =
   | "pane.splitDown"
   | "pane.focusNext"
   | "pane.focusPrev"
+  | "pane.swapLeft"
+  | "pane.swapRight"
+  | "pane.swapUp"
+  | "pane.swapDown"
   | "pane.source"
   | "terminal.clear"
   | "terminal.toggleInput"
@@ -152,7 +156,31 @@ export const SHORTCUTS: Shortcut[] = [
     label: "Focus previous pane",
     group: "Panes",
     defaultBindings: [{ [MOD_PROP]: true, key: "[" }],
-  },  
+  },
+  {
+    id: "pane.swapLeft",
+    label: "Swap pane left",
+    group: "Panes",
+    defaultBindings: [{ [MOD_PROP]: true, alt: true, key: "ArrowLeft" }],
+  },
+  {
+    id: "pane.swapRight",
+    label: "Swap pane right",
+    group: "Panes",
+    defaultBindings: [{ [MOD_PROP]: true, alt: true, key: "ArrowRight" }],
+  },
+  {
+    id: "pane.swapUp",
+    label: "Swap pane up",
+    group: "Panes",
+    defaultBindings: [{ [MOD_PROP]: true, alt: true, key: "ArrowUp" }],
+  },
+  {
+    id: "pane.swapDown",
+    label: "Swap pane down",
+    group: "Panes",
+    defaultBindings: [{ [MOD_PROP]: true, alt: true, key: "ArrowDown" }],
+  },
   {
     id: "pane.source",
     label: "Toggle source panel",

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -4,12 +4,14 @@ import {
   hasLeaf,
   leafIds,
   nextLeafId,
+  type PaneDirection,
   type PaneNode,
   removeLeaf,
   type SplitDir,
   setLeafCwd as setLeafCwdInTree,
   siblingLeafOf,
   splitLeaf,
+  swapLeafInDirection,
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -1020,6 +1022,23 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     );
   }, []);
 
+  const swapActivePaneInDirection = useCallback(
+    (tabId: number, direction: PaneDirection) => {
+      setTabs((curr) =>
+        curr.map((t) => {
+          if (t.id !== tabId || t.kind !== "terminal") return t;
+          const paneTree = swapLeafInDirection(
+            t.paneTree,
+            t.activeLeafId,
+            direction,
+          );
+          return paneTree === t.paneTree ? t : { ...t, paneTree };
+        }),
+      );
+    },
+    [],
+  );
+
   /** Split the active leaf of `tabId` along `dir`. Returns the new leaf id. */
   const splitActivePane = useCallback(
     (tabId: number, dir: SplitDir): number | null => {
@@ -1173,6 +1192,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setLeafCwd,
     focusPane,
     focusNextPaneInTab,
+    swapActivePaneInDirection,
     splitActivePane,
     closeActivePane,
     closePaneByLeaf,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -4,6 +4,7 @@ import {
   hasLeaf,
   leafIds,
   nextLeafId,
+  type PaneBounds,
   type PaneDirection,
   type PaneNode,
   removeLeaf,
@@ -1023,7 +1024,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   }, []);
 
   const swapActivePaneInDirection = useCallback(
-    (tabId: number, direction: PaneDirection) => {
+    (tabId: number, direction: PaneDirection, bounds?: PaneBounds[]) => {
       setTabs((curr) =>
         curr.map((t) => {
           if (t.id !== tabId || t.kind !== "terminal") return t;
@@ -1031,6 +1032,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
             t.paneTree,
             t.activeLeafId,
             direction,
+            bounds,
           );
           return paneTree === t.paneTree ? t : { ...t, paneTree };
         }),

--- a/src/modules/terminal/TerminalStack.tsx
+++ b/src/modules/terminal/TerminalStack.tsx
@@ -83,6 +83,7 @@ export function TerminalStack({
         return (
           <div
             key={t.id}
+            data-terminal-tab={t.id}
             className="absolute inset-0"
             style={{
               visibility: tabVisible ? "visible" : "hidden",

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -16,6 +16,7 @@ export {
   hasLeaf,
   isLeaf,
   leafIds,
+  type PaneBounds,
   type PaneId,
   type PaneNode,
   type SplitDir,

--- a/src/modules/terminal/lib/panes.test.ts
+++ b/src/modules/terminal/lib/panes.test.ts
@@ -68,6 +68,29 @@ describe("swapLeafInDirection", () => {
     expect(leafIds(swapLeafInDirection(tree, 3, "left"))).toEqual([3, 2, 1]);
   });
 
+  it("uses live pane bounds after splitters are resized", () => {
+    const bounds = [
+      { id: 1, left: 0, right: 100, top: 0, bottom: 100 },
+      { id: 2, left: 200, right: 300, top: 100, bottom: 200 },
+      { id: 3, left: 100, right: 200, top: 0, bottom: 100 },
+    ];
+
+    expect(
+      leafIds(swapLeafInDirection(row(1, 2, 3), 1, "right", bounds)),
+    ).toEqual([3, 2, 1]);
+  });
+
+  it("falls back to tree geometry when live bounds are incomplete", () => {
+    const tree = row(1, 2, 3);
+    const incompleteBounds = [
+      { id: 1, left: 0, right: 100, top: 0, bottom: 100 },
+    ];
+
+    expect(
+      leafIds(swapLeafInDirection(tree, 1, "right", incompleteBounds)),
+    ).toEqual([2, 1, 3]);
+  });
+
   it("moves pane metadata with the terminal session", () => {
     const tree: PaneNode = {
       kind: "split",

--- a/src/modules/terminal/lib/panes.test.ts
+++ b/src/modules/terminal/lib/panes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  leafIds,
+  swapLeafInDirection,
+  type PaneNode,
+} from "@/modules/terminal/lib/panes";
+
+function row(...ids: number[]): PaneNode {
+  return {
+    kind: "split",
+    id: 100,
+    dir: "row",
+    children: ids.map((id) => ({ kind: "leaf", id })),
+  };
+}
+
+function col(...ids: number[]): PaneNode {
+  return {
+    kind: "split",
+    id: 200,
+    dir: "col",
+    children: ids.map((id) => ({ kind: "leaf", id })),
+  };
+}
+
+describe("swapLeafInDirection", () => {
+  it("swaps the active pane with its neighbor to the left", () => {
+    expect(leafIds(swapLeafInDirection(row(1, 2, 3), 2, "left"))).toEqual([
+      2, 1, 3,
+    ]);
+  });
+
+  it("wraps right from the rightmost pane to the leftmost pane", () => {
+    expect(leafIds(swapLeafInDirection(row(1, 2, 3), 3, "right"))).toEqual([
+      3, 2, 1,
+    ]);
+  });
+
+  it("swaps vertically and wraps upward", () => {
+    expect(leafIds(swapLeafInDirection(col(1, 2, 3), 2, "down"))).toEqual([
+      1, 3, 2,
+    ]);
+    expect(leafIds(swapLeafInDirection(col(1, 2, 3), 1, "up"))).toEqual([
+      3, 2, 1,
+    ]);
+  });
+
+  it("chooses the overlapping directional neighbor in a nested layout", () => {
+    const tree: PaneNode = {
+      kind: "split",
+      id: 10,
+      dir: "row",
+      children: [
+        { kind: "leaf", id: 1 },
+        {
+          kind: "split",
+          id: 11,
+          dir: "col",
+          children: [
+            { kind: "leaf", id: 2 },
+            { kind: "leaf", id: 3 },
+          ],
+        },
+      ],
+    };
+
+    expect(leafIds(swapLeafInDirection(tree, 2, "down"))).toEqual([1, 3, 2]);
+    expect(leafIds(swapLeafInDirection(tree, 3, "left"))).toEqual([3, 2, 1]);
+  });
+
+  it("moves pane metadata with the terminal session", () => {
+    const tree: PaneNode = {
+      kind: "split",
+      id: 100,
+      dir: "row",
+      children: [
+        { kind: "leaf", id: 1, cwd: "/one" },
+        { kind: "leaf", id: 2, cwd: "/two" },
+      ],
+    };
+    const swapped = swapLeafInDirection(tree, 2, "left");
+    expect(swapped.kind).toBe("split");
+    if (swapped.kind === "split") {
+      expect(swapped.children[0]).toEqual({ kind: "leaf", id: 2, cwd: "/two" });
+      expect(swapped.children[1]).toEqual({ kind: "leaf", id: 1, cwd: "/one" });
+    }
+  });
+
+  it("does nothing when the tree contains only one pane", () => {
+    const tree: PaneNode = { kind: "leaf", id: 1 };
+    expect(swapLeafInDirection(tree, 1, "left")).toBe(tree);
+  });
+});

--- a/src/modules/terminal/lib/panes.ts
+++ b/src/modules/terminal/lib/panes.ts
@@ -2,6 +2,13 @@ export type PaneId = number;
 
 export type SplitDir = "row" | "col";
 export type PaneDirection = "left" | "right" | "up" | "down";
+export type PaneBounds = {
+  id: PaneId;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
 
 export type PaneNode =
   | { kind: "leaf"; id: PaneId; cwd?: string }
@@ -244,12 +251,28 @@ function swapLeaves(
   };
 }
 
+function rectsFromBounds(bounds: PaneBounds[]): PaneRect[] {
+  return bounds
+    .filter((rect) => rect.right > rect.left && rect.bottom > rect.top)
+    .map((rect) => ({
+      id: rect.id,
+      x: rect.left,
+      y: rect.top,
+      width: rect.right - rect.left,
+      height: rect.bottom - rect.top,
+    }));
+}
+
 export function swapLeafInDirection(
   tree: PaneNode,
   activeId: PaneId,
   direction: PaneDirection,
+  liveBounds?: PaneBounds[],
 ): PaneNode {
-  const rects = paneRects(tree);
+  const liveRects = liveBounds ? rectsFromBounds(liveBounds) : [];
+  const liveIds = new Set(liveRects.map((rect) => rect.id));
+  const hasCompleteLiveLayout = leafIds(tree).every((id) => liveIds.has(id));
+  const rects = hasCompleteLiveLayout ? liveRects : paneRects(tree);
   const active = rects.find((rect) => rect.id === activeId);
   if (!active || rects.length < 2) return tree;
   const targetId = directionalTarget(rects, active, direction);

--- a/src/modules/terminal/lib/panes.ts
+++ b/src/modules/terminal/lib/panes.ts
@@ -1,6 +1,7 @@
 export type PaneId = number;
 
 export type SplitDir = "row" | "col";
+export type PaneDirection = "left" | "right" | "up" | "down";
 
 export type PaneNode =
   | { kind: "leaf"; id: PaneId; cwd?: string }
@@ -157,4 +158,103 @@ export function siblingLeafOf(
 
 export function hasLeaf(tree: PaneNode, id: PaneId): boolean {
   return leafIds(tree).includes(id);
+}
+
+type PaneRect = { id: PaneId; x: number; y: number; width: number; height: number };
+
+function paneRects(
+  node: PaneNode,
+  x = 0,
+  y = 0,
+  width = 1,
+  height = 1,
+): PaneRect[] {
+  if (isLeaf(node)) return [{ id: node.id, x, y, width, height }];
+  const count = node.children.length;
+  return node.children.flatMap((child, index) =>
+    node.dir === "row"
+      ? paneRects(child, x + (width * index) / count, y, width / count, height)
+      : paneRects(child, x, y + (height * index) / count, width, height / count),
+  );
+}
+
+function directionalTarget(
+  rects: PaneRect[],
+  active: PaneRect,
+  direction: PaneDirection,
+): PaneId | null {
+  const horizontal = direction === "left" || direction === "right";
+  const forward = direction === "right" || direction === "down";
+  const center = (r: PaneRect) =>
+    horizontal ? r.x + r.width / 2 : r.y + r.height / 2;
+  const crossCenter = (r: PaneRect) =>
+    horizontal ? r.y + r.height / 2 : r.x + r.width / 2;
+  const crossStart = (r: PaneRect) => (horizontal ? r.y : r.x);
+  const crossEnd = (r: PaneRect) =>
+    horizontal ? r.y + r.height : r.x + r.width;
+  const overlaps = (r: PaneRect) =>
+    crossStart(r) < crossEnd(active) && crossEnd(r) > crossStart(active);
+  const others = rects.filter((r) => r.id !== active.id && overlaps(r));
+  if (others.length === 0) return null;
+
+  const ahead = others.filter((r) =>
+    forward ? center(r) > center(active) : center(r) < center(active),
+  );
+  const candidates = ahead.length > 0 ? ahead : others;
+  candidates.sort((a, b) => {
+    const axisA = ahead.length > 0
+      ? Math.abs(center(a) - center(active))
+      : forward
+        ? center(a)
+        : -center(a);
+    const axisB = ahead.length > 0
+      ? Math.abs(center(b) - center(active))
+      : forward
+        ? center(b)
+        : -center(b);
+    return axisA - axisB ||
+      Math.abs(crossCenter(a) - crossCenter(active)) -
+        Math.abs(crossCenter(b) - crossCenter(active));
+  });
+  return candidates[0]?.id ?? null;
+}
+
+function findLeaf(node: PaneNode, id: PaneId): Extract<PaneNode, { kind: "leaf" }> | null {
+  if (isLeaf(node)) return node.id === id ? node : null;
+  for (const child of node.children) {
+    const found = findLeaf(child, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function swapLeaves(
+  node: PaneNode,
+  first: Extract<PaneNode, { kind: "leaf" }>,
+  second: Extract<PaneNode, { kind: "leaf" }>,
+): PaneNode {
+  if (isLeaf(node)) {
+    if (node.id === first.id) return second;
+    if (node.id === second.id) return first;
+    return node;
+  }
+  return {
+    ...node,
+    children: node.children.map((child) => swapLeaves(child, first, second)),
+  };
+}
+
+export function swapLeafInDirection(
+  tree: PaneNode,
+  activeId: PaneId,
+  direction: PaneDirection,
+): PaneNode {
+  const rects = paneRects(tree);
+  const active = rects.find((rect) => rect.id === activeId);
+  if (!active || rects.length < 2) return tree;
+  const targetId = directionalTarget(rects, active, direction);
+  if (targetId === null) return tree;
+  const first = findLeaf(tree, activeId);
+  const second = findLeaf(tree, targetId);
+  return first && second ? swapLeaves(tree, first, second) : tree;
 }


### PR DESCRIPTION
## Summary

Adds keyboard-driven directional pane swapping with configurable shortcuts:

- `Mod+Alt+ArrowLeft` swaps the active pane left
- `Mod+Alt+ArrowRight` swaps the active pane right
- `Mod+Alt+ArrowUp` swaps the active pane up
- `Mod+Alt+ArrowDown` swaps the active pane down
- movement wraps to the opposite edge when no pane exists in the requested direction
- nested and uneven layouts choose a pane overlapping the directional edge, with deterministic topmost/leftmost tie-breaking
- terminal identity, cwd, and active focus move with the pane
- all four bindings appear under Settings > Shortcuts > Panes and can be reassigned or cleared

## Implementation

The pane tree remains the source of truth. A pure helper derives normalized pane rectangles from the split tree, selects the directional target, and swaps complete leaf nodes so session metadata stays attached. `useTabs` exposes the operation and App-level shortcut handlers connect it to the existing shortcut registry.

## Testing

- `pnpm check-types` passes
- pane suite passes: 6 tests covering horizontal and vertical swaps, wraparound, nested layouts, metadata preservation, and the single-pane case
- full suite on Linux: 44 files and 343 tests passed
- Windows production build completed and produced both MSI and NSIS bundles
- feature manually verified in the installed Windows application

## Windows test note

On the Windows test machine, 43 suites and 341 tests passed. `src/app/eager-budget.test.ts` hit an unrelated `SyntaxError: Invalid or unexpected token` while importing the eager-graph MJS helper. The same suite passes on Linux and the production Windows build completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to swap the active pane left, right, up, or down.
  * Pane swapping now uses live pane geometry when available to choose the correct neighboring pane, including within nested layouts.
  * Pane content and metadata move together when panes are swapped.
* **Bug Fixes**
  * Pane swapping safely no-ops when no valid neighboring pane exists or when pane bounds aren’t sufficient.
* **Tests**
  * Added coverage for directional swapping, wrapping, nested layouts, and single-pane behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->