### PR TITLE
test: add coverage for untested pure-logic modules

### DIFF
--- a/src/modules/ai/lib/compact.test.ts
+++ b/src/modules/ai/lib/compact.test.ts
@@ -1,0 +1,117 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { compactModelMessages, compactModelMessagesDetailed } from "./compact";
+
+const BIG = "x".repeat(2000);
+
+function readCall(id: string, path: string): ModelMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: id,
+        toolName: "read_file",
+        input: { path },
+      },
+    ],
+  } as unknown as ModelMessage;
+}
+
+function readResult(id: string, value: string): ModelMessage {
+  return {
+    role: "tool",
+    content: [
+      { type: "tool-result", toolCallId: id, output: { type: "text", value } },
+    ],
+  } as unknown as ModelMessage;
+}
+
+function writeCall(id: string, path: string): ModelMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: id,
+        toolName: "write_file",
+        input: { path },
+      },
+    ],
+  } as unknown as ModelMessage;
+}
+
+function outputOf(message: ModelMessage): { __elided?: boolean } {
+  const parts = message.content as Array<{ output?: { __elided?: boolean } }>;
+  return parts[0].output ?? {};
+}
+
+function isElided(message: ModelMessage): boolean {
+  return outputOf(message).__elided === true;
+}
+
+describe("compactModelMessagesDetailed", () => {
+  it("returns the input untouched when it fits the context budget", () => {
+    const messages = [{ role: "user", content: "hi" }] as ModelMessage[];
+    const result = compactModelMessagesDetailed(messages, 1000);
+    expect(result.compacted).toBe(false);
+    expect(result.messages).toBe(messages);
+  });
+
+  it("elides a read result once its file has been written", () => {
+    const messages = [
+      readCall("c1", "/a.txt"),
+      readResult("c1", BIG),
+      writeCall("c2", "/a.txt"),
+      { role: "user", content: BIG } as ModelMessage,
+    ];
+    const result = compactModelMessagesDetailed(messages, 1000);
+    expect(result.compacted).toBe(true);
+    expect(isElided(result.messages[1])).toBe(true);
+  });
+
+  it("keeps the latest read of a path and elides the superseded one", () => {
+    const messages = [
+      readCall("c1", "/a.txt"),
+      readResult("c1", BIG),
+      readCall("c2", "/a.txt"),
+      readResult("c2", BIG),
+      { role: "user", content: BIG } as ModelMessage,
+    ];
+    const result = compactModelMessagesDetailed(messages, 1000);
+    expect(isElided(result.messages[1])).toBe(true);
+    expect(isElided(result.messages[3])).toBe(false);
+  });
+
+  it("does not elide superseded reads while under the budget", () => {
+    const messages = [
+      readCall("c1", "/a.txt"),
+      readResult("c1", "tiny"),
+      readCall("c2", "/a.txt"),
+      readResult("c2", "tiny"),
+    ];
+    const result = compactModelMessagesDetailed(messages, 100_000);
+    expect(result.compacted).toBe(false);
+    expect(isElided(result.messages[1])).toBe(false);
+  });
+
+  it("is idempotent: re-running does not re-elide an already-elided result", () => {
+    const messages = [
+      readCall("c1", "/a.txt"),
+      readResult("c1", BIG),
+      writeCall("c2", "/a.txt"),
+      { role: "user", content: BIG } as ModelMessage,
+    ];
+    const once = compactModelMessagesDetailed(messages, 1000);
+    const twice = compactModelMessagesDetailed(once.messages, 1000);
+    expect(twice.compacted).toBe(false);
+    expect(isElided(twice.messages[1])).toBe(true);
+  });
+});
+
+describe("compactModelMessages", () => {
+  it("returns the messages array from the detailed result", () => {
+    const messages = [{ role: "user", content: "hi" }] as ModelMessage[];
+    expect(compactModelMessages(messages, 1000)).toBe(messages);
+  });
+});

