### PR TITLE
fix(tooling): remove shebang from eager-graph.mjs so vitest can import it

### DIFF
--- a/scripts/eager-graph.mjs
+++ b/scripts/eager-graph.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Static eager-import tracer. BFS from an entry following only *static* value
 // imports (`import ... from "x"`, `export ... from "x"`). `import type` /
 // `export type` are erased by the compiler, and `import("x")` /


### PR DESCRIPTION
## What

Removes the `#!/usr/bin/env node` shebang from `scripts/eager-graph.mjs` — one line — so vitest can import it again.

## Why

Since the vite bump in #1017, `pnpm test` fails on a fresh checkout: vitest can no longer import `scripts/eager-graph.mjs`, and both `eager-budget.test.ts` suites die with a stackless `SyntaxError: Invalid or unexpected token`. Plain `node` imports the file fine — the regression is specific to the vitest/vite transform pipeline, and removing the shebang fixes it.

## How

The shebang was decorative: the script is only ever run as `node scripts/eager-graph.mjs` (the `analyze:eager` script) or imported as a library by the test — never executed directly. Verified the failure is shebang-specific by importing an otherwise-identical copy without the first line.

## Testing

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (677 tests — eager-budget suites pass again)
- [x] Manual smoke-test: `node scripts/eager-graph.mjs src/main.tsx` still works from the CLI
- [x] Platforms tested: Windows

## Screenshots / GIFs

N/A — tooling only.

## Notes for reviewer

Unrelated but observed while here: `pnpm knip` also fails on a clean checkout since the recent tool bumps (config hints + unused-export findings). Happy to file that separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the executable interpreter declaration from an internal script; no user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->