### PR TITLE
feat(ai): add Eden AI as a provider

### DIFF
--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -71,6 +71,7 @@ const PROVIDER_ICON = {
   deepseek: DeepseekIcon,
   mistral: MistralIcon,
   openrouter: GlobeIcon,
+  edenai: GlobeIcon,
   "openai-compatible": PlugIcon,
   lmstudio: ComputerIcon,
   mlx: AppleIcon,

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -95,7 +95,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     label: "Eden AI",
     keyringAccount: "edenai-api-key",
     keyPrefix: null,
-    consoleUrl: "https://app.edenai.run/v2/settings/api",
+    consoleUrl: "https://app.edenai.run/admin/api-settings/features-preferences",
   },
   {
     id: "openai-compatible",

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -10,6 +10,7 @@ export type ProviderId =
   | "deepseek"
   | "mistral"
   | "openrouter"
+  | "edenai"
   | "openai-compatible"
   | "lmstudio"
   | "mlx"
@@ -88,6 +89,13 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     keyringAccount: "openrouter-api-key",
     keyPrefix: "sk-or-",
     consoleUrl: "https://openrouter.ai/keys",
+  },
+  {
+    id: "edenai",
+    label: "Eden AI",
+    keyringAccount: "edenai-api-key",
+    keyPrefix: null,
+    consoleUrl: "https://app.edenai.run/v2/settings/api",
   },
   {
     id: "openai-compatible",
@@ -588,6 +596,16 @@ export const MODELS = [
     label: "OpenRouter",
     hint: "Configurable",
     description: "Any model on OpenRouter by id.",
+    capabilities: { intelligence: 3, speed: 3, cost: 3 },
+  },
+
+  // ── Eden AI (EU gateway; vendor-prefixed model id supplied at runtime) ────
+  {
+    id: "edenai-custom",
+    provider: "edenai",
+    label: "Eden AI",
+    hint: "Configurable",
+    description: "Any Eden AI model by id (e.g. openai/gpt-4o-mini). EU endpoint available.",
     capabilities: { intelligence: 3, speed: 3, cost: 3 },
   },
 

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -161,6 +161,16 @@ export async function buildLanguageModel(
       })(resolvedModelId);
       break;
     }
+    case "edenai": {
+      const { createOpenAICompatible } =
+        await import("@ai-sdk/openai-compatible");
+      built = createOpenAICompatible({
+        name: "edenai",
+        baseURL: "https://api.edenai.run/v3",
+        apiKey: key,
+      })(resolvedModelId);
+      break;
+    }
     case "openai-compatible": {
       if (!compatURL) {
         throw new Error(

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -20,6 +20,7 @@ export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   groq: null,
   deepseek: null,
   mistral: null,
+  edenai: null,
   openrouter: null,
   "openai-compatible": null,
   lmstudio: null,

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -26,6 +26,7 @@ const ICON_BY_PROVIDER = {
   deepseek: DeepseekIcon,
   mistral: MistralIcon,
   openrouter: GlobeIcon,
+  edenai: GlobeIcon,
   "openai-compatible": PlugIcon,
   lmstudio: ComputerIcon,
   mlx: AppleIcon,


### PR DESCRIPTION
## What

Adds Eden AI as a provider, wired the same way as the existing OpenRouter and Mistral providers.

Eden AI is a French, EU-based OpenAI-compatible gateway. It reuses the `createOpenAICompatible` path with base URL `https://api.edenai.run/v3` and `EDENAI_API_KEY`. Model ids are vendor-prefixed, e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `mistral/mistral-small-latest`.

## Why Eden AI (EU / GDPR / data residency)

For terax-ai users with European data-protection requirements, Eden AI provides:

- **EU data residency**: a dedicated EU endpoint (`https://api.eu.edenai.run/v3`) that processes and routes prompts and outputs within the European Union (non-EU models are rejected).
- **Zero data retention**: prompts and outputs are not stored by default and are removed within 24 hours.
- **Compliance**: SOC 2 and ISO 27001, DPA as standard, designed around GDPR and the EU AI Act.

One OpenAI-compatible key reaches many upstream vendors while keeping data in the EU. Refs: https://www.edenai.co/post/eu-ai-endpoint-how-to-keep-ai-requests-and-data-in-europe and https://www.edenai.co/data-compliancy

## Changes

- `src/modules/ai/config.ts`: `edenai` in the `ProviderId` union, a `PROVIDERS` entry (keyring account `edenai-api-key`), and a configurable model entry.
- `src/modules/ai/lib/agent.ts`: a `buildLanguageModel` branch (`createOpenAICompatible`, base URL `https://api.edenai.run/v3`).
- `src/modules/ai/lib/keyring.ts` and the provider-icon maps (`AiStatusBarControls.tsx`, `ProviderIcon.tsx`): the new `edenai` entry.

## Testing

- `tsc --noEmit` is clean.
- `vitest run` on `config.test.ts` and `agents.test.ts` passes (46 tests).
- Live: verified against the real Eden AI API with a real key, using the exact `buildLanguageModel` path (`createOpenAICompatible({ name: "edenai", baseURL: "https://api.edenai.run/v3", apiKey })`). Three vendors returned completions: `anthropic/claude-sonnet-4-5`, `openai/gpt-4o-mini`, `mistral/mistral-small-latest`.

I saw that CONTRIBUTING asks to discuss new AI providers first, so I'm very happy to convert this into an issue/discussion if you prefer, or to adjust anything here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eden AI as a supported AI provider.
  * Added an Eden AI custom model option with selectable capabilities.
  * Enabled Eden AI provider/API key configuration and model resolution.
  * Added Eden AI icon support across provider-related interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->