--- a/src/modules/ai/lib/redact.test.ts
+++ b/src/modules/ai/lib/redact.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { redactSensitive } from "./redact";
+
+const SECRETS: Array<{ name: string; secret: string }> = [
+  { name: "openai key", secret: "sk-proj-abcdefghijklmnopqrstuvwxyz012345" },
+  { name: "anthropic key", secret: "sk-ant-abcdefghijklmnopqrstuvwxyz012345" },
+  { name: "aws access key", secret: "AKIA1234567890ABCDEF" },
+  { name: "github token", secret: `ghp_${"a".repeat(36)}` },
+  { name: "github pat", secret: `github_pat_${"A".repeat(40)}` },
+  { name: "google api key", secret: `AIza${"a".repeat(35)}` },
+  { name: "slack token", secret: `xoxb-${"1".repeat(12)}` },
+  { name: "stripe key", secret: `sk_live_${"a".repeat(24)}` },
+  { name: "jwt", secret: "eyJabcdefgh.ZYXWVUTSR.qwertyuiop" },
+];
+
+describe("redactSensitive", () => {
+  for (const { name, secret } of SECRETS) {
+    it(`removes a ${name} from surrounding text`, () => {
+      const out = redactSensitive(`prefix ${secret} suffix`);
+      expect(out).not.toContain(secret);
+      expect(out).toContain("<REDACTED");
+      expect(out.startsWith("prefix ")).toBe(true);
+      expect(out.endsWith(" suffix")).toBe(true);
+    });
+  }
+
+  it("redacts a bearer token while keeping the header name", () => {
+    const out = redactSensitive(
+      "Authorization: Bearer abcdefghijklmnopqrstuvwx",
+    );
+    expect(out).not.toContain("abcdefghijklmnopqrstuvwx");
+    expect(out).toContain("Authorization:");
+  });
+
+  it("redacts an assigned secret value but keeps the key name", () => {
+    const out = redactSensitive('MY_SECRET_KEY="hunter2hunter2"');
+    expect(out).toContain("MY_SECRET_KEY");
+    expect(out).not.toContain("hunter2hunter2");
+    expect(out).toContain("<REDACTED>");
+  });
+
+  it("redacts a password assignment", () => {
+    const out = redactSensitive("DB_PASSWORD=p@ssw0rdlong");
+    expect(out).not.toContain("p@ssw0rdlong");
+    expect(out).toContain("DB_PASSWORD");
+  });
+
+  it("leaves non-sensitive text untouched", () => {
+    const text = "just a normal log line with no secrets";
+    expect(redactSensitive(text)).toBe(text);
+  });
+
+  it("redacts every secret when several appear together", () => {
+    const input = `openai sk-proj-${"a".repeat(24)} and aws AKIA1234567890ABCDEF`;
+    const out = redactSensitive(input);
+    expect(out).not.toContain("AKIA1234567890ABCDEF");
+    expect(out).not.toContain(`sk-proj-${"a".repeat(24)}`);
+  });
+});

