### PR TITLE
fix(pty): preserve terminal response order

### DIFF
--- a/src-tauri/src/modules/pty/da_filter.rs
+++ b/src-tauri/src/modules/pty/da_filter.rs
@@ -84,8 +84,9 @@ impl DaFilter {
                             let middle = &self.hold[2..self.hold.len() - 1];
                             let is_response =
                                 middle.contains(&b'?') || middle.contains(&b';');
+                            let is_startup_query = !self.saw_output && out.is_empty();
                             let prefix = middle.first().copied().unwrap_or(0);
-                            if is_response {
+                            if is_response || !is_startup_query {
                                 out.extend_from_slice(&self.hold);
                             } else {
                                 match prefix {
@@ -175,11 +176,34 @@ mod tests {
     }
 
     #[test]
-    fn embedded_da_preserves_surrounding() {
+    fn da_after_output_in_same_chunk_passes_through() {
         let mut f = DaFilter::new();
-        let (out, replies) = run(&mut f, b"pre\x1b[0cpost");
-        assert_eq!(out, b"prepost");
-        assert_eq!(replies, vec![DA1_REPLY.to_vec()]);
+        let input = b"pre\x1b[0cpost";
+        let (out, replies) = run(&mut f, input);
+        assert_eq!(out, input);
+        assert!(replies.is_empty());
+    }
+
+    #[test]
+    fn da_after_osc_queries_passes_through() {
+        let mut f = DaFilter::new();
+        let input = b"\x1b]10;?\x07\x1b]11;?\x07\x1b[c";
+        let (out, replies) = run(&mut f, input);
+        assert_eq!(out, input);
+        assert!(replies.is_empty());
+    }
+
+    #[test]
+    fn da_after_output_in_prior_chunk_passes_through() {
+        let mut f = DaFilter::new();
+        let (initial, initial_replies) = run(&mut f, b"prompt");
+        assert_eq!(initial, b"prompt");
+        assert!(initial_replies.is_empty());
+
+        let input = b"\x1b[c";
+        let (out, replies) = run(&mut f, input);
+        assert_eq!(out, input);
+        assert!(replies.is_empty());
     }
 
     #[test]
@@ -210,11 +234,12 @@ mod tests {
     }
 
     #[test]
-    fn double_esc() {
+    fn da_after_escape_passes_through() {
         let mut f = DaFilter::new();
-        let (out, replies) = run(&mut f, b"\x1b\x1b[c");
-        assert_eq!(out, b"\x1b");
-        assert_eq!(replies, vec![DA1_REPLY.to_vec()]);
+        let input = b"\x1b\x1b[c";
+        let (out, replies) = run(&mut f, input);
+        assert_eq!(out, input);
+        assert!(replies.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

Limits the Rust PTY DA filter's synthetic replies to leading startup queries. Adds regression coverage for DA queries following OSC queries, prior output, and an escape byte.

## Why

Closes #485.
Closes #932.

The backend DA filter replied directly to the PTY before earlier OSC queries reached xterm.js. Applications such as Yazi use DA1 as the final sentinel for a capability-query batch, so the premature DA1 reply caused them to stop reading and interpret later OSC replies as keyboard input.

## How

Uses the filter's existing `saw_output` state and current output buffer to distinguish leading startup queries from later query batches. Leading DA and PowerShell CPR startup fallbacks remain unchanged. Once output is headed to xterm.js, DA queries pass through so xterm.js owns and preserves the full response order.

## Testing

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean, 359 tests passed
- [x] Manual smoke-test of the affected feature
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] `cargo test --locked` clean, 251 tests passed
- [x] No `#[tauri::command]` signature changed
- [x] Tested in `pnpm tauri dev`
- [x] Platforms tested: macOS
- [x] Shells tested: zsh

Manual checks:

- Launched and exited Yazi without leaked OSC text, automatic Rename mode, or a trapped tab.
- Verified terminal query replies arrive in request order: OSC 10, OSC 11, then DA1.
- Confirmed the existing startup DA and CPR regression tests remain green.
- CodeRabbit reviewed the uncommitted diff with zero findings.

## Screenshots / GIFs

Not applicable. This changes terminal protocol routing without a visual UI change. Reproduction screenshots are available in #932.

## Notes for reviewer

The primary regression risk is Windows PowerShell startup. This change preserves the existing leading DA and CPR fallback behavior, and the existing tests for those paths remain green. Windows was covered by the platform-neutral unit tests but was not manually tested.

<img width="3456" height="2168" alt="YaziInTerax" src="https://github.com/user-attachments/assets/0c1d42a9-05d2-4393-a0dd-18c114f711d1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of terminal device-attribute query sequences.
  * Prevented unintended automatic replies when these sequences appear after prior output, OSC queries, or escape sequences.
  * Preserved qualifying sequences unchanged when they should pass through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->