### PR TITLE
fix(explorer): prevent sidebar scroll bleed on long search results

### DIFF
--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -167,7 +167,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   };
 
   return (
-    <div className="flex flex-col">
+    <div className={cn("flex flex-col", active && "min-h-0 flex-1")}>
       {open ? (
         <div className="relative shrink-0 px-2 py-1.5 animate-in fade-in-0 slide-in-from-top-3 duration-200 ease-out">
           <HugeiconsIcon


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits - it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

Constrain `ExplorerSearch`'s root div to available height so only the results list scrolls, not the entire sidebar.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

When search returns 100+ results in a home-directory workspace, the sidebar's entire column (input, tab switcher, results) scrolls as one unit because the wrapper `div` lacks `min-h-0`, preventing the flex parent from clipping it. The search input and Files | Source Control rail should stay pinned.

## How
<!-- Brief notes on the approach, only if non-obvious. -->

Added `min-h-0 flex-1` conditionally via `cn()` to the wrapper `div` — only when search is active — so the inner ScrollArea has a bounded parent to flex against. Mirrors the same pattern used in `SourceControlPanel.tsx` and `FileExplorer.tsx`.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own -
     describe the actual flows you exercised. -->

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [ ] Platforms tested: macOS
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

https://github.com/user-attachments/assets/f0a3fa39-0fc7-4c62-b21a-14c9224298ad

https://github.com/user-attachments/assets/ca8e4358-9006-4c77-99c1-76950ce3cc62


## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Explorer search layout when entering a query, allowing results to use available space more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->