--- a/src/modules/ai/lib/snippets.test.ts
+++ b/src/modules/ai/lib/snippets.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  expandSnippetTokens,
+  isValidHandle,
+  normalizeHandle,
+  type Snippet,
+} from "./snippets";
+
+function snippet(
+  over: Partial<Snippet> & Pick<Snippet, "id" | "handle">,
+): Snippet {
+  return { name: "", description: "", content: "", ...over };
+}
+
+describe("normalizeHandle", () => {
+  it("lowercases and hyphenates whitespace", () => {
+    expect(normalizeHandle("Hello World")).toBe("hello-world");
+  });
+
+  it("drops characters outside [a-z0-9-]", () => {
+    expect(normalizeHandle("My Cool Snippet!!")).toBe("my-cool-snippet");
+  });
+
+  it("collapses repeated hyphens and trims leading/trailing ones", () => {
+    expect(normalizeHandle("--a--b--")).toBe("a-b");
+  });
+});
+
+describe("isValidHandle", () => {
+  it("accepts lowercase alphanumeric handles", () => {
+    expect(isValidHandle("foo-bar")).toBe(true);
+    expect(isValidHandle("a")).toBe(true);
+  });
+
+  it("rejects empty, leading-hyphen, and uppercase handles", () => {
+    expect(isValidHandle("")).toBe(false);
+    expect(isValidHandle("-x")).toBe(false);
+    expect(isValidHandle("Foo")).toBe(false);
+  });
+});
+
+describe("expandSnippetTokens", () => {
+  const snippets = [
+    snippet({ id: "1", handle: "greet", content: "Hello" }),
+    snippet({ id: "2", handle: "bye", content: "Goodbye" }),
+  ];
+
+  it("replaces a known token and emits its block", () => {
+    const { body, blocks } = expandSnippetTokens("#greet now", snippets);
+    expect(body).toBe("now");
+    expect(blocks).toEqual(['<snippet name="greet">\nHello\n</snippet>']);
+  });
+
+  it("matches handles case-insensitively", () => {
+    const { body, blocks } = expandSnippetTokens("do #GREET please", snippets);
+    expect(body).not.toContain("#GREET");
+    expect(blocks).toEqual(['<snippet name="greet">\nHello\n</snippet>']);
+  });
+
+  it("expands multiple distinct tokens in order", () => {
+    const { blocks } = expandSnippetTokens("#greet and #bye", snippets);
+    expect(blocks).toEqual([
+      '<snippet name="greet">\nHello\n</snippet>',
+      '<snippet name="bye">\nGoodbye\n</snippet>',
+    ]);
+  });
+
+  it("emits a repeated snippet only once", () => {
+    const { blocks } = expandSnippetTokens("#greet #greet", snippets);
+    expect(blocks).toHaveLength(1);
+  });
+
+  it("leaves unknown tokens untouched", () => {
+    const { body, blocks } = expandSnippetTokens("say #missing ok", snippets);
+    expect(body).toBe("say #missing ok");
+    expect(blocks).toEqual([]);
+  });
+
+  it("does not expand a token glued to a preceding word", () => {
+    const { body, blocks } = expandSnippetTokens("email#greet", snippets);
+    expect(body).toBe("email#greet");
+    expect(blocks).toEqual([]);
+  });
+});

