### PR TITLE
fix(terminal): styled xterm scrollbar + ignore IME composition in glo…

### DIFF
--- a/src/modules/shortcuts/lib/useGlobalShortcuts.ts
+++ b/src/modules/shortcuts/lib/useGlobalShortcuts.ts
@@ -25,6 +25,9 @@ export function useGlobalShortcuts(
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // While an IME is composing (Chinese/Japanese/Korean), keystrokes belong
+      // to candidate selection; preventing them would swallow the first input.
+      if (e.isComposing || e.keyCode === 229) return;
       const { handlers, options } = latest.current;
       for (const s of SHORTCUTS) {
         if (e.repeat && !s.allowRepeat) continue;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -211,14 +211,30 @@ html[data-chrome="borderless"] #settings-root {
 }
 .xterm .xterm-viewport,
 .xterm-viewport {
-  scrollbar-width: none !important;
-  -ms-overflow-style: none !important;
+  scrollbar-width: thin !important;
+  -ms-overflow-style: auto !important;
 }
 .xterm .xterm-viewport::-webkit-scrollbar,
 .xterm-viewport::-webkit-scrollbar {
-  width: 0 !important;
-  height: 0 !important;
-  display: none !important;
+  width: 10px !important;
+  height: 10px !important;
+  display: block !important;
+}
+.xterm .xterm-viewport::-webkit-scrollbar-track,
+.xterm-viewport::-webkit-scrollbar-track {
+  background: transparent !important;
+}
+.xterm .xterm-viewport::-webkit-scrollbar-thumb,
+.xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--border) !important;
+  border-radius: 5px !important;
+  border: 2px solid transparent !important;
+  background-clip: content-box !important;
+}
+.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover,
+.xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground) !important;
+  background-clip: content-box !important;
 }
 .xterm,
 .xterm-screen,


### PR DESCRIPTION
…bal shortcuts

Split out of the i18n PR (#968) to keep that PR to one logical change:
- global shortcuts: skip handling while an IME is composing (isComposing / keyCode 229)
- xterm viewport: show a thin styled scrollbar instead of hiding it

<!--
PR title should follow Conventional Commits - it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own -
     describe the actual flows you exercised. -->

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: <!-- macOS / Linux / Windows -->
- [x] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->
