### PR TITLE
test: add coverage for more pure-logic helpers

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isMarkdownPath } from "./utils";
+
+describe("isMarkdownPath", () => {
+  it("matches markdown extensions case-insensitively", () => {
+    expect(isMarkdownPath("README.md")).toBe(true);
+    expect(isMarkdownPath("notes.markdown")).toBe(true);
+    expect(isMarkdownPath("doc.mdx")).toBe(true);
+    expect(isMarkdownPath("a/b/c.Md")).toBe(true);
+  });
+
+  it("only matches the extension at the end of the path", () => {
+    expect(isMarkdownPath("file.md.txt")).toBe(false);
+    expect(isMarkdownPath("x.mdxx")).toBe(false);
+  });
+
+  it("rejects non-markdown or extensionless paths", () => {
+    expect(isMarkdownPath("file.txt")).toBe(false);
+    expect(isMarkdownPath("mdfile")).toBe(false);
+    expect(isMarkdownPath("md")).toBe(false);
+  });
+});

--- a/src/modules/ai/lib/agents.test.ts
+++ b/src/modules/ai/lib/agents.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { type Agent, BUILTIN_AGENTS, findAgent } from "./agents";
+
+const custom: Agent = {
+  id: "a-1",
+  name: "Mine",
+  description: "",
+  instructions: "",
+  icon: "spark",
+  builtIn: false,
+};
+
+const all = [...BUILTIN_AGENTS, custom];
+
+describe("BUILTIN_AGENTS", () => {
+  it("all carry unique ids and the builtIn flag", () => {
+    const ids = BUILTIN_AGENTS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(BUILTIN_AGENTS.every((a) => a.builtIn)).toBe(true);
+  });
+});
+
+describe("findAgent", () => {
+  it("returns the agent whose id matches", () => {
+    expect(findAgent(all, "a-1")).toBe(custom);
+  });
+
+  it("falls back to the first builtin for a missing id", () => {
+    expect(findAgent(all, "does-not-exist")).toBe(BUILTIN_AGENTS[0]);
+  });
+
+  it("falls back to the first builtin for null, undefined, or empty id", () => {
+    expect(findAgent(all, null)).toBe(BUILTIN_AGENTS[0]);
+    expect(findAgent(all, undefined)).toBe(BUILTIN_AGENTS[0]);
+    expect(findAgent(all, "")).toBe(BUILTIN_AGENTS[0]);
+  });
+});

--- a/src/modules/explorer/lib/contextActions.test.ts
+++ b/src/modules/explorer/lib/contextActions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { relativePath } from "./contextActions";
+
+describe("relativePath", () => {
+  it("returns '.' when the path is the root itself", () => {
+    expect(relativePath("/a/b", "/a/b")).toBe(".");
+  });
+
+  it("strips the root prefix for a descendant path", () => {
+    expect(relativePath("/a/b", "/a/b/c/d")).toBe("c/d");
+  });
+
+  it("does not relativize a sibling that only shares the root prefix", () => {
+    expect(relativePath("/a/b", "/a/bc/d")).toBe("/a/bc/d");
+  });
+
+  it("returns an unrelated path unchanged", () => {
+    expect(relativePath("/a/b", "/x/y")).toBe("/x/y");
+  });
+});

--- a/src/modules/terminal/block/lib/readBlock.test.ts
+++ b/src/modules/terminal/block/lib/readBlock.test.ts
@@ -1,0 +1,47 @@
+import type { Terminal } from "@xterm/xterm";
+import { describe, expect, it } from "vitest";
+import { readRangeText } from "./readBlock";
+
+function fakeTerm(lines: (string | undefined)[]): Terminal {
+  return {
+    buffer: {
+      active: {
+        length: lines.length,
+        getLine: (i: number) =>
+          lines[i] === undefined
+            ? undefined
+            : { translateToString: () => lines[i] as string },
+      },
+    },
+  } as unknown as Terminal;
+}
+
+describe("readRangeText", () => {
+  it("joins the requested line range", () => {
+    expect(readRangeText(fakeTerm(["a", "b", "c"]), 0, 2)).toBe("a\nb\nc");
+  });
+
+  it("drops trailing empty lines", () => {
+    expect(readRangeText(fakeTerm(["a", "b", "c", "", ""]), 0, 4)).toBe(
+      "a\nb\nc",
+    );
+  });
+
+  it("clamps the end to the last buffer line", () => {
+    expect(readRangeText(fakeTerm(["a", "b", "c"]), 1, 99)).toBe("b\nc");
+  });
+
+  it("clamps a negative start to zero", () => {
+    expect(readRangeText(fakeTerm(["a", "b", "c"]), -5, 2)).toBe("a\nb\nc");
+  });
+
+  it("returns an empty string when every line is blank", () => {
+    expect(readRangeText(fakeTerm(["", ""]), 0, 1)).toBe("");
+  });
+
+  it("treats a missing line as empty", () => {
+    expect(readRangeText(fakeTerm(["x0", undefined, "x2"]), 0, 2)).toBe(
+      "x0\n\nx2",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for four more pure-logic helpers that had no coverage.
Test-only: no production files are touched. Independent of the earlier coverage
PR (branched from `main`).

## Why

Same reasoning as before: small, pure, load-bearing helpers with no test to lock
their behavior. Each commit adds a focused characterization test.

- `terminal/block/lib/readBlock` - `readRangeText` captures a terminal buffer
  line range (used to feed command output into the AI composer)
- `explorer/lib/contextActions` - `relativePath` derives a root-relative path
- `ai/lib/agents` - `findAgent` resolves the active agent with a safe fallback
- `lib/utils` - `isMarkdownPath` decides which files open as markdown

## How

One commit per helper. Assertions were written against the actual runtime
behavior. Coverage focuses on the edge cases that would actually break: end/start
clamping and trailing-blank trimming in `readRangeText`; the prefix boundary in
`relativePath` (so `/a/bc` is not relativized against `/a/b`); the
missing/null/undefined/empty fallback in `findAgent`; and the end-anchored
extension match in `isMarkdownPath` (so `file.md.txt` does not match).

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suites pass; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Every commit is test-only. No public API, behavior, dependency, or config
  change.
- `readRangeText` is tested with a minimal fake `Terminal` (only the
  `buffer.active` surface it reads).
- Same unrelated pre-existing failure as noted before, flagged for transparency:
  `src/app/eager-budget.test.ts` fails locally under Windows with
  `git core.autocrlf=true` (vitest evaluates the imported `.mjs` via `new
  Script`, which does not strip the shebang, and CRLF defeats Vite's shebang
  stripping). The committed blob is LF and it passes on Linux CI, so it is not
  touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for Markdown path validation, including case-insensitive extensions and path boundaries.
  * Added tests for built-in agent identification and fallback lookup behavior.
  * Added coverage for relative path handling in explorer actions.
  * Added terminal text-range tests covering clamping, blank lines, missing lines, and line joining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->