--- a/src/modules/editor/lib/autocomplete/prompt.test.ts
+++ b/src/modules/editor/lib/autocomplete/prompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildUserPrompt, trimContext } from "./prompt";
+
+describe("trimContext", () => {
+  it("leaves short prefix and suffix unchanged", () => {
+    expect(trimContext("abc", "xyz")).toEqual({ prefix: "abc", suffix: "xyz" });
+  });
+
+  it("keeps the tail of an over-long prefix (nearest the cursor)", () => {
+    const prefix = `${"x".repeat(5000)}TAIL`;
+    const { prefix: out } = trimContext(prefix, "");
+    expect(out).toHaveLength(4000);
+    expect(out.endsWith("TAIL")).toBe(true);
+  });
+
+  it("keeps the head of an over-long suffix (nearest the cursor)", () => {
+    const suffix = `HEAD${"y".repeat(5000)}`;
+    const { suffix: out } = trimContext("", suffix);
+    expect(out).toHaveLength(2000);
+    expect(out.startsWith("HEAD")).toBe(true);
+  });
+});
+
+describe("buildUserPrompt", () => {
+  it("wraps prefix and suffix in fenced blocks", () => {
+    const prompt = buildUserPrompt({
+      prefix: "foo",
+      suffix: "bar",
+      filename: null,
+      language: null,
+      indentUnit: null,
+    });
+    expect(prompt).toContain("PREFIX:\n<<<\nfoo\n>>>");
+    expect(prompt).toContain("SUFFIX:\n<<<\nbar\n>>>");
+  });
+
+  it("omits the metadata block when no metadata is provided", () => {
+    const prompt = buildUserPrompt({
+      prefix: "x",
+      suffix: "y",
+      filename: null,
+      language: null,
+      indentUnit: null,
+    });
+    expect(prompt.startsWith("PREFIX:")).toBe(true);
+  });
+
+  it("includes file, language, and space-indent metadata", () => {
+    const prompt = buildUserPrompt({
+      prefix: "x",
+      suffix: "y",
+      filename: "a.ts",
+      language: "typescript",
+      indentUnit: "  ",
+    });
+    expect(prompt).toContain("File: a.ts");
+    expect(prompt).toContain("Language: typescript");
+    expect(prompt).toContain("Indent: 2 spaces");
+  });
+
+  it("labels a tab indent unit as tabs", () => {
+    const prompt = buildUserPrompt({
+      prefix: "x",
+      suffix: "y",
+      filename: null,
+      language: null,
+      indentUnit: "\t",
+    });
+    expect(prompt).toContain("Indent: tabs");
+  });
+
+  it("truncates the embedded context to the trim limits", () => {
+    const prompt = buildUserPrompt({
+      prefix: "p".repeat(5000),
+      suffix: "s".repeat(5000),
+      filename: null,
+      language: null,
+      indentUnit: null,
+    });
+    expect(prompt).toContain("p".repeat(4000));
+    expect(prompt).not.toContain("p".repeat(4001));
+    expect(prompt).toContain("s".repeat(2000));
+    expect(prompt).not.toContain("s".repeat(2001));
+  });
+});

--- a/src/modules/git-history/lib/graph.test.ts
+++ b/src/modules/git-history/lib/graph.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { GitLogEntry } from "@/modules/ai/lib/native";
+import { LANE_COLORS, laneColor, layoutGraph } from "./graph";
+
+function commit(sha: string, parents: string[]): GitLogEntry {
+  return { sha, parents } as unknown as GitLogEntry;
+}
+
+describe("laneColor", () => {
+  it("cycles through the palette by lane index", () => {
+    expect(laneColor(0)).toBe(LANE_COLORS[0]);
+    expect(laneColor(1)).toBe(LANE_COLORS[1]);
+    expect(laneColor(LANE_COLORS.length)).toBe(LANE_COLORS[0]);
+  });
+});
+
+describe("layoutGraph", () => {
+  it("returns nothing for an empty log", () => {
+    const { rows, state } = layoutGraph([]);
+    expect(rows).toEqual([]);
+    expect(state.lanes).toEqual([]);
+  });
+
+  it("keeps a linear history in a single lane", () => {
+    const { rows } = layoutGraph([
+      commit("c", ["b"]),
+      commit("b", ["a"]),
+      commit("a", []),
+    ]);
+    expect(rows.map((r) => r.lane)).toEqual([0, 0, 0]);
+    expect(rows.every((r) => r.laneCount === 1)).toBe(true);
+  });
+
+  it("colors each node by its lane", () => {
+    const { rows } = layoutGraph([
+      commit("E", ["D"]),
+      commit("D", ["C", "B"]),
+      commit("C", ["A"]),
+      commit("B", ["A"]),
+      commit("A", []),
+    ]);
+    for (const row of rows) {
+      expect(row.nodeColor).toBe(laneColor(row.lane));
+    }
+  });
+
+  it("assigns a second lane to a diverging branch", () => {
+    const { rows } = layoutGraph([
+      commit("E", ["D"]),
+      commit("D", ["C", "B"]),
+      commit("C", ["A"]),
+      commit("B", ["A"]),
+      commit("A", []),
+    ]);
+    expect(rows.map((r) => `${r.sha}:${r.lane}`)).toEqual([
+      "E:0",
+      "D:0",
+      "C:0",
+      "B:1",
+      "A:0",
+    ]);
+    expect(rows.map((r) => r.laneCount)).toEqual([1, 2, 2, 2, 2]);
+  });
+
+  it("emits a branch edge when a merge commit fans out a parent", () => {
+    const { rows } = layoutGraph([
+      commit("D", ["C", "B"]),
+      commit("C", ["A"]),
+      commit("B", ["A"]),
+      commit("A", []),
+    ]);
+    const mergeRow = rows.find((r) => r.sha === "D");
+    expect(mergeRow?.bottomEdges).toContainEqual(
+      expect.objectContaining({ kind: "branch", fromLane: 0, toLane: 1 }),
+    );
+  });
+
+  it("emits a merge edge when two lanes collapse into one commit", () => {
+    const { rows } = layoutGraph([
+      commit("D", ["C", "B"]),
+      commit("C", ["A"]),
+      commit("B", ["A"]),
+      commit("A", []),
+    ]);
+    const rootRow = rows.find((r) => r.sha === "A");
+    expect(rootRow?.topEdges).toContainEqual(
+      expect.objectContaining({ kind: "merge", toLane: 0 }),
+    );
+  });
+
+  it("keeps lane indices stable across pagination", () => {
+    const log = [
+      commit("E", ["D"]),
+      commit("D", ["C", "B"]),
+      commit("C", ["A"]),
+      commit("B", ["A"]),
+      commit("A", []),
+    ];
+    const whole = layoutGraph(log).rows.map((r) => `${r.sha}:${r.lane}`);
+
+    for (let split = 1; split < log.length; split++) {
+      const page1 = layoutGraph(log.slice(0, split));
+      const page2 = layoutGraph(log.slice(split), page1.state);
+      const paged = [...page1.rows, ...page2.rows].map(
+        (r) => `${r.sha}:${r.lane}`,
+      );
+      expect(paged).toEqual(whole);
+    }
+  });
+});

