### PR TITLE
fix(ai): ignore Enter and other keys during IME composition in the composer

### DIFF
--- a/src/lib/ime.test.ts
+++ b/src/lib/ime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isImeComposing } from "./ime";
+
+describe("isImeComposing", () => {
+  it("is true while a candidate is being composed (isComposing set)", () => {
+    // Enter pressed to confirm an IME candidate: must be treated as composition.
+    expect(isImeComposing({ isComposing: true, keyCode: 13 })).toBe(true);
+  });
+
+  it("is true for Chromium's 229 'Process' keyCode before isComposing is set", () => {
+    // macOS reports this for the Enter that confirms a candidate (#873).
+    expect(isImeComposing({ isComposing: false, keyCode: 229 })).toBe(true);
+  });
+
+  it("is false for a plain Enter outside composition", () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 13 })).toBe(false);
+  });
+
+  it("is false for ordinary character typing", () => {
+    expect(isImeComposing({ isComposing: false, keyCode: 65 })).toBe(false);
+  });
+});

--- a/src/lib/ime.ts
+++ b/src/lib/ime.ts
@@ -1,0 +1,17 @@
+/**
+ * True when a keyboard event belongs to an active IME composition session
+ * (e.g. typing Chinese pinyin, Japanese kana, Korean jamo). While composing,
+ * keys such as Enter commit the in-progress candidate into the field and must
+ * not trigger app-level shortcuts like submitting a chat message.
+ *
+ * `keyCode === 229` ("Process") is what Chromium reports for every key pressed
+ * inside an IME session before `isComposing` has been set — notably the Enter
+ * that confirms a candidate on macOS — so we guard on both. The terminal's key
+ * handler uses the same check (see modules/terminal/lib/rendererPool.ts).
+ */
+export function isImeComposing(e: {
+  isComposing: boolean;
+  keyCode: number;
+}): boolean {
+  return e.isComposing || e.keyCode === 229;
+}

--- a/src/modules/ai/components/AiComposerInput.tsx
+++ b/src/modules/ai/components/AiComposerInput.tsx
@@ -1,5 +1,6 @@
 import { Popover, PopoverAnchor } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
+import { isImeComposing } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import { usePresence } from "@/lib/usePresence";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -218,6 +219,11 @@ export function AiComposerInput() {
               onClick={updateTrigger}
               onSelect={updateTrigger}
               onKeyDown={(e) => {
+                // While an IME is composing (e.g. Chinese pinyin) Enter commits
+                // the candidate into the textarea — it must not pick a picker
+                // item or submit the message. Let the IME own every keystroke
+                // until composition ends. (#873)
+                if (isImeComposing(e.nativeEvent)) return;
                 if (pickerOpen) {
                   const items = fileTrigger ? filteredFiles : filteredItems;
                   if (e.key === "ArrowDown") {


### PR DESCRIPTION
## What
Adds an `isImeComposing` guard to the AI composer's key handler so keys pressed during an IME composition (Chinese pinyin, Japanese kana, Korean jamo) are left to the IME instead of being handled by the composer.

## Why
Closes #873. On macOS, pressing Enter to confirm an IME candidate was submitting the AI message instead of committing the candidate, because the composer's `onKeyDown` ran before composition ended.

## How
Pulled the check into a small `src/lib/ime.ts` helper: an event is treated as composing when `isComposing` is set, or when `keyCode === 229` (Chromium's "Process" code, which macOS reports for the Enter that confirms a candidate before `isComposing` flips). The composer now early-returns on that, without calling preventDefault, so the IME still receives the key. This is the same check the terminal handler already uses.

## Testing
- New unit tests in `src/lib/ime.ts` cover both bug cases (isComposing set, and the 229 keyCode while isComposing is still false) plus plain Enter and ordinary typing. They pass:

```
 RUN  v4.1.9
 ✓ src/lib/ime.test.ts (4 tests) 5ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Notes for reviewer
I couldn't capture a GIF or do a full `pnpm tauri dev` smoke on a macOS box for this one, so a quick check that confirming a pinyin/kana candidate with Enter no longer fires a submit would be appreciated. The fix follows the existing terminal IME guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling for input methods such as Japanese, Chinese, and Korean IMEs.
  * Enter and candidate-selection keystrokes are no longer incorrectly treated as picker actions or message submissions while composing text.

* **Tests**
  * Added coverage for active IME composition, Chromium composition events, and regular keyboard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->