### PR TITLE
test(ai): cover edit tool guards and multi_edit atomicity

### DIFF
--- a/src/modules/ai/tools/edit.test.ts
+++ b/src/modules/ai/tools/edit.test.ts
@@ -1,0 +1,232 @@
+import type { ToolExecutionOptions } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "./context";
+
+const nativeMock = vi.hoisted(() => ({
+  canonicalize: vi.fn(async (path: string) => path),
+  readFile: vi.fn(),
+  writeFile: vi.fn(async () => undefined),
+}));
+
+vi.mock("../lib/native", () => ({ native: nativeMock }));
+
+vi.mock("../lib/security", () => ({
+  checkWritableCanonical: vi.fn(async (path: string) => ({
+    ok: true as const,
+    canonical: path,
+  })),
+}));
+
+vi.mock("../store/planStore", () => ({
+  newQueuedEditId: () => "queued-edit",
+  usePlanStore: { getState: () => ({ active: false, enqueue: vi.fn() }) },
+}));
+
+import { buildEditTools } from "./edit";
+
+const toolOptions: ToolExecutionOptions = {
+  toolCallId: "tool-call",
+  messages: [],
+};
+
+const FILE = "/workspace/a.txt";
+
+function makeContext(readCache: Map<string, { size: number; hash: number }>) {
+  return {
+    getCwd: () => "/workspace",
+    getWorkspaceRoot: () => "/workspace",
+    getTerminalContext: () => null,
+    isActiveTerminalPrivate: () => false,
+    injectIntoActivePty: () => false,
+    openPreview: () => false,
+    spawnAgent: () => null,
+    readAgentOutput: () => null,
+    readCache,
+    getSessionId: () => "session",
+  } as unknown as ToolContext;
+}
+
+/** Context with the file already marked as read, satisfying read-before-edit. */
+function readContext() {
+  return makeContext(new Map([[FILE, { size: 0, hash: 0 }]]));
+}
+
+function setFile(content: string) {
+  nativeMock.readFile.mockResolvedValue({
+    kind: "text",
+    content,
+    size: content.length,
+  });
+}
+
+type EditResult = { error?: string; replacements?: number };
+
+async function runEdit(
+  ctx: ToolContext,
+  input: Record<string, unknown>,
+): Promise<EditResult> {
+  const execute = buildEditTools(ctx).edit.execute;
+  if (!execute) throw new Error("edit tool has no execute");
+  return (await execute(input as never, toolOptions)) as unknown as EditResult;
+}
+
+async function runMultiEdit(
+  ctx: ToolContext,
+  input: Record<string, unknown>,
+): Promise<EditResult> {
+  const execute = buildEditTools(ctx).multi_edit.execute;
+  if (!execute) throw new Error("multi_edit tool has no execute");
+  return (await execute(input as never, toolOptions)) as unknown as EditResult;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  nativeMock.canonicalize.mockImplementation(async (p: string) => p);
+  nativeMock.writeFile.mockResolvedValue(undefined);
+});
+
+describe("edit tool guards", () => {
+  it("refuses to edit a file that was never read (read-before-edit)", async () => {
+    setFile("hello world");
+    const result = await runEdit(makeContext(new Map()), {
+      path: FILE,
+      old_string: "hello",
+      new_string: "bye",
+    });
+    expect(result.error).toContain("read_file");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("errors when old_string is absent", async () => {
+    setFile("hello world");
+    const result = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "missing",
+      new_string: "x",
+    });
+    expect(result.error).toContain("not found");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("errors when old_string is not unique and replace_all is off", async () => {
+    setFile("a a");
+    const result = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "a",
+      new_string: "b",
+    });
+    expect(result.error).toContain("not unique");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects an identical old and new string", async () => {
+    setFile("hello");
+    const result = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "hello",
+      new_string: "hello",
+    });
+    expect(result.error).toContain("identical");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty old_string", async () => {
+    setFile("hello");
+    const result = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "",
+      new_string: "x",
+    });
+    expect(result.error).toContain("empty");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("refuses binary and oversized files", async () => {
+    nativeMock.readFile.mockResolvedValue({ kind: "binary", size: 10 });
+    const binary = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "a",
+      new_string: "b",
+    });
+    expect(binary.error).toContain("binary");
+
+    nativeMock.readFile.mockResolvedValue({
+      kind: "toolarge",
+      size: 999,
+      limit: 10,
+    });
+    const large = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "a",
+      new_string: "b",
+    });
+    expect(large.error).toContain("too large");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("edit tool replacement", () => {
+  it("writes the file with a single unique replacement", async () => {
+    setFile("hello world");
+    const result = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "world",
+      new_string: "there",
+    });
+    expect(result.replacements).toBe(1);
+    expect(nativeMock.writeFile).toHaveBeenCalledWith(FILE, "hello there");
+  });
+
+  it("replaces every occurrence and counts them with replace_all", async () => {
+    setFile("a b a b a");
+    const result = await runEdit(readContext(), {
+      path: FILE,
+      old_string: "a",
+      new_string: "z",
+      replace_all: true,
+    });
+    expect(result.replacements).toBe(3);
+    expect(nativeMock.writeFile).toHaveBeenCalledWith(FILE, "z b z b z");
+  });
+});
+
+describe("multi_edit atomicity", () => {
+  it("applies edits in order against the running buffer", async () => {
+    setFile("one two");
+    const result = await runMultiEdit(readContext(), {
+      path: FILE,
+      edits: [
+        { old_string: "one", new_string: "1" },
+        { old_string: "two", new_string: "2" },
+      ],
+    });
+    expect(result.replacements).toBe(2);
+    expect(nativeMock.writeFile).toHaveBeenCalledWith(FILE, "1 2");
+  });
+
+  it("writes nothing when a later edit in the batch fails", async () => {
+    setFile("one two");
+    const result = await runMultiEdit(readContext(), {
+      path: FILE,
+      edits: [
+        { old_string: "one", new_string: "1" },
+        { old_string: "absent", new_string: "x" },
+      ],
+    });
+    expect(result.error).toContain("not found");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when a later edit is non-unique", async () => {
+    setFile("one dup dup");
+    const result = await runMultiEdit(readContext(), {
+      path: FILE,
+      edits: [
+        { old_string: "one", new_string: "1" },
+        { old_string: "dup", new_string: "x" },
+      ],
+    });
+    expect(result.error).toContain("not unique");
+    expect(nativeMock.writeFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the `edit` and `multi_edit` AI tools. Test-only: no
production files are touched.

## Why

Both tools are part of the AI tool surface and they mutate files on disk, but
neither had a test. CONTRIBUTING calls out both the AI tool surface and
filesystem mutation (no data loss on partial failure) as load-bearing paths that
need their invariants locked.

## How

Follows the existing `tools/search.test.ts` pattern: `vi.hoisted` mocks for
`../lib/native`, plus mocks for `../lib/security` and `../store/planStore` so the
tests exercise the edit logic itself rather than path safety (already covered
separately) or plan-mode queuing.

Locked behavior:

- **Guards**, each also asserting nothing is written: the read-before-edit
  invariant, `old_string` absent, `old_string` not unique without `replace_all`,
  `old_string` identical to `new_string`, empty `old_string`, and binary or
  oversized files.
- **Replacement**: a single unique replacement writes the expected content and
  reports `replacements: 1`; `replace_all` rewrites every occurrence and counts
  them.
- **multi_edit atomicity**: edits apply in order against the running buffer, and
  when any later edit fails (missing or non-unique `old_string`) the whole batch
  aborts before `writeFile` is called.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose: my token lacks
  the `workflow` scope, so a branch containing the recent
  `.github/workflows/ci.yml` dependabot bump cannot be pushed to my fork. This
  branch only adds a new file, so it should merge cleanly. Happy to rebase if you
  prefer.
- Same unrelated pre-existing failure noted on the earlier PRs, flagged for
  transparency: `src/app/eager-budget.test.ts` fails locally under Windows with
  `git core.autocrlf=true` (vitest evaluates the imported `.mjs` via `new
  Script`, which does not strip the shebang, and CRLF defeats Vite's shebang
  stripping). The committed blob is LF and it passes on Linux CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for file editing operations.
  * Verified validation for missing, ambiguous, empty, duplicate, binary, and oversized content.
  * Confirmed single and replace-all edits report accurate replacement counts.
  * Ensured multi-edit operations apply changes in order and remain atomic when any edit fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->