--- a/src/modules/git-history/lib/remoteWebUrl.test.ts
+++ b/src/modules/git-history/lib/remoteWebUrl.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { commitWebUrl, hostLabel, parseRemoteWebUrl } from "./remoteWebUrl";
+
+describe("parseRemoteWebUrl", () => {
+  it("parses an scp-style GitHub remote", () => {
+    expect(parseRemoteWebUrl("git@github.com:owner/repo.git")).toEqual({
+      host: "github",
+      hostname: "github.com",
+      owner: "owner",
+      repo: "repo",
+      baseUrl: "https://github.com/owner/repo",
+    });
+  });
+
+  it("parses an https GitHub remote", () => {
+    expect(parseRemoteWebUrl("https://github.com/owner/repo.git")).toEqual({
+      host: "github",
+      hostname: "github.com",
+      owner: "owner",
+      repo: "repo",
+      baseUrl: "https://github.com/owner/repo",
+    });
+  });
+
+  it("recognizes GitLab and Bitbucket hosts", () => {
+    expect(parseRemoteWebUrl("git@gitlab.com:group/proj.git")?.host).toBe(
+      "gitlab",
+    );
+    expect(parseRemoteWebUrl("https://bitbucket.org/team/app.git")?.host).toBe(
+      "bitbucket",
+    );
+  });
+
+  it("strips an optional .git suffix and leading slash", () => {
+    expect(parseRemoteWebUrl("https://github.com/owner/repo")?.repo).toBe(
+      "repo",
+    );
+    expect(parseRemoteWebUrl("git@github.com:owner/repo")?.repo).toBe("repo");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseRemoteWebUrl("  git@github.com:owner/repo.git  ")?.owner).toBe(
+      "owner",
+    );
+  });
+
+  it("lowercases the hostname but preserves owner/repo case", () => {
+    const info = parseRemoteWebUrl("git@GitHub.com:Owner/Repo.git");
+    expect(info?.hostname).toBe("github.com");
+    expect(info?.owner).toBe("Owner");
+    expect(info?.repo).toBe("Repo");
+  });
+
+  it("accepts a www. host prefix", () => {
+    expect(parseRemoteWebUrl("https://www.github.com/o/r.git")?.host).toBe(
+      "github",
+    );
+  });
+
+  it("returns null for unsupported hosts", () => {
+    expect(parseRemoteWebUrl("https://example.com/o/r.git")).toBeNull();
+  });
+
+  it("returns null when the path lacks an owner and repo", () => {
+    expect(parseRemoteWebUrl("https://github.com/onlyowner")).toBeNull();
+  });
+
+  it("returns null for empty or nullish input", () => {
+    expect(parseRemoteWebUrl("")).toBeNull();
+    expect(parseRemoteWebUrl("   ")).toBeNull();
+    expect(parseRemoteWebUrl(null)).toBeNull();
+    expect(parseRemoteWebUrl(undefined)).toBeNull();
+  });
+});
+
+describe("commitWebUrl", () => {
+  it("builds host-specific commit paths", () => {
+    const github = parseRemoteWebUrl("git@github.com:owner/repo.git");
+    const gitlab = parseRemoteWebUrl("git@gitlab.com:group/proj.git");
+    const bitbucket = parseRemoteWebUrl("https://bitbucket.org/team/app.git");
+    if (!github || !gitlab || !bitbucket) throw new Error("expected parses");
+
+    expect(commitWebUrl(github, "abc123")).toBe(
+      "https://github.com/owner/repo/commit/abc123",
+    );
+    expect(commitWebUrl(gitlab, "abc123")).toBe(
+      "https://gitlab.com/group/proj/-/commit/abc123",
+    );
+    expect(commitWebUrl(bitbucket, "abc123")).toBe(
+      "https://bitbucket.org/team/app/commits/abc123",
+    );
+  });
+});
+
+describe("hostLabel", () => {
+  it("names each supported host", () => {
+    const github = parseRemoteWebUrl("git@github.com:owner/repo.git");
+    const gitlab = parseRemoteWebUrl("git@gitlab.com:group/proj.git");
+    const bitbucket = parseRemoteWebUrl("https://bitbucket.org/team/app.git");
+    if (!github || !gitlab || !bitbucket) throw new Error("expected parses");
+
+    expect(hostLabel(github)).toBe("View on GitHub");
+    expect(hostLabel(gitlab)).toBe("View on GitLab");
+    expect(hostLabel(bitbucket)).toBe("View on Bitbucket");
+  });
+});

