### PR TITLE
test(shortcuts): cover keybinding display and matching

### DIFF
--- a/src/modules/shortcuts/shortcuts.test.ts
+++ b/src/modules/shortcuts/shortcuts.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { getBindingTokens, type KeyBinding, matchBinding } from "./shortcuts";
+
+// These tests run in the vitest node environment, where the Tauri OS plugin is
+// unavailable so `IS_MAC` resolves to false. That makes the non-mac token
+// branch deterministic across host platforms.
+
+function event(over: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: "",
+    code: "",
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ...over,
+  } as KeyboardEvent;
+}
+
+describe("getBindingTokens", () => {
+  it("returns nothing for an undefined binding", () => {
+    expect(getBindingTokens(undefined)).toEqual([]);
+  });
+
+  it("lists modifiers in order, then the key", () => {
+    const binding: KeyBinding = { key: "k", ctrl: true, shift: true };
+    expect(getBindingTokens(binding)).toEqual(["Ctrl", "Shift", "K"]);
+  });
+
+  it("labels space and arrow keys", () => {
+    expect(getBindingTokens({ key: " ", meta: true })).toEqual([
+      "Win",
+      "Space",
+    ]);
+    expect(getBindingTokens({ key: "ArrowUp", alt: true })).toEqual([
+      "Alt",
+      "↑",
+    ]);
+  });
+
+  it("uppercases a single-character key", () => {
+    expect(getBindingTokens({ key: "c" })).toEqual(["C"]);
+  });
+});
+
+describe("matchBinding", () => {
+  it("matches when key and all modifiers agree", () => {
+    expect(
+      matchBinding(event({ key: "c", ctrlKey: true }), {
+        key: "c",
+        ctrl: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the key case-insensitively", () => {
+    expect(
+      matchBinding(event({ key: "C", ctrlKey: true }), {
+        key: "c",
+        ctrl: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("fails when a required modifier is missing", () => {
+    expect(matchBinding(event({ key: "c" }), { key: "c", ctrl: true })).toBe(
+      false,
+    );
+  });
+
+  it("fails when an extra modifier is pressed", () => {
+    expect(
+      matchBinding(event({ key: "c", ctrlKey: true, shiftKey: true }), {
+        key: "c",
+        ctrl: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the physical code for alt combinations", () => {
+    // Alt often rewrites e.key (here to "ç"); the binding still matches via e.code.
+    expect(
+      matchBinding(event({ key: "ç", code: "KeyC", altKey: true }), {
+        key: "c",
+        alt: true,
+      }),
+    ).toBe(true);
+    expect(
+      matchBinding(event({ key: "ç", code: "KeyD", altKey: true }), {
+        key: "c",
+        alt: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("only accepts digit keys for the jump-to-tab shortcut", () => {
+    expect(
+      matchBinding(event({ key: "3" }), { key: "1" }, "tab.selectByIndex"),
+    ).toBe(true);
+    expect(
+      matchBinding(event({ key: "x" }), { key: "1" }, "tab.selectByIndex"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the keymap helpers `getBindingTokens` and `matchBinding`.
Test-only: no production files are touched.

## Why

Both functions are load-bearing for shortcuts (one renders the display tokens,
the other decides whether a `KeyboardEvent` fires a binding) but had no test.

## How

Assertions were written against the actual runtime behavior:

- `getBindingTokens`: modifier ordering, space/arrow key labels, single-char
  uppercasing, and the empty-binding case.
- `matchBinding`: exact modifier agreement, case-insensitive key match, the
  physical-code fallback for Alt combinations (Alt often rewrites `e.key`, so the
  binding matches via `e.code`), and the digit-only jump-to-tab special case.

The tests run in the vitest node environment, where the Tauri OS plugin is
unavailable so `IS_MAC` resolves to false; that makes the non-mac token branch
deterministic across host platforms (noted in a comment in the test).

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- `matchBinding` is exercised with plain event-shaped objects (only the fields it
  reads: `key`, `code`, and the four modifier flags).
- Same unrelated pre-existing failure noted on the earlier PRs, flagged for
  transparency: `src/app/eager-budget.test.ts` fails locally under Windows with
  `git core.autocrlf=true` (vitest evaluates the imported `.mjs` via `new
  Script`, which does not strip the shebang, and CRLF defeats Vite's shebang
  stripping). The committed blob is LF and it passes on Linux CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for keyboard shortcut display and matching behavior.
  * Verified modifier ordering, special key labels, case-insensitive matching, and physical-key fallback handling.
  * Added validation for missing or extra modifiers and restricted index-selection shortcuts to numeric keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->