--- a/src/modules/spaces/lib/spaceColor.test.ts
+++ b/src/modules/spaces/lib/spaceColor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { accentFor, SPACE_COLORS, spaceInitial } from "./spaceColor";
+
+describe("accentFor", () => {
+  it("returns the palette color for an in-range index", () => {
+    expect(accentFor({ color: 0 })).toBe(SPACE_COLORS[0]);
+    expect(accentFor({ color: SPACE_COLORS.length - 1 })).toBe(
+      SPACE_COLORS[SPACE_COLORS.length - 1],
+    );
+  });
+
+  it("falls back to the theme primary for out-of-range, negative, or unset colors", () => {
+    expect(accentFor({ color: SPACE_COLORS.length })).toBe("var(--primary)");
+    expect(accentFor({ color: -1 })).toBe("var(--primary)");
+    expect(accentFor({})).toBe("var(--primary)");
+  });
+});
+
+describe("spaceInitial", () => {
+  it("uppercases the first non-whitespace character", () => {
+    expect(spaceInitial("hi")).toBe("H");
+    expect(spaceInitial("  bar")).toBe("B");
+  });
+
+  it("returns a placeholder for empty or whitespace-only names", () => {
+    expect(spaceInitial("")).toBe("?");
+    expect(spaceInitial("   ")).toBe("?");
+  });
+});

--- a/src/modules/statusbar/lib/pathUtils.test.ts
+++ b/src/modules/statusbar/lib/pathUtils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { segmentsFromCwd } from "./pathUtils";
+
+function shape(cwd: string, home: string | null) {
+  return segmentsFromCwd(cwd, home).map((s) => ({
+    label: s.label,
+    fullPath: s.fullPath,
+    isHome: s.isHome,
+  }));
+}
+
+describe("segmentsFromCwd", () => {
+  it("renders a path under home with a ~ root and accumulated paths", () => {
+    expect(shape("/Users/me/projects/terax", "/Users/me")).toEqual([
+      { label: "~", fullPath: "/Users/me", isHome: true },
+      { label: "projects", fullPath: "/Users/me/projects", isHome: false },
+      { label: "terax", fullPath: "/Users/me/projects/terax", isHome: false },
+    ]);
+  });
+
+  it("collapses the home directory itself to a single ~ segment", () => {
+    expect(shape("/Users/me", "/Users/me")).toEqual([
+      { label: "~", fullPath: "/Users/me", isHome: true },
+    ]);
+  });
+
+  it("does not treat a sibling that merely shares the home prefix as home", () => {
+    const segments = shape("/Users/mefoo", "/Users/me");
+    expect(segments[0]).toEqual({ label: "/", fullPath: "/", isHome: false });
+    expect(segments.map((s) => s.label)).toEqual(["/", "Users", "mefoo"]);
+  });
+
+  it("builds unix absolute paths from the / root", () => {
+    expect(shape("/usr/local/bin", null)).toEqual([
+      { label: "/", fullPath: "/", isHome: false },
+      { label: "usr", fullPath: "/usr", isHome: false },
+      { label: "local", fullPath: "/usr/local", isHome: false },
+      { label: "bin", fullPath: "/usr/local/bin", isHome: false },
+    ]);
+  });
+
+  it("uses the drive letter as the root on Windows paths", () => {
+    expect(shape("C:/Users/me/proj", null)).toEqual([
+      { label: "C:", fullPath: "C:/", isHome: false },
+      { label: "Users", fullPath: "C:/Users", isHome: false },
+      { label: "me", fullPath: "C:/Users/me", isHome: false },
+      { label: "proj", fullPath: "C:/Users/me/proj", isHome: false },
+    ]);
+  });
+
+  it("normalizes backslash separators", () => {
+    expect(shape("C:\\Users\\me\\proj", null).map((s) => s.label)).toEqual([
+      "C:",
+      "Users",
+      "me",
+      "proj",
+    ]);
+  });
+
+  it("returns just the root for a bare drive or /", () => {
+    expect(shape("C:/", null)).toEqual([
+      { label: "C:", fullPath: "C:/", isHome: false },
+    ]);
+    expect(shape("/", null)).toEqual([
+      { label: "/", fullPath: "/", isHome: false },
+    ]);
+  });
+});

--- a/src/modules/theme/validateTheme.test.ts
+++ b/src/modules/theme/validateTheme.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { validateTheme } from "./validateTheme";
+
+function baseTheme(over: Record<string, unknown> = {}) {
+  return {
+    id: "ok-id",
+    name: "Cool Theme",
+    variants: { dark: { colors: { background: "#000" } } },
+    ...over,
+  };
+}
+
+describe("validateTheme", () => {
+  it("rejects a non-object payload", () => {
+    expect(validateTheme("nope")).toEqual({
+      ok: false,
+      error: "Theme must be a JSON object",
+    });
+  });
+
+  it("rejects ids that are not kebab-case or too short", () => {
+    expect(validateTheme(baseTheme({ id: "Foo" })).ok).toBe(false);
+    expect(validateTheme(baseTheme({ id: "a" })).ok).toBe(false);
+    expect(validateTheme(baseTheme({ id: "has space" })).ok).toBe(false);
+  });
+
+  it("requires a non-empty name and trims it", () => {
+    expect(validateTheme(baseTheme({ name: "  " })).ok).toBe(false);
+    const result = validateTheme(baseTheme({ name: "  Padded  " }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.theme.name).toBe("Padded");
+  });
+
+  it("requires a variants object with at least one of light or dark", () => {
+    expect(validateTheme(baseTheme({ variants: undefined })).ok).toBe(false);
+    expect(validateTheme(baseTheme({ variants: {} }))).toEqual({
+      ok: false,
+      error: "variants must contain at least one of: light, dark",
+    });
+  });
+
+  it("accepts a minimal single-variant theme", () => {
+    const result = validateTheme({
+      id: "ok-id",
+      name: "X",
+      variants: { dark: {} },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects unrecognized color keys", () => {
+    const result = validateTheme(
+      baseTheme({ variants: { dark: { colors: { nope: "#fff" } } } }),
+    );
+    expect(result).toEqual({
+      ok: false,
+      error: "variants.dark.colors.nope is not a recognized color key",
+    });
+  });
+
+  it("rejects empty color values", () => {
+    const result = validateTheme(
+      baseTheme({ variants: { dark: { colors: { background: "" } } } }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("requires the terminal ansi palette to have exactly 16 entries", () => {
+    const result = validateTheme(
+      baseTheme({ variants: { dark: { terminal: { ansi: ["#000"] } } } }),
+    );
+    expect(result).toEqual({
+      ok: false,
+      error: "variants.dark.terminal.ansi must be an array of 16 strings",
+    });
+  });
+
+  it("captures optional author, description, and editor theme", () => {
+    const result = validateTheme(
+      baseTheme({
+        author: "me",
+        description: "a theme",
+        editorTheme: { dark: "tokyo" },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.theme.author).toBe("me");
+      expect(result.theme.description).toBe("a theme");
+      expect(result.theme.editorTheme).toEqual({ dark: "tokyo" });
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for nine pure-logic modules that had no coverage. Test-only: no
production files are touched.

## Why

These modules are small, pure, and load-bearing, but nothing locked their
behavior. Each commit adds a focused characterization test so a future refactor
can't silently change the contract. Areas covered:

- `git-history/lib/remoteWebUrl` - scp/https remote parsing, commit URLs, labels
- `git-history/lib/graph` - commit lane layout and pagination stability
- `ai/lib/redact` - secret scrubbing before the terminal buffer reaches the model
- `ai/lib/compact` - model-message context compaction
- `ai/lib/snippets` - #handle normalization and token expansion
- `editor/lib/autocomplete/prompt` - fill-in-the-middle prompt building
- `statusbar/lib/pathUtils` - cwd breadcrumb segmentation
- `theme/validateTheme` - untrusted theme file validation
- `spaces/lib/spaceColor` - space accent lookup and initials

## How

One commit per module. Assertions were written against the actual runtime
behavior of each function, so the tests assert the intended contract rather than
incidental output (for example the redaction tests assert that the secret value
is removed, not the exact `<REDACTED:kind>` label). Where a limitation exists but
would be a behavior change to "fix" (for example `ssh://` remotes returning
null), it is left as-is and not asserted either way.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suites pass; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Every commit is test-only. No public API, behavior, dependency, or config
  change.
- Unrelated pre-existing failure, flagged for transparency: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`. vitest evaluates the
  imported `scripts/eager-graph.mjs` via `new Script`, which does not strip the
  shebang, and the CRLF line ending defeats Vite's shebang stripping. The
  committed blob is LF and the suite passes on Linux CI, so this is not touched
  here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for AI message compaction, sensitive-data redaction, snippet expansion, and editor autocomplete prompts.
  * Added tests for Git history graph layouts and remote repository links.
  * Added validation coverage for space colors, path handling, and custom themes.
  * Verified edge cases including truncation, duplicate handling, platform-specific paths, invalid inputs, and idempotent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->