### PR TITLE
feat(markdown): GitHub-style rendering for markdown preview

### DIFF
--- a/markdown-preview-demo.md
+++ b/markdown-preview-demo.md
@@ -1,0 +1,229 @@
+---
+name: markdown-preview-demo
+description: >-
+  A quick tour of everything the markdown preview handles: headings, alerts,
+  lists, tables, task lists, code, footnotes, anchors, local images and
+  inline HTML.
+metadata:
+  type: demo
+  version: 2.0
+tags:
+  - preview
+  - rendering
+---
+
+# Markdown preview demo
+
+This file exercises the features a typical README or skill file uses. Open it
+side by side with GitHub's rendering to compare; everything here is plain
+GitHub-flavored markdown, so the file stays valid there too.
+
+## Contents
+
+These links are the same anchors GitHub generates, and they scroll the
+preview pane in place:
+
+- [Text basics](#text-basics)
+- [Alerts](#alerts)
+- [Lists](#lists)
+- [Tables](#tables)
+- [Code](#code)
+- [Images and local files](#images-and-local-files)
+- [Inline HTML](#inline-html)
+- [What's in a slug?](#whats-in-a-slug)
+- [Live refresh](#live-refresh)
+
+## Text basics
+
+Regular paragraph with **bold**, *italic*, `inline code`, a
+[link](https://example.com), ~~strikethrough~~, and a footnote reference.[^1]
+
+> A blockquote spanning a couple of lines, because quoting other people's
+> documentation is half of technical writing.
+
+[^1]: Footnotes are part of GitHub-flavored markdown too.
+
+## Alerts
+
+All five GitHub alert types render with their icons and hues, in light and
+dark themes:
+
+> [!NOTE]
+> Useful information that users should know, even when skimming.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+Alerts follow GitHub's rules exactly. An unknown type stays a plain
+blockquote:
+
+> [!DANGER]
+> There is no DANGER alert type, so this renders as the literal text.
+
+So does a marker with content on the same line:
+
+> [!TIP] An inline marker like this one is not an alert on GitHub either.
+
+## Lists
+
+Bullet lists, nested two spaces deep:
+
+- Terminal
+- Editor
+  - Markdown preview
+  - Syntax highlighting
+- Explorer
+
+Numbered lists, where nested items align under the parent's *text* (three
+spaces):
+
+1. Gather requirements
+2. Build the thing
+   1. Prototype
+   2. Simplify
+   3. Verify
+3. Ship it
+
+Task lists:
+
+- [x] Render frontmatter as a table
+- [x] Fix list markers
+- [ ] Bask in glory
+
+## Tables
+
+A standard pipe table sizes to its content, exactly like GitHub:
+
+| Feature     | Markdown source   | Renders as    |
+| ----------- | ----------------- | ------------- |
+| Frontmatter | `---` YAML block  | Table         |
+| Task list   | `- [x] done`      | Checkboxes    |
+| Code fence  | ` ```ts `         | Highlighted   |
+
+Layout control stays in markdown: a directive comment above the table
+(invisible on GitHub, which just renders the plain table). Full width,
+columns still sized by content:
+
+<!-- table width="100%" -->
+| Left | Right |
+|------|-------|
+| Fills the page width | however small the content is |
+
+Equal columns at the table's natural width; width and cols are independent:
+
+<!-- table cols="equal" -->
+| Q1 | Q2 | Q3 | Q4 |
+|----|----|----|----|
+| 25% | 25% | 25% | 25% |
+
+Both together, full width and equal:
+
+<!-- table width="100%" cols="equal" -->
+| North | South | East | West |
+|-------|-------|------|------|
+| a | b | c | d |
+
+Custom columns, fixed widths where you want them, `auto` shares the rest:
+
+<!-- table width="100%" cols="12%, auto, 25%" -->
+| ID (12%) | Description (auto) | Owner (25%) |
+|----|-------------|-------|
+| 7 | The auto middle column absorbs whatever space the fixed ones leave behind. | terax |
+
+(Raw HTML tables with `<colgroup>` work too; the directive just writes that
+markup for you.)
+
+## Code
+
+```ts
+export function greet(name: string): string {
+  // Highlighting comes from the app's own renderer.
+  return `Hello, ${name}!`;
+}
+```
+
+Shell fences get the command treatment:
+
+```bash
+corepack enable pnpm
+pnpm install
+```
+
+Plain fences with no language tag must keep their layout too; ASCII diagrams
+live and die by whitespace:
+
+```
+workspace          top-level folder: settings + docs
+  └─ src           application code: ui, services, storage
+      └─ tests     unit + integration, run on every push
+```
+
+## Images and local files
+
+A relative path resolves against this file's directory, like GitHub resolves
+it against the repo:
+
+![Terax app icon](src-tauri/icons/128x128.png)
+
+The dot-slash form works the same way:
+
+![Terax app icon again, smaller](./src-tauri/icons/64x64.png)
+
+A missing file degrades to the browser's standard broken-image state, no
+errors, exactly like GitHub:
+
+![This image intentionally does not exist](assets/does-not-exist.png)
+
+One deliberate difference: a bare relative *link* such as [the
+roadmap](ROADMAP.md) renders as plain text here, because the preview cannot
+navigate between files yet and a dead link would be worse. The dot-slash form
+[./ROADMAP.md](./ROADMAP.md) stays an anchor. On GitHub both navigate.
+
+## Inline HTML
+
+<div align="center">
+  <h3>A centered HTML block</h3>
+  <p>Press <kbd>Ctrl</kbd> + <kbd>K</kbd> to do something impressive.</p>
+</div>
+
+<details>
+<summary>Click to expand</summary>
+
+Hidden content works too, handy for long changelogs. H<sub>2</sub>O and
+E = mc<sup>2</sup> for good measure.
+
+</details>
+
+## What's in a slug?
+
+Heading anchors match GitHub's slugger: this section's id is
+`whats-in-a-slug`, punctuation stripped, spaces hyphenated. Duplicate
+headings get numeric suffixes:
+
+### Twin heading
+
+The first twin keeps the bare slug.
+
+### Twin heading
+
+The second becomes `twin-heading-1`:
+[jump to the second twin](#twin-heading-1).
+
+## Live refresh
+
+Edit this file in another editor, or let an agent rewrite it, and the
+preview re-reads on save while keeping your scroll position. Nothing to
+screenshot here; try it live.
+
+---
+
+That horizontal rule above is the last feature. The end.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3687,8 +3687,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.7.8:
-    resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
+  deslop-js@0.8.1:
+    resolution: {integrity: sha512-a8wpwOPo6HsYyRndn17C88mNzeQD6t17yhZ8qpyFWTxj5jQeWtXDj+zJfnuT8++5A4LaNeNAnKs1edVWuadNdQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4798,8 +4798,8 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
-  oxlint-plugin-react-doctor@0.7.8:
-    resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
+  oxlint-plugin-react-doctor@0.8.1:
+    resolution: {integrity: sha512-ETjgoKrY0EYpK51BsbvgpWySkWaLgJ6z7yB/BfOosi+TUY4+GiDmhWfjJCeul+tpDJEFKR5MnpENjlUrmtZ5Dw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -4992,8 +4992,8 @@ packages:
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     hasBin: true
 
-  react-doctor@0.7.8:
-    resolution: {integrity: sha512-G3spmtZJE/gWWPRJ3rpgUWTPRDJpEmdRja7iNZ7RAXlfpEO+NWVzPTca/cPI9hLwPo2Aq5/BZggo5JDBrwGrlA==}
+  react-doctor@0.8.1:
+    resolution: {integrity: sha512-lP/MaS7dDMeVFpWBjh8qYp6NYcb/1TmsAwSixqkqOI50fea9kfh89fyn+UUAC3vb53FGIqwvDPZIjlJR6BgGAQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -9159,7 +9159,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.7.8:
+  deslop-js@0.8.1:
     dependencies:
       '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
@@ -10569,7 +10569,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxlint-plugin-react-doctor@0.7.8:
+  oxlint-plugin-react-doctor@0.8.1:
     dependencies:
       '@typescript-eslint/types': 8.64.0
       eslint-scope: 9.1.2
@@ -10819,19 +10819,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0)):
+  react-doctor@0.8.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.8
+      deslop-js: 0.8.1
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.7.8
+      oxlint-plugin-react-doctor: 0.8.1
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -10893,7 +10893,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0))
+      react-doctor: 0.8.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3687,8 +3687,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.8.1:
-    resolution: {integrity: sha512-a8wpwOPo6HsYyRndn17C88mNzeQD6t17yhZ8qpyFWTxj5jQeWtXDj+zJfnuT8++5A4LaNeNAnKs1edVWuadNdQ==}
+  deslop-js@0.7.8:
+    resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -4798,8 +4798,8 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
-  oxlint-plugin-react-doctor@0.8.1:
-    resolution: {integrity: sha512-ETjgoKrY0EYpK51BsbvgpWySkWaLgJ6z7yB/BfOosi+TUY4+GiDmhWfjJCeul+tpDJEFKR5MnpENjlUrmtZ5Dw==}
+  oxlint-plugin-react-doctor@0.7.8:
+    resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.66.0:
@@ -4992,8 +4992,8 @@ packages:
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     hasBin: true
 
-  react-doctor@0.8.1:
-    resolution: {integrity: sha512-lP/MaS7dDMeVFpWBjh8qYp6NYcb/1TmsAwSixqkqOI50fea9kfh89fyn+UUAC3vb53FGIqwvDPZIjlJR6BgGAQ==}
+  react-doctor@0.7.8:
+    resolution: {integrity: sha512-G3spmtZJE/gWWPRJ3rpgUWTPRDJpEmdRja7iNZ7RAXlfpEO+NWVzPTca/cPI9hLwPo2Aq5/BZggo5JDBrwGrlA==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -9159,7 +9159,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.8.1:
+  deslop-js@0.7.8:
     dependencies:
       '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
@@ -10569,7 +10569,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxlint-plugin-react-doctor@0.8.1:
+  oxlint-plugin-react-doctor@0.7.8:
     dependencies:
       '@typescript-eslint/types': 8.64.0
       eslint-scope: 9.1.2
@@ -10819,19 +10819,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.8.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0)):
+  react-doctor@0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.66.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.8.1
+      deslop-js: 0.7.8
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0
-      oxlint-plugin-react-doctor: 0.8.1
+      oxlint-plugin-react-doctor: 0.7.8
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -10893,7 +10893,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.8.1(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0))
+      react-doctor: 0.7.8(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(eslint@10.4.1(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:

--- a/src/components/ai-elements/chat-code.test.tsx
+++ b/src/components/ai-elements/chat-code.test.tsx
@@ -4,10 +4,8 @@ import { describe, expect, it } from "vitest";
 import { ChatCodeBlock } from "./chat-code";
 
 describe("ChatCodeBlock run action default", () => {
-  // Chat renders without a CodeRunActionProvider and relies on the context
-  // defaulting to true; a silent default flip would strip chat's
-  // run-in-terminal button. The preview opts out explicitly (locked in
-  // RenderedMarkdown.test.tsx).
+  // Chat relies on the context default staying true; a silent flip would
+  // strip its run-in-terminal button.
   it("renders the run-in-terminal button without a provider", () => {
     const html = renderToStaticMarkup(<ChatCodeBlock code="ls -la" lang="bash" />);
     expect(html).toContain('aria-label="Run in active terminal"');

--- a/src/components/ai-elements/chat-code.test.tsx
+++ b/src/components/ai-elements/chat-code.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ChatCodeBlock } from "./chat-code";
+
+describe("ChatCodeBlock run action default", () => {
+  // Chat renders without a CodeRunActionProvider and relies on the context
+  // defaulting to true; a silent default flip would strip chat's
+  // run-in-terminal button. The preview opts out explicitly (locked in
+  // RenderedMarkdown.test.tsx).
+  it("renders the run-in-terminal button without a provider", () => {
+    const html = renderToStaticMarkup(<ChatCodeBlock code="ls -la" lang="bash" />);
+    expect(html).toContain('aria-label="Run in active terminal"');
+    expect(html).toContain('aria-label="Copy code"');
+  });
+});

--- a/src/components/ai-elements/chat-code.tsx
+++ b/src/components/ai-elements/chat-code.tsx
@@ -21,6 +21,11 @@ import { highlight, isHighlightable, type HighlightedNode } from "./chat-code-le
 const StreamingCtx = createContext(false);
 export const ChatStreamingProvider = StreamingCtx.Provider;
 
+// Run-in-terminal targets the active tab's PTY, which only exists in chat;
+// document previews disable it via this context.
+const RunActionCtx = createContext(true);
+export const CodeRunActionProvider = RunActionCtx.Provider;
+
 const POSIX_SHELL = new Set([
   "bash",
   "sh",
@@ -179,6 +184,7 @@ const HighlightedPre = memo(function HighlightedPre({
 function CommandCard({ code, lang }: { code: string; lang: string }) {
   const isMultiline = code.includes("\n");
   const prompt = shellPrompt(lang);
+  const runEnabled = useContext(RunActionCtx);
   return (
     <div className="not-prose my-2 overflow-hidden rounded-lg border border-border/50 bg-muted/40">
       <div className="flex items-center justify-between gap-2 px-3 py-1.5">
@@ -186,7 +192,7 @@ function CommandCard({ code, lang }: { code: string; lang: string }) {
           {normalizeLangLabel(lang)}
         </span>
         <div className="flex items-center gap-1">
-          <RunInTerminalButton command={code} />
+          {runEnabled && <RunInTerminalButton command={code} />}
           <CopyButton text={code} />
         </div>
       </div>

--- a/src/components/ai-elements/markdown-code.tsx
+++ b/src/components/ai-elements/markdown-code.tsx
@@ -18,12 +18,8 @@ export function markdownCodeText(children?: ReactNode): string {
   return "";
 }
 
-/**
- * `components.code` override shared by the chat's and the markdown
- * preview's Streamdown renderers. Handles both inline
- * (`code`) and fenced blocks (className "language-X"). Fenced blocks
- * delegate to the Lezer-based renderer; inline stays a plain pill.
- */
+// `components.code` override shared by the chat and markdown preview
+// Streamdown renderers.
 export function MarkdownCode({
   className,
   children,

--- a/src/components/ai-elements/markdown-code.tsx
+++ b/src/components/ai-elements/markdown-code.tsx
@@ -19,9 +19,10 @@ export function markdownCodeText(children?: ReactNode): string {
 }
 
 /**
- * Streamdown `components.code` override. Handles both inline (`code`) and
- * fenced blocks (className "language-X"). Fenced blocks delegate to the
- * Lezer-based renderer; inline stays a plain pill.
+ * `components.code` override shared by the chat's and the markdown
+ * preview's Streamdown renderers. Handles both inline
+ * (`code`) and fenced blocks (className "language-X"). Fenced blocks
+ * delegate to the Lezer-based renderer; inline stays a plain pill.
  */
 export function MarkdownCode({
   className,

--- a/src/modules/markdown/MarkdownPreviewPane.test.ts
+++ b/src/modules/markdown/MarkdownPreviewPane.test.ts
@@ -1,19 +1,307 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  watchAdd: vi.fn(),
+  watchRemove: vi.fn(),
+  listenFsChanged: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/core", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  invoke: mocks.invoke,
+}));
+vi.mock("@/modules/workspace", () => ({
+  currentWorkspaceEnv: () => ({ kind: "local" }),
+}));
+vi.mock("@/modules/explorer/lib/watch", () => ({
+  watchAdd: mocks.watchAdd,
+  watchRemove: mocks.watchRemove,
+  listenFsChanged: mocks.listenFsChanged,
+}));
+
+import { type Status, syncPreviewFile } from "./MarkdownPreviewPane";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const src = readFileSync(path.join(here, "MarkdownPreviewPane.tsx"), "utf8");
-const streamdownMatch = src.match(/<Streamdown[\s\S]*?<\/Streamdown>/);
-const streamdownJsx = streamdownMatch?.[0] ?? "";
+const paneSrc = readFileSync(
+  path.join(here, "MarkdownPreviewPane.tsx"),
+  "utf8",
+);
+const renderSrc = readFileSync(path.join(here, "RenderedMarkdown.tsx"), "utf8");
+const themeCss = readFileSync(path.join(here, "markdown-theme.css"), "utf8");
 
-describe("MarkdownPreviewPane Streamdown configuration", () => {
-  it("renders complete markdown files in static mode", () => {
-    expect(streamdownJsx).toMatch(/mode="static"/);
+describe("markdown preview configuration", () => {
+  it("renders through Streamdown in static mode (#913 invariant)", () => {
+    expect(renderSrc).toMatch(/mode="static"/);
+    expect(renderSrc).toMatch(/parseIncompleteMarkdown=\{false\}/);
   });
 
-  it("does not run streaming incomplete-markdown repair for files", () => {
-    expect(streamdownJsx).toMatch(/parseIncompleteMarkdown=\{false\}/);
+  it("disables Streamdown's link-safety popup in favor of the a policy", () => {
+    expect(renderSrc).toMatch(/linkSafety=\{LINK_SAFETY_OFF\}/);
+    expect(renderSrc).toMatch(/enabled: false/);
+  });
+
+  it("loads the base stylesheet before the Terax theme mapping", () => {
+    const base = renderSrc.indexOf('import "./markdown-base.css"');
+    const theme = renderSrc.indexOf('import "./markdown-theme.css"');
+    expect(base).toBeGreaterThan(-1);
+    expect(theme).toBeGreaterThan(base);
+  });
+
+  it("scopes GitHub styles to a markdown-body container", () => {
+    expect(paneSrc).toMatch(/className="markdown-body/);
+  });
+
+  it("keeps code blocks on the app's Lezer renderer", () => {
+    expect(renderSrc).toMatch(/code: .*MarkdownCode/);
+  });
+
+  it("renders inline HTML only through the sanitizer, then harden, last", () => {
+    expect(renderSrc).toMatch(
+      /defaultRehypePlugins\.raw,\s*rehypeTableDirectives,\s*rehypeGithubAlerts,\s*rehypeHeadingAnchors,\s*\[rehypeLocalImages, imageBase\],\s*\[rehypeSanitize, sanitizeSchema\],\s*\[\s*rehypeHarden,/,
+    );
+    expect(renderSrc).toMatch(/rehypePlugins=\{plugins\}/);
+    expect(renderSrc).toMatch(/buildRehypePlugins\(baseDir\)/);
+  });
+
+  it("threads the document directory into the image resolver", () => {
+    expect(paneSrc).toMatch(/baseDir=\{parentDir\(path\)\}/);
+  });
+
+  it("wires the watcher-backed loader as the pane's only read path", () => {
+    expect(paneSrc).toMatch(
+      /useEffect\(\(\) => syncPreviewFile\(path, setStatus\), \[path\]\)/,
+    );
+    // One invoke site: refresh reuses the same read, so there is no second
+    // code path that could reintroduce a loading flash.
+    expect(paneSrc.match(/invoke</g)).toHaveLength(1);
+  });
+
+  it("extends the sanitizer allowlist only with enumerated values", () => {
+    expect(renderSrc).toMatch(
+      /tagNames: \[\.\.\.\(streamdownSchema\.tagNames \?\? \[\]\), "colgroup", "col"\]/,
+    );
+    // Alert classes are enumerated per element, never a blanket allowance.
+    expect(renderSrc).toContain('"markdown-alert-title"');
+    expect(renderSrc).toContain('"markdown-alert-caution"');
+    expect(renderSrc).not.toMatch(/\[\s*"className"\s*\]/);
+    // Image URL schemes gain exactly the asset protocol, nothing broader.
+    expect(renderSrc).toMatch(
+      /src: \[\.\.\.\(streamdownSchema\.protocols\?\.src \?\? \[\]\), "asset"\]/,
+    );
+  });
+
+  it("contains render failures to the pane with an error boundary", () => {
+    expect(renderSrc).toMatch(/getDerivedStateFromError/);
+  });
+
+  it("opens links in the OS browser instead of navigating the webview", () => {
+    expect(renderSrc).toMatch(/openUrl/);
+    expect(renderSrc).toMatch(/preventDefault/);
+  });
+
+  // Fragment resolution is pane-scoped (multiple previews stay mounted with
+  // duplicate heading ids); the scroll call itself is locked here because
+  // the node test environment cannot observe scrollIntoView.
+  it("scrolls fragment links in-pane, before the openUrl branch", () => {
+    expect(renderSrc).toMatch(/href\.startsWith\("#"\)/);
+    expect(renderSrc).toMatch(
+      /resolveFragment\(e\.currentTarget, href\.slice\(1\)\)\?\.scrollIntoView\(\)/,
+    );
+    expect(renderSrc.indexOf('href.startsWith("#")')).toBeLessThan(
+      renderSrc.indexOf("OPENABLE_URL.test(href)"),
+    );
+  });
+});
+
+describe("markdown-theme.css theme mapping", () => {
+  it("maps GitHub color variables to Terax theme tokens", () => {
+    expect(themeCss).toMatch(/--fgColor-default: var\(--foreground\)/);
+    expect(themeCss).toMatch(/--bgColor-default: var\(--background\)/);
+    expect(themeCss).toMatch(/--borderColor-default: var\(--border\)/);
+  });
+
+  it("restores list markers removed by Tailwind's preflight reset", () => {
+    expect(themeCss).toMatch(/\.markdown-body ul \{\s*list-style-type: disc/);
+    expect(themeCss).toMatch(
+      /\.markdown-body ol \{\s*list-style-type: decimal/,
+    );
+  });
+
+  it("honors standard table width markup GitHub ignores", () => {
+    expect(themeCss).toMatch(
+      /table\[width="100%"\] \{\s*display: table;\s*width: 100%/,
+    );
+    expect(themeCss).toMatch(/:has\(> colgroup\) \{\s*table-layout: fixed/);
+  });
+
+  it("underlines links so they read as links under monochrome themes", () => {
+    expect(themeCss).toMatch(
+      /\.markdown-body a \{\s*font-weight: 600;\s*text-decoration: underline/,
+    );
+  });
+
+  it("keeps GitHub pre/code styles out of ChatCodeBlock internals", () => {
+    expect(themeCss).toMatch(/\.markdown-body \.not-prose pre/);
+    expect(themeCss).toMatch(/revert-layer/);
+  });
+
+  it("switches status hues on the app theme class, not the OS media query", () => {
+    expect(themeCss).toMatch(/\.dark \.markdown-body/);
+    expect(themeCss).toMatch(/\.light \.markdown-body/);
+    expect(themeCss).not.toMatch(/@media/);
+  });
+});
+
+type Deferred = {
+  promise: Promise<unknown>;
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: (v: unknown) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const text = (content: string) => ({ kind: "text", content, size: 1 });
+
+describe("syncPreviewFile refresh on external change", () => {
+  const FILE = "D:/notes/readme.md";
+  let reads: Deferred[];
+  let statuses: Status[];
+  let fsHandler: (paths: string[]) => void;
+  let unlisten: Mock<() => void>;
+
+  beforeEach(() => {
+    reads = [];
+    statuses = [];
+    unlisten = vi.fn<() => void>();
+    mocks.invoke.mockReset().mockImplementation(() => {
+      const d = deferred();
+      reads.push(d);
+      return d.promise;
+    });
+    mocks.watchAdd.mockReset();
+    mocks.watchRemove.mockReset();
+    mocks.listenFsChanged.mockReset().mockImplementation((h) => {
+      fsHandler = h;
+      return Promise.resolve(unlisten);
+    });
+  });
+
+  const start = () => syncPreviewFile(FILE, (s) => statuses.push(s));
+
+  it("watches the parent directory and removes the same path on cleanup", async () => {
+    const stop = start();
+    await flush();
+    expect(mocks.watchAdd).toHaveBeenCalledExactlyOnceWith(["D:/notes"]);
+    expect(mocks.watchRemove).not.toHaveBeenCalled();
+    expect(unlisten).not.toHaveBeenCalled();
+    stop();
+    expect(mocks.watchRemove).toHaveBeenCalledExactlyOnceWith(
+      mocks.watchAdd.mock.calls[0][0],
+    );
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("disposes a listener that resolves after cleanup (rapid path switch)", async () => {
+    let resolveListen!: (un: () => void) => void;
+    mocks.listenFsChanged.mockImplementation(
+      () => new Promise((res) => (resolveListen = res)),
+    );
+    const stop = start();
+    stop();
+    resolveListen(unlisten);
+    await flush();
+    expect(unlisten).toHaveBeenCalledOnce();
+  });
+
+  it("re-reads on a change event for the file, ignoring sibling paths", async () => {
+    start();
+    reads[0].resolve(text("v1"));
+    await flush();
+    expect(mocks.invoke).toHaveBeenCalledOnce();
+
+    fsHandler(["D:/notes/other.md"]);
+    expect(mocks.invoke).toHaveBeenCalledOnce();
+
+    // Backend emits canonical paths, backslashed on Windows.
+    fsHandler(["D:\\notes\\readme.md"]);
+    expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the ready content on screen during a refresh (no loading flash)", async () => {
+    start();
+    reads[0].resolve(text("v1"));
+    await flush();
+    expect(statuses).toEqual([
+      { kind: "loading" },
+      { kind: "ready", content: "v1" },
+    ]);
+
+    fsHandler([FILE]);
+    await flush();
+    // Re-read in flight: no state change at all, so React never remounts.
+    expect(statuses).toHaveLength(2);
+
+    reads[1].resolve(text("v2"));
+    await flush();
+    expect(statuses[2]).toMatchObject({ kind: "ready", content: "v2" });
+    expect(statuses.filter((s) => s.kind === "loading")).toHaveLength(1);
+  });
+
+  it("drops a slow read that finishes after a newer read started", async () => {
+    start();
+    reads[0].resolve(text("v1"));
+    await flush();
+
+    fsHandler([FILE]);
+    fsHandler([FILE]);
+    reads[2].resolve(text("v3"));
+    await flush();
+    reads[1].resolve(text("v2"));
+    await flush();
+
+    expect(statuses[statuses.length - 1]).toMatchObject({
+      kind: "ready",
+      content: "v3",
+    });
+    expect(statuses.some((s) => s.kind === "ready" && s.content === "v2")).toBe(
+      false,
+    );
+  });
+
+  it("moves to the error state when the file is deleted", async () => {
+    start();
+    reads[0].resolve(text("v1"));
+    await flush();
+
+    fsHandler([FILE]);
+    reads[1].reject("no such file");
+    await flush();
+    expect(statuses[statuses.length - 1]).toEqual({
+      kind: "error",
+      message: "no such file",
+    });
+  });
+
+  it("ignores reads and events resolving after cleanup", async () => {
+    const stop = start();
+    await flush();
+    stop();
+    reads[0].resolve(text("v1"));
+    fsHandler([FILE]);
+    await flush();
+    expect(statuses).toEqual([{ kind: "loading" }]);
+    expect(mocks.invoke).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/markdown/MarkdownPreviewPane.test.ts
+++ b/src/modules/markdown/MarkdownPreviewPane.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { defaultRehypePlugins } from "streamdown";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -22,7 +23,17 @@ vi.mock("@/modules/explorer/lib/watch", () => ({
   listenFsChanged: mocks.listenFsChanged,
 }));
 
+import { rehypeGithubAlerts } from "./githubAlerts";
+import { rehypeHeadingAnchors } from "./headingAnchors";
+import { rehypeLocalImages } from "./localImages";
 import { type Status, syncPreviewFile } from "./MarkdownPreviewPane";
+import {
+  buildRehypePlugins,
+  components,
+  rehypePlugins,
+  sanitizeSchema,
+} from "./RenderedMarkdown";
+import { rehypeTableDirectives } from "./tableDirectives";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const paneSrc = readFileSync(
@@ -30,84 +41,99 @@ const paneSrc = readFileSync(
   "utf8",
 );
 const renderSrc = readFileSync(path.join(here, "RenderedMarkdown.tsx"), "utf8");
-const themeCss = readFileSync(path.join(here, "markdown-theme.css"), "utf8");
+
+type Schema = {
+  tagNames?: string[];
+  attributes?: Record<string, unknown[]>;
+  protocols?: Record<string, unknown[]>;
+};
 
 describe("markdown preview configuration", () => {
-  it("renders through Streamdown in static mode, no streaming parse", () => {
+  // Order is load-bearing: sanitize must prune after every feature plugin
+  // and harden must vet URLs last; asserted on the built array itself.
+  it("pipeline order and sanitizer schema contract", () => {
+    const plugins = buildRehypePlugins("D:/x") as unknown[];
+    const [sanitizeFn, streamdownSchema] = defaultRehypePlugins.sanitize as [
+      unknown,
+      Schema,
+    ];
+    const [hardenFn] = defaultRehypePlugins.harden as [unknown, unknown];
+
+    expect(plugins).toHaveLength(7);
+    expect(plugins[0]).toBe(defaultRehypePlugins.raw);
+    expect(plugins[1]).toBe(rehypeTableDirectives);
+    expect(plugins[2]).toBe(rehypeGithubAlerts);
+    expect(plugins[3]).toBe(rehypeHeadingAnchors);
+
+    const local = plugins[4] as [unknown, unknown];
+    expect(local[0]).toBe(rehypeLocalImages);
+    expect(local[1]).toBe("D:/x");
+
+    const sanitize = plugins[5] as [unknown, unknown];
+    expect(sanitize[0]).toBe(sanitizeFn);
+    expect(sanitize[1]).toBe(sanitizeSchema);
+
+    const harden = plugins[6] as [unknown, Record<string, unknown>];
+    expect(harden[0]).toBe(hardenFn);
+    // Blocked URLs degrade to plain text: bare relative links are routine
+    // in GitHub-authored files and the "[blocked]" badge reads as content.
+    expect(harden[1].linkBlockPolicy).toBe("text-only");
+    expect(harden[1].imageBlockPolicy).toBe("text-only");
+
+    // The exported default chain and component map stay wired the same way.
+    expect(rehypePlugins).toHaveLength(7);
+    expect(typeof components.a).toBe("function");
+
+    // Schema additions are enumerated on top of Streamdown's lists, never
+    // broader.
+    expect(sanitizeSchema.tagNames).toEqual([
+      ...(streamdownSchema.tagNames ?? []),
+      "colgroup",
+      "col",
+    ]);
+    expect(sanitizeSchema.protocols.src).toEqual([
+      ...(streamdownSchema.protocols?.src ?? []),
+      "asset",
+    ]);
+
+    const attrs = sanitizeSchema.attributes as Record<string, unknown[]>;
+    expect(attrs.div).toContainEqual([
+      "className",
+      "markdown-alert",
+      "markdown-alert-note",
+      "markdown-alert-tip",
+      "markdown-alert-important",
+      "markdown-alert-warning",
+      "markdown-alert-caution",
+    ]);
+    expect(attrs.p).toContainEqual(["className", "markdown-alert-title"]);
+    // A bare "className" entry would allow any class on that element.
+    for (const list of Object.values(attrs)) {
+      expect(list).not.toContain("className");
+    }
+  });
+
+  // No behavioral cousin exists for these JSX props; pin the source text.
+  it("RenderedMarkdown wiring pins", () => {
     expect(renderSrc).toMatch(/mode="static"/);
     expect(renderSrc).toMatch(/parseIncompleteMarkdown=\{false\}/);
-  });
-
-  it("disables Streamdown's link-safety popup in favor of the a policy", () => {
     expect(renderSrc).toMatch(/linkSafety=\{LINK_SAFETY_OFF\}/);
     expect(renderSrc).toMatch(/enabled: false/);
-  });
-
-  // Sanitize/harden placement is proven behaviorally in localImages.test
-  // and githubAlerts.test; this only pins the relative order of the chain,
-  // insensitive to formatting.
-  it("renders inline HTML only through the sanitizer, then harden, last", () => {
-    const chain = renderSrc.slice(
-      renderSrc.indexOf("export const buildRehypePlugins"),
-    );
-    const positions = [
-      "defaultRehypePlugins.raw",
-      "rehypeTableDirectives",
-      "rehypeGithubAlerts",
-      "rehypeHeadingAnchors",
-      "rehypeLocalImages",
-      "rehypeSanitize",
-      "rehypeHarden",
-    ].map((id) => chain.indexOf(id));
-    for (let i = 0; i < positions.length; i++) {
-      expect(positions[i]).toBeGreaterThan(i === 0 ? -1 : positions[i - 1]);
-    }
+    // The only guard that link clicks never navigate the privileged webview.
+    expect(renderSrc).toMatch(/e\.preventDefault\(\)/);
+    expect(renderSrc).toMatch(/openUrl/);
     expect(renderSrc).toMatch(/rehypePlugins=\{plugins\}/);
     expect(renderSrc).toMatch(/buildRehypePlugins\(baseDir\)/);
   });
 
-  it("threads the document directory into the image resolver", () => {
+  it("pane wiring pins", () => {
     expect(paneSrc).toMatch(/baseDir=\{parentDir\(path\)\}/);
-  });
-
-  it("wires the watcher-backed loader as the pane's only read path", () => {
     expect(paneSrc).toMatch(
       /useEffect\(\(\) => syncPreviewFile\(path, setStatus\), \[path\]\)/,
     );
     // One invoke site: refresh reuses the same read, so there is no second
     // code path that could reintroduce a loading flash.
     expect(paneSrc.match(/invoke</g)).toHaveLength(1);
-  });
-
-  it("extends the sanitizer allowlist only with enumerated values", () => {
-    expect(renderSrc).toMatch(
-      /tagNames: \[\.\.\.\(streamdownSchema\.tagNames \?\? \[\]\), "colgroup", "col"\]/,
-    );
-    // Alert classes are enumerated per element, never a blanket allowance.
-    expect(renderSrc).toContain('"markdown-alert-title"');
-    expect(renderSrc).toContain('"markdown-alert-caution"');
-    expect(renderSrc).not.toMatch(/\[\s*"className"\s*\]/);
-    // Image URL schemes gain exactly the asset protocol, nothing broader.
-    expect(renderSrc).toMatch(
-      /src: \[\.\.\.\(streamdownSchema\.protocols\?\.src \?\? \[\]\), "asset"\]/,
-    );
-  });
-
-  it("contains render failures to the pane with an error boundary", () => {
-    expect(renderSrc).toMatch(/getDerivedStateFromError/);
-  });
-
-  it("opens links in the OS browser instead of navigating the webview", () => {
-    expect(renderSrc).toMatch(/openUrl/);
-    expect(renderSrc).toMatch(/preventDefault/);
-  });
-});
-
-describe("markdown-theme.css theme mapping", () => {
-  // The stylesheet must never key off the OS media query: the app theme
-  // class (.dark/.light) has to win regardless of the OS setting.
-  it("switches status hues on the app theme class, not the OS media query", () => {
-    expect(themeCss).not.toMatch(/@media/);
   });
 });
 
@@ -236,7 +262,7 @@ describe("syncPreviewFile refresh on external change", () => {
     );
   });
 
-  it("leaves ready when a refresh finds the file turned binary", async () => {
+  it("leaves ready when a refresh finds the file binary or past the limit", async () => {
     start();
     reads[0].resolve(text("v1"));
     await flush();
@@ -245,15 +271,9 @@ describe("syncPreviewFile refresh on external change", () => {
     reads[1].resolve({ kind: "binary", size: 8 });
     await flush();
     expect(statuses[statuses.length - 1]).toEqual({ kind: "binary" });
-  });
-
-  it("leaves ready when a refresh finds the file grown past the limit", async () => {
-    start();
-    reads[0].resolve(text("v1"));
-    await flush();
 
     fsHandler([FILE]);
-    reads[1].resolve({ kind: "toolarge", size: 99, limit: 10 });
+    reads[2].resolve({ kind: "toolarge", size: 99, limit: 10 });
     await flush();
     expect(statuses[statuses.length - 1]).toEqual({
       kind: "toolarge",

--- a/src/modules/markdown/MarkdownPreviewPane.test.ts
+++ b/src/modules/markdown/MarkdownPreviewPane.test.ts
@@ -33,7 +33,7 @@ const renderSrc = readFileSync(path.join(here, "RenderedMarkdown.tsx"), "utf8");
 const themeCss = readFileSync(path.join(here, "markdown-theme.css"), "utf8");
 
 describe("markdown preview configuration", () => {
-  it("renders through Streamdown in static mode (#913 invariant)", () => {
+  it("renders through Streamdown in static mode, no streaming parse", () => {
     expect(renderSrc).toMatch(/mode="static"/);
     expect(renderSrc).toMatch(/parseIncompleteMarkdown=\{false\}/);
   });

--- a/src/modules/markdown/MarkdownPreviewPane.test.ts
+++ b/src/modules/markdown/MarkdownPreviewPane.test.ts
@@ -43,25 +43,25 @@ describe("markdown preview configuration", () => {
     expect(renderSrc).toMatch(/enabled: false/);
   });
 
-  it("loads the base stylesheet before the Terax theme mapping", () => {
-    const base = renderSrc.indexOf('import "./markdown-base.css"');
-    const theme = renderSrc.indexOf('import "./markdown-theme.css"');
-    expect(base).toBeGreaterThan(-1);
-    expect(theme).toBeGreaterThan(base);
-  });
-
-  it("scopes GitHub styles to a markdown-body container", () => {
-    expect(paneSrc).toMatch(/className="markdown-body/);
-  });
-
-  it("keeps code blocks on the app's Lezer renderer", () => {
-    expect(renderSrc).toMatch(/code: .*MarkdownCode/);
-  });
-
+  // Sanitize/harden placement is proven behaviorally in localImages.test
+  // and githubAlerts.test; this only pins the relative order of the chain,
+  // insensitive to formatting.
   it("renders inline HTML only through the sanitizer, then harden, last", () => {
-    expect(renderSrc).toMatch(
-      /defaultRehypePlugins\.raw,\s*rehypeTableDirectives,\s*rehypeGithubAlerts,\s*rehypeHeadingAnchors,\s*\[rehypeLocalImages, imageBase\],\s*\[rehypeSanitize, sanitizeSchema\],\s*\[\s*rehypeHarden,/,
+    const chain = renderSrc.slice(
+      renderSrc.indexOf("export const buildRehypePlugins"),
     );
+    const positions = [
+      "defaultRehypePlugins.raw",
+      "rehypeTableDirectives",
+      "rehypeGithubAlerts",
+      "rehypeHeadingAnchors",
+      "rehypeLocalImages",
+      "rehypeSanitize",
+      "rehypeHarden",
+    ].map((id) => chain.indexOf(id));
+    for (let i = 0; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(i === 0 ? -1 : positions[i - 1]);
+    }
     expect(renderSrc).toMatch(/rehypePlugins=\{plugins\}/);
     expect(renderSrc).toMatch(/buildRehypePlugins\(baseDir\)/);
   });
@@ -101,56 +101,12 @@ describe("markdown preview configuration", () => {
     expect(renderSrc).toMatch(/openUrl/);
     expect(renderSrc).toMatch(/preventDefault/);
   });
-
-  // Fragment resolution is pane-scoped (multiple previews stay mounted with
-  // duplicate heading ids); the scroll call itself is locked here because
-  // the node test environment cannot observe scrollIntoView.
-  it("scrolls fragment links in-pane, before the openUrl branch", () => {
-    expect(renderSrc).toMatch(/href\.startsWith\("#"\)/);
-    expect(renderSrc).toMatch(
-      /resolveFragment\(e\.currentTarget, href\.slice\(1\)\)\?\.scrollIntoView\(\)/,
-    );
-    expect(renderSrc.indexOf('href.startsWith("#")')).toBeLessThan(
-      renderSrc.indexOf("OPENABLE_URL.test(href)"),
-    );
-  });
 });
 
 describe("markdown-theme.css theme mapping", () => {
-  it("maps GitHub color variables to Terax theme tokens", () => {
-    expect(themeCss).toMatch(/--fgColor-default: var\(--foreground\)/);
-    expect(themeCss).toMatch(/--bgColor-default: var\(--background\)/);
-    expect(themeCss).toMatch(/--borderColor-default: var\(--border\)/);
-  });
-
-  it("restores list markers removed by Tailwind's preflight reset", () => {
-    expect(themeCss).toMatch(/\.markdown-body ul \{\s*list-style-type: disc/);
-    expect(themeCss).toMatch(
-      /\.markdown-body ol \{\s*list-style-type: decimal/,
-    );
-  });
-
-  it("honors standard table width markup GitHub ignores", () => {
-    expect(themeCss).toMatch(
-      /table\[width="100%"\] \{\s*display: table;\s*width: 100%/,
-    );
-    expect(themeCss).toMatch(/:has\(> colgroup\) \{\s*table-layout: fixed/);
-  });
-
-  it("underlines links so they read as links under monochrome themes", () => {
-    expect(themeCss).toMatch(
-      /\.markdown-body a \{\s*font-weight: 600;\s*text-decoration: underline/,
-    );
-  });
-
-  it("keeps GitHub pre/code styles out of ChatCodeBlock internals", () => {
-    expect(themeCss).toMatch(/\.markdown-body \.not-prose pre/);
-    expect(themeCss).toMatch(/revert-layer/);
-  });
-
+  // The stylesheet must never key off the OS media query: the app theme
+  // class (.dark/.light) has to win regardless of the OS setting.
   it("switches status hues on the app theme class, not the OS media query", () => {
-    expect(themeCss).toMatch(/\.dark \.markdown-body/);
-    expect(themeCss).toMatch(/\.light \.markdown-body/);
     expect(themeCss).not.toMatch(/@media/);
   });
 });
@@ -278,6 +234,32 @@ describe("syncPreviewFile refresh on external change", () => {
     expect(statuses.some((s) => s.kind === "ready" && s.content === "v2")).toBe(
       false,
     );
+  });
+
+  it("leaves ready when a refresh finds the file turned binary", async () => {
+    start();
+    reads[0].resolve(text("v1"));
+    await flush();
+
+    fsHandler([FILE]);
+    reads[1].resolve({ kind: "binary", size: 8 });
+    await flush();
+    expect(statuses[statuses.length - 1]).toEqual({ kind: "binary" });
+  });
+
+  it("leaves ready when a refresh finds the file grown past the limit", async () => {
+    start();
+    reads[0].resolve(text("v1"));
+    await flush();
+
+    fsHandler([FILE]);
+    reads[1].resolve({ kind: "toolarge", size: 99, limit: 10 });
+    await flush();
+    expect(statuses[statuses.length - 1]).toEqual({
+      kind: "toolarge",
+      size: 99,
+      limit: 10,
+    });
   });
 
   it("moves to the error state when the file is deleted", async () => {

--- a/src/modules/markdown/MarkdownPreviewPane.tsx
+++ b/src/modules/markdown/MarkdownPreviewPane.tsx
@@ -1,17 +1,22 @@
-import { MarkdownCode } from "@/components/ai-elements/markdown-code";
 import { cn } from "@/lib/utils";
+import {
+  listenFsChanged,
+  watchAdd,
+  watchRemove,
+} from "@/modules/explorer/lib/watch";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
-import { Streamdown } from "streamdown";
+import { parentDir } from "./localImages";
 import { MarkdownViewToggle } from "./MarkdownViewToggle";
+import { RenderedMarkdown } from "./RenderedMarkdown";
 
 type ReadResult =
   | { kind: "text"; content: string; size: number }
   | { kind: "binary"; size: number }
   | { kind: "toolarge"; size: number; limit: number };
 
-type Status =
+export type Status =
   | { kind: "loading" }
   | { kind: "ready"; content: string }
   | { kind: "binary" }
@@ -24,20 +29,28 @@ type Props = {
   onSetView: (mode: "rendered" | "raw") => void;
 };
 
-const components = { code: MarkdownCode };
+/**
+ * Loads the file and keeps it fresh: the fs watcher (dir-level, the backend
+ * only watches directories, same as useEditorFileSync) triggers re-reads on
+ * external change. Refresh reads never pass through "loading", so the pane
+ * keeps the previous render (and scroll position) until new content lands;
+ * only a failed read (e.g. file deleted) leaves the "ready" state.
+ */
+export function syncPreviewFile(
+  path: string,
+  setStatus: (status: Status) => void,
+): () => void {
+  let cancelled = false;
+  let latest = 0;
 
-export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
-  const [status, setStatus] = useState<Status>({ kind: "loading" });
-
-  useEffect(() => {
-    let cancelled = false;
-    setStatus({ kind: "loading" });
+  const read = () => {
+    const seq = ++latest;
     invoke<ReadResult>("fs_read_file", {
       path,
       workspace: currentWorkspaceEnv(),
     })
       .then((res) => {
-        if (cancelled) return;
+        if (cancelled || seq !== latest) return;
         if (res.kind === "text") {
           setStatus({ kind: "ready", content: res.content });
         } else if (res.kind === "binary") {
@@ -47,12 +60,37 @@ export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
         }
       })
       .catch((e) => {
-        if (!cancelled) setStatus({ kind: "error", message: String(e) });
+        if (cancelled || seq !== latest) return;
+        setStatus({ kind: "error", message: String(e) });
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [path]);
+  };
+
+  setStatus({ kind: "loading" });
+  read();
+
+  const dir = parentDir(path);
+  watchAdd([dir]);
+  const target = path.replace(/\\/g, "/");
+  let unlisten: (() => void) | undefined;
+  void listenFsChanged((paths) => {
+    if (cancelled) return;
+    if (paths.some((p) => p.replace(/\\/g, "/") === target)) read();
+  }).then((un) => {
+    if (cancelled) un();
+    else unlisten = un;
+  });
+
+  return () => {
+    cancelled = true;
+    unlisten?.();
+    watchRemove([dir]);
+  };
+}
+
+export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+  useEffect(() => syncPreviewFile(path, setStatus), [path]);
 
   return (
     <div
@@ -63,7 +101,7 @@ export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
     >
       <MarkdownViewToggle mode="rendered" onChange={onSetView} />
       <div className="flex-1 overflow-auto">
-        <div className="px-8 py-6">
+        <article className="markdown-body mx-auto max-w-[980px] select-text px-8 py-6">
           {status.kind === "loading" && (
             <p className="text-[12px] text-muted-foreground">Loading…</p>
           )}
@@ -74,7 +112,7 @@ export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
           )}
           {status.kind === "binary" && (
             <p className="text-[12px] text-muted-foreground">
-              Binary file — cannot render as markdown.
+              Binary file, cannot render as markdown.
             </p>
           )}
           {status.kind === "toolarge" && (
@@ -83,16 +121,12 @@ export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
             </p>
           )}
           {status.kind === "ready" && (
-            <Streamdown
-              className="select-text [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-              components={components}
-              mode="static"
-              parseIncompleteMarkdown={false}
-            >
-              {status.content}
-            </Streamdown>
+            <RenderedMarkdown
+              content={status.content}
+              baseDir={parentDir(path)}
+            />
           )}
-        </div>
+        </article>
       </div>
     </div>
   );

--- a/src/modules/markdown/MarkdownPreviewPane.tsx
+++ b/src/modules/markdown/MarkdownPreviewPane.tsx
@@ -29,14 +29,8 @@ type Props = {
   onSetView: (mode: "rendered" | "raw") => void;
 };
 
-/**
- * Loads the file and keeps it fresh: the fs watcher (dir-level, the backend
- * only watches directories, same as useEditorFileSync) triggers re-reads on
- * external change. Refresh reads never pass through "loading", so the pane
- * keeps the previous render (and scroll position) until new content lands;
- * "ready" only ends when a refresh stops yielding text: a failed read (e.g.
- * file deleted), binary content, or a file grown past the size limit.
- */
+// Re-reads on external change via the dir-level fs watcher; refreshes skip
+// "loading" so the pane keeps the previous render and scroll position.
 export function syncPreviewFile(
   path: string,
   setStatus: (status: Status) => void,

--- a/src/modules/markdown/MarkdownPreviewPane.tsx
+++ b/src/modules/markdown/MarkdownPreviewPane.tsx
@@ -98,7 +98,7 @@ export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
     >
       <MarkdownViewToggle mode="rendered" onChange={onSetView} />
       <div className="flex-1 overflow-auto">
-        <article className="markdown-body mx-auto max-w-[980px] select-text px-8 py-6">
+        <article className="markdown-body select-text px-8 py-6">
           {status.kind === "loading" && (
             <p className="text-[12px] text-muted-foreground">Loading…</p>
           )}

--- a/src/modules/markdown/MarkdownPreviewPane.tsx
+++ b/src/modules/markdown/MarkdownPreviewPane.tsx
@@ -34,7 +34,8 @@ type Props = {
  * only watches directories, same as useEditorFileSync) triggers re-reads on
  * external change. Refresh reads never pass through "loading", so the pane
  * keeps the previous render (and scroll position) until new content lands;
- * only a failed read (e.g. file deleted) leaves the "ready" state.
+ * "ready" only ends when a refresh stops yielding text: a failed read (e.g.
+ * file deleted), binary content, or a file grown past the size limit.
  */
 export function syncPreviewFile(
   path: string,
@@ -75,10 +76,12 @@ export function syncPreviewFile(
   void listenFsChanged((paths) => {
     if (cancelled) return;
     if (paths.some((p) => p.replace(/\\/g, "/") === target)) read();
-  }).then((un) => {
-    if (cancelled) un();
-    else unlisten = un;
-  });
+  })
+    .then((un) => {
+      if (cancelled) un();
+      else unlisten = un;
+    })
+    .catch((e) => console.error("[markdown-preview] fs listen failed", e));
 
   return () => {
     cancelled = true;

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -15,16 +15,13 @@ const render = (content: string) =>
   renderToStaticMarkup(<RenderedMarkdown content={content} />);
 
 describe("RenderedMarkdown", () => {
-  it("keeps <pre> for plain fences, whitespace preserved", () => {
-    const html = render("```\na\n  b\n```");
-    expect(html).toMatch(/<pre/);
-    expect(html).toContain("a\n  b");
-  });
-
-  it("unwraps language fences so ChatCodeBlock owns the block", () => {
-    const html = render("```ts\nconst x = 1;\n```");
-    expect(html).not.toMatch(/<pre[^>]*><div/);
-    expect(html).toContain("not-prose");
+  it("keeps <pre> for plain fences; language fences unwrap for ChatCodeBlock", () => {
+    const plain = render("```\na\n  b\n```");
+    expect(plain).toMatch(/<pre/);
+    expect(plain).toContain("a\n  b");
+    const fenced = render("```ts\nconst x = 1;\n```");
+    expect(fenced).not.toMatch(/<pre[^>]*><div/);
+    expect(fenced).toContain("not-prose");
   });
 
   it("renders frontmatter keys as the table header row", () => {
@@ -32,6 +29,9 @@ describe("RenderedMarkdown", () => {
     expect(html).toContain("<th>name</th>");
     expect(html).toContain("<th>description</th>");
     expect(html).toContain("Body");
+    // Duplicate keys must keep both columns, never collapse into one.
+    const dup = render("---\nname: a\nname: b\n---\nBody\n");
+    expect(dup.match(/<th>name<\/th>/g)).toHaveLength(2);
   });
 
   it("renders frontmatter values as inert text, never HTML", () => {
@@ -44,11 +44,6 @@ describe("RenderedMarkdown", () => {
     const html = render("```bash\nls -la\n```");
     expect(html).toContain('aria-label="Copy code"');
     expect(html).not.toContain("Run in active terminal");
-  });
-
-  it("renders duplicate frontmatter keys without collapsing entries", () => {
-    const html = render("---\nname: a\nname: b\n---\nBody\n");
-    expect(html.match(/<th>name<\/th>/g)).toHaveLength(2);
   });
 
   it("keeps GFM on through Streamdown's default remark plugins", () => {
@@ -193,7 +188,10 @@ describe("handleLinkClick", () => {
 
   it("scrolls only the pane's scroll container for fragments, never openUrl", () => {
     const scroller = scrollerFake();
-    handleLinkClick("#setup", targetIn({ "user-content-setup": 250 }, scroller));
+    handleLinkClick(
+      "#setup",
+      targetIn({ "user-content-setup": 250 }, scroller),
+    );
     expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 - 8 });
     expect(opener.openUrl).not.toHaveBeenCalled();
   });
@@ -207,14 +205,11 @@ describe("handleLinkClick", () => {
     ]);
   });
 
-  it("does nothing for file:, relative and missing hrefs", () => {
+  it("does nothing for file:, relative, missing and javascript: hrefs", () => {
     handleLinkClick("file:///etc/passwd", targetIn({}));
     handleLinkClick("docs/guide.md", targetIn({}));
     handleLinkClick(undefined, targetIn({}));
-    expect(opener.openUrl).not.toHaveBeenCalled();
-  });
-
-  it("never opens a javascript: href even if one reached the handler", () => {
+    // Defense in depth: the pipeline strips these, the handler still must not open them.
     handleLinkClick("javascript:alert(1)", targetIn({}));
     handleLinkClick("JaVaScRiPt:alert(1)", targetIn({}));
     expect(opener.openUrl).not.toHaveBeenCalled();
@@ -222,13 +217,10 @@ describe("handleLinkClick", () => {
 });
 
 describe("PreviewErrorBoundary", () => {
-  it("derives the failed state from a render error", () => {
+  it("derives failed state from a render error and shows the Raw-view hint", () => {
     expect(PreviewErrorBoundary.getDerivedStateFromError()).toEqual({
       failed: true,
     });
-  });
-
-  it("failed state renders the Raw-view hint instead of children", () => {
     const boundary = new PreviewErrorBoundary({ children: "content" });
     boundary.state = { failed: true };
     const html = renderToStaticMarkup(boundary.render());

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -24,14 +24,18 @@ describe("RenderedMarkdown", () => {
     expect(fenced).toContain("not-prose");
   });
 
-  it("renders frontmatter keys as the table header row", () => {
+  it("renders frontmatter as one key/value row per entry, like GitHub", () => {
     const html = render("---\nname: demo\ndescription: A thing\n---\nBody\n");
-    expect(html).toContain("<th>name</th>");
-    expect(html).toContain("<th>description</th>");
+    expect(html).toMatch(
+      /<tr><th scope="row">name<\/th><td[^>]*>demo<\/td><\/tr>/,
+    );
+    expect(html).toMatch(
+      /<tr><th scope="row">description<\/th><td[^>]*>A thing<\/td><\/tr>/,
+    );
     expect(html).toContain("Body");
-    // Duplicate keys must keep both columns, never collapse into one.
+    // Duplicate keys must keep both rows, never collapse into one.
     const dup = render("---\nname: a\nname: b\n---\nBody\n");
-    expect(dup.match(/<th>name<\/th>/g)).toHaveLength(2);
+    expect(dup.match(/<th scope="row">name<\/th>/g)).toHaveLength(2);
   });
 
   it("renders frontmatter values as inert text, never HTML", () => {

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -1,6 +1,15 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
-import { RenderedMarkdown } from "./RenderedMarkdown";
+import { defaultRehypePlugins } from "streamdown";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const opener = vi.hoisted(() => ({ openUrl: vi.fn(() => Promise.resolve()) }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: opener.openUrl }));
+
+import {
+  handleLinkClick,
+  PreviewErrorBoundary,
+  RenderedMarkdown,
+} from "./RenderedMarkdown";
 
 const render = (content: string) =>
   renderToStaticMarkup(<RenderedMarkdown content={content} />);
@@ -121,5 +130,99 @@ describe("RenderedMarkdown", () => {
     // the streaming path #913 removed measured ~3.3s on a comparable doc.
     // The threshold splits the two regimes without being CI-flaky.
     expect(ms).toBeLessThan(3000);
+  });
+
+  it("neutralizes javascript: hrefs through the real pipeline", () => {
+    for (const md of [
+      "[x](javascript:alert(1))",
+      "[y](JaVaScRiPt:alert(1))",
+      '<a href="javascript:alert(1)">z</a>',
+    ]) {
+      const html = render(md);
+      expect(html.toLowerCase()).not.toContain("javascript:");
+    }
+  });
+});
+
+// Streamdown exposes its sanitize/harden entries as [plugin, options]
+// tuples; RenderedMarkdown destructures them to extend the schema. A minor
+// release reshaping these internals must fail loudly here, not silently
+// drop sanitization.
+describe("Streamdown internal plugin shape (2.5.0 tuple contract)", () => {
+  it("sanitize and harden are [function, object] tuples", () => {
+    for (const entry of [
+      defaultRehypePlugins.sanitize,
+      defaultRehypePlugins.harden,
+    ] as unknown[]) {
+      expect(Array.isArray(entry)).toBe(true);
+      const [plugin, options] = entry as [unknown, unknown];
+      expect(typeof plugin).toBe("function");
+      expect(typeof options).toBe("object");
+      expect(options).not.toBeNull();
+    }
+  });
+});
+
+// Node-environment fakes: handleLinkClick only needs closest/querySelector
+// on the current target, mirroring the resolveFragment fakes in
+// headingAnchors.test.tsx.
+const targetIn = (ids: Record<string, { scrollIntoView: () => void }>) =>
+  ({
+    closest: () => ({
+      querySelector: (sel: string) => {
+        const id = JSON.parse(sel.slice("[id=".length, -1)) as string;
+        return ids[id] ?? null;
+      },
+    }),
+  }) as unknown as Element;
+
+describe("handleLinkClick", () => {
+  beforeEach(() => {
+    opener.openUrl.mockClear();
+  });
+
+  it("scrolls fragment hrefs via resolveFragment, never openUrl", () => {
+    const el = { scrollIntoView: vi.fn() };
+    handleLinkClick("#setup", targetIn({ "user-content-setup": el }));
+    expect(el.scrollIntoView).toHaveBeenCalledOnce();
+    expect(opener.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("opens https and mailto hrefs in the OS browser", () => {
+    handleLinkClick("https://example.com/x", targetIn({}));
+    handleLinkClick("mailto:a@b.c", targetIn({}));
+    expect(opener.openUrl.mock.calls).toEqual([
+      ["https://example.com/x"],
+      ["mailto:a@b.c"],
+    ]);
+  });
+
+  it("does nothing for file:, relative and missing hrefs", () => {
+    handleLinkClick("file:///etc/passwd", targetIn({}));
+    handleLinkClick("docs/guide.md", targetIn({}));
+    handleLinkClick(undefined, targetIn({}));
+    expect(opener.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("never opens a javascript: href even if one reached the handler", () => {
+    handleLinkClick("javascript:alert(1)", targetIn({}));
+    handleLinkClick("JaVaScRiPt:alert(1)", targetIn({}));
+    expect(opener.openUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe("PreviewErrorBoundary", () => {
+  it("derives the failed state from a render error", () => {
+    expect(PreviewErrorBoundary.getDerivedStateFromError()).toEqual({
+      failed: true,
+    });
+  });
+
+  it("failed state renders the Raw-view hint instead of children", () => {
+    const boundary = new PreviewErrorBoundary({ children: "content" });
+    boundary.state = { failed: true };
+    const html = renderToStaticMarkup(boundary.render());
+    expect(html).toContain("Use the Raw view");
+    expect(html).not.toContain("content");
   });
 });

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -185,7 +185,10 @@ const targetIn = (
       querySelector: (sel: string) => {
         const id = JSON.parse(sel.slice("[id=".length, -1)) as string;
         return id in ids
-          ? { getBoundingClientRect: () => ({ top: ids[id] }) }
+          ? {
+              getBoundingClientRect: () => ({ top: ids[id] }),
+              closest: () => null,
+            }
           : null;
       },
     }),
@@ -199,7 +202,7 @@ describe("handleLinkClick", () => {
   it("scrolls only the pane's scroll container for fragments, never openUrl", () => {
     const scroller = scrollerFake();
     handleLinkClick("#setup", targetIn({ "user-content-setup": 250 }, scroller));
-    expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 });
+    expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 - 8 });
     expect(opener.openUrl).not.toHaveBeenCalled();
   });
 

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -103,16 +103,14 @@ describe("RenderedMarkdown", () => {
     expect(html).not.toContain("data-streamdown");
   });
 
-  // The unified pipeline recurses per nesting level; pathological depth
-  // overflows the call stack during render, which the pane's error boundary
-  // converts to the Raw-view hint in the client. Static server rendering
-  // has no boundaries, so the throw itself is the observable here.
+  // Pathological depth overflows the call stack during render; the client
+  // shows the error boundary, but here the throw itself is the observable.
   it("pathological nesting fails inside the render, not past it", () => {
     const deep = `${"> ".repeat(2000)}x`;
     expect(() => render(deep)).toThrow();
   });
 
-  it("7k-line document stays a one-time static parse (#913 class)", () => {
+  it("7k-line document stays a one-time static parse", () => {
     const lines: string[] = [];
     for (let i = 0; i < 7000; i++) {
       lines.push(
@@ -126,9 +124,8 @@ describe("RenderedMarkdown", () => {
       `[markdown perf] 7000-line static render: ${Math.round(ms)}ms`,
     );
     expect(html).toContain("Heading 6950");
-    // Coarse guard only: the static path lands well under a second here;
-    // the streaming path #913 removed measured ~3.3s on a comparable doc.
-    // The threshold splits the two regimes without being CI-flaky.
+    // Coarse guard: static lands well under a second; the removed
+    // streaming path measured ~3.3s on a comparable document.
     expect(ms).toBeLessThan(3000);
   });
 
@@ -144,10 +141,8 @@ describe("RenderedMarkdown", () => {
   });
 });
 
-// Streamdown exposes its sanitize/harden entries as [plugin, options]
-// tuples; RenderedMarkdown destructures them to extend the schema. A minor
-// release reshaping these internals must fail loudly here, not silently
-// drop sanitization.
+// RenderedMarkdown destructures Streamdown's [plugin, options] tuples; a
+// release reshaping them must fail loudly here, not silently drop sanitizing.
 describe("Streamdown internal plugin shape (2.5.0 tuple contract)", () => {
   it("sanitize and harden are [function, object] tuples", () => {
     for (const entry of [
@@ -163,12 +158,9 @@ describe("Streamdown internal plugin shape (2.5.0 tuple contract)", () => {
   });
 });
 
-// Node-environment fakes: handleLinkClick resolves the fragment via
-// closest/querySelector and scrolls the pane's parent scroll container,
-// mirroring the fakes in headingAnchors.test.tsx. Targets carry ONLY
-// getBoundingClientRect: a regression back to target.scrollIntoView (which
-// shears every scrollable ancestor, including overflow-hidden ones the user
-// cannot scroll back) would throw here.
+// Node-environment fakes mirroring headingAnchors.test.tsx. Targets carry
+// ONLY getBoundingClientRect: a regression back to target.scrollIntoView
+// would throw here.
 const scrollerFake = () => ({
   scrollTop: 40,
   getBoundingClientRect: () => ({ top: 10 }),

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { RenderedMarkdown } from "./RenderedMarkdown";
+
+const render = (content: string) =>
+  renderToStaticMarkup(<RenderedMarkdown content={content} />);
+
+describe("RenderedMarkdown", () => {
+  it("keeps <pre> for plain fences, whitespace preserved", () => {
+    const html = render("```\na\n  b\n```");
+    expect(html).toMatch(/<pre/);
+    expect(html).toContain("a\n  b");
+  });
+
+  it("unwraps language fences so ChatCodeBlock owns the block", () => {
+    const html = render("```ts\nconst x = 1;\n```");
+    expect(html).not.toMatch(/<pre[^>]*><div/);
+    expect(html).toContain("not-prose");
+  });
+
+  it("renders frontmatter keys as the table header row", () => {
+    const html = render("---\nname: demo\ndescription: A thing\n---\nBody\n");
+    expect(html).toContain("<th>name</th>");
+    expect(html).toContain("<th>description</th>");
+    expect(html).toContain("Body");
+  });
+
+  it("renders frontmatter values as inert text, never HTML", () => {
+    const html = render("---\nname: <img src=x onerror=alert(1)>\n---\nBody\n");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("shell blocks keep copy but omit run-in-terminal in the preview", () => {
+    const html = render("```bash\nls -la\n```");
+    expect(html).toContain('aria-label="Copy code"');
+    expect(html).not.toContain("Run in active terminal");
+  });
+
+  it("renders duplicate frontmatter keys without collapsing entries", () => {
+    const html = render("---\nname: a\nname: b\n---\nBody\n");
+    expect(html.match(/<th>name<\/th>/g)).toHaveLength(2);
+  });
+
+  it("keeps GFM on through Streamdown's default remark plugins", () => {
+    const html = render(
+      "~~gone~~\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\n- [x] done",
+    );
+    expect(html).toContain("<del>gone</del>");
+    expect(html).toContain("<table>");
+    expect(html).toMatch(/<input[^>]*type="checkbox"/);
+  });
+
+  it("renders script, iframe, style and event handlers inert", () => {
+    expect(render("<script>alert(1)</script>ok")).not.toContain("<script");
+    expect(render('<iframe src="https://x"></iframe>\n\nok')).not.toContain(
+      "<iframe",
+    );
+    expect(render("<style>p{color:red}</style>\n\nok")).not.toContain("<style");
+    const html = render('<div onclick="alert(1)">text</div>');
+    expect(html).toContain("<div>text</div>");
+    expect(html.toLowerCase()).not.toContain("onclick");
+  });
+
+  it("renders GitHub-allowed raw HTML: kbd, details/summary, sub/sup", () => {
+    const html = render(
+      "press <kbd>Ctrl</kbd>\n\n<details><summary>More</summary>body</details>\n\nH<sub>2</sub>O and e=mc<sup>2</sup>",
+    );
+    expect(html).toContain("<kbd>Ctrl</kbd>");
+    expect(html).toContain("<summary>More</summary>");
+    expect(html).toContain("<sub>2</sub>");
+    expect(html).toContain("<sup>2</sup>");
+  });
+
+  it("external links keep href and destination tooltip; fragments stay", () => {
+    const html = render("[ext](https://example.com/x) [frag](#section)");
+    expect(html).toContain('href="https://example.com/x"');
+    expect(html).toContain('title="https://example.com/x"');
+    expect(html).toContain('href="#section"');
+    // Our anchor, not Streamdown's link-safety button.
+    expect(html).not.toContain("<button");
+  });
+
+  it("degrades bare relative file links to plain text, no blocked badge", () => {
+    const html = render("see [the docs](docs/guide.md) for more");
+    expect(html).toContain("<span>the docs</span>");
+    expect(html).not.toContain("[blocked]");
+    expect(html).not.toContain("docs/guide.md");
+  });
+
+  it("keeps GitHub table markup free of Streamdown chrome", () => {
+    const html = render("| a | b |\n|---|---|\n| 1 | 2 |");
+    expect(html).toContain("<table>");
+    expect(html).not.toContain("data-streamdown");
+  });
+
+  // The unified pipeline recurses per nesting level; pathological depth
+  // overflows the call stack during render, which the pane's error boundary
+  // converts to the Raw-view hint in the client. Static server rendering
+  // has no boundaries, so the throw itself is the observable here.
+  it("pathological nesting fails inside the render, not past it", () => {
+    const deep = `${"> ".repeat(2000)}x`;
+    expect(() => render(deep)).toThrow();
+  });
+
+  it("7k-line document stays a one-time static parse (#913 class)", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 7000; i++) {
+      lines.push(
+        i % 50 === 0 ? `## Heading ${i}` : `line ${i} with *em* and \`code\``,
+      );
+    }
+    const start = performance.now();
+    const html = render(lines.join("\n"));
+    const ms = performance.now() - start;
+    console.info(
+      `[markdown perf] 7000-line static render: ${Math.round(ms)}ms`,
+    );
+    expect(html).toContain("Heading 6950");
+    // Coarse guard only: the static path lands well under a second here;
+    // the streaming path #913 removed measured ~3.3s on a comparable doc.
+    // The threshold splits the two regimes without being CI-flaky.
+    expect(ms).toBeLessThan(3000);
+  });
+});

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -163,15 +163,30 @@ describe("Streamdown internal plugin shape (2.5.0 tuple contract)", () => {
   });
 });
 
-// Node-environment fakes: handleLinkClick only needs closest/querySelector
-// on the current target, mirroring the resolveFragment fakes in
-// headingAnchors.test.tsx.
-const targetIn = (ids: Record<string, { scrollIntoView: () => void }>) =>
+// Node-environment fakes: handleLinkClick resolves the fragment via
+// closest/querySelector and scrolls the pane's parent scroll container,
+// mirroring the fakes in headingAnchors.test.tsx. Targets carry ONLY
+// getBoundingClientRect: a regression back to target.scrollIntoView (which
+// shears every scrollable ancestor, including overflow-hidden ones the user
+// cannot scroll back) would throw here.
+const scrollerFake = () => ({
+  scrollTop: 40,
+  getBoundingClientRect: () => ({ top: 10 }),
+  scrollTo: vi.fn(),
+});
+
+const targetIn = (
+  ids: Record<string, number>,
+  scroller: ReturnType<typeof scrollerFake> | null = scrollerFake(),
+) =>
   ({
     closest: () => ({
+      parentElement: scroller,
       querySelector: (sel: string) => {
         const id = JSON.parse(sel.slice("[id=".length, -1)) as string;
-        return ids[id] ?? null;
+        return id in ids
+          ? { getBoundingClientRect: () => ({ top: ids[id] }) }
+          : null;
       },
     }),
   }) as unknown as Element;
@@ -181,10 +196,10 @@ describe("handleLinkClick", () => {
     opener.openUrl.mockClear();
   });
 
-  it("scrolls fragment hrefs via resolveFragment, never openUrl", () => {
-    const el = { scrollIntoView: vi.fn() };
-    handleLinkClick("#setup", targetIn({ "user-content-setup": el }));
-    expect(el.scrollIntoView).toHaveBeenCalledOnce();
+  it("scrolls only the pane's scroll container for fragments, never openUrl", () => {
+    const scroller = scrollerFake();
+    handleLinkClick("#setup", targetIn({ "user-content-setup": 250 }, scroller));
+    expect(scroller.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 });
     expect(opener.openUrl).not.toHaveBeenCalled();
   });
 

--- a/src/modules/markdown/RenderedMarkdown.test.tsx
+++ b/src/modules/markdown/RenderedMarkdown.test.tsx
@@ -225,10 +225,30 @@ describe("PreviewErrorBoundary", () => {
     expect(PreviewErrorBoundary.getDerivedStateFromError()).toEqual({
       failed: true,
     });
-    const boundary = new PreviewErrorBoundary({ children: "content" });
-    boundary.state = { failed: true };
+    const boundary = new PreviewErrorBoundary({
+      content: "# bad",
+      children: "content",
+    });
+    boundary.state = { failed: true, content: "# bad" };
     const html = renderToStaticMarkup(boundary.render());
     expect(html).toContain("Use the Raw view");
     expect(html).not.toContain("content");
+  });
+
+  // The pane re-reads through the fs watcher without remounting, so a
+  // failed render must not pin the fallback for the pane's whole life.
+  it("retries when the content changes and holds the fallback otherwise", () => {
+    expect(
+      PreviewErrorBoundary.getDerivedStateFromProps(
+        { content: "# fixed" },
+        { failed: true, content: "# bad" },
+      ),
+    ).toEqual({ failed: false, content: "# fixed" });
+    expect(
+      PreviewErrorBoundary.getDerivedStateFromProps(
+        { content: "# bad" },
+        { failed: true, content: "# bad" },
+      ),
+    ).toBeNull();
   });
 });

--- a/src/modules/markdown/RenderedMarkdown.tsx
+++ b/src/modules/markdown/RenderedMarkdown.tsx
@@ -20,6 +20,23 @@ const OPENABLE_URL = /^(https?:|mailto:)/i;
 type Components = NonNullable<StreamdownProps["components"]>;
 type RehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
 
+// Click policy for preview links, after the anchor's preventDefault: an
+// in-page fragment scrolls within the clicking link's own pane (never an
+// external destination, so it never reaches openUrl and never navigates the
+// webview); http(s)/mailto open in the OS browser; anything else (file:,
+// bare relative paths) does nothing.
+export function handleLinkClick(
+  href: string | undefined,
+  currentTarget: Element,
+): void {
+  if (!href) return;
+  if (href.startsWith("#")) {
+    resolveFragment(currentTarget, href.slice(1))?.scrollIntoView();
+  } else if (OPENABLE_URL.test(href)) {
+    void openUrl(href).catch(console.error);
+  }
+}
+
 export const components: Components = {
   // Links open in the OS browser like every other Terax surface (terminal,
   // editor, git history); a plain anchor would navigate the privileged
@@ -33,15 +50,7 @@ export const components: Components = {
       title={href}
       onClick={(e) => {
         e.preventDefault();
-        if (!href) return;
-        // In-page TOC links scroll within this pane only; a fragment is
-        // not an external destination, so it never reaches openUrl and
-        // never navigates the webview.
-        if (href.startsWith("#")) {
-          resolveFragment(e.currentTarget, href.slice(1))?.scrollIntoView();
-        } else if (OPENABLE_URL.test(href)) {
-          void openUrl(href).catch(console.error);
-        }
+        handleLinkClick(href, e.currentTarget);
       }}
     >
       {children}
@@ -63,15 +72,17 @@ export const components: Components = {
       Array.isArray(cls) && cls.some((c) => String(c).startsWith("language-"));
     return fenced ? children : <pre {...props}>{children}</pre>;
   },
-  // The rest pins Streamdown's chat chrome back to plain elements so the
-  // vendored GitHub stylesheet owns the look. Per tag: table gets wrapped in
-  // a bordered card with copy/download/fullscreen controls; thead/tbody/tr/
-  // th/td repaint header background, row dividers, cell padding and a 14px
-  // cell font; ul/ol/li use inside markers, li padding and inlined
-  // paragraphs; blockquote italicizes and recolors; strong renders a <span>
-  // GitHub's element selectors miss; sub/sup fix the font-size the browser
-  // sizes relatively; img gets a rounded card with a hover download button;
-  // p unwraps images from paragraphs, changing GitHub spacing. Untouched
+  // The rest removes Streamdown's chat chrome by pinning each tag back to
+  // the plain element; the GitHub look then comes from the vendored
+  // stylesheet, not these components. What each Streamdown default would
+  // otherwise add: table wraps itself in a bordered card with copy/download/
+  // fullscreen controls; thead/tbody/tr/th/td repaint header background,
+  // row dividers, cell padding and a 14px cell font; ul/ol/li use inside
+  // markers, li padding and inlined paragraphs; blockquote italicizes and
+  // recolors; strong renders a <span> GitHub's element selectors miss;
+  // sub/sup override the font-size the browser already sizes relatively;
+  // img wraps itself in a rounded card with a hover download button; p
+  // unwraps images from paragraphs, changing GitHub spacing. Untouched
   // defaults (headings, hr, section footnote cleanup) only carry utility
   // classes that the unlayered GitHub stylesheet already outranks.
   table: "table",
@@ -99,6 +110,9 @@ export const components: Components = {
 // The GFM alert classes emitted by rehypeGithubAlerts are allowlisted as
 // enumerated className values on the exact elements that carry them; never
 // a blanket className allowance (the MPE CVE-2025-65716 lesson).
+// These destructurings rely on Streamdown's internal [plugin, options]
+// tuple shape as of 2.5.0 (caret range; a minor reshaping these internals
+// is caught by the tuple-shape guard test).
 const [rehypeSanitize, streamdownSchema] = defaultRehypePlugins.sanitize as [
   unknown,
   {
@@ -187,13 +201,16 @@ const LINK_SAFETY_OFF = { enabled: false };
 // (thousands of nested blockquotes or divs) and the app mounts no error
 // boundary of its own; contain failures to the pane so the Raw toggle
 // survives.
-class PreviewErrorBoundary extends Component<
+export class PreviewErrorBoundary extends Component<
   { children: ReactNode },
   { failed: boolean }
 > {
   state = { failed: false };
   static getDerivedStateFromError() {
     return { failed: true };
+  }
+  componentDidCatch(error: unknown) {
+    console.error("[markdown-preview] render failed", error);
   }
   render() {
     if (this.state.failed) {

--- a/src/modules/markdown/RenderedMarkdown.tsx
+++ b/src/modules/markdown/RenderedMarkdown.tsx
@@ -1,0 +1,276 @@
+import { CodeRunActionProvider } from "@/components/ai-elements/chat-code";
+import { MarkdownCode } from "@/components/ai-elements/markdown-code";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Component, type ReactNode, useMemo } from "react";
+import {
+  defaultRehypePlugins,
+  Streamdown,
+  type StreamdownProps,
+} from "streamdown";
+import { splitFrontmatter } from "./frontmatter";
+import { rehypeGithubAlerts } from "./githubAlerts";
+import { rehypeHeadingAnchors, resolveFragment } from "./headingAnchors";
+import { rehypeLocalImages } from "./localImages";
+import { rehypeTableDirectives } from "./tableDirectives";
+import "./markdown-base.css";
+import "./markdown-theme.css";
+
+const OPENABLE_URL = /^(https?:|mailto:)/i;
+
+type Components = NonNullable<StreamdownProps["components"]>;
+type RehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
+
+export const components: Components = {
+  // Links open in the OS browser like every other Terax surface (terminal,
+  // editor, git history); a plain anchor would navigate the privileged
+  // webview to the external page instead. The title reveals the true
+  // destination on hover, since rendered link text can spoof it. Replaces
+  // Streamdown's link-safety button/popup (disabled below).
+  a: ({ node: _node, href, children, ...props }) => (
+    <a
+      {...props}
+      href={href}
+      title={href}
+      onClick={(e) => {
+        e.preventDefault();
+        if (!href) return;
+        // In-page TOC links scroll within this pane only; a fragment is
+        // not an external destination, so it never reaches openUrl and
+        // never navigates the webview.
+        if (href.startsWith("#")) {
+          resolveFragment(e.currentTarget, href.slice(1))?.scrollIntoView();
+        } else if (OPENABLE_URL.test(href)) {
+          void openUrl(href).catch(console.error);
+        }
+      }}
+    >
+      {children}
+    </a>
+  ),
+  // Shared fenced/inline renderer (keeps the #887 MarkdownCode behavior)
+  // instead of Streamdown's shiki code block with copy/download controls.
+  // Strip the AST `node` so it doesn't leak onto the DOM element through
+  // MarkdownCode's prop spread.
+  code: ({ node: _node, ...props }) => <MarkdownCode {...props} />,
+  // Streamdown's default pre drops the <pre> wrapper entirely. Language
+  // fences render ChatCodeBlock, which owns its chrome; plain fences keep
+  // <pre> for whitespace and GitHub block styling.
+  pre: ({ node, children, ...props }) => {
+    const child = node?.children[0];
+    const cls =
+      child?.type === "element" ? child.properties.className : undefined;
+    const fenced =
+      Array.isArray(cls) && cls.some((c) => String(c).startsWith("language-"));
+    return fenced ? children : <pre {...props}>{children}</pre>;
+  },
+  // The rest pins Streamdown's chat chrome back to plain elements so the
+  // vendored GitHub stylesheet owns the look. Per tag: table gets wrapped in
+  // a bordered card with copy/download/fullscreen controls; thead/tbody/tr/
+  // th/td repaint header background, row dividers, cell padding and a 14px
+  // cell font; ul/ol/li use inside markers, li padding and inlined
+  // paragraphs; blockquote italicizes and recolors; strong renders a <span>
+  // GitHub's element selectors miss; sub/sup fix the font-size the browser
+  // sizes relatively; img gets a rounded card with a hover download button;
+  // p unwraps images from paragraphs, changing GitHub spacing. Untouched
+  // defaults (headings, hr, section footnote cleanup) only carry utility
+  // classes that the unlayered GitHub stylesheet already outranks.
+  table: "table",
+  thead: "thead",
+  tbody: "tbody",
+  tr: "tr",
+  th: "th",
+  td: "td",
+  ul: "ul",
+  ol: "ol",
+  li: "li",
+  blockquote: "blockquote",
+  strong: "strong",
+  sub: "sub",
+  sup: "sup",
+  img: "img",
+  p: "p",
+};
+
+// Sanitizing is non-negotiable: the preview runs in the privileged Tauri
+// webview, so HTML from an arbitrary file must never execute. Streamdown's
+// schema follows GitHub's sanitization allowlist; colgroup/col are added for
+// the table layout directives (purely presentational, no script or URL
+// surface; width= and span= are already in the global attribute allowlist).
+// The GFM alert classes emitted by rehypeGithubAlerts are allowlisted as
+// enumerated className values on the exact elements that carry them; never
+// a blanket className allowance (the MPE CVE-2025-65716 lesson).
+const [rehypeSanitize, streamdownSchema] = defaultRehypePlugins.sanitize as [
+  unknown,
+  {
+    tagNames?: string[];
+    attributes?: Record<string, unknown[]>;
+    protocols?: Record<string, unknown[]>;
+  },
+];
+export const sanitizeSchema = {
+  ...streamdownSchema,
+  // rehypeLocalImages rewrites relative srcs through convertFileSrc, which
+  // yields http://asset.localhost/... on Windows (http is already allowed)
+  // and asset://localhost/... elsewhere; asset is the one extra scheme.
+  protocols: {
+    ...streamdownSchema.protocols,
+    src: [...(streamdownSchema.protocols?.src ?? []), "asset"],
+  },
+  tagNames: [...(streamdownSchema.tagNames ?? []), "colgroup", "col"],
+  attributes: {
+    ...streamdownSchema.attributes,
+    div: [
+      ...(streamdownSchema.attributes?.div ?? []),
+      [
+        "className",
+        "markdown-alert",
+        "markdown-alert-note",
+        "markdown-alert-tip",
+        "markdown-alert-important",
+        "markdown-alert-warning",
+        "markdown-alert-caution",
+      ],
+    ],
+    p: [
+      ...(streamdownSchema.attributes?.p ?? []),
+      ["className", "markdown-alert-title"],
+    ],
+  },
+};
+
+// Streamdown's own harden options (allow-all URL prefixes; the sanitizer
+// above is the real gate), except blocked URLs degrade to plain text: bare
+// relative links ("docs/x.md") are routine in GitHub-authored files and the
+// default gray "[blocked]" badge would read as document content. Navigation
+// is owned by the `a` component either way.
+const [rehypeHarden, hardenOptions] = defaultRehypePlugins.harden as [
+  unknown,
+  Record<string, unknown>,
+];
+
+// Order is load-bearing: rehype-raw materializes raw HTML and comments, the
+// directive plugin rewrites tables, the alerts plugin rewrites marker
+// blockquotes, the anchors plugin assigns heading slug ids, the local-images
+// plugin rewrites relative srcs to asset URLs (harden would otherwise block
+// them), sanitize prunes next so nothing bypasses it (clobbering ids to
+// user-content-<slug>, same as GitHub), harden vets link/image URLs last.
+// Built from the plugins Streamdown itself exports
+// because passing any rehypePlugins replaces its internal chain wholesale
+// (and its allowedTags prop only extends the untouched default chain);
+// reusing the exported raw pass also keeps Streamdown's raw-HTML detection
+// keyed to it.
+export const buildRehypePlugins = (imageBase?: string) =>
+  [
+    defaultRehypePlugins.raw,
+    rehypeTableDirectives,
+    rehypeGithubAlerts,
+    rehypeHeadingAnchors,
+    [rehypeLocalImages, imageBase],
+    [rehypeSanitize, sanitizeSchema],
+    [
+      rehypeHarden,
+      {
+        ...hardenOptions,
+        linkBlockPolicy: "text-only",
+        imageBlockPolicy: "text-only",
+      },
+    ],
+  ] as RehypePlugins;
+
+export const rehypePlugins = buildRehypePlugins();
+
+// Chat keeps Streamdown's link-safety popup; the preview replaces it with
+// the `a` component's OS-browser policy above.
+const LINK_SAFETY_OFF = { enabled: false };
+
+// The unified pipeline can overflow the call stack on pathological nesting
+// (thousands of nested blockquotes or divs) and the app mounts no error
+// boundary of its own; contain failures to the pane so the Raw toggle
+// survives.
+class PreviewErrorBoundary extends Component<
+  { children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    if (this.state.failed) {
+      return (
+        <p className="text-[12px] text-destructive">
+          Failed to render this file as markdown. Use the Raw view to inspect
+          it.
+        </p>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// baseDir is the previewed file's directory; without it (callers that only
+// have text) relative images keep degrading through harden's text-only
+// policy, everything else renders the same.
+type RenderedMarkdownProps = { content: string; baseDir?: string };
+
+export function RenderedMarkdown({ content, baseDir }: RenderedMarkdownProps) {
+  return (
+    <PreviewErrorBoundary>
+      <CodeRunActionProvider value={false}>
+        <RenderedMarkdownInner content={content} baseDir={baseDir} />
+      </CodeRunActionProvider>
+    </PreviewErrorBoundary>
+  );
+}
+
+// Like GitHub: a leading YAML frontmatter block renders as a table with the
+// keys as the header row, followed by the rest of the document. Values stay
+// plain text nodes, so this path is inert even though it bypasses the
+// rehype sanitizer.
+function RenderedMarkdownInner({ content, baseDir }: RenderedMarkdownProps) {
+  const { entries, body } = splitFrontmatter(content);
+  // Stable per baseDir so Streamdown's processor cache keeps hitting.
+  const plugins = useMemo(() => buildRehypePlugins(baseDir), [baseDir]);
+  return (
+    <>
+      {entries.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              {entries.map(([key], i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: entries are immutable per mount; index disambiguates duplicate keys
+                <th key={`${key}-${i}`}>{key}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              {entries.map(([key, value], i) => (
+                <td
+                  // biome-ignore lint/suspicious/noArrayIndexKey: entries are immutable per mount; index disambiguates duplicate keys
+                  key={`${key}-${i}`}
+                  className="whitespace-pre-wrap align-top"
+                >
+                  {value}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      )}
+      {/* mode="static" + parseIncompleteMarkdown={false} keep the #913
+          invariant: one synchronous parse, no block splitting, streaming
+          repair or animation. Remark plugins stay Streamdown's defaults
+          (GFM + fence metadata). */}
+      <Streamdown
+        mode="static"
+        parseIncompleteMarkdown={false}
+        linkSafety={LINK_SAFETY_OFF}
+        rehypePlugins={plugins}
+        components={components}
+      >
+        {body}
+      </Streamdown>
+    </>
+  );
+}

--- a/src/modules/markdown/RenderedMarkdown.tsx
+++ b/src/modules/markdown/RenderedMarkdown.tsx
@@ -204,26 +204,14 @@ function RenderedMarkdownInner({ content, baseDir }: RenderedMarkdownProps) {
     <>
       {entries.length > 0 && (
         <table>
-          <thead>
-            <tr>
-              {entries.map(([key], i) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: entries are immutable per mount; index disambiguates duplicate keys
-                <th key={`${key}-${i}`}>{key}</th>
-              ))}
-            </tr>
-          </thead>
           <tbody>
-            <tr>
-              {entries.map(([key, value], i) => (
-                <td
-                  // biome-ignore lint/suspicious/noArrayIndexKey: entries are immutable per mount; index disambiguates duplicate keys
-                  key={`${key}-${i}`}
-                  className="whitespace-pre-wrap align-top"
-                >
-                  {value}
-                </td>
-              ))}
-            </tr>
+            {entries.map(([key, value], i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: entries are immutable per mount; index disambiguates duplicate keys
+              <tr key={`${key}-${i}`}>
+                <th scope="row">{key}</th>
+                <td className="whitespace-pre-wrap align-top">{value}</td>
+              </tr>
+            ))}
           </tbody>
         </table>
       )}

--- a/src/modules/markdown/RenderedMarkdown.tsx
+++ b/src/modules/markdown/RenderedMarkdown.tsx
@@ -20,11 +20,6 @@ const OPENABLE_URL = /^(https?:|mailto:)/i;
 type Components = NonNullable<StreamdownProps["components"]>;
 type RehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
 
-// Click policy for preview links, after the anchor's preventDefault: an
-// in-page fragment scrolls the pane's own scroll container (never an
-// external destination, so it never reaches openUrl and never navigates the
-// webview); http(s)/mailto open in the OS browser; anything else (file:,
-// bare relative paths) does nothing.
 export function handleLinkClick(
   href: string | undefined,
   currentTarget: Element,
@@ -38,11 +33,8 @@ export function handleLinkClick(
 }
 
 export const components: Components = {
-  // Links open in the OS browser like every other Terax surface (terminal,
-  // editor, git history); a plain anchor would navigate the privileged
-  // webview to the external page instead. The title reveals the true
-  // destination on hover, since rendered link text can spoof it. Replaces
-  // Streamdown's link-safety button/popup (disabled below).
+  // A plain anchor would navigate the privileged webview; the title shows
+  // the real destination since link text can spoof it.
   a: ({ node: _node, href, children, ...props }) => (
     <a
       {...props}
@@ -56,14 +48,11 @@ export const components: Components = {
       {children}
     </a>
   ),
-  // Shared fenced/inline renderer (keeps the #887 MarkdownCode behavior)
-  // instead of Streamdown's shiki code block with copy/download controls.
-  // Strip the AST `node` so it doesn't leak onto the DOM element through
-  // MarkdownCode's prop spread.
+  // Strip the AST `node` so MarkdownCode's prop spread doesn't leak it
+  // onto the DOM element.
   code: ({ node: _node, ...props }) => <MarkdownCode {...props} />,
-  // Streamdown's default pre drops the <pre> wrapper entirely. Language
-  // fences render ChatCodeBlock, which owns its chrome; plain fences keep
-  // <pre> for whitespace and GitHub block styling.
+  // Fenced blocks render ChatCodeBlock; plain fences keep <pre> for
+  // whitespace.
   pre: ({ node, children, ...props }) => {
     const child = node?.children[0];
     const cls =
@@ -72,19 +61,8 @@ export const components: Components = {
       Array.isArray(cls) && cls.some((c) => String(c).startsWith("language-"));
     return fenced ? children : <pre {...props}>{children}</pre>;
   },
-  // The rest removes Streamdown's chat chrome by pinning each tag back to
-  // the plain element; the GitHub look then comes from the vendored
-  // stylesheet, not these components. What each Streamdown default would
-  // otherwise add: table wraps itself in a bordered card with copy/download/
-  // fullscreen controls; thead/tbody/tr/th/td repaint header background,
-  // row dividers, cell padding and a 14px cell font; ul/ol/li use inside
-  // markers, li padding and inlined paragraphs; blockquote italicizes and
-  // recolors; strong renders a <span> GitHub's element selectors miss;
-  // sub/sup override the font-size the browser already sizes relatively;
-  // img wraps itself in a rounded card with a hover download button; p
-  // unwraps images from paragraphs, changing GitHub spacing. Untouched
-  // defaults (headings, hr, section footnote cleanup) only carry utility
-  // classes that the unlayered GitHub stylesheet already outranks.
+  // Pin these tags to plain elements: Streamdown's defaults add chat
+  // chrome that the vendored stylesheet replaces.
   table: "table",
   thead: "thead",
   tbody: "tbody",
@@ -102,17 +80,9 @@ export const components: Components = {
   p: "p",
 };
 
-// Sanitizing is non-negotiable: the preview runs in the privileged Tauri
-// webview, so HTML from an arbitrary file must never execute. Streamdown's
-// schema follows GitHub's sanitization allowlist; colgroup/col are added for
-// the table layout directives (purely presentational, no script or URL
-// surface; width= and span= are already in the global attribute allowlist).
-// The GFM alert classes emitted by rehypeGithubAlerts are allowlisted as
-// enumerated className values on the exact elements that carry them; never
-// a blanket className allowance (the MPE CVE-2025-65716 lesson).
-// These destructurings rely on Streamdown's internal [plugin, options]
-// tuple shape as of 2.5.0 (caret range; a minor reshaping these internals
-// is caught by the tuple-shape guard test).
+// HTML from an arbitrary previewed file must never execute in the
+// privileged webview; schema additions are enumerated, never a blanket
+// className allowance.
 const [rehypeSanitize, streamdownSchema] = defaultRehypePlugins.sanitize as [
   unknown,
   {
@@ -123,9 +93,8 @@ const [rehypeSanitize, streamdownSchema] = defaultRehypePlugins.sanitize as [
 ];
 export const sanitizeSchema = {
   ...streamdownSchema,
-  // rehypeLocalImages rewrites relative srcs through convertFileSrc, which
-  // yields http://asset.localhost/... on Windows (http is already allowed)
-  // and asset://localhost/... elsewhere; asset is the one extra scheme.
+  // convertFileSrc yields http://asset.localhost/... on Windows (http is
+  // already allowed) and asset://localhost/... elsewhere.
   protocols: {
     ...streamdownSchema.protocols,
     src: [...(streamdownSchema.protocols?.src ?? []), "asset"],
@@ -152,27 +121,16 @@ export const sanitizeSchema = {
   },
 };
 
-// Streamdown's own harden options (allow-all URL prefixes; the sanitizer
-// above is the real gate), except blocked URLs degrade to plain text: bare
-// relative links ("docs/x.md") are routine in GitHub-authored files and the
-// default gray "[blocked]" badge would read as document content. Navigation
-// is owned by the `a` component either way.
+// Blocked URLs degrade to plain text: bare relative links are routine in
+// GitHub-authored files and the default "[blocked]" badge reads as content.
 const [rehypeHarden, hardenOptions] = defaultRehypePlugins.harden as [
   unknown,
   Record<string, unknown>,
 ];
 
-// Order is load-bearing: rehype-raw materializes raw HTML and comments, the
-// directive plugin rewrites tables, the alerts plugin rewrites marker
-// blockquotes, the anchors plugin assigns heading slug ids, the local-images
-// plugin rewrites relative srcs to asset URLs (harden would otherwise block
-// them), sanitize prunes next so nothing bypasses it (clobbering ids to
-// user-content-<slug>, same as GitHub), harden vets link/image URLs last.
-// Built from the plugins Streamdown itself exports
-// because passing any rehypePlugins replaces its internal chain wholesale
-// (and its allowedTags prop only extends the untouched default chain);
-// reusing the exported raw pass also keeps Streamdown's raw-HTML detection
-// keyed to it.
+// Order is load-bearing: sanitize prunes after every feature plugin,
+// harden vets URLs last. Rebuilt from Streamdown's exported defaults
+// because passing rehypePlugins replaces its internal chain wholesale.
 export const buildRehypePlugins = (imageBase?: string) =>
   [
     defaultRehypePlugins.raw,
@@ -193,14 +151,11 @@ export const buildRehypePlugins = (imageBase?: string) =>
 
 export const rehypePlugins = buildRehypePlugins();
 
-// Chat keeps Streamdown's link-safety popup; the preview replaces it with
-// the `a` component's OS-browser policy above.
+// Preview only; chat keeps Streamdown's link-safety popup.
 const LINK_SAFETY_OFF = { enabled: false };
 
-// The unified pipeline can overflow the call stack on pathological nesting
-// (thousands of nested blockquotes or divs) and the app mounts no error
-// boundary of its own; contain failures to the pane so the Raw toggle
-// survives.
+// Pathological nesting can overflow the pipeline's call stack and the app
+// mounts no error boundary of its own; contain failures so Raw view survives.
 export class PreviewErrorBoundary extends Component<
   { children: ReactNode },
   { failed: boolean }
@@ -225,9 +180,8 @@ export class PreviewErrorBoundary extends Component<
   }
 }
 
-// baseDir is the previewed file's directory; without it (callers that only
-// have text) relative images keep degrading through harden's text-only
-// policy, everything else renders the same.
+// baseDir is the previewed file's directory; without it relative images
+// degrade through harden's text-only policy.
 type RenderedMarkdownProps = { content: string; baseDir?: string };
 
 export function RenderedMarkdown({ content, baseDir }: RenderedMarkdownProps) {
@@ -240,10 +194,8 @@ export function RenderedMarkdown({ content, baseDir }: RenderedMarkdownProps) {
   );
 }
 
-// Like GitHub: a leading YAML frontmatter block renders as a table with the
-// keys as the header row, followed by the rest of the document. Values stay
-// plain text nodes, so this path is inert even though it bypasses the
-// rehype sanitizer.
+// Frontmatter values render as plain text nodes, inert even though they
+// bypass the rehype sanitizer.
 function RenderedMarkdownInner({ content, baseDir }: RenderedMarkdownProps) {
   const { entries, body } = splitFrontmatter(content);
   // Stable per baseDir so Streamdown's processor cache keeps hitting.
@@ -275,10 +227,7 @@ function RenderedMarkdownInner({ content, baseDir }: RenderedMarkdownProps) {
           </tbody>
         </table>
       )}
-      {/* mode="static" + parseIncompleteMarkdown={false} keep the #913
-          invariant: one synchronous parse, no block splitting, streaming
-          repair or animation. Remark plugins stay Streamdown's defaults
-          (GFM + fence metadata). */}
+      {/* Static mode: one synchronous parse, no streaming repair. */}
       <Streamdown
         mode="static"
         parseIncompleteMarkdown={false}

--- a/src/modules/markdown/RenderedMarkdown.tsx
+++ b/src/modules/markdown/RenderedMarkdown.tsx
@@ -9,7 +9,7 @@ import {
 } from "streamdown";
 import { splitFrontmatter } from "./frontmatter";
 import { rehypeGithubAlerts } from "./githubAlerts";
-import { rehypeHeadingAnchors, resolveFragment } from "./headingAnchors";
+import { rehypeHeadingAnchors, scrollToFragment } from "./headingAnchors";
 import { rehypeLocalImages } from "./localImages";
 import { rehypeTableDirectives } from "./tableDirectives";
 import "./markdown-base.css";
@@ -21,7 +21,7 @@ type Components = NonNullable<StreamdownProps["components"]>;
 type RehypePlugins = NonNullable<StreamdownProps["rehypePlugins"]>;
 
 // Click policy for preview links, after the anchor's preventDefault: an
-// in-page fragment scrolls within the clicking link's own pane (never an
+// in-page fragment scrolls the pane's own scroll container (never an
 // external destination, so it never reaches openUrl and never navigates the
 // webview); http(s)/mailto open in the OS browser; anything else (file:,
 // bare relative paths) does nothing.
@@ -31,7 +31,7 @@ export function handleLinkClick(
 ): void {
   if (!href) return;
   if (href.startsWith("#")) {
-    resolveFragment(currentTarget, href.slice(1))?.scrollIntoView();
+    scrollToFragment(currentTarget, href.slice(1));
   } else if (OPENABLE_URL.test(href)) {
     void openUrl(href).catch(console.error);
   }

--- a/src/modules/markdown/RenderedMarkdown.tsx
+++ b/src/modules/markdown/RenderedMarkdown.tsx
@@ -157,12 +157,22 @@ const LINK_SAFETY_OFF = { enabled: false };
 // Pathological nesting can overflow the pipeline's call stack and the app
 // mounts no error boundary of its own; contain failures so Raw view survives.
 export class PreviewErrorBoundary extends Component<
-  { children: ReactNode },
-  { failed: boolean }
+  { content: string; children: ReactNode },
+  { failed: boolean; content: string }
 > {
-  state = { failed: false };
+  state = { failed: false, content: this.props.content };
   static getDerivedStateFromError() {
     return { failed: true };
+  }
+  // Edits arrive through the fs watcher without a remount, so new content
+  // gets a fresh attempt; otherwise one bad render pins the fallback for
+  // the rest of the pane's life.
+  static getDerivedStateFromProps(
+    props: { content: string },
+    state: { failed: boolean; content: string },
+  ) {
+    if (props.content === state.content) return null;
+    return { failed: false, content: props.content };
   }
   componentDidCatch(error: unknown) {
     console.error("[markdown-preview] render failed", error);
@@ -186,7 +196,7 @@ type RenderedMarkdownProps = { content: string; baseDir?: string };
 
 export function RenderedMarkdown({ content, baseDir }: RenderedMarkdownProps) {
   return (
-    <PreviewErrorBoundary>
+    <PreviewErrorBoundary content={content}>
       <CodeRunActionProvider value={false}>
         <RenderedMarkdownInner content={content} baseDir={baseDir} />
       </CodeRunActionProvider>

--- a/src/modules/markdown/frontmatter.test.ts
+++ b/src/modules/markdown/frontmatter.test.ts
@@ -1,15 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { splitFrontmatter } from "./frontmatter";
 
-describe("splitFrontmatter", () => {
-  it("returns content untouched when there is no frontmatter", () => {
-    const content = "# Title\n\nBody text.\n";
-    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
-  });
+type Entries = [string, string][];
 
+describe("splitFrontmatter", () => {
   it("splits a simple mapping into entries and body", () => {
     const { entries, body } = splitFrontmatter(
-      "---\nname: my-skill\ndescription: Does things\n---\n\n# Title\n",
+      "---\n# header comment\nname: my-skill\n\ndescription: Does things\n---\n\n# Title\n",
     );
     expect(entries).toEqual([
       ["name", "my-skill"],
@@ -18,117 +15,114 @@ describe("splitFrontmatter", () => {
     expect(body).toBe("\n# Title\n");
   });
 
-  it("handles CRLF line endings", () => {
-    const { entries, body } = splitFrontmatter(
+  const scalarCases: [string, string, Entries][] = [
+    [
+      "colons inside values stay in the value (strict YAML rejects these)",
+      'description: Use when asked: "write a PRD", or similar',
+      [["description", 'Use when asked: "write a PRD", or similar']],
+    ],
+    [
+      "matching surrounding quotes are stripped",
+      "title: \"Hello: world\"\nalt: 'single'",
+      [
+        ["title", "Hello: world"],
+        ["alt", "single"],
+      ],
+    ],
+    ["empty values stay empty", "empty:", [["empty", ""]]],
+    [
+      "plain scalars stay verbatim strings",
+      "count: 3\nenabled: true",
+      [
+        ["count", "3"],
+        ["enabled", "true"],
+      ],
+    ],
+  ];
+
+  it("parses scalar values", () => {
+    for (const [, yaml, expected] of scalarCases) {
+      const { entries } = splitFrontmatter(`---\n${yaml}\n---\nBody\n`);
+      expect(entries).toEqual(expected);
+    }
+  });
+
+  const blockCases: [string, string, Entries][] = [
+    [
+      "nested maps render as dedented text",
+      "name: x\nmetadata:\n  type: project",
+      [
+        ["name", "x"],
+        ["metadata", "type: project"],
+      ],
+    ],
+    [
+      ">- folds newlines into spaces",
+      "description: >-\n  First line\n  second line.",
+      [["description", "First line second line."]],
+    ],
+    [
+      "| preserves line breaks",
+      "notes: |\n  one\n  two",
+      [["notes", "one\ntwo"]],
+    ],
+  ];
+
+  it("parses block collections and scalars", () => {
+    for (const [, yaml, expected] of blockCases) {
+      const { entries } = splitFrontmatter(`---\n${yaml}\n---\nBody\n`);
+      expect(entries).toEqual(expected);
+    }
+  });
+
+  const fenceCases: [string, string, Entries, string][] = [
+    [
+      "CRLF line endings",
       "---\r\nname: my-skill\r\n---\r\nBody\r\n",
-    );
-    expect(entries).toEqual([["name", "my-skill"]]);
-    expect(body).toBe("Body\r\n");
-  });
-
-  it("rejects the whole block when a later line fails, losing no content", () => {
-    const content =
-      "---\nname: ok\ndesc: text\n  illegal continuation\n---\nBody\n";
-    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
-  });
-
-  it("tolerates a leading BOM", () => {
-    const { entries, body } = splitFrontmatter(
+      [["name", "my-skill"]],
+      "Body\r\n",
+    ],
+    [
+      "a leading BOM",
       "\uFEFF---\nname: x\n---\nBody\n",
-    );
-    expect(entries).toEqual([["name", "x"]]);
-    expect(body).toBe("Body\n");
+      [["name", "x"]],
+      "Body\n",
+    ],
+    [
+      "a closing fence as the last line of the file",
+      "---\nname: x\n---",
+      [["name", "x"]],
+      "",
+    ],
+  ];
+
+  it("accepts fence variants", () => {
+    for (const [, content, expected, expectedBody] of fenceCases) {
+      const { entries, body } = splitFrontmatter(content);
+      expect(entries).toEqual(expected);
+      expect(body).toBe(expectedBody);
+    }
   });
 
-  it("accepts colons inside values (strict YAML rejects these)", () => {
-    const { entries } = splitFrontmatter(
-      '---\ndescription: Use when asked: "write a PRD", or similar\n---\nBody\n',
-    );
-    expect(entries).toEqual([
-      ["description", 'Use when asked: "write a PRD", or similar'],
-    ]);
-  });
+  const rejectionCases: [string, string][] = [
+    ["there is no frontmatter", "# Title\n\nBody text.\n"],
+    [
+      "a later line fails, losing no content",
+      "---\nname: ok\ndesc: text\n  illegal continuation\n---\nBody\n",
+    ],
+    [
+      "the first line is not a key: value pair",
+      "---\n{ not: valid: yaml\n---\nBody\n",
+    ],
+    [
+      "the fence is not on the very first line",
+      "intro\n---\nname: x\n---\nBody\n",
+    ],
+  ];
 
-  it("strips matching surrounding quotes", () => {
-    const { entries } = splitFrontmatter(
-      "---\ntitle: \"Hello: world\"\nalt: 'single'\n---\nBody\n",
-    );
-    expect(entries).toEqual([
-      ["title", "Hello: world"],
-      ["alt", "single"],
-    ]);
-  });
-
-  it("renders nested blocks as dedented text", () => {
-    const { entries } = splitFrontmatter(
-      "---\nname: x\nmetadata:\n  type: project\n---\nBody\n",
-    );
-    expect(entries).toEqual([
-      ["name", "x"],
-      ["metadata", "type: project"],
-    ]);
-  });
-
-  it("renders list values as dedented text", () => {
-    const { entries } = splitFrontmatter(
-      "---\ntags:\n  - alpha\n  - beta\n---\nBody\n",
-    );
-    expect(entries).toEqual([["tags", "- alpha\n- beta"]]);
-  });
-
-  it("folds >- block scalars into a single line", () => {
-    const { entries } = splitFrontmatter(
-      "---\ndescription: >-\n  First line\n  second line.\n---\nBody\n",
-    );
-    expect(entries).toEqual([["description", "First line second line."]]);
-  });
-
-  it("preserves line breaks in | block scalars", () => {
-    const { entries } = splitFrontmatter(
-      "---\nnotes: |\n  one\n  two\n---\nBody\n",
-    );
-    expect(entries).toEqual([["notes", "one\ntwo"]]);
-  });
-
-  it("keeps empty values empty and plain scalars verbatim", () => {
-    const { entries } = splitFrontmatter(
-      "---\ncount: 3\nenabled: true\nempty:\n---\nBody\n",
-    );
-    expect(entries).toEqual([
-      ["count", "3"],
-      ["enabled", "true"],
-      ["empty", ""],
-    ]);
-  });
-
-  it("skips blank lines and comments between entries", () => {
-    const { entries } = splitFrontmatter(
-      "---\n# header comment\nname: x\n\ndescription: y\n---\nBody\n",
-    );
-    expect(entries).toEqual([
-      ["name", "x"],
-      ["description", "y"],
-    ]);
-  });
-
-  it("leaves structurally invalid blocks in the body", () => {
-    const content = "---\n{ not: valid: yaml\n---\nBody\n";
-    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
-  });
-
-  it("leaves scalar documents in the body (setext heading case)", () => {
-    const content = "---\nJust a heading\n---\nBody\n";
-    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
-  });
-
-  it("only recognizes frontmatter on the very first line", () => {
-    const content = "intro\n---\nname: x\n---\nBody\n";
-    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
-  });
-
-  it("accepts a closing fence as the last line of the file", () => {
-    const { entries, body } = splitFrontmatter("---\nname: x\n---");
-    expect(entries).toEqual([["name", "x"]]);
-    expect(body).toBe("");
+  it("leaves non-mappings and misplaced blocks in the body", () => {
+    for (const [, content] of rejectionCases) {
+      expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
+    }
   });
 });

--- a/src/modules/markdown/frontmatter.test.ts
+++ b/src/modules/markdown/frontmatter.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { splitFrontmatter } from "./frontmatter";
+
+describe("splitFrontmatter", () => {
+  it("returns content untouched when there is no frontmatter", () => {
+    const content = "# Title\n\nBody text.\n";
+    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
+  });
+
+  it("splits a simple mapping into entries and body", () => {
+    const { entries, body } = splitFrontmatter(
+      "---\nname: my-skill\ndescription: Does things\n---\n\n# Title\n",
+    );
+    expect(entries).toEqual([
+      ["name", "my-skill"],
+      ["description", "Does things"],
+    ]);
+    expect(body).toBe("\n# Title\n");
+  });
+
+  it("handles CRLF line endings", () => {
+    const { entries, body } = splitFrontmatter(
+      "---\r\nname: my-skill\r\n---\r\nBody\r\n",
+    );
+    expect(entries).toEqual([["name", "my-skill"]]);
+    expect(body).toBe("Body\r\n");
+  });
+
+  it("rejects the whole block when a later line fails, losing no content", () => {
+    const content =
+      "---\nname: ok\ndesc: text\n  illegal continuation\n---\nBody\n";
+    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
+  });
+
+  it("tolerates a leading BOM", () => {
+    const { entries, body } = splitFrontmatter(
+      "\uFEFF---\nname: x\n---\nBody\n",
+    );
+    expect(entries).toEqual([["name", "x"]]);
+    expect(body).toBe("Body\n");
+  });
+
+  it("accepts colons inside values (strict YAML rejects these)", () => {
+    const { entries } = splitFrontmatter(
+      '---\ndescription: Use when asked: "write a PRD", or similar\n---\nBody\n',
+    );
+    expect(entries).toEqual([
+      ["description", 'Use when asked: "write a PRD", or similar'],
+    ]);
+  });
+
+  it("strips matching surrounding quotes", () => {
+    const { entries } = splitFrontmatter(
+      "---\ntitle: \"Hello: world\"\nalt: 'single'\n---\nBody\n",
+    );
+    expect(entries).toEqual([
+      ["title", "Hello: world"],
+      ["alt", "single"],
+    ]);
+  });
+
+  it("renders nested blocks as dedented text", () => {
+    const { entries } = splitFrontmatter(
+      "---\nname: x\nmetadata:\n  type: project\n---\nBody\n",
+    );
+    expect(entries).toEqual([
+      ["name", "x"],
+      ["metadata", "type: project"],
+    ]);
+  });
+
+  it("renders list values as dedented text", () => {
+    const { entries } = splitFrontmatter(
+      "---\ntags:\n  - alpha\n  - beta\n---\nBody\n",
+    );
+    expect(entries).toEqual([["tags", "- alpha\n- beta"]]);
+  });
+
+  it("folds >- block scalars into a single line", () => {
+    const { entries } = splitFrontmatter(
+      "---\ndescription: >-\n  First line\n  second line.\n---\nBody\n",
+    );
+    expect(entries).toEqual([["description", "First line second line."]]);
+  });
+
+  it("preserves line breaks in | block scalars", () => {
+    const { entries } = splitFrontmatter(
+      "---\nnotes: |\n  one\n  two\n---\nBody\n",
+    );
+    expect(entries).toEqual([["notes", "one\ntwo"]]);
+  });
+
+  it("keeps empty values empty and plain scalars verbatim", () => {
+    const { entries } = splitFrontmatter(
+      "---\ncount: 3\nenabled: true\nempty:\n---\nBody\n",
+    );
+    expect(entries).toEqual([
+      ["count", "3"],
+      ["enabled", "true"],
+      ["empty", ""],
+    ]);
+  });
+
+  it("skips blank lines and comments between entries", () => {
+    const { entries } = splitFrontmatter(
+      "---\n# header comment\nname: x\n\ndescription: y\n---\nBody\n",
+    );
+    expect(entries).toEqual([
+      ["name", "x"],
+      ["description", "y"],
+    ]);
+  });
+
+  it("leaves structurally invalid blocks in the body", () => {
+    const content = "---\n{ not: valid: yaml\n---\nBody\n";
+    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
+  });
+
+  it("leaves scalar documents in the body (setext heading case)", () => {
+    const content = "---\nJust a heading\n---\nBody\n";
+    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
+  });
+
+  it("only recognizes frontmatter on the very first line", () => {
+    const content = "intro\n---\nname: x\n---\nBody\n";
+    expect(splitFrontmatter(content)).toEqual({ entries: [], body: content });
+  });
+
+  it("accepts a closing fence as the last line of the file", () => {
+    const { entries, body } = splitFrontmatter("---\nname: x\n---");
+    expect(entries).toEqual([["name", "x"]]);
+    expect(body).toBe("");
+  });
+});

--- a/src/modules/markdown/frontmatter.ts
+++ b/src/modules/markdown/frontmatter.ts
@@ -1,7 +1,5 @@
 export type SplitResult = {
-  /** Key/value pairs for the frontmatter table; empty when none was found. */
   entries: [string, string][];
-  /** Markdown content with the frontmatter block removed. */
   body: string;
 };
 
@@ -9,16 +7,10 @@ export type SplitResult = {
 // GitHub. Closing fence may be the last line of the file.
 const FRONTMATTER_RE = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
-// Conventional frontmatter keys: word characters, dots, dashes.
 const KEY_RE = /^([A-Za-z0-9_][\w.-]*):(?:[ \t]+(.*))?$/;
 
-/**
- * GitHub renders a leading YAML frontmatter block in .md previews as a table
- * with the keys as the header row. Mirror that: split the block off and hand
- * back displayable key/value pairs. Anything that does not look like a
- * key/value mapping is left in the body untouched so it renders as ordinary
- * markdown.
- */
+// GitHub renders a leading YAML frontmatter block as a table with keys as
+// the header row; anything not a flat mapping stays in the body untouched.
 export function splitFrontmatter(content: string): SplitResult {
   const m = FRONTMATTER_RE.exec(content);
   if (!m) return { entries: [], body: content };
@@ -27,19 +19,9 @@ export function splitFrontmatter(content: string): SplitResult {
   return { entries, body: content.slice(m[0].length) };
 }
 
-/**
- * Deliberately minimal YAML-subset parser: a full YAML library (the yaml
- * package measures ~25 kB gzipped) is too expensive against the total-JS
- * size budget (.size-limit.json) for what this table needs. Supports what
- * frontmatter uses in practice: flat `key: value` pairs, quoted values,
- * `key:` followed by an indented block (nested maps / lists, displayed as
- * dedented text), and `|` / `>` block scalars. One deliberate leniency
- * beyond strict YAML: a colon followed by a space inside a plain value is
- * accepted (strict YAML rejects it), since that is the most common
- * frontmatter mistake and the intent is unambiguous. Structurally
- * unrecognized input returns null so the whole block falls back to
- * rendering as markdown.
- */
+// Hand-rolled YAML subset: a real YAML dep is ~25 kB gzip against the size
+// budget. Lenient on ": " in plain values; unrecognized structure returns
+// null so the block renders as ordinary markdown.
 function parseMapping(text: string): [string, string][] | null {
   const lines = text.split(/\r?\n/);
   const entries: [string, string][] = [];

--- a/src/modules/markdown/frontmatter.ts
+++ b/src/modules/markdown/frontmatter.ts
@@ -1,0 +1,98 @@
+export type SplitResult = {
+  /** Key/value pairs for the frontmatter table; empty when none was found. */
+  entries: [string, string][];
+  /** Markdown content with the frontmatter block removed. */
+  body: string;
+};
+
+// Leading BOM tolerated; the block must start on the very first line, like on
+// GitHub. Closing fence may be the last line of the file.
+const FRONTMATTER_RE = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+// Conventional frontmatter keys: word characters, dots, dashes.
+const KEY_RE = /^([A-Za-z0-9_][\w.-]*):(?:[ \t]+(.*))?$/;
+
+/**
+ * GitHub renders a leading YAML frontmatter block in .md previews as a table
+ * with the keys as the header row. Mirror that: split the block off and hand
+ * back displayable key/value pairs. Anything that does not look like a
+ * key/value mapping is left in the body untouched so it renders as ordinary
+ * markdown.
+ */
+export function splitFrontmatter(content: string): SplitResult {
+  const m = FRONTMATTER_RE.exec(content);
+  if (!m) return { entries: [], body: content };
+  const entries = parseMapping(m[1]);
+  if (!entries || entries.length === 0) return { entries: [], body: content };
+  return { entries, body: content.slice(m[0].length) };
+}
+
+/**
+ * Deliberately minimal YAML-subset parser: a full YAML library (the yaml
+ * package measures ~25 kB gzipped) is too expensive against the total-JS
+ * size budget (.size-limit.json) for what this table needs. Supports what
+ * frontmatter uses in practice: flat `key: value` pairs, quoted values,
+ * `key:` followed by an indented block (nested maps / lists, displayed as
+ * dedented text), and `|` / `>` block scalars. One deliberate leniency
+ * beyond strict YAML: a colon followed by a space inside a plain value is
+ * accepted (strict YAML rejects it), since that is the most common
+ * frontmatter mistake and the intent is unambiguous. Structurally
+ * unrecognized input returns null so the whole block falls back to
+ * rendering as markdown.
+ */
+function parseMapping(text: string): [string, string][] | null {
+  const lines = text.split(/\r?\n/);
+  const entries: [string, string][] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "" || line.trimStart().startsWith("#")) {
+      i++;
+      continue;
+    }
+    if (/^[ \t]/.test(line)) return null;
+    const m = KEY_RE.exec(line);
+    if (!m) return null;
+    const key = m[1];
+    const rest = (m[2] ?? "").trim();
+    i++;
+    if (rest === "" || /^[>|][+-]?$/.test(rest)) {
+      const block: string[] = [];
+      while (
+        i < lines.length &&
+        (lines[i].trim() === "" || /^[ \t]/.test(lines[i]))
+      ) {
+        block.push(lines[i]);
+        i++;
+      }
+      const dedented = dedent(block);
+      entries.push([
+        key,
+        rest.startsWith(">") ? dedented.replace(/\n+/g, " ").trim() : dedented,
+      ]);
+    } else {
+      entries.push([key, unquote(rest)]);
+    }
+  }
+  return entries;
+}
+
+function dedent(lines: string[]): string {
+  const nonBlank = lines.filter((l) => l.trim() !== "");
+  if (nonBlank.length === 0) return "";
+  const indent = Math.min(
+    ...nonBlank.map((l) => (/^[ \t]*/.exec(l) as RegExpExecArray)[0].length),
+  );
+  return lines
+    .map((l) => l.slice(indent))
+    .join("\n")
+    .trim();
+}
+
+function unquote(value: string): string {
+  const q = value[0];
+  if ((q === '"' || q === "'") && value.length >= 2 && value.endsWith(q)) {
+    return value.slice(1, -1);
+  }
+  return value;
+}

--- a/src/modules/markdown/frontmatter.ts
+++ b/src/modules/markdown/frontmatter.ts
@@ -9,8 +9,8 @@ const FRONTMATTER_RE = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 const KEY_RE = /^([A-Za-z0-9_][\w.-]*):(?:[ \t]+(.*))?$/;
 
-// GitHub renders a leading YAML frontmatter block as a table with keys as
-// the header row; anything not a flat mapping stays in the body untouched.
+// GitHub renders a leading YAML frontmatter block as a table with one
+// key/value row per entry; anything not a flat mapping stays in the body.
 export function splitFrontmatter(content: string): SplitResult {
   const m = FRONTMATTER_RE.exec(content);
   if (!m) return { entries: [], body: content };

--- a/src/modules/markdown/githubAlerts.test.tsx
+++ b/src/modules/markdown/githubAlerts.test.tsx
@@ -17,18 +17,19 @@ const render = (md: string) =>
     </Streamdown>,
   );
 
+// The lowercase row locks GitHub's case-insensitive marker matching.
 const TYPES = [
   ["NOTE", "note", "Note"],
   ["TIP", "tip", "Tip"],
   ["IMPORTANT", "important", "Important"],
   ["WARNING", "warning", "Warning"],
   ["CAUTION", "caution", "Caution"],
+  ["note", "note", "Note"],
 ] as const;
 
 describe("rehypeGithubAlerts", () => {
-  it.each(TYPES)(
-    "[!%s] renders the classed alert structure through the full pipeline",
-    (marker, cls, title) => {
+  it("renders every alert type", () => {
+    for (const [marker, cls, title] of TYPES) {
       const html = render(`> [!${marker}]\n> body text`);
       expect(html).toContain(
         `<div class="markdown-alert markdown-alert-${cls}">`,
@@ -37,101 +38,59 @@ describe("rehypeGithubAlerts", () => {
       expect(html).toContain("body text");
       expect(html).not.toContain("<blockquote");
       expect(html).not.toContain(`[!${marker}]`);
-    },
-  );
-
-  it("matches the marker case-insensitively like GitHub", () => {
-    const html = render("> [!note]\n> body");
-    expect(html).toContain('class="markdown-alert markdown-alert-note"');
-    expect(html).toContain(">Note</p>");
+    }
   });
 
-  it("keeps the alert classes through the sanitizer", () => {
-    const html = render("> [!CAUTION]\n> body");
-    expect(html).toContain('class="markdown-alert markdown-alert-caution"');
-    expect(html).toContain('class="markdown-alert-title"');
+  it("marker-line branches", () => {
+    // Two trailing spaces after the marker are a GFM hard break: the marker
+    // becomes its own text node followed by a <br>, both spliced out.
+    const hardBreak = render(
+      "> [!NOTE]  \n> See [docs](https://example.com) and `inline code`.\n>\n> - one\n> - two",
+    );
+    expect(hardBreak).toContain('class="markdown-alert markdown-alert-note"');
+    expect(hardBreak).toContain(">Note</p>");
+    expect(hardBreak).toContain('href="https://example.com/"');
+    expect(hardBreak).toContain("inline code");
+    expect(hardBreak).toContain("<li>one</li>");
+    expect(hardBreak).toContain("<li>two</li>");
+    expect(hardBreak).not.toContain("[!NOTE]");
+    expect(hardBreak).not.toContain("<br");
+
+    const markerOnly = render("> [!WARNING]");
+    expect(markerOnly).toContain(
+      'class="markdown-alert markdown-alert-warning"',
+    );
+    expect(markerOnly).toContain(">Warning</p>");
+  });
+
+  it("non-alerts stay plain blockquotes", () => {
+    const rejected: [string, string][] = [
+      ["> [!NOTE] heads up\n> body", "[!NOTE] heads up"],
+      ["> [!NOTES]\n> body", "[!NOTES]"],
+      ["> [!DANGER]\n> body", "[!DANGER]"],
+      ["> intro line\n> [!NOTE]", "[!NOTE]"],
+      ["> intro paragraph\n>\n> [!NOTE]\n> body", "[!NOTE]"],
+    ];
+    for (const [md, survivingMarker] of rejected) {
+      const html = render(md);
+      expect(html).toContain("<blockquote");
+      expect(html).toContain(survivingMarker);
+      expect(html).not.toContain("markdown-alert");
+    }
+
+    // An alert nested inside an alert: the outer transforms, the inner
+    // stays a plain blockquote.
+    const nested = render(
+      "> [!NOTE]\n> outer body\n>\n> > [!TIP]\n> > inner body",
+    );
+    expect(nested).toContain('class="markdown-alert markdown-alert-note"');
+    expect(nested).not.toContain("markdown-alert-tip");
+    expect(nested).toContain("<blockquote");
+    expect(nested).toContain("[!TIP]");
   });
 
   it("sanitizer enumerates values: unknown classes on raw divs are pruned", () => {
     const html = render('<div class="markdown-alert evil-hook">x</div>');
     expect(html).not.toContain("evil-hook");
-  });
-
-  it("alert content renders full markdown: links, code, lists", () => {
-    const html = render(
-      "> [!TIP]\n> See [docs](https://example.com) and `inline code`.\n>\n> - one\n> - two",
-    );
-    expect(html).toContain("markdown-alert-tip");
-    expect(html).toContain('href="https://example.com/"');
-    expect(html).toContain("inline code");
-    expect(html).toContain("<li>one</li>");
-    expect(html).toContain("<li>two</li>");
-  });
-
-  // Two trailing spaces after the marker are a GFM hard break: the marker
-  // becomes its own text node followed by a <br>, both spliced out.
-  it("a hard break after the marker keeps the content, no stray newline", () => {
-    const html = render("> [!NOTE]  \n> content here");
-    expect(html).toContain('class="markdown-alert markdown-alert-note"');
-    expect(html).toContain(">Note</p>");
-    expect(html).toContain("<p>content here</p>");
-    expect(html).not.toContain("[!NOTE]");
-    expect(html).not.toContain("<br");
-  });
-
-  it("a marker-only blockquote renders as an alert with just the title", () => {
-    const html = render("> [!WARNING]");
-    expect(html).toContain('class="markdown-alert markdown-alert-warning"');
-    expect(html).toContain(">Warning</p>");
-  });
-
-  it("content on the marker line stays a plain blockquote", () => {
-    const html = render("> [!NOTE] heads up\n> body");
-    expect(html).toContain("<blockquote");
-    expect(html).toContain("[!NOTE] heads up");
-    expect(html).not.toContain("markdown-alert");
-  });
-
-  it("a misspelled or unknown type stays a plain blockquote", () => {
-    for (const md of ["> [!NOTES]\n> body", "> [!DANGER]\n> body"]) {
-      const html = render(md);
-      expect(html).toContain("<blockquote");
-      expect(html).not.toContain("markdown-alert");
-    }
-  });
-
-  it("a marker preceded by content stays a plain blockquote", () => {
-    for (const md of [
-      "> intro line\n> [!NOTE]",
-      "> intro paragraph\n>\n> [!NOTE]\n> body",
-    ]) {
-      const html = render(md);
-      expect(html).toContain("<blockquote");
-      expect(html).toContain("[!NOTE]");
-      expect(html).not.toContain("markdown-alert");
-    }
-  });
-
-  it("an alert nested inside a blockquote stays a plain blockquote", () => {
-    const html = render("> > [!NOTE]\n> > inner");
-    expect(html).not.toContain("markdown-alert");
-    expect(html).toContain("[!NOTE]");
-  });
-
-  it("an alert nested inside an alert stays a plain blockquote", () => {
-    const html = render(
-      "> [!NOTE]\n> outer body\n>\n> > [!TIP]\n> > inner body",
-    );
-    expect(html).toContain('class="markdown-alert markdown-alert-note"');
-    expect(html).not.toContain("markdown-alert-tip");
-    expect(html).toContain("<blockquote");
-    expect(html).toContain("[!TIP]");
-  });
-
-  it("a non-alert blockquote is untouched", () => {
-    const html = render("> just a quote\n> second line");
-    expect(html).toContain("<blockquote");
-    expect(html).toContain("just a quote");
-    expect(html).not.toContain("markdown-alert");
   });
 });

--- a/src/modules/markdown/githubAlerts.test.tsx
+++ b/src/modules/markdown/githubAlerts.test.tsx
@@ -1,0 +1,126 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { Streamdown } from "streamdown";
+import { describe, expect, it } from "vitest";
+import { components, rehypePlugins } from "./RenderedMarkdown";
+
+// Uses the real pipeline exported by RenderedMarkdown, so plugin order and
+// sanitizer schema cannot drift from what the preview actually runs.
+const render = (md: string) =>
+  renderToStaticMarkup(
+    <Streamdown
+      mode="static"
+      parseIncompleteMarkdown={false}
+      rehypePlugins={rehypePlugins}
+      components={components}
+    >
+      {md}
+    </Streamdown>,
+  );
+
+const TYPES = [
+  ["NOTE", "note", "Note"],
+  ["TIP", "tip", "Tip"],
+  ["IMPORTANT", "important", "Important"],
+  ["WARNING", "warning", "Warning"],
+  ["CAUTION", "caution", "Caution"],
+] as const;
+
+describe("rehypeGithubAlerts", () => {
+  it.each(TYPES)(
+    "[!%s] renders the classed alert structure through the full pipeline",
+    (marker, cls, title) => {
+      const html = render(`> [!${marker}]\n> body text`);
+      expect(html).toContain(
+        `<div class="markdown-alert markdown-alert-${cls}">`,
+      );
+      expect(html).toContain(`<p class="markdown-alert-title">${title}</p>`);
+      expect(html).toContain("body text");
+      expect(html).not.toContain("<blockquote");
+      expect(html).not.toContain(`[!${marker}]`);
+    },
+  );
+
+  it("matches the marker case-insensitively like GitHub", () => {
+    const html = render("> [!note]\n> body");
+    expect(html).toContain('class="markdown-alert markdown-alert-note"');
+    expect(html).toContain(">Note</p>");
+  });
+
+  it("keeps the alert classes through the sanitizer", () => {
+    const html = render("> [!CAUTION]\n> body");
+    expect(html).toContain('class="markdown-alert markdown-alert-caution"');
+    expect(html).toContain('class="markdown-alert-title"');
+  });
+
+  it("sanitizer enumerates values: unknown classes on raw divs are pruned", () => {
+    const html = render('<div class="markdown-alert evil-hook">x</div>');
+    expect(html).not.toContain("evil-hook");
+  });
+
+  it("alert content renders full markdown: links, code, lists", () => {
+    const html = render(
+      "> [!TIP]\n> See [docs](https://example.com) and `inline code`.\n>\n> - one\n> - two",
+    );
+    expect(html).toContain("markdown-alert-tip");
+    expect(html).toContain('href="https://example.com/"');
+    expect(html).toContain("inline code");
+    expect(html).toContain("<li>one</li>");
+    expect(html).toContain("<li>two</li>");
+  });
+
+  it("a marker-only blockquote renders as an alert with just the title", () => {
+    const html = render("> [!WARNING]");
+    expect(html).toContain('class="markdown-alert markdown-alert-warning"');
+    expect(html).toContain(">Warning</p>");
+  });
+
+  it("content on the marker line stays a plain blockquote", () => {
+    const html = render("> [!NOTE] heads up\n> body");
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("[!NOTE] heads up");
+    expect(html).not.toContain("markdown-alert");
+  });
+
+  it("a misspelled or unknown type stays a plain blockquote", () => {
+    for (const md of ["> [!NOTES]\n> body", "> [!DANGER]\n> body"]) {
+      const html = render(md);
+      expect(html).toContain("<blockquote");
+      expect(html).not.toContain("markdown-alert");
+    }
+  });
+
+  it("a marker preceded by content stays a plain blockquote", () => {
+    for (const md of [
+      "> intro line\n> [!NOTE]",
+      "> intro paragraph\n>\n> [!NOTE]\n> body",
+    ]) {
+      const html = render(md);
+      expect(html).toContain("<blockquote");
+      expect(html).toContain("[!NOTE]");
+      expect(html).not.toContain("markdown-alert");
+    }
+  });
+
+  it("an alert nested inside a blockquote stays a plain blockquote", () => {
+    const html = render("> > [!NOTE]\n> > inner");
+    expect(html).not.toContain("markdown-alert");
+    expect(html).toContain("[!NOTE]");
+  });
+
+  it("an alert nested inside an alert stays a plain blockquote", () => {
+    const html = render(
+      "> [!NOTE]\n> outer body\n>\n> > [!TIP]\n> > inner body",
+    );
+    expect(html).toContain('class="markdown-alert markdown-alert-note"');
+    expect(html).not.toContain("markdown-alert-tip");
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("[!TIP]");
+  });
+
+  it("a non-alert blockquote is untouched", () => {
+    const html = render("> just a quote\n> second line");
+    expect(html).toContain("<blockquote");
+    expect(html).toContain("just a quote");
+    expect(html).not.toContain("markdown-alert");
+  });
+});

--- a/src/modules/markdown/githubAlerts.test.tsx
+++ b/src/modules/markdown/githubAlerts.test.tsx
@@ -68,6 +68,18 @@ describe("rehypeGithubAlerts", () => {
     expect(html).toContain("<li>two</li>");
   });
 
+  // Two trailing spaces after the marker are a GFM hard break: the marker
+  // becomes its own text node followed by a <br>, the branch that splices
+  // both out and strips the leading newline from the remaining content.
+  it("a hard break after the marker keeps the content, no stray newline", () => {
+    const html = render("> [!NOTE]  \n> content here");
+    expect(html).toContain('class="markdown-alert markdown-alert-note"');
+    expect(html).toContain(">Note</p>");
+    expect(html).toContain("<p>content here</p>");
+    expect(html).not.toContain("[!NOTE]");
+    expect(html).not.toContain("<br");
+  });
+
   it("a marker-only blockquote renders as an alert with just the title", () => {
     const html = render("> [!WARNING]");
     expect(html).toContain('class="markdown-alert markdown-alert-warning"');

--- a/src/modules/markdown/githubAlerts.test.tsx
+++ b/src/modules/markdown/githubAlerts.test.tsx
@@ -69,8 +69,7 @@ describe("rehypeGithubAlerts", () => {
   });
 
   // Two trailing spaces after the marker are a GFM hard break: the marker
-  // becomes its own text node followed by a <br>, the branch that splices
-  // both out and strips the leading newline from the remaining content.
+  // becomes its own text node followed by a <br>, both spliced out.
   it("a hard break after the marker keeps the content, no stray newline", () => {
     const html = render("> [!NOTE]  \n> content here");
     expect(html).toContain('class="markdown-alert markdown-alert-note"');

--- a/src/modules/markdown/githubAlerts.ts
+++ b/src/modules/markdown/githubAlerts.ts
@@ -1,0 +1,98 @@
+/**
+ * GFM alerts: a blockquote whose first line is exactly one of [!NOTE],
+ * [!TIP], [!IMPORTANT], [!WARNING] or [!CAUTION] becomes the structure the
+ * vendored GitHub stylesheet (markdown-base.css) already styles:
+ *
+ *   <div class="markdown-alert markdown-alert-note">
+ *     <p class="markdown-alert-title">Note</p>
+ *     ...the blockquote's remaining content, unchanged...
+ *   </div>
+ *
+ * GitHub semantics: the marker is case-insensitive and must sit alone on
+ * the blockquote's first line with nothing before it. Content on the marker
+ * line, an unknown type, or a marker arriving after other content leaves
+ * the blockquote untouched, so the text renders literally like on GitHub.
+ *
+ * Runs after rehype-raw and before rehype-sanitize, which vets the injected
+ * markup and prunes class names to the enumerated allowlist in
+ * RenderedMarkdown.tsx. Title icons are CSS mask data URIs in
+ * markdown-theme.css, so the sanitizer never admits svg/path elements.
+ */
+import type { HNode } from "./tableDirectives";
+
+const MARKER = /^\[!(note|tip|important|warning|caution)\][^\S\n]*(?:\n|$)/i;
+
+export function rehypeGithubAlerts() {
+  return (tree: unknown) => {
+    visit(tree as HNode, false);
+  };
+}
+
+// ponytail: GitHub-parity ceiling, alerts never nest. A marker blockquote
+// inside another blockquote (or inside an alert) stays a plain blockquote.
+function visit(node: HNode, insideQuote: boolean): void {
+  const quote = node.type === "element" && node.tagName === "blockquote";
+  if (quote && !insideQuote) tryTransform(node);
+  for (const child of node.children ?? []) {
+    visit(child, insideQuote || quote);
+  }
+}
+
+function tryTransform(quote: HNode): void {
+  const kids = quote.children ?? [];
+  let p: HNode | undefined;
+  let pIndex = -1;
+  for (let i = 0; i < kids.length; i++) {
+    const k = kids[i];
+    if (k.type === "element") {
+      p = k;
+      pIndex = i;
+      break;
+    }
+    if (k.type === "text" && (k.value ?? "").trim() !== "") return;
+  }
+  if (p?.tagName !== "p" || !p.children?.length) return;
+
+  const first = p.children[0];
+  if (first.type !== "text" || typeof first.value !== "string") return;
+  const m = MARKER.exec(first.value);
+  if (!m) return;
+
+  if (m[0].endsWith("\n")) {
+    // Marker plus soft break: the rest of the paragraph is alert content.
+    first.value = first.value.slice(m[0].length);
+    if (first.value === "") p.children.shift();
+  } else {
+    // Marker is the entire text node. Anything else on that line except a
+    // trailing hard break means it is not an alert (GitHub semantics).
+    const next = p.children[1];
+    if (!next) {
+      kids.splice(pIndex, 1);
+    } else if (next.type === "element" && next.tagName === "br") {
+      p.children.splice(0, 2);
+      const lead = p.children[0];
+      if (lead?.type === "text" && typeof lead.value === "string") {
+        lead.value = lead.value.replace(/^\n/, "");
+      }
+    } else {
+      return;
+    }
+  }
+
+  const type = m[1].toLowerCase();
+  quote.tagName = "div";
+  quote.properties = {
+    className: ["markdown-alert", `markdown-alert-${type}`],
+  };
+  quote.children = [
+    {
+      type: "element",
+      tagName: "p",
+      properties: { className: ["markdown-alert-title"] },
+      children: [
+        { type: "text", value: type[0].toUpperCase() + type.slice(1) },
+      ],
+    },
+    ...kids,
+  ];
+}

--- a/src/modules/markdown/githubAlerts.ts
+++ b/src/modules/markdown/githubAlerts.ts
@@ -1,23 +1,6 @@
-/**
- * GFM alerts: a blockquote whose first line is exactly one of [!NOTE],
- * [!TIP], [!IMPORTANT], [!WARNING] or [!CAUTION] becomes the structure the
- * vendored GitHub stylesheet (markdown-base.css) already styles:
- *
- *   <div class="markdown-alert markdown-alert-note">
- *     <p class="markdown-alert-title">Note</p>
- *     ...the blockquote's remaining content, unchanged...
- *   </div>
- *
- * GitHub semantics: the marker is case-insensitive and must sit alone on
- * the blockquote's first line with nothing before it. Content on the marker
- * line, an unknown type, or a marker arriving after other content leaves
- * the blockquote untouched, so the text renders literally like on GitHub.
- *
- * Runs after rehype-raw and before rehype-sanitize, which vets the injected
- * markup and prunes class names to the enumerated allowlist in
- * RenderedMarkdown.tsx. Title icons are CSS mask data URIs in
- * markdown-theme.css, so the sanitizer never admits svg/path elements.
- */
+// GFM alert blockquotes ([!NOTE] etc.) become the div structure
+// markdown-base.css styles; runs after rehype-raw and before
+// rehype-sanitize, which vets the injected markup.
 import type { HNode } from "./tableDirectives";
 
 const MARKER = /^\[!(note|tip|important|warning|caution)\][^\S\n]*(?:\n|$)/i;
@@ -28,8 +11,7 @@ export function rehypeGithubAlerts() {
   };
 }
 
-// ponytail: GitHub-parity ceiling, alerts never nest. A marker blockquote
-// inside another blockquote (or inside an alert) stays a plain blockquote.
+// Alerts never nest, like GitHub.
 function visit(node: HNode, insideQuote: boolean): void {
   const quote = node.type === "element" && node.tagName === "blockquote";
   if (quote && !insideQuote) tryTransform(node);

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -151,24 +151,55 @@ describe("scrollToFragment", () => {
     scrollTo: vi.fn(),
   });
 
-  const paneOver = (ids: Record<string, number>, parent: unknown) =>
+  // A block target (heading) is its own closest() match; an inline target
+  // (footnote sup anchor) resolves to its enclosing block's rect instead,
+  // so the line containing it is never clipped at the container edge.
+  const blockTarget = (top: number) => {
+    const el = {
+      getBoundingClientRect: () => ({ top }),
+      closest: () => el,
+    };
+    return el;
+  };
+  const inlineTarget = (top: number, blockTop: number) => ({
+    getBoundingClientRect: () => ({ top }),
+    closest: () => ({ getBoundingClientRect: () => ({ top: blockTop }) }),
+  });
+
+  const paneOver = (ids: Record<string, unknown>, parent: unknown) =>
     ({
       parentElement: parent,
       querySelector: (sel: string) => {
         const id = JSON.parse(sel.slice("[id=".length, -1)) as string;
-        return id in ids
-          ? { getBoundingClientRect: () => ({ top: ids[id] }) }
-          : null;
+        return (ids[id] as Element | undefined) ?? null;
       },
     }) as unknown as Element;
 
   it("scrolls the pane's own scroll container, not the target", () => {
     const s = scroller();
     scrollToFragment(
-      linkIn(paneOver({ "user-content-live-refresh": 250 }, s)),
+      linkIn(paneOver({ "user-content-live-refresh": blockTarget(250) }, s)),
       "live-refresh",
     );
-    expect(s.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 });
+    expect(s.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 - 8 });
+  });
+
+  it("scrolls an inline target's enclosing block, not the raised sup rect", () => {
+    const s = scroller();
+    scrollToFragment(
+      linkIn(paneOver({ "user-content-fnref-1": inlineTarget(244, 230) }, s)),
+      "fnref-1",
+    );
+    expect(s.scrollTo).toHaveBeenCalledWith({ top: 230 - 10 + 40 - 8 });
+  });
+
+  it("clamps at zero for targets near the document top", () => {
+    const s = { ...scroller(), scrollTop: 0 };
+    scrollToFragment(
+      linkIn(paneOver({ "user-content-intro": blockTarget(12) }, s)),
+      "intro",
+    );
+    expect(s.scrollTo).toHaveBeenCalledWith({ top: 0 });
   });
 
   it("does nothing when the fragment does not resolve", () => {
@@ -178,6 +209,9 @@ describe("scrollToFragment", () => {
   });
 
   it("does nothing when the pane has no scroll container", () => {
-    scrollToFragment(linkIn(paneOver({ "user-content-x": 5 }, null)), "x");
+    scrollToFragment(
+      linkIn(paneOver({ "user-content-x": blockTarget(5) }, null)),
+      "x",
+    );
   });
 });

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -2,11 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { Streamdown } from "streamdown";
 import { describe, expect, it, vi } from "vitest";
 import { resolveFragment, scrollToFragment } from "./headingAnchors";
-import {
-  components,
-  RenderedMarkdown,
-  rehypePlugins,
-} from "./RenderedMarkdown";
+import { components, rehypePlugins } from "./RenderedMarkdown";
 
 // The real exported pipeline, so slugs and the sanitizer's user-content-
 // clobber cannot drift from what the preview actually emits.
@@ -23,73 +19,34 @@ const render = (md: string) =>
   );
 
 describe("rehypeHeadingAnchors", () => {
-  it("emits ids in the sanitizer's clobbered user-content- form", () => {
-    expect(render("## Section")).toContain('id="user-content-section"');
+  it("slugifies like GitHub, in the sanitizer's clobbered user-content- form", () => {
+    const cases: Array<[md: string, id: string]> = [
+      ["## Section", "user-content-section"],
+      ["## What's new?", "user-content-whats-new"],
+      ["### Foo_bar-baz! (qux)", "user-content-foo_bar-baz-qux"],
+      ["## Use `pnpm test` now", "user-content-use-pnpm-test-now"],
+      ["## Héllo Wörld", "user-content-héllo-wörld"],
+      // GitHub drops the emoji but keeps the following space's hyphen.
+      ["## \u{1F680} Launch", "user-content--launch"],
+      ["# one", "user-content-one"],
+      ["###### six", "user-content-six"],
+    ];
+    for (const [md, id] of cases) {
+      expect(render(md)).toContain(`id="${id}"`);
+    }
   });
 
-  it("strips punctuation like GitHub: What's new? -> whats-new", () => {
-    expect(render("## What's new?")).toContain('id="user-content-whats-new"');
-  });
-
-  it("keeps hyphens and underscores, drops other punctuation", () => {
-    expect(render("### Foo_bar-baz! (qux)")).toContain(
-      'id="user-content-foo_bar-baz-qux"',
-    );
-  });
-
-  it("suffixes duplicate slugs -1, -2 per document", () => {
-    const html = render("# Setup\n\n## Setup\n\n### Setup");
-    expect(html).toContain('id="user-content-setup"');
-    expect(html).toContain('id="user-content-setup-1"');
-    expect(html).toContain('id="user-content-setup-2"');
-  });
-
-  // A literal "Setup 1" heading collides with the -1 suffix the second
-  // "Setup" already claimed, so it gets suffixed again: setup-1-1.
-  it("resolves suffix collisions: Setup, Setup, 'Setup 1'", () => {
-    const html = render("# Setup\n\n## Setup\n\n### Setup 1");
+  // The third "Setup" takes -2; a literal "Setup 1" then collides with the
+  // -1 suffix already claimed, so it gets suffixed again: setup-1-1.
+  it("suffixes and dedups duplicate slugs", () => {
+    const html = render("# Setup\n\n## Setup\n\n### Setup\n\n#### Setup 1");
     const ids = [...html.matchAll(/id="([^"]+)"/g)].map((m) => m[1]);
     expect(ids).toEqual([
       "user-content-setup",
       "user-content-setup-1",
+      "user-content-setup-2",
       "user-content-setup-1-1",
     ]);
-  });
-
-  it("includes code span text in the slug", () => {
-    expect(render("## Use `pnpm test` now")).toContain(
-      'id="user-content-use-pnpm-test-now"',
-    );
-  });
-
-  // GitHub drops the emoji but keeps the following space's hyphen.
-  it("keeps unicode letters and drops leading emoji like GitHub", () => {
-    expect(render("## Héllo Wörld")).toContain('id="user-content-héllo-wörld"');
-    expect(render("## \u{1F680} Launch")).toContain('id="user-content--launch"');
-  });
-
-  it("covers h1 through h6", () => {
-    const html = render(
-      "# one\n\n## two\n\n### three\n\n#### four\n\n##### five\n\n###### six",
-    );
-    for (const s of ["one", "two", "three", "four", "five", "six"]) {
-      expect(html).toContain(`id="user-content-${s}"`);
-    }
-  });
-
-  it("fragment links survive the pipeline as anchors with the raw slug", () => {
-    const html = render("[jump](#whats-new)\n\n## What's new?");
-    expect(html).toContain('href="#whats-new"');
-    expect(html).toContain('id="user-content-whats-new"');
-  });
-
-  it("frontmatter table headers never get ids", () => {
-    const html = renderToStaticMarkup(
-      <RenderedMarkdown content={"---\nname: demo\n---\n## name\n"} />,
-    );
-    expect(html).toContain("<th>name</th>");
-    expect(html).not.toMatch(/<th[^>]+id=/);
-    expect(html).toContain('id="user-content-name"');
   });
 });
 
@@ -107,33 +64,27 @@ const linkIn = (pane: Element | null) =>
   ({ closest: () => pane }) as unknown as Element;
 
 describe("resolveFragment", () => {
-  it("prefers the sanitizer's user-content- form over the bare id", () => {
-    const el = resolveFragment(
-      linkIn(paneWith(["user-content-setup", "setup"])),
-      "setup",
-    );
-    expect(el?.id).toBe("user-content-setup");
-  });
-
-  it("falls back to the bare fragment id", () => {
-    const el = resolveFragment(linkIn(paneWith(["setup"])), "setup");
-    expect(el?.id).toBe("setup");
-  });
-
-  it("decodes percent-encoded fragments", () => {
-    const el = resolveFragment(
-      linkIn(paneWith(["user-content-héllo-wörld"])),
-      "h%C3%A9llo-w%C3%B6rld",
-    );
-    expect(el?.id).toBe("user-content-héllo-wörld");
-  });
-
-  it("survives malformed percent escapes without throwing", () => {
-    expect(resolveFragment(linkIn(paneWith([])), "100%")).toBeNull();
-  });
-
-  it("returns null when the link sits outside a preview pane", () => {
-    expect(resolveFragment(linkIn(null), "setup")).toBeNull();
+  it("resolves fragments against the pane's ids", () => {
+    const cases: Array<
+      [paneIds: string[] | null, fragment: string, expected: string | null]
+    > = [
+      // Prefers the sanitizer's user-content- form over the bare id.
+      [["user-content-setup", "setup"], "setup", "user-content-setup"],
+      [["setup"], "setup", "setup"],
+      [
+        ["user-content-héllo-wörld"],
+        "h%C3%A9llo-w%C3%B6rld",
+        "user-content-héllo-wörld",
+      ],
+      // Malformed percent escape must return null, not throw.
+      [[], "100%", null],
+      // Link outside a preview pane.
+      [null, "setup", null],
+    ];
+    for (const [ids, fragment, expected] of cases) {
+      const el = resolveFragment(linkIn(ids && paneWith(ids)), fragment);
+      expect(el?.id ?? null).toBe(expected);
+    }
   });
 });
 
@@ -170,74 +121,53 @@ describe("scrollToFragment", () => {
     }) as unknown as Element;
 
   it("scrolls the pane's own scroll container, not the target", () => {
-    const s = scroller();
-    scrollToFragment(
-      linkIn(paneOver({ "user-content-live-refresh": blockTarget(250) }, s)),
-      "live-refresh",
-    );
-    expect(s.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 - 8 });
-  });
-
-  it("scrolls an inline target's enclosing block, not the raised sup rect", () => {
-    const s = scroller();
-    scrollToFragment(
-      linkIn(paneOver({ "user-content-fnref-1": inlineTarget(244, 230) }, s)),
-      "fnref-1",
-    );
-    expect(s.scrollTo).toHaveBeenCalledWith({ top: 230 - 10 + 40 - 8 });
-  });
-
-  it("clamps at zero for targets near the document top", () => {
-    const s = { ...scroller(), scrollTop: 0 };
-    scrollToFragment(
-      linkIn(paneOver({ "user-content-intro": blockTarget(12) }, s)),
-      "intro",
-    );
-    expect(s.scrollTo).toHaveBeenCalledWith({ top: 0 });
+    const cases = [
+      { target: blockTarget(250), scrollTop: 40, top: 250 - 10 + 40 - 8 },
+      // Inline target: the enclosing block's rect, not the raised sup rect.
+      { target: inlineTarget(244, 230), scrollTop: 40, top: 230 - 10 + 40 - 8 },
+      // Targets near the document top clamp at zero.
+      { target: blockTarget(12), scrollTop: 0, top: 0 },
+    ];
+    for (const c of cases) {
+      const s = { ...scroller(), scrollTop: c.scrollTop };
+      scrollToFragment(linkIn(paneOver({ "user-content-x": c.target }, s)), "x");
+      expect(s.scrollTo).toHaveBeenCalledWith({ top: c.top });
+    }
   });
 
   // Under CSS zoom rects are visual px, scrollTop/offsetHeight layout px:
-  // scale 625/500 = 1.25, so (250-10)/1.25 + 40 - 8 = 224.
+  // scale 625/500 = 1.25, so (250-10)/1.25 + 40 - 8 = 224. offsetHeight 0
+  // (detached/unmeasured scroller) would divide by zero; the guard forces
+  // scale 1 so the unzoomed math still holds.
   it("divides the visual anchor delta by CSS zoom scale", () => {
-    const s = {
-      scrollTop: 40,
-      offsetHeight: 500,
-      getBoundingClientRect: () => ({ top: 10, height: 625 }),
-      scrollTo: vi.fn(),
-    };
-    scrollToFragment(
-      linkIn(paneOver({ "user-content-live-refresh": blockTarget(250) }, s)),
-      "live-refresh",
-    );
-    expect(s.scrollTo).toHaveBeenCalledWith({ top: 224 });
+    const cases = [
+      { offsetHeight: 500, top: 224 },
+      { offsetHeight: 0, top: 250 - 10 + 40 - 8 },
+    ];
+    for (const c of cases) {
+      const s = {
+        scrollTop: 40,
+        offsetHeight: c.offsetHeight,
+        getBoundingClientRect: () => ({ top: 10, height: 625 }),
+        scrollTo: vi.fn(),
+      };
+      scrollToFragment(
+        linkIn(paneOver({ "user-content-x": blockTarget(250) }, s)),
+        "x",
+      );
+      expect(s.scrollTo).toHaveBeenCalledWith({ top: c.top });
+    }
   });
 
-  // offsetHeight 0 (detached/unmeasured scroller) would divide by zero; the
-  // guard forces scale 1 so the unzoomed math still holds.
-  it("falls back to scale 1 when the scroller has no layout height", () => {
-    const s = {
-      scrollTop: 40,
-      offsetHeight: 0,
-      getBoundingClientRect: () => ({ top: 10, height: 625 }),
-      scrollTo: vi.fn(),
-    };
-    scrollToFragment(
-      linkIn(paneOver({ "user-content-x": blockTarget(250) }, s)),
-      "x",
-    );
-    expect(s.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 - 8 });
-  });
-
-  it("does nothing when the fragment does not resolve", () => {
+  it("no-ops on unresolved fragments and missing scroll containers", () => {
     const s = scroller();
     scrollToFragment(linkIn(paneOver({}, s)), "missing");
     expect(s.scrollTo).not.toHaveBeenCalled();
-  });
-
-  it("does nothing when the pane has no scroll container", () => {
-    scrollToFragment(
-      linkIn(paneOver({ "user-content-x": blockTarget(5) }, null)),
-      "x",
-    );
+    expect(() =>
+      scrollToFragment(
+        linkIn(paneOver({ "user-content-x": blockTarget(5) }, null)),
+        "x",
+      ),
+    ).not.toThrow();
   });
 });

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -202,6 +202,42 @@ describe("scrollToFragment", () => {
     expect(s.scrollTo).toHaveBeenCalledWith({ top: 0 });
   });
 
+  // CSS zoom (Ctrl+=, .zoom-content) makes getBoundingClientRect report
+  // VISUAL px while scrollTop/offsetHeight stay LAYOUT px. A 1.25x scroller
+  // reports rect height 625 over offsetHeight 500; the visual anchor delta
+  // (250-10)=240 must be divided by 1.25 -> 192 layout px before adding the
+  // layout scrollTop and cushion: 40 + 192 - 8 = 224. These node fakes prove
+  // only the arithmetic; the real webview proves the pixels line up.
+  it("divides the visual anchor delta by CSS zoom scale", () => {
+    const s = {
+      scrollTop: 40,
+      offsetHeight: 500,
+      getBoundingClientRect: () => ({ top: 10, height: 625 }),
+      scrollTo: vi.fn(),
+    };
+    scrollToFragment(
+      linkIn(paneOver({ "user-content-live-refresh": blockTarget(250) }, s)),
+      "live-refresh",
+    );
+    expect(s.scrollTo).toHaveBeenCalledWith({ top: 224 });
+  });
+
+  // offsetHeight 0 (detached/unmeasured scroller) would divide by zero; the
+  // guard forces scale 1 so the unzoomed math still holds.
+  it("falls back to scale 1 when the scroller has no layout height", () => {
+    const s = {
+      scrollTop: 40,
+      offsetHeight: 0,
+      getBoundingClientRect: () => ({ top: 10, height: 625 }),
+      scrollTo: vi.fn(),
+    };
+    scrollToFragment(
+      linkIn(paneOver({ "user-content-x": blockTarget(250) }, s)),
+      "x",
+    );
+    expect(s.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 - 8 });
+  });
+
   it("does nothing when the fragment does not resolve", () => {
     const s = scroller();
     scrollToFragment(linkIn(paneOver({}, s)), "missing");

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -1,0 +1,130 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { Streamdown } from "streamdown";
+import { describe, expect, it } from "vitest";
+import { resolveFragment } from "./headingAnchors";
+import {
+  components,
+  RenderedMarkdown,
+  rehypePlugins,
+} from "./RenderedMarkdown";
+
+// Uses the real pipeline exported by RenderedMarkdown, so the slugs and the
+// sanitizer's user-content- clobber cannot drift from what the preview
+// actually emits.
+const render = (md: string) =>
+  renderToStaticMarkup(
+    <Streamdown
+      mode="static"
+      parseIncompleteMarkdown={false}
+      rehypePlugins={rehypePlugins}
+      components={components}
+    >
+      {md}
+    </Streamdown>,
+  );
+
+describe("rehypeHeadingAnchors", () => {
+  it("emits ids in the sanitizer's clobbered user-content- form", () => {
+    expect(render("## Section")).toContain('id="user-content-section"');
+  });
+
+  it("strips punctuation like GitHub: What's new? -> whats-new", () => {
+    expect(render("## What's new?")).toContain('id="user-content-whats-new"');
+  });
+
+  it("keeps hyphens and underscores, drops other punctuation", () => {
+    expect(render("### Foo_bar-baz! (qux)")).toContain(
+      'id="user-content-foo_bar-baz-qux"',
+    );
+  });
+
+  it("suffixes duplicate slugs -1, -2 per document", () => {
+    const html = render("# Setup\n\n## Setup\n\n### Setup");
+    expect(html).toContain('id="user-content-setup"');
+    expect(html).toContain('id="user-content-setup-1"');
+    expect(html).toContain('id="user-content-setup-2"');
+  });
+
+  it("includes code span text in the slug", () => {
+    expect(render("## Use `pnpm test` now")).toContain(
+      'id="user-content-use-pnpm-test-now"',
+    );
+  });
+
+  // Unicode letters survive via \p{L}; GitHub drops the emoji but keeps
+  // the following space's hyphen (#-launch). Decomposed combining marks
+  // and ZWJ sequences are the documented slugger ceiling.
+  it("keeps unicode letters and drops leading emoji like GitHub", () => {
+    expect(render("## Héllo Wörld")).toContain('id="user-content-héllo-wörld"');
+    expect(render("## 🚀 Launch")).toContain('id="user-content--launch"');
+  });
+
+  it("covers h1 through h6", () => {
+    const html = render(
+      "# one\n\n## two\n\n### three\n\n#### four\n\n##### five\n\n###### six",
+    );
+    for (const s of ["one", "two", "three", "four", "five", "six"]) {
+      expect(html).toContain(`id="user-content-${s}"`);
+    }
+  });
+
+  it("fragment links survive the pipeline as anchors with the raw slug", () => {
+    const html = render("[jump](#whats-new)\n\n## What's new?");
+    expect(html).toContain('href="#whats-new"');
+    expect(html).toContain('id="user-content-whats-new"');
+  });
+
+  it("frontmatter table headers never get ids", () => {
+    const html = renderToStaticMarkup(
+      <RenderedMarkdown content={"---\nname: demo\n---\n## name\n"} />,
+    );
+    expect(html).toContain("<th>name</th>");
+    expect(html).not.toMatch(/<th[^>]+id=/);
+    expect(html).toContain('id="user-content-name"');
+  });
+});
+
+// Node-environment fakes: resolveFragment only needs closest/querySelector,
+// and its selector strings are plain [id="..."] attribute selectors the
+// fake can parse back with JSON.parse.
+const paneWith = (ids: string[]) =>
+  ({
+    querySelector: (sel: string) => {
+      const id = JSON.parse(sel.slice("[id=".length, -1)) as string;
+      return ids.includes(id) ? ({ id } as unknown as Element) : null;
+    },
+  }) as unknown as Element;
+
+const linkIn = (pane: Element | null) =>
+  ({ closest: () => pane }) as unknown as Element;
+
+describe("resolveFragment", () => {
+  it("prefers the sanitizer's user-content- form over the bare id", () => {
+    const el = resolveFragment(
+      linkIn(paneWith(["user-content-setup", "setup"])),
+      "setup",
+    );
+    expect(el?.id).toBe("user-content-setup");
+  });
+
+  it("falls back to the bare fragment id", () => {
+    const el = resolveFragment(linkIn(paneWith(["setup"])), "setup");
+    expect(el?.id).toBe("setup");
+  });
+
+  it("decodes percent-encoded fragments", () => {
+    const el = resolveFragment(
+      linkIn(paneWith(["user-content-héllo-wörld"])),
+      "h%C3%A9llo-w%C3%B6rld",
+    );
+    expect(el?.id).toBe("user-content-héllo-wörld");
+  });
+
+  it("survives malformed percent escapes without throwing", () => {
+    expect(resolveFragment(linkIn(paneWith([])), "100%")).toBeNull();
+  });
+
+  it("returns null when the link sits outside a preview pane", () => {
+    expect(resolveFragment(linkIn(null), "setup")).toBeNull();
+  });
+});

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -8,9 +8,8 @@ import {
   rehypePlugins,
 } from "./RenderedMarkdown";
 
-// Uses the real pipeline exported by RenderedMarkdown, so the slugs and the
-// sanitizer's user-content- clobber cannot drift from what the preview
-// actually emits.
+// The real exported pipeline, so slugs and the sanitizer's user-content-
+// clobber cannot drift from what the preview actually emits.
 const render = (md: string) =>
   renderToStaticMarkup(
     <Streamdown
@@ -63,12 +62,10 @@ describe("rehypeHeadingAnchors", () => {
     );
   });
 
-  // Unicode letters survive via \p{L}; GitHub drops the emoji but keeps
-  // the following space's hyphen (#-launch). Decomposed combining marks
-  // and ZWJ sequences are the documented slugger ceiling.
+  // GitHub drops the emoji but keeps the following space's hyphen.
   it("keeps unicode letters and drops leading emoji like GitHub", () => {
     expect(render("## Héllo Wörld")).toContain('id="user-content-héllo-wörld"');
-    expect(render("## 🚀 Launch")).toContain('id="user-content--launch"');
+    expect(render("## \u{1F680} Launch")).toContain('id="user-content--launch"');
   });
 
   it("covers h1 through h6", () => {
@@ -96,9 +93,8 @@ describe("rehypeHeadingAnchors", () => {
   });
 });
 
-// Node-environment fakes: resolveFragment only needs closest/querySelector,
-// and its selector strings are plain [id="..."] attribute selectors the
-// fake can parse back with JSON.parse.
+// Node-environment fakes: resolveFragment's selectors are plain [id="..."]
+// forms the fake can parse back with JSON.parse.
 const paneWith = (ids: string[]) =>
   ({
     querySelector: (sel: string) => {
@@ -142,8 +138,7 @@ describe("resolveFragment", () => {
 });
 
 // Targets expose ONLY getBoundingClientRect: a regression back to
-// target.scrollIntoView (which shears every scrollable ancestor, including
-// the overflow-hidden pane wrapper the user cannot scroll back) throws here.
+// target.scrollIntoView (which shears overflow-hidden ancestors) throws here.
 describe("scrollToFragment", () => {
   const scroller = () => ({
     scrollTop: 40,
@@ -151,9 +146,8 @@ describe("scrollToFragment", () => {
     scrollTo: vi.fn(),
   });
 
-  // A block target (heading) is its own closest() match; an inline target
-  // (footnote sup anchor) resolves to its enclosing block's rect instead,
-  // so the line containing it is never clipped at the container edge.
+  // A block target is its own closest() match; an inline target resolves
+  // to its enclosing block's rect instead.
   const blockTarget = (top: number) => {
     const el = {
       getBoundingClientRect: () => ({ top }),
@@ -202,12 +196,8 @@ describe("scrollToFragment", () => {
     expect(s.scrollTo).toHaveBeenCalledWith({ top: 0 });
   });
 
-  // CSS zoom (Ctrl+=, .zoom-content) makes getBoundingClientRect report
-  // VISUAL px while scrollTop/offsetHeight stay LAYOUT px. A 1.25x scroller
-  // reports rect height 625 over offsetHeight 500; the visual anchor delta
-  // (250-10)=240 must be divided by 1.25 -> 192 layout px before adding the
-  // layout scrollTop and cushion: 40 + 192 - 8 = 224. These node fakes prove
-  // only the arithmetic; the real webview proves the pixels line up.
+  // Under CSS zoom rects are visual px, scrollTop/offsetHeight layout px:
+  // scale 625/500 = 1.25, so (250-10)/1.25 + 40 - 8 = 224.
   it("divides the visual anchor delta by CSS zoom scale", () => {
     const s = {
       scrollTop: 40,

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -45,6 +45,18 @@ describe("rehypeHeadingAnchors", () => {
     expect(html).toContain('id="user-content-setup-2"');
   });
 
+  // A literal "Setup 1" heading collides with the -1 suffix the second
+  // "Setup" already claimed, so it gets suffixed again: setup-1-1.
+  it("resolves suffix collisions: Setup, Setup, 'Setup 1'", () => {
+    const html = render("# Setup\n\n## Setup\n\n### Setup 1");
+    const ids = [...html.matchAll(/id="([^"]+)"/g)].map((m) => m[1]);
+    expect(ids).toEqual([
+      "user-content-setup",
+      "user-content-setup-1",
+      "user-content-setup-1-1",
+    ]);
+  });
+
   it("includes code span text in the slug", () => {
     expect(render("## Use `pnpm test` now")).toContain(
       'id="user-content-use-pnpm-test-now"',

--- a/src/modules/markdown/headingAnchors.test.tsx
+++ b/src/modules/markdown/headingAnchors.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { Streamdown } from "streamdown";
-import { describe, expect, it } from "vitest";
-import { resolveFragment } from "./headingAnchors";
+import { describe, expect, it, vi } from "vitest";
+import { resolveFragment, scrollToFragment } from "./headingAnchors";
 import {
   components,
   RenderedMarkdown,
@@ -138,5 +138,46 @@ describe("resolveFragment", () => {
 
   it("returns null when the link sits outside a preview pane", () => {
     expect(resolveFragment(linkIn(null), "setup")).toBeNull();
+  });
+});
+
+// Targets expose ONLY getBoundingClientRect: a regression back to
+// target.scrollIntoView (which shears every scrollable ancestor, including
+// the overflow-hidden pane wrapper the user cannot scroll back) throws here.
+describe("scrollToFragment", () => {
+  const scroller = () => ({
+    scrollTop: 40,
+    getBoundingClientRect: () => ({ top: 10 }),
+    scrollTo: vi.fn(),
+  });
+
+  const paneOver = (ids: Record<string, number>, parent: unknown) =>
+    ({
+      parentElement: parent,
+      querySelector: (sel: string) => {
+        const id = JSON.parse(sel.slice("[id=".length, -1)) as string;
+        return id in ids
+          ? { getBoundingClientRect: () => ({ top: ids[id] }) }
+          : null;
+      },
+    }) as unknown as Element;
+
+  it("scrolls the pane's own scroll container, not the target", () => {
+    const s = scroller();
+    scrollToFragment(
+      linkIn(paneOver({ "user-content-live-refresh": 250 }, s)),
+      "live-refresh",
+    );
+    expect(s.scrollTo).toHaveBeenCalledWith({ top: 250 - 10 + 40 });
+  });
+
+  it("does nothing when the fragment does not resolve", () => {
+    const s = scroller();
+    scrollToFragment(linkIn(paneOver({}, s)), "missing");
+    expect(s.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the pane has no scroll container", () => {
+    scrollToFragment(linkIn(paneOver({ "user-content-x": 5 }, null)), "x");
   });
 });

--- a/src/modules/markdown/headingAnchors.ts
+++ b/src/modules/markdown/headingAnchors.ts
@@ -1,14 +1,5 @@
-/**
- * Heading anchors: h1-h6 get GitHub-style slug ids so a README's TOC links
- * ([Section](#section)) jump within the preview. Slug rules match GitHub:
- * lowercase text content (code spans included), punctuation stripped except
- * hyphens and underscores, spaces to hyphens, duplicate slugs suffixed -1,
- * -2 per document.
- *
- * Runs before rehype-sanitize on purpose: the sanitizer's default schema
- * clobbers every id to user-content-<slug>, which is exactly the form
- * GitHub serves, and resolveFragment looks the prefixed form up first.
- */
+// GitHub-style heading slug ids. Runs before rehype-sanitize, which
+// clobbers every id to user-content-<slug>, the form GitHub serves.
 import type { HNode } from "./tableDirectives";
 
 const HEADING = /^h[1-6]$/;
@@ -37,10 +28,8 @@ function textOf(node: HNode): string {
   return (node.children ?? []).map(textOf).join("");
 }
 
-// ponytail: ASCII-first take on GitHub's slugger. \p{L}\p{N} keeps plain
-// unicode letters the way GitHub does, but exotic cases (decomposed
-// combining marks, emoji ZWJ sequences) can differ from GitHub's full
-// regex; extend only if a real document hits one.
+// Simplified GitHub slugger; exotic unicode (combining marks, ZWJ
+// sequences) can differ.
 function slugify(text: string): string {
   return text
     .toLowerCase()
@@ -48,15 +37,9 @@ function slugify(text: string): string {
     .replace(/ /g, "-");
 }
 
-/**
- * Resolves an in-page fragment within the clicking link's own preview pane.
- * Multiple panes stay mounted at once (hidden ones are merely invisible),
- * so heading ids duplicate across panes and a global getElementById could
- * hit the wrong document; closest(".markdown-body") scopes the lookup.
- * The sanitizer's clobbered form wins over the bare fragment, matching
- * GitHub. JSON.stringify yields a valid quoted CSS string, so no CSS.escape
- * (which the node test environment lacks).
- */
+// Hidden panes stay mounted and ids duplicate across documents, so scope
+// to the link's own pane. JSON.stringify quotes the id (no CSS.escape in
+// the node test environment).
 export function resolveFragment(
   link: Element,
   fragment: string,
@@ -75,39 +58,17 @@ export function resolveFragment(
   );
 }
 
-// Fragment targets can be inline elements, like a footnote reference's
-// raised sup anchor (line-height 0 and a -0.5em relative shift in the
-// GitHub stylesheet). Aligning that rect to the exact container top clips
-// the line that contains it, so the view appears to land below the
-// reference. Scrolling the enclosing block instead keeps the whole line
-// visible; a heading is its own closest() match, so block targets are
-// unaffected.
+// Inline fragment targets (a footnote's raised sup anchor) sit above their
+// line box; landing on the enclosing block keeps the whole line visible.
 const BLOCK_ANCHOR = "p, li, h1, h2, h3, h4, h5, h6, td, th, blockquote, pre";
 
-// Breathing room above the landing block, so text never sits flush against
-// the clipped edge of the scroll container.
+// Breathing room above the landing block.
 const SCROLL_CUSHION = 8;
 
-/**
- * Scrolls the pane's own scroll container (the markdown-body article's
- * parent, the overflow-auto div) so the fragment's target lands at the
- * top. Element.scrollIntoView would scroll EVERY scrollable ancestor,
- * including the pane's overflow-hidden wrapper and the tab stack above it;
- * hidden-overflow boxes ignore the wheel, so the user could never scroll
- * those back and the pane stayed visually sheared with a blank bottom.
- *
- * Ctrl+= zoom is CSS `zoom: var(--app-zoom)` on an ancestor (globals.css
- * .zoom-content, App.tsx <main>), not native webview zoom. Under CSS zoom
- * Chromium splits its geometry: getBoundingClientRect reports VISUAL
- * (zoom-scaled) px, but scrollTop/scrollTo and offsetHeight stay in LAYOUT
- * (unzoomed) px. Feeding a visual rect delta into a layout scrollTop
- * overshot by the zoom factor, so the landing drifted further the more the
- * user zoomed. Divide the visual delta by the scroller's own scale (its
- * visual height over its layout height, both border-box, exactly the zoom,
- * 1 when unzoomed) to convert back to layout scroll units. offsetHeight not
- * clientHeight: a wide table's horizontal scrollbar shrinks clientHeight and
- * would poison the ratio.
- */
+// scrollIntoView would also scroll overflow-hidden ancestors the user
+// cannot scroll back. Under CSS zoom rects are visual px but scrollTop is
+// layout px: divide by the scroller's visual/layout height ratio
+// (offsetHeight, so a horizontal scrollbar cannot skew it).
 export function scrollToFragment(link: Element, fragment: string): void {
   const target = resolveFragment(link, fragment);
   if (!target) return;

--- a/src/modules/markdown/headingAnchors.ts
+++ b/src/modules/markdown/headingAnchors.ts
@@ -1,0 +1,76 @@
+/**
+ * Heading anchors: h1-h6 get GitHub-style slug ids so a README's TOC links
+ * ([Section](#section)) jump within the preview. Slug rules match GitHub:
+ * lowercase text content (code spans included), punctuation stripped except
+ * hyphens and underscores, spaces to hyphens, duplicate slugs suffixed -1,
+ * -2 per document.
+ *
+ * Runs before rehype-sanitize on purpose: the sanitizer's default schema
+ * clobbers every id to user-content-<slug>, which is exactly the form
+ * GitHub serves, and resolveFragment looks the prefixed form up first.
+ */
+import type { HNode } from "./tableDirectives";
+
+const HEADING = /^h[1-6]$/;
+
+export function rehypeHeadingAnchors() {
+  return (tree: unknown) => {
+    visit(tree as HNode, new Set());
+  };
+}
+
+function visit(node: HNode, used: Set<string>): void {
+  if (node.type === "element" && HEADING.test(node.tagName ?? "")) {
+    const base = slugify(textOf(node));
+    let id = base;
+    for (let n = 1; used.has(id); n++) id = `${base}-${n}`;
+    used.add(id);
+    node.properties = { ...node.properties, id };
+  }
+  for (const child of node.children ?? []) {
+    visit(child, used);
+  }
+}
+
+function textOf(node: HNode): string {
+  if (node.type === "text") return node.value ?? "";
+  return (node.children ?? []).map(textOf).join("");
+}
+
+// ponytail: ASCII-first take on GitHub's slugger. \p{L}\p{N} keeps plain
+// unicode letters the way GitHub does, but exotic cases (decomposed
+// combining marks, emoji ZWJ sequences) can differ from GitHub's full
+// regex; extend only if a real document hits one.
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}_\- ]/gu, "")
+    .replace(/ /g, "-");
+}
+
+/**
+ * Resolves an in-page fragment within the clicking link's own preview pane.
+ * Multiple panes stay mounted at once (hidden ones are merely invisible),
+ * so heading ids duplicate across panes and a global getElementById could
+ * hit the wrong document; closest(".markdown-body") scopes the lookup.
+ * The sanitizer's clobbered form wins over the bare fragment, matching
+ * GitHub. JSON.stringify yields a valid quoted CSS string, so no CSS.escape
+ * (which the node test environment lacks).
+ */
+export function resolveFragment(
+  link: Element,
+  fragment: string,
+): Element | null {
+  const pane = link.closest(".markdown-body");
+  if (!pane) return null;
+  let id = fragment;
+  try {
+    id = decodeURIComponent(fragment);
+  } catch {
+    // Malformed percent escape: fall back to the raw fragment.
+  }
+  return (
+    pane.querySelector(`[id=${JSON.stringify(`user-content-${id}`)}]`) ??
+    pane.querySelector(`[id=${JSON.stringify(id)}]`)
+  );
+}

--- a/src/modules/markdown/headingAnchors.ts
+++ b/src/modules/markdown/headingAnchors.ts
@@ -95,6 +95,18 @@ const SCROLL_CUSHION = 8;
  * including the pane's overflow-hidden wrapper and the tab stack above it;
  * hidden-overflow boxes ignore the wheel, so the user could never scroll
  * those back and the pane stayed visually sheared with a blank bottom.
+ *
+ * Ctrl+= zoom is CSS `zoom: var(--app-zoom)` on an ancestor (globals.css
+ * .zoom-content, App.tsx <main>), not native webview zoom. Under CSS zoom
+ * Chromium splits its geometry: getBoundingClientRect reports VISUAL
+ * (zoom-scaled) px, but scrollTop/scrollTo and offsetHeight stay in LAYOUT
+ * (unzoomed) px. Feeding a visual rect delta into a layout scrollTop
+ * overshot by the zoom factor, so the landing drifted further the more the
+ * user zoomed. Divide the visual delta by the scroller's own scale (its
+ * visual height over its layout height, both border-box, exactly the zoom,
+ * 1 when unzoomed) to convert back to layout scroll units. offsetHeight not
+ * clientHeight: a wide table's horizontal scrollbar shrinks clientHeight and
+ * would poison the ratio.
  */
 export function scrollToFragment(link: Element, fragment: string): void {
   const target = resolveFragment(link, fragment);
@@ -102,10 +114,12 @@ export function scrollToFragment(link: Element, fragment: string): void {
   const scroller = link.closest(".markdown-body")?.parentElement;
   if (!scroller) return;
   const anchor = target.closest(BLOCK_ANCHOR) ?? target;
+  const box = scroller.getBoundingClientRect();
+  const layoutHeight = scroller.offsetHeight;
+  const scale = layoutHeight > 0 ? box.height / layoutHeight : 1;
   const top =
-    anchor.getBoundingClientRect().top -
-    scroller.getBoundingClientRect().top +
-    scroller.scrollTop -
+    scroller.scrollTop +
+    (anchor.getBoundingClientRect().top - box.top) / scale -
     SCROLL_CUSHION;
   scroller.scrollTo({ top: Math.max(0, top) });
 }

--- a/src/modules/markdown/headingAnchors.ts
+++ b/src/modules/markdown/headingAnchors.ts
@@ -75,9 +75,22 @@ export function resolveFragment(
   );
 }
 
+// Fragment targets can be inline elements, like a footnote reference's
+// raised sup anchor (line-height 0 and a -0.5em relative shift in the
+// GitHub stylesheet). Aligning that rect to the exact container top clips
+// the line that contains it, so the view appears to land below the
+// reference. Scrolling the enclosing block instead keeps the whole line
+// visible; a heading is its own closest() match, so block targets are
+// unaffected.
+const BLOCK_ANCHOR = "p, li, h1, h2, h3, h4, h5, h6, td, th, blockquote, pre";
+
+// Breathing room above the landing block, so text never sits flush against
+// the clipped edge of the scroll container.
+const SCROLL_CUSHION = 8;
+
 /**
  * Scrolls the pane's own scroll container (the markdown-body article's
- * parent, the overflow-auto div) so the fragment's heading lands at the
+ * parent, the overflow-auto div) so the fragment's target lands at the
  * top. Element.scrollIntoView would scroll EVERY scrollable ancestor,
  * including the pane's overflow-hidden wrapper and the tab stack above it;
  * hidden-overflow boxes ignore the wheel, so the user could never scroll
@@ -88,9 +101,11 @@ export function scrollToFragment(link: Element, fragment: string): void {
   if (!target) return;
   const scroller = link.closest(".markdown-body")?.parentElement;
   if (!scroller) return;
+  const anchor = target.closest(BLOCK_ANCHOR) ?? target;
   const top =
-    target.getBoundingClientRect().top -
+    anchor.getBoundingClientRect().top -
     scroller.getBoundingClientRect().top +
-    scroller.scrollTop;
-  scroller.scrollTo({ top });
+    scroller.scrollTop -
+    SCROLL_CUSHION;
+  scroller.scrollTo({ top: Math.max(0, top) });
 }

--- a/src/modules/markdown/headingAnchors.ts
+++ b/src/modules/markdown/headingAnchors.ts
@@ -74,3 +74,23 @@ export function resolveFragment(
     pane.querySelector(`[id=${JSON.stringify(id)}]`)
   );
 }
+
+/**
+ * Scrolls the pane's own scroll container (the markdown-body article's
+ * parent, the overflow-auto div) so the fragment's heading lands at the
+ * top. Element.scrollIntoView would scroll EVERY scrollable ancestor,
+ * including the pane's overflow-hidden wrapper and the tab stack above it;
+ * hidden-overflow boxes ignore the wheel, so the user could never scroll
+ * those back and the pane stayed visually sheared with a blank bottom.
+ */
+export function scrollToFragment(link: Element, fragment: string): void {
+  const target = resolveFragment(link, fragment);
+  if (!target) return;
+  const scroller = link.closest(".markdown-body")?.parentElement;
+  if (!scroller) return;
+  const top =
+    target.getBoundingClientRect().top -
+    scroller.getBoundingClientRect().top +
+    scroller.scrollTop;
+  scroller.scrollTo({ top });
+}

--- a/src/modules/markdown/localImages.test.tsx
+++ b/src/modules/markdown/localImages.test.tsx
@@ -5,10 +5,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { Streamdown } from "streamdown";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// convertFileSrc mirrors Tauri's internals: the whole path is
-// percent-encoded and served from http://asset.localhost/ on Windows
-// (asset://localhost/ elsewhere; one test switches the implementation to
-// lock the asset scheme through the sanitizer).
+// The fake mirrors Tauri's convertFileSrc: percent-encoded path served from
+// http://asset.localhost/ on Windows, asset://localhost/ elsewhere.
 const tauri = vi.hoisted(() => ({
   convertFileSrc: vi.fn<(path: string, protocol?: string) => string>(),
 }));
@@ -140,9 +138,8 @@ describe("rehypeLocalImages through the full pipeline", () => {
     expect(html).not.toContain("<img");
   });
 
-  // A drive-letter src parses as a URL with a "c:" scheme, so the resolver
-  // leaves it alone and the sanitizer's protocol allowlist strips it; the
-  // image degrades to its alt text through harden's text-only policy.
+  // A drive-letter src parses as a URL with a "c:" scheme; the resolver
+  // leaves it alone and the sanitizer strips it.
   it("a bare drive-letter src (C:/x.png) is stripped, alt text remains", () => {
     const html = render("![shot](C:/x.png)", "D:\\notes");
     expect(tauri.convertFileSrc).not.toHaveBeenCalled();
@@ -152,11 +149,9 @@ describe("rehypeLocalImages through the full pipeline", () => {
   });
 });
 
-// The traversal-stays-allowed policy above (and the comment in
-// localImages.ts) leans on the shipped assetProtocol scope of ["**"]: the
-// asset protocol already serves any path, so the preview adds no new
-// reachability. If the maintainer ever tightens that scope, this must fail
-// so the joinPath traversal policy gets revisited alongside it.
+// The traversal-stays-allowed policy leans on the shipped assetProtocol
+// scope of ["**"]; if that scope is ever tightened, this must fail so the
+// joinPath traversal policy gets revisited alongside it.
 describe("tauri.conf.json assetProtocol contract", () => {
   it("asset protocol is enabled with the wildcard scope", () => {
     const here = path.dirname(fileURLToPath(import.meta.url));

--- a/src/modules/markdown/localImages.test.tsx
+++ b/src/modules/markdown/localImages.test.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { Streamdown } from "streamdown";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -116,10 +119,60 @@ describe("rehypeLocalImages through the full pipeline", () => {
     );
   });
 
+  it("the asset scheme form resolves ../ traversal and encoded spaces", () => {
+    tauri.convertFileSrc.mockImplementation(
+      (path) => `asset://localhost/${encodeURIComponent(path)}`,
+    );
+    const up = render("![x](../x.png)", "/home/u/docs");
+    expect(up).toContain(
+      `src="asset://localhost/${encodeURIComponent("/home/u/x.png")}"`,
+    );
+    const spaced = render("![s](my%20shot.png)", "/home/u");
+    expect(spaced).toContain(
+      `src="asset://localhost/${encodeURIComponent("/home/u/my shot.png")}"`,
+    );
+    expect(spaced).not.toContain("%2520");
+  });
+
   it("no other scheme sneaks into img src through the sanitizer", () => {
     const html = render('<img src="foo://x/y.png" alt="f">', "D:\\notes");
     expect(html).not.toContain("foo://");
     expect(html).not.toContain("<img");
+  });
+
+  // A drive-letter src parses as a URL with a "c:" scheme, so the resolver
+  // leaves it alone and the sanitizer's protocol allowlist strips it; the
+  // image degrades to its alt text through harden's text-only policy.
+  it("a bare drive-letter src (C:/x.png) is stripped, alt text remains", () => {
+    const html = render("![shot](C:/x.png)", "D:\\notes");
+    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
+    expect(html).not.toContain("C:/x.png");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("shot");
+  });
+});
+
+// The traversal-stays-allowed policy above (and the comment in
+// localImages.ts) leans on the shipped assetProtocol scope of ["**"]: the
+// asset protocol already serves any path, so the preview adds no new
+// reachability. If the maintainer ever tightens that scope, this must fail
+// so the joinPath traversal policy gets revisited alongside it.
+describe("tauri.conf.json assetProtocol contract", () => {
+  it("asset protocol is enabled with the wildcard scope", () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const conf = JSON.parse(
+      readFileSync(
+        path.join(here, "../../../src-tauri/tauri.conf.json"),
+        "utf8",
+      ),
+    ) as {
+      app: {
+        security: { assetProtocol?: { enable?: boolean; scope?: string[] } };
+      };
+    };
+    const assetProtocol = conf.app.security.assetProtocol;
+    expect(assetProtocol?.enable).toBe(true);
+    expect(assetProtocol?.scope).toContain("**");
   });
 });
 

--- a/src/modules/markdown/localImages.test.tsx
+++ b/src/modules/markdown/localImages.test.tsx
@@ -41,19 +41,17 @@ const render = (md: string, baseDir?: string) =>
   );
 
 describe("rehypeLocalImages through the full pipeline", () => {
-  it("resolves a bare relative src against the document directory", () => {
-    const html = render("![shot](img.png)", "D:\\notes");
-    expect(html).toContain(`src="${windowsForm("D:/notes/img.png")}"`);
-  });
-
-  it("resolves ./ nested paths", () => {
-    const html = render("![a](./a/b.png)", "D:\\notes");
-    expect(html).toContain(`src="${windowsForm("D:/notes/a/b.png")}"`);
-  });
-
-  it("resolves ../ traversal into the parent directory", () => {
-    const html = render("![x](../x.png)", "D:\\ws\\docs");
-    expect(html).toContain(`src="${windowsForm("D:/ws/x.png")}"`);
+  it("resolves relative srcs against the document directory", () => {
+    const cases: Array<[md: string, baseDir: string, resolved: string]> = [
+      ["![shot](img.png)", "D:\\notes", "D:/notes/img.png"],
+      ["![a](./a/b.png)", "D:\\notes", "D:/notes/a/b.png"],
+      ["![x](../x.png)", "D:\\ws\\docs", "D:/ws/x.png"],
+      // Backslash traversal past the drive root clamps at the root.
+      ['<img src="..\\..\\..\\img.png" alt="up">', "D:\\notes", "D:/img.png"],
+    ];
+    for (const [md, baseDir, resolved] of cases) {
+      expect(render(md, baseDir)).toContain(`src="${windowsForm(resolved)}"`);
+    }
   });
 
   // Documented behavior: escaping above the workspace stays allowed, same
@@ -63,26 +61,6 @@ describe("rehypeLocalImages through the full pipeline", () => {
     expect(html).toContain(`src="${windowsForm("D:/other/x.png")}"`);
   });
 
-  it("clamps backslash traversal past the drive root at the root", () => {
-    const html = render(
-      '<img src="..\\..\\..\\img.png" alt="up">',
-      "D:\\notes",
-    );
-    expect(html).toContain(`src="${windowsForm("D:/img.png")}"`);
-  });
-
-  it("passes http(s) srcs through byte-identical, no conversion", () => {
-    const html = render("![r](https://example.com/a.png)", "D:\\notes");
-    expect(html).toContain('src="https://example.com/a.png"');
-    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
-  });
-
-  it("leaves root-absolute srcs unresolved (GitHub repo-root semantics)", () => {
-    const html = render("![a](/assets/x.png)", "D:\\notes");
-    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
-    expect(html).not.toContain("asset.localhost");
-  });
-
   it("no base directory: plugin no-ops, harden degrades to alt text", () => {
     const html = render("![shot](img.png)");
     expect(tauri.convertFileSrc).not.toHaveBeenCalled();
@@ -90,21 +68,45 @@ describe("rehypeLocalImages through the full pipeline", () => {
     expect(html).toContain("shot");
   });
 
-  it("percent-encoded spaces survive the round trip without double encoding", () => {
-    const html = render("![shot](my%20shot.png)", "D:\\n");
-    expect(html).toContain(`src="${windowsForm("D:/n/my shot.png")}"`);
-    expect(html).not.toContain("%2520");
-  });
-
-  it("literal spaces in raw HTML srcs survive the round trip", () => {
-    const html = render('<img src="my shot.png" alt="s">', "D:\\n");
-    expect(html).toContain(`src="${windowsForm("D:/n/my shot.png")}"`);
-  });
-
-  it("# in a file name survives via its percent-encoded form", () => {
-    const html = render("![v](notes%23v2.png)", "D:\\n");
-    expect(html).toContain(`src="${windowsForm("D:/n/notes#v2.png")}"`);
+  it("decodes exactly once through the round trip", () => {
+    const cases: Array<[md: string, resolved: string]> = [
+      ["![shot](my%20shot.png)", "D:/n/my shot.png"],
+      ['<img src="my shot.png" alt="s">', "D:/n/my shot.png"],
+      ["![v](notes%23v2.png)", "D:/n/notes#v2.png"],
+    ];
+    for (const [md, resolved] of cases) {
+      const html = render(md, "D:\\n");
+      expect(html).toContain(`src="${windowsForm(resolved)}"`);
+      // Double encoding would surface as %2520 in the served URL.
+      expect(html).not.toContain("%2520");
+    }
     expect(windowsForm("D:/n/notes#v2.png")).toContain("%23");
+  });
+
+  it("never rewrites non-relative srcs", () => {
+    const cases: Array<[md: string, survivingSrc: string | null]> = [
+      ["![r](https://example.com/a.png)", 'src="https://example.com/a.png"'],
+      // Root-absolute means repo root on GitHub; here it stays unresolved.
+      ["![a](/x.png)", null],
+      ["![d](data:image/png;base64,AAAA)", null],
+    ];
+    for (const [md, survivingSrc] of cases) {
+      const html = render(md, "D:\\notes");
+      if (survivingSrc) expect(html).toContain(survivingSrc);
+      expect(html).not.toContain("asset.localhost");
+    }
+    // data: byte-identity holds at the transformer; downstream the pipeline's
+    // sanitizer strips data: imgs entirely, so it is only observable here.
+    const src = "data:image/png;base64,AAAA";
+    const img = {
+      type: "element",
+      tagName: "img",
+      properties: { src },
+      children: [],
+    };
+    rehypeLocalImages("D:/notes")({ type: "root", children: [img] });
+    expect(img.properties.src).toBe(src);
+    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
   });
 
   it("the asset scheme (macOS/Linux form) survives the sanitizer", () => {
@@ -117,35 +119,17 @@ describe("rehypeLocalImages through the full pipeline", () => {
     );
   });
 
-  it("the asset scheme form resolves ../ traversal and encoded spaces", () => {
-    tauri.convertFileSrc.mockImplementation(
-      (path) => `asset://localhost/${encodeURIComponent(path)}`,
-    );
-    const up = render("![x](../x.png)", "/home/u/docs");
-    expect(up).toContain(
-      `src="asset://localhost/${encodeURIComponent("/home/u/x.png")}"`,
-    );
-    const spaced = render("![s](my%20shot.png)", "/home/u");
-    expect(spaced).toContain(
-      `src="asset://localhost/${encodeURIComponent("/home/u/my shot.png")}"`,
-    );
-    expect(spaced).not.toContain("%2520");
-  });
-
-  it("no other scheme sneaks into img src through the sanitizer", () => {
-    const html = render('<img src="foo://x/y.png" alt="f">', "D:\\notes");
-    expect(html).not.toContain("foo://");
-    expect(html).not.toContain("<img");
-  });
-
   // A drive-letter src parses as a URL with a "c:" scheme; the resolver
-  // leaves it alone and the sanitizer strips it.
-  it("a bare drive-letter src (C:/x.png) is stripped, alt text remains", () => {
-    const html = render("![shot](C:/x.png)", "D:\\notes");
+  // leaves both alone and the sanitizer strips them.
+  it("no other scheme sneaks into img src through the sanitizer", () => {
+    const foo = render('<img src="foo://x/y.png" alt="f">', "D:\\notes");
+    expect(foo).not.toContain("foo://");
+    expect(foo).not.toContain("<img");
+    const drive = render("![shot](C:/x.png)", "D:\\notes");
     expect(tauri.convertFileSrc).not.toHaveBeenCalled();
-    expect(html).not.toContain("C:/x.png");
-    expect(html).not.toContain("<img");
-    expect(html).toContain("shot");
+    expect(drive).not.toContain("C:/x.png");
+    expect(drive).not.toContain("<img");
+    expect(drive).toContain("shot");
   });
 });
 
@@ -171,37 +155,21 @@ describe("tauri.conf.json assetProtocol contract", () => {
   });
 });
 
-describe("rehypeLocalImages transformer", () => {
-  it("leaves data: srcs byte-identical", () => {
-    const src = "data:image/png;base64,AAAA";
-    const img = {
-      type: "element",
-      tagName: "img",
-      properties: { src },
-      children: [],
-    };
-    rehypeLocalImages("D:/notes")({ type: "root", children: [img] });
-    expect(img.properties.src).toBe(src);
-    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
-  });
-});
-
 describe("joinPath", () => {
-  it("joins and normalizes across separator styles", () => {
-    expect(joinPath("D:\\a\\b", "img.png")).toBe("D:/a/b/img.png");
-    expect(joinPath("D:/a/b", "./c/img.png")).toBe("D:/a/b/c/img.png");
-    expect(joinPath("D:/a/b", "../img.png")).toBe("D:/a/img.png");
-  });
-
-  it("clamps .. at the drive root and at /", () => {
-    expect(joinPath("D:/a", "../../../x.png")).toBe("D:/x.png");
-    expect(joinPath("/home/u", "../../../x.png")).toBe("/x.png");
-  });
-
-  it("preserves the UNC lead-in", () => {
-    expect(joinPath("\\\\server\\share\\docs", "../x.png")).toBe(
-      "//server/share/x.png",
-    );
+  it("joins, normalizes and clamps across separator styles", () => {
+    const cases: Array<[base: string, rel: string, joined: string]> = [
+      ["D:\\a\\b", "img.png", "D:/a/b/img.png"],
+      ["D:/a/b", "./c/img.png", "D:/a/b/c/img.png"],
+      ["D:/a/b", "../img.png", "D:/a/img.png"],
+      // .. clamps at the drive root and at /.
+      ["D:/a", "../../../x.png", "D:/x.png"],
+      ["/home/u", "../../../x.png", "/x.png"],
+      // The UNC //server/share lead-in must survive traversal.
+      ["\\\\server\\share\\docs", "../x.png", "//server/share/x.png"],
+    ];
+    for (const [base, rel, joined] of cases) {
+      expect(joinPath(base, rel)).toBe(joined);
+    }
   });
 });
 

--- a/src/modules/markdown/localImages.test.tsx
+++ b/src/modules/markdown/localImages.test.tsx
@@ -1,0 +1,167 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { Streamdown } from "streamdown";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// convertFileSrc mirrors Tauri's internals: the whole path is
+// percent-encoded and served from http://asset.localhost/ on Windows
+// (asset://localhost/ elsewhere; one test switches the implementation to
+// lock the asset scheme through the sanitizer).
+const tauri = vi.hoisted(() => ({
+  convertFileSrc: vi.fn<(path: string, protocol?: string) => string>(),
+}));
+vi.mock("@tauri-apps/api/core", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  convertFileSrc: tauri.convertFileSrc,
+}));
+
+import { joinPath, parentDir, rehypeLocalImages } from "./localImages";
+import { buildRehypePlugins, components } from "./RenderedMarkdown";
+
+const windowsForm = (path: string, protocol = "asset") =>
+  `http://${protocol}.localhost/${encodeURIComponent(path)}`;
+
+beforeEach(() => {
+  tauri.convertFileSrc.mockReset();
+  tauri.convertFileSrc.mockImplementation(windowsForm);
+});
+
+// The real pipeline exported by RenderedMarkdown, so plugin order and the
+// sanitizer schema cannot drift from what the preview actually runs.
+const render = (md: string, baseDir?: string) =>
+  renderToStaticMarkup(
+    <Streamdown
+      mode="static"
+      parseIncompleteMarkdown={false}
+      rehypePlugins={buildRehypePlugins(baseDir)}
+      components={components}
+    >
+      {md}
+    </Streamdown>,
+  );
+
+describe("rehypeLocalImages through the full pipeline", () => {
+  it("resolves a bare relative src against the document directory", () => {
+    const html = render("![shot](img.png)", "D:\\notes");
+    expect(html).toContain(`src="${windowsForm("D:/notes/img.png")}"`);
+  });
+
+  it("resolves ./ nested paths", () => {
+    const html = render("![a](./a/b.png)", "D:\\notes");
+    expect(html).toContain(`src="${windowsForm("D:/notes/a/b.png")}"`);
+  });
+
+  it("resolves ../ traversal into the parent directory", () => {
+    const html = render("![x](../x.png)", "D:\\ws\\docs");
+    expect(html).toContain(`src="${windowsForm("D:/ws/x.png")}"`);
+  });
+
+  // Documented behavior: escaping above the workspace stays allowed, same
+  // as the editor previewing arbitrary paths (assetProtocol scope ["**"]).
+  it("resolves traversal above the workspace to the escaped path", () => {
+    const html = render("![x](../../other/x.png)", "D:\\ws\\docs");
+    expect(html).toContain(`src="${windowsForm("D:/other/x.png")}"`);
+  });
+
+  it("clamps backslash traversal past the drive root at the root", () => {
+    const html = render(
+      '<img src="..\\..\\..\\img.png" alt="up">',
+      "D:\\notes",
+    );
+    expect(html).toContain(`src="${windowsForm("D:/img.png")}"`);
+  });
+
+  it("passes http(s) srcs through byte-identical, no conversion", () => {
+    const html = render("![r](https://example.com/a.png)", "D:\\notes");
+    expect(html).toContain('src="https://example.com/a.png"');
+    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
+  });
+
+  it("leaves root-absolute srcs unresolved (GitHub repo-root semantics)", () => {
+    const html = render("![a](/assets/x.png)", "D:\\notes");
+    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
+    expect(html).not.toContain("asset.localhost");
+  });
+
+  it("no base directory: plugin no-ops, harden degrades to alt text", () => {
+    const html = render("![shot](img.png)");
+    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
+    expect(html).not.toContain("<img");
+    expect(html).toContain("shot");
+  });
+
+  it("percent-encoded spaces survive the round trip without double encoding", () => {
+    const html = render("![shot](my%20shot.png)", "D:\\n");
+    expect(html).toContain(`src="${windowsForm("D:/n/my shot.png")}"`);
+    expect(html).not.toContain("%2520");
+  });
+
+  it("literal spaces in raw HTML srcs survive the round trip", () => {
+    const html = render('<img src="my shot.png" alt="s">', "D:\\n");
+    expect(html).toContain(`src="${windowsForm("D:/n/my shot.png")}"`);
+  });
+
+  it("# in a file name survives via its percent-encoded form", () => {
+    const html = render("![v](notes%23v2.png)", "D:\\n");
+    expect(html).toContain(`src="${windowsForm("D:/n/notes#v2.png")}"`);
+    expect(windowsForm("D:/n/notes#v2.png")).toContain("%23");
+  });
+
+  it("the asset scheme (macOS/Linux form) survives the sanitizer", () => {
+    tauri.convertFileSrc.mockImplementation(
+      (path) => `asset://localhost/${encodeURIComponent(path)}`,
+    );
+    const html = render("![a](img.png)", "/home/u/notes");
+    expect(html).toContain(
+      `src="asset://localhost/${encodeURIComponent("/home/u/notes/img.png")}"`,
+    );
+  });
+
+  it("no other scheme sneaks into img src through the sanitizer", () => {
+    const html = render('<img src="foo://x/y.png" alt="f">', "D:\\notes");
+    expect(html).not.toContain("foo://");
+    expect(html).not.toContain("<img");
+  });
+});
+
+describe("rehypeLocalImages transformer", () => {
+  it("leaves data: srcs byte-identical", () => {
+    const src = "data:image/png;base64,AAAA";
+    const img = {
+      type: "element",
+      tagName: "img",
+      properties: { src },
+      children: [],
+    };
+    rehypeLocalImages("D:/notes")({ type: "root", children: [img] });
+    expect(img.properties.src).toBe(src);
+    expect(tauri.convertFileSrc).not.toHaveBeenCalled();
+  });
+});
+
+describe("joinPath", () => {
+  it("joins and normalizes across separator styles", () => {
+    expect(joinPath("D:\\a\\b", "img.png")).toBe("D:/a/b/img.png");
+    expect(joinPath("D:/a/b", "./c/img.png")).toBe("D:/a/b/c/img.png");
+    expect(joinPath("D:/a/b", "../img.png")).toBe("D:/a/img.png");
+  });
+
+  it("clamps .. at the drive root and at /", () => {
+    expect(joinPath("D:/a", "../../../x.png")).toBe("D:/x.png");
+    expect(joinPath("/home/u", "../../../x.png")).toBe("/x.png");
+  });
+
+  it("preserves the UNC lead-in", () => {
+    expect(joinPath("\\\\server\\share\\docs", "../x.png")).toBe(
+      "//server/share/x.png",
+    );
+  });
+});
+
+describe("parentDir", () => {
+  it("handles both separators, root files and bare names", () => {
+    expect(parentDir("D:\\a\\b.md")).toBe("D:\\a");
+    expect(parentDir("D:/a/b.md")).toBe("D:/a");
+    expect(parentDir("/readme.md")).toBe("/");
+    expect(parentDir("readme.md")).toBe("");
+  });
+});

--- a/src/modules/markdown/localImages.ts
+++ b/src/modules/markdown/localImages.ts
@@ -1,17 +1,6 @@
-/**
- * Local image resolution: a relative img src in a previewed file (img.png,
- * ./a/b.png, ../x.png) resolves against the document's directory and loads
- * through Tauri's asset protocol via convertFileSrc, the maintainer-preferred
- * zero-copy path (#572, #314; EditorPane precedent). http(s), data: and any
- * other absolute URL stay untouched.
- *
- * Runs before rehype-sanitize/rehype-harden on purpose: harden blocks
- * relative srcs (imageBlockPolicy "text-only"), so the rewrite must happen
- * first. The converted URL then survives sanitize through its protocol
- * allowlist (http on Windows, the enumerated asset scheme elsewhere) and
- * harden's wildcard prefixes. A missing file is served as a protocol error
- * the img element renders as the standard broken-image/alt state.
- */
+// Relative img srcs resolve against the document's directory and load
+// through Tauri's asset protocol. Must run before sanitize/harden, which
+// would block relative srcs; the rewritten URL passes the allowlist.
 import { convertFileSrc } from "@tauri-apps/api/core";
 import type { HNode } from "./tableDirectives";
 
@@ -36,14 +25,9 @@ function visit(node: HNode, baseDir: string): void {
   }
 }
 
-// Anything that parses as a URL has a scheme (http, https, data, asset,
-// mailto; a Windows drive path like C:/x.png parses with a "c:" scheme) and
-// stays untouched; the sanitizer's protocol allowlist decides its fate.
-// ponytail: root-absolute srcs ("/assets/x.png") resolve against the repo
-// root on GitHub, but no workspace-root path is available in this module,
-// so they pass through unresolved and render as the browser's silent
-// broken-image/alt state; resolve against the workspace root if a root
-// store ever lands.
+// Anything with a scheme (http, data, even a C:/ drive path) is left for
+// the sanitizer's protocol allowlist to vet. Root-absolute srcs ("/x.png")
+// would need a workspace root to resolve like GitHub; unresolved for now.
 function isRelative(src: string): boolean {
   if (src.startsWith("/")) return false;
   try {
@@ -54,9 +38,8 @@ function isRelative(src: string): boolean {
   }
 }
 
-// Markdown authors percent-encode spaces and # in paths (my%20shot.png);
-// the joined filesystem path needs the real file name, and convertFileSrc
-// re-encodes it for the URL, so decode exactly once before joining.
+// Authors percent-encode paths (my%20shot.png); decode exactly once before
+// joining, convertFileSrc re-encodes for the URL.
 function decodeSrc(src: string): string {
   try {
     return decodeURIComponent(src);
@@ -66,13 +49,9 @@ function decodeSrc(src: string): string {
   }
 }
 
-/**
- * Lexical join + normalize with forward slashes throughout (Tauri accepts
- * them on Windows). ".." never climbs past the root (drive letter, UNC
- * lead-in or "/"); traversal above the workspace stays allowed on purpose,
- * matching the editor's preview of arbitrary paths under the shipped
- * assetProtocol scope of ["**"].
- */
+// Lexical join/normalize with forward slashes (Tauri accepts them on
+// Windows). ".." never climbs past a root; traversal above the workspace is
+// deliberate, matching the editor under the shipped assetProtocol ["**"].
 export function joinPath(dir: string, rel: string): string {
   const parts = `${dir}/${rel}`.replace(/\\/g, "/").split("/");
   const out: string[] = [];
@@ -95,7 +74,7 @@ export function joinPath(dir: string, rel: string): string {
   return out.join("/");
 }
 
-/** Directory of a file path; handles / and \ separators. "" when none. */
+/** Parent directory; "" when the path has no separator. */
 export function parentDir(path: string): string {
   const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   if (i < 0) return "";

--- a/src/modules/markdown/localImages.ts
+++ b/src/modules/markdown/localImages.ts
@@ -1,0 +1,103 @@
+/**
+ * Local image resolution: a relative img src in a previewed file (img.png,
+ * ./a/b.png, ../x.png) resolves against the document's directory and loads
+ * through Tauri's asset protocol via convertFileSrc, the maintainer-preferred
+ * zero-copy path (#572, #314; EditorPane precedent). http(s), data: and any
+ * other absolute URL stay untouched.
+ *
+ * Runs before rehype-sanitize/rehype-harden on purpose: harden blocks
+ * relative srcs (imageBlockPolicy "text-only"), so the rewrite must happen
+ * first. The converted URL then survives sanitize through its protocol
+ * allowlist (http on Windows, the enumerated asset scheme elsewhere) and
+ * harden's wildcard prefixes. A missing file is served as a protocol error
+ * the img element renders as the standard broken-image/alt state.
+ */
+import { convertFileSrc } from "@tauri-apps/api/core";
+import type { HNode } from "./tableDirectives";
+
+export function rehypeLocalImages(baseDir?: string) {
+  return (tree: unknown) => {
+    if (baseDir) visit(tree as HNode, baseDir);
+  };
+}
+
+function visit(node: HNode, baseDir: string): void {
+  if (node.type === "element" && node.tagName === "img") {
+    const src = node.properties?.src;
+    if (typeof src === "string" && isRelative(src)) {
+      node.properties = {
+        ...node.properties,
+        src: convertFileSrc(joinPath(baseDir, decodeSrc(src))),
+      };
+    }
+  }
+  for (const child of node.children ?? []) {
+    visit(child, baseDir);
+  }
+}
+
+// Anything that parses as a URL has a scheme (http, https, data, asset,
+// mailto; a Windows drive path like C:/x.png parses with a "c:" scheme) and
+// stays untouched; the sanitizer's protocol allowlist decides its fate.
+// ponytail: root-absolute srcs ("/assets/x.png") resolve against the repo
+// root on GitHub, but no workspace-root path is available in this module,
+// so they pass through unresolved and render as the browser's silent
+// broken-image/alt state; resolve against the workspace root if a root
+// store ever lands.
+function isRelative(src: string): boolean {
+  if (src.startsWith("/")) return false;
+  try {
+    new URL(src);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+// Markdown authors percent-encode spaces and # in paths (my%20shot.png);
+// the joined filesystem path needs the real file name, and convertFileSrc
+// re-encodes it for the URL, so decode exactly once before joining.
+function decodeSrc(src: string): string {
+  try {
+    return decodeURIComponent(src);
+  } catch {
+    // Malformed escape: treat the src as a literal file name.
+    return src;
+  }
+}
+
+/**
+ * Lexical join + normalize with forward slashes throughout (Tauri accepts
+ * them on Windows). ".." never climbs past the root (drive letter, UNC
+ * lead-in or "/"); traversal above the workspace stays allowed on purpose,
+ * matching the editor's preview of arbitrary paths under the shipped
+ * assetProtocol scope of ["**"].
+ */
+export function joinPath(dir: string, rel: string): string {
+  const parts = `${dir}/${rel}`.replace(/\\/g, "/").split("/");
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part === ".") continue;
+    if (part === "") {
+      // Keep leading empties ("/x" and UNC "//server/share"), drop the rest.
+      if (out.length === 0 || out[out.length - 1] === "") out.push(part);
+      continue;
+    }
+    if (part === "..") {
+      const last = out[out.length - 1];
+      if (last !== undefined && last !== "" && !/^[A-Za-z]:$/.test(last)) {
+        out.pop();
+      }
+      continue;
+    }
+    out.push(part);
+  }
+  return out.join("/");
+}
+
+/** Directory of a file path; handles / and \ separators. "" when none. */
+export function parentDir(path: string): string {
+  const i = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (i < 0) return "";
+  return i === 0 ? path.slice(0, 1) : path.slice(0, i);
+}

--- a/src/modules/markdown/markdown-base.css
+++ b/src/modules/markdown/markdown-base.css
@@ -1,0 +1,1258 @@
+/*! Vendored from github-markdown-css v5.9.0 (MIT license).
+ * https://github.com/sindresorhus/github-markdown-css
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ *
+ * Auto-generated from GitHub Primer's markdown styles. Vendored (rather
+ * than a dependency) so the preview's look can evolve independently of
+ * GitHub's. Color variables are re-pointed at Terax theme tokens in
+ * markdown-theme.css, which must load after this file (import order in
+ * RenderedMarkdown.tsx). */
+
+.markdown-body {
+  --base-size-16: 1rem;
+  --base-size-24: 1.5rem;
+  --base-size-4: 0.25rem;
+  --base-size-40: 2.5rem;
+  --base-size-8: 0.5rem;
+  --base-text-weight-medium: 500;
+  --base-text-weight-normal: 400;
+  --base-text-weight-semibold: 600;
+  --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  --fontStack-sansSerif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --fgColor-accent: Highlight;
+}
+@media (prefers-color-scheme: dark) {
+  .markdown-body, [data-theme="dark"] {
+    /*dark */
+    color-scheme: dark;
+    --fgColor-accent: #4493f8;
+    --bgColor-attention-muted: #bb800926;
+    --bgColor-default: #0d1117;
+    --bgColor-muted: #151b23;
+    --bgColor-neutral-muted: #656c7633;
+    --borderColor-accent-emphasis: #1f6feb;
+    --borderColor-attention-emphasis: #9e6a03;
+    --borderColor-danger-emphasis: #da3633;
+    --borderColor-default: #3d444d;
+    --borderColor-done-emphasis: #8957e5;
+    --borderColor-success-emphasis: #238636;
+    --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
+    --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+    --color-prettylights-syntax-carriage-return-bg: #b62324;
+    --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+    --color-prettylights-syntax-comment: #9198a1;
+    --color-prettylights-syntax-constant: #79c0ff;
+    --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+    --color-prettylights-syntax-entity: #d2a8ff;
+    --color-prettylights-syntax-entity-tag: #7ee787;
+    --color-prettylights-syntax-keyword: #ff7b72;
+    --color-prettylights-syntax-markup-bold: #f0f6fc;
+    --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+    --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+    --color-prettylights-syntax-markup-deleted-bg: #67060c;
+    --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+    --color-prettylights-syntax-markup-heading: #1f6feb;
+    --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+    --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
+    --color-prettylights-syntax-markup-inserted-bg: #033a16;
+    --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+    --color-prettylights-syntax-markup-italic: #f0f6fc;
+    --color-prettylights-syntax-markup-list: #f2cc60;
+    --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+    --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
+    --color-prettylights-syntax-string: #a5d6ff;
+    --color-prettylights-syntax-string-regexp: #7ee787;
+    --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+    --color-prettylights-syntax-variable: #ffa657;
+    --fgColor-attention: #d29922;
+    --fgColor-danger: #f85149;
+    --fgColor-default: #f0f6fc;
+    --fgColor-done: #ab7df8;
+    --fgColor-muted: #9198a1;
+    --fgColor-success: #3fb950;
+    --borderColor-muted: #3d444db3;
+    --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
+    --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
+    --focus-outlineColor: var(--borderColor-accent-emphasis);
+    --borderColor-neutral-muted: var(--borderColor-muted);
+  }
+}
+@media (prefers-color-scheme: light) {
+  .markdown-body, [data-theme="light"] {
+    /*light */
+    color-scheme: light;
+    --fgColor-danger: #d1242f;
+    --bgColor-attention-muted: #fff8c5;
+    --bgColor-muted: #f6f8fa;
+    --bgColor-neutral-muted: #818b981f;
+    --borderColor-accent-emphasis: #0969da;
+    --borderColor-attention-emphasis: #9a6700;
+    --borderColor-danger-emphasis: #cf222e;
+    --borderColor-default: #d1d9e0;
+    --borderColor-done-emphasis: #8250df;
+    --borderColor-success-emphasis: #1a7f37;
+    --color-prettylights-syntax-brackethighlighter-angle: #59636e;
+    --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+    --color-prettylights-syntax-carriage-return-bg: #cf222e;
+    --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+    --color-prettylights-syntax-comment: #59636e;
+    --color-prettylights-syntax-constant: #0550ae;
+    --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+    --color-prettylights-syntax-entity: #6639ba;
+    --color-prettylights-syntax-entity-tag: #0550ae;
+    --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
+    --color-prettylights-syntax-keyword: #cf222e;
+    --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+    --color-prettylights-syntax-markup-changed-text: #953800;
+    --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+    --color-prettylights-syntax-markup-deleted-text: #82071e;
+    --color-prettylights-syntax-markup-heading: #0550ae;
+    --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+    --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+    --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+    --color-prettylights-syntax-markup-inserted-text: #116329;
+    --color-prettylights-syntax-markup-list: #3b2300;
+    --color-prettylights-syntax-meta-diff-range: #8250df;
+    --color-prettylights-syntax-string: #0a3069;
+    --color-prettylights-syntax-string-regexp: #116329;
+    --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+    --color-prettylights-syntax-variable: #953800;
+    --fgColor-accent: #0969da;
+    --fgColor-attention: #9a6700;
+    --fgColor-done: #8250df;
+    --fgColor-muted: #59636e;
+    --fgColor-success: #1a7f37;
+    --bgColor-default: #ffffff;
+    --borderColor-muted: #d1d9e0b3;
+    --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
+    --color-prettylights-syntax-markup-bold: #1f2328;
+    --color-prettylights-syntax-markup-italic: #1f2328;
+    --color-prettylights-syntax-storage-modifier-import: #1f2328;
+    --fgColor-default: #1f2328;
+    --focus-outlineColor: var(--borderColor-accent-emphasis);
+    --borderColor-neutral-muted: var(--borderColor-muted);
+  }
+}
+
+.markdown-body {
+  /** CSS default easing. Use for hover state changes and micro-interactions. */
+  /** Accelerating motion. Use for elements exiting the viewport (moving off-screen). */
+  /** Smooth acceleration and deceleration. Use for elements moving or morphing within the viewport. */
+  /** Decelerating motion. Use for elements entering the viewport or appearing on screen. */
+  /** Constant motion with no acceleration. Use for continuous animations like progress bars or loaders. */
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  font-weight: var(--base-text-weight-normal, 400);
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-default);
+  font-family: var(--fontStack-sansSerif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji");
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.markdown-body a {
+  text-decoration: underline;
+  text-underline-offset: .2rem;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  fill: currentColor;
+  vertical-align: text-bottom;
+}
+
+.markdown-body h1:hover .anchor .octicon-link:before,
+.markdown-body h2:hover .anchor .octicon-link:before,
+.markdown-body h3:hover .anchor .octicon-link:before,
+.markdown-body h4:hover .anchor .octicon-link:before,
+.markdown-body h5:hover .anchor .octicon-link:before,
+.markdown-body h6:hover .anchor .octicon-link:before {
+  width: 16px;
+  height: 16px;
+  content: ' ';
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+  mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+}
+
+.markdown-body details,
+.markdown-body figcaption,
+.markdown-body figure {
+  display: block;
+}
+
+.markdown-body summary {
+  display: list-item;
+}
+
+.markdown-body [hidden] {
+  display: none !important;
+}
+
+.markdown-body a {
+  background-color: rgba(0,0,0,0);
+  color: var(--fgColor-accent);
+  text-decoration: none;
+}
+
+.markdown-body abbr[title] {
+  border-bottom: none;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+.markdown-body b,
+.markdown-body strong {
+  font-weight: var(--base-text-weight-semibold, 600);
+}
+
+.markdown-body dfn {
+  font-style: italic;
+}
+
+.markdown-body h1 {
+  margin: .67em 0;
+  font-weight: var(--base-text-weight-semibold, 600);
+  padding-bottom: .3em;
+  font-size: 2em;
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+
+.markdown-body mark {
+  background-color: var(--bgColor-attention-muted);
+  color: var(--fgColor-default);
+}
+
+.markdown-body small {
+  font-size: 90%;
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-body sub {
+  bottom: -0.25em;
+}
+
+.markdown-body sup {
+  top: -0.5em;
+}
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre,
+.markdown-body samp {
+  font-family: monospace;
+  font-size: 1em;
+}
+
+.markdown-body figure {
+  margin: 1em var(--base-size-40);
+}
+
+.markdown-body hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: rgba(0,0,0,0);
+  border-bottom: 1px solid var(--borderColor-muted);
+  height: .25em;
+  padding: 0;
+  margin: var(--base-size-24) 0;
+  background-color: var(--borderColor-default);
+  border: 0;
+}
+
+.markdown-body input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
+  -webkit-appearance: button;
+  appearance: button;
+}
+
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.markdown-body [type=number]::-webkit-inner-spin-button,
+.markdown-body [type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.markdown-body [type=search]::-webkit-search-cancel-button,
+.markdown-body [type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54;
+}
+
+.markdown-body ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body ::placeholder {
+  color: var(--fgColor-muted);
+  opacity: 1;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  font-variant: tabular-nums;
+}
+
+.markdown-body td,
+.markdown-body th {
+  padding: 0;
+}
+
+.markdown-body details summary {
+  cursor: pointer;
+}
+
+.markdown-body a:focus,
+.markdown-body [role=button]:focus,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=checkbox]:focus {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:focus:not(:focus-visible),
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body input[type=radio]:focus:not(:focus-visible),
+.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+  outline: solid 1px rgba(0,0,0,0);
+}
+
+.markdown-body a:focus-visible,
+.markdown-body [role=button]:focus-visible,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:not([class]):focus,
+.markdown-body a:not([class]):focus-visible,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline-offset: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: var(--base-size-4);
+  font: 11px var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);
+  line-height: 10px;
+  color: var(--fgColor-default);
+  vertical-align: middle;
+  background-color: var(--bgColor-muted);
+  border: solid 1px var(--borderColor-neutral-muted);
+  border-bottom-color: var(--borderColor-neutral-muted);
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 var(--borderColor-neutral-muted);
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: var(--base-size-24);
+  margin-bottom: var(--base-size-16);
+  font-weight: var(--base-text-weight-semibold, 600);
+  line-height: 1.25;
+}
+
+.markdown-body h2 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  padding-bottom: .3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+
+.markdown-body h3 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: 1.25em;
+}
+
+.markdown-body h4 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: .875em;
+}
+
+.markdown-body h6 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: .85em;
+  color: var(--fgColor-muted);
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: var(--fgColor-muted);
+  border-left: .25em solid var(--borderColor-default);
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body dd {
+  margin-left: 0;
+}
+
+.markdown-body tt,
+.markdown-body code,
+.markdown-body samp {
+  font-family: var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);
+  font-size: 12px;
+}
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);
+  font-size: 12px;
+  word-wrap: normal;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}
+
+.markdown-body input::-webkit-outer-spin-button,
+.markdown-body input::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.markdown-body .mr-2 {
+  margin-right: var(--base-size-8, 8px) !important;
+}
+
+.markdown-body::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body .absent {
+  color: var(--fgColor-danger);
+}
+
+.markdown-body .anchor {
+  float: left;
+  padding-right: var(--base-size-4);
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.markdown-body .anchor:focus {
+  outline: none;
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre,
+.markdown-body details {
+  margin-top: 0;
+  margin-bottom: var(--base-size-16);
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+  color: var(--fgColor-default);
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2,
+.markdown-body summary h3,
+.markdown-body summary h4,
+.markdown-body summary h5,
+.markdown-body summary h6 {
+  display: inline-block;
+}
+
+.markdown-body summary h1 .anchor,
+.markdown-body summary h2 .anchor,
+.markdown-body summary h3 .anchor,
+.markdown-body summary h4 .anchor,
+.markdown-body summary h5 .anchor,
+.markdown-body summary h6 .anchor {
+  margin-left: -40px;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2 {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.markdown-body ol[type="a s"] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type="A s"] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type="i s"] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type="I s"] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.markdown-body div>ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body li>p {
+  margin-top: var(--base-size-16);
+}
+
+.markdown-body li+li {
+  margin-top: .25em;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: var(--base-size-16);
+  font-size: 1em;
+  font-style: italic;
+  font-weight: var(--base-text-weight-semibold, 600);
+}
+
+.markdown-body dl dd {
+  padding: 0 var(--base-size-16);
+  margin-bottom: var(--base-size-16);
+}
+
+.markdown-body table th {
+  font-weight: var(--base-text-weight-semibold, 600);
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid var(--borderColor-default);
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: var(--bgColor-default);
+  border-top: 1px solid var(--borderColor-muted);
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: var(--bgColor-muted);
+}
+
+.markdown-body table img {
+  background-color: rgba(0,0,0,0);
+}
+
+.markdown-body img[align=right] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align=left] {
+  padding-right: 20px;
+}
+
+.markdown-body .emoji {
+  max-width: none;
+  vertical-align: text-top;
+  background-color: rgba(0,0,0,0);
+}
+
+.markdown-body span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid var(--borderColor-default);
+}
+
+.markdown-body span.frame span img {
+  display: block;
+  float: left;
+}
+
+.markdown-body span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: var(--fgColor-default);
+}
+
+.markdown-body span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-center>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.markdown-body span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.markdown-body span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-right>span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.markdown-body span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+  margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  background-color: var(--bgColor-neutral-muted);
+  border-radius: 6px;
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+  display: none;
+}
+
+.markdown-body del code {
+  text-decoration: inherit;
+}
+
+.markdown-body samp {
+  font-size: 85%;
+}
+
+.markdown-body pre code {
+  font-size: 100%;
+}
+
+.markdown-body pre>code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: rgba(0,0,0,0);
+  border: 0;
+}
+
+.markdown-body .highlight {
+  margin-bottom: var(--base-size-16);
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  padding: var(--base-size-16);
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-muted);
+  border-radius: 6px;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: rgba(0,0,0,0);
+  border: 0;
+}
+
+.markdown-body .csv-data td,
+.markdown-body .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.markdown-body .csv-data .blob-num {
+  padding: 10px var(--base-size-8) 9px;
+  text-align: right;
+  background: var(--bgColor-default);
+  border: 0;
+}
+
+.markdown-body .csv-data tr {
+  border-top: 0;
+}
+
+.markdown-body .csv-data th {
+  font-weight: var(--base-text-weight-semibold, 600);
+  background: var(--bgColor-muted);
+  border-top: 0;
+}
+
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
+.markdown-body .footnotes {
+  font-size: 12px;
+  color: var(--fgColor-muted);
+  border-top: 1px solid var(--borderColor-default);
+}
+
+.markdown-body .footnotes ol {
+  padding-left: var(--base-size-16);
+}
+
+.markdown-body .footnotes ol ul {
+  display: inline-block;
+  padding-left: var(--base-size-16);
+  margin-top: var(--base-size-16);
+}
+
+.markdown-body .footnotes li {
+  position: relative;
+}
+
+.markdown-body .footnotes li:target::before {
+  position: absolute;
+  top: calc(var(--base-size-8)*-1);
+  right: calc(var(--base-size-8)*-1);
+  bottom: calc(var(--base-size-8)*-1);
+  left: calc(var(--base-size-24)*-1);
+  pointer-events: none;
+  content: "";
+  border: 2px solid var(--borderColor-accent-emphasis);
+  border-radius: 6px;
+}
+
+.markdown-body .footnotes li:target {
+  color: var(--fgColor-default);
+}
+
+.markdown-body .footnotes .data-footnote-backref g-emoji {
+  font-family: monospace;
+}
+
+.markdown-body .pl-c {
+  color: var(--color-prettylights-syntax-comment);
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-s .pl-v {
+  color: var(--color-prettylights-syntax-constant);
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: var(--color-prettylights-syntax-entity);
+}
+
+.markdown-body .pl-smi,
+.markdown-body .pl-s .pl-s1 {
+  color: var(--color-prettylights-syntax-storage-modifier-import);
+}
+
+.markdown-body .pl-ent {
+  color: var(--color-prettylights-syntax-entity-tag);
+}
+
+.markdown-body .pl-k {
+  color: var(--color-prettylights-syntax-keyword);
+}
+
+.markdown-body .pl-s,
+.markdown-body .pl-pds,
+.markdown-body .pl-s .pl-pse .pl-s1,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-sr .pl-sra {
+  color: var(--color-prettylights-syntax-string);
+}
+
+.markdown-body .pl-v,
+.markdown-body .pl-smw {
+  color: var(--color-prettylights-syntax-variable);
+}
+
+.markdown-body .pl-bu {
+  color: var(--color-prettylights-syntax-brackethighlighter-unmatched);
+}
+
+.markdown-body .pl-ii {
+  color: var(--color-prettylights-syntax-invalid-illegal-text);
+  background-color: var(--color-prettylights-syntax-invalid-illegal-bg);
+}
+
+.markdown-body .pl-c2 {
+  color: var(--color-prettylights-syntax-carriage-return-text);
+  background-color: var(--color-prettylights-syntax-carriage-return-bg);
+}
+
+.markdown-body .pl-sr .pl-cce {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-string-regexp);
+}
+
+.markdown-body .pl-ml {
+  color: var(--color-prettylights-syntax-markup-list);
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-heading);
+}
+
+.markdown-body .pl-mi {
+  font-style: italic;
+  color: var(--color-prettylights-syntax-markup-italic);
+}
+
+.markdown-body .pl-mb {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-bold);
+}
+
+.markdown-body .pl-md {
+  color: var(--color-prettylights-syntax-markup-deleted-text);
+  background-color: var(--color-prettylights-syntax-markup-deleted-bg);
+}
+
+.markdown-body .pl-mi1 {
+  color: var(--color-prettylights-syntax-markup-inserted-text);
+  background-color: var(--color-prettylights-syntax-markup-inserted-bg);
+}
+
+.markdown-body .pl-mc {
+  color: var(--color-prettylights-syntax-markup-changed-text);
+  background-color: var(--color-prettylights-syntax-markup-changed-bg);
+}
+
+.markdown-body .pl-mi2 {
+  color: var(--color-prettylights-syntax-markup-ignored-text);
+  background-color: var(--color-prettylights-syntax-markup-ignored-bg);
+}
+
+.markdown-body .pl-mdr {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-meta-diff-range);
+}
+
+.markdown-body .pl-ba {
+  color: var(--color-prettylights-syntax-brackethighlighter-angle);
+}
+
+.markdown-body .pl-sg {
+  color: var(--color-prettylights-syntax-sublimelinter-gutter-mark);
+}
+
+.markdown-body .pl-corl {
+  text-decoration: underline;
+  color: var(--color-prettylights-syntax-constant-other-reference-link);
+}
+
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+.markdown-body button:focus:not(:focus-visible),
+.markdown-body summary:focus:not(:focus-visible),
+.markdown-body a:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.markdown-body [tabindex="0"]:focus:not(:focus-visible),
+.markdown-body details-dialog:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.markdown-body g-emoji {
+  display: inline-block;
+  min-width: 1ch;
+  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 1em;
+  font-style: normal !important;
+  font-weight: var(--base-text-weight-normal, 400);
+  line-height: 1;
+  vertical-align: -0.075em;
+}
+
+.markdown-body g-emoji img {
+  width: 1em;
+  height: 1em;
+}
+
+.markdown-body a:has(>p,>div,>pre,>blockquote) {
+  display: block;
+}
+
+.markdown-body a:has(>p,>div,>pre,>blockquote):not(:has(.snippet-clipboard-content,>pre)) {
+  width: fit-content;
+}
+
+.markdown-body a:has(>p,>div,>pre,>blockquote):has(.snippet-clipboard-content,>pre):focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: 2px;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item label {
+  font-weight: var(--base-text-weight-normal, 400);
+}
+
+.markdown-body .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.markdown-body .task-list-item+.task-list-item {
+  margin-top: var(--base-size-4);
+}
+
+.markdown-body .task-list-item .handle {
+  display: none;
+}
+
+.markdown-body .task-list-item-checkbox {
+  margin: 0 .2em .25em -1.4em;
+  vertical-align: middle;
+}
+
+.markdown-body ul:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body ol:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body .contains-task-list:hover .task-list-item-convert-container,
+.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+  display: block;
+  width: auto;
+  height: 24px;
+  overflow: visible;
+  clip-path: none;
+}
+
+.markdown-body ::-webkit-calendar-picker-indicator {
+  filter: invert(50%);
+}
+
+.markdown-body .markdown-alert {
+  padding: var(--base-size-8) var(--base-size-16);
+  margin-bottom: var(--base-size-16);
+  color: inherit;
+  border-left: .25em solid var(--borderColor-default);
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+  font-weight: var(--base-text-weight-medium, 500);
+  align-items: center;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: var(--borderColor-accent-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: var(--fgColor-accent);
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: var(--borderColor-done-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: var(--fgColor-done);
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: var(--borderColor-attention-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: var(--fgColor-attention);
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: var(--borderColor-success-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: var(--fgColor-success);
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: var(--borderColor-danger-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: var(--fgColor-danger);
+}
+
+.markdown-body>*:first-child>.heading-element:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body .highlight pre:has(+.zeroclipboard-container) {
+  min-height: 52px;
+}
+

--- a/src/modules/markdown/markdown-base.css
+++ b/src/modules/markdown/markdown-base.css
@@ -2,11 +2,8 @@
  * https://github.com/sindresorhus/github-markdown-css
  * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
  *
- * Auto-generated from GitHub Primer's markdown styles. Vendored (rather
- * than a dependency) so the preview's look can evolve independently of
- * GitHub's. Color variables are re-pointed at Terax theme tokens in
- * markdown-theme.css, which must load after this file (import order in
- * RenderedMarkdown.tsx). */
+ * Color variables are re-pointed at Terax theme tokens in
+ * markdown-theme.css, which must load after this file. */
 
 .markdown-body {
   --base-size-16: 1rem;

--- a/src/modules/markdown/markdown-theme.css
+++ b/src/modules/markdown/markdown-theme.css
@@ -1,0 +1,183 @@
+/* markdown-base.css (vendored GitHub markdown styles) provides the layout
+ * (spacing, headings, tables) but switches palettes on the OS
+ * prefers-color-scheme media query. Terax instead defines semantic tokens on
+ * <html> (stylesheet defaults in globals.css, overridden per theme by
+ * applyTheme() for non-default and custom themes) and toggles a .light/.dark
+ * root class, so this file re-points the base stylesheet's color variables
+ * at those tokens. It must load after markdown-base.css (import order in
+ * RenderedMarkdown.tsx) to win the cascade over its media-query blocks. */
+.markdown-body {
+  --fontStack-sansSerif: var(--font-sans, "Inter Variable", sans-serif);
+  --fontStack-monospace: "JetBrains Mono", ui-monospace, SFMono-Regular,
+    Menlo, Consolas, "Liberation Mono", monospace;
+  --fgColor-default: var(--foreground);
+  --fgColor-muted: var(--muted-foreground);
+  --fgColor-accent: var(--primary);
+  --fgColor-danger: var(--destructive);
+  --bgColor-default: var(--background);
+  --bgColor-muted: var(--muted);
+  --bgColor-neutral-muted: color-mix(
+    in srgb,
+    var(--foreground) 10%,
+    transparent
+  );
+  --bgColor-danger-muted: color-mix(
+    in srgb,
+    var(--destructive) 15%,
+    transparent
+  );
+  --borderColor-default: var(--border);
+  --borderColor-muted: color-mix(in srgb, var(--border) 70%, transparent);
+  --borderColor-neutral-muted: color-mix(
+    in srgb,
+    var(--border) 70%,
+    transparent
+  );
+  --borderColor-accent-emphasis: var(--primary);
+  --borderColor-danger-emphasis: var(--destructive);
+  --focus-outlineColor: var(--ring);
+}
+
+/* Terax themes often keep --primary close to the foreground color, so link
+ * color alone is invisible; underline like the raw editor view (see
+ * markdownExtras.ts) and bolden like the previous renderer did. */
+.markdown-body a {
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2.5px;
+  text-decoration-color: color-mix(in srgb, var(--primary) 45%, transparent);
+}
+.markdown-body a:hover {
+  text-decoration-color: var(--primary);
+}
+
+/* ChatCodeBlock (language fences and shell cards) fully styles itself and
+ * marks its root with .not-prose. The base stylesheet's descendant rules
+ * for pre/code would otherwise bleed into its internals (solid background,
+ * 16px padding and margin inside the card). revert-layer hands these
+ * properties back to the component's own (layered) Tailwind styles. */
+.markdown-body .not-prose pre,
+.markdown-body .not-prose code {
+  margin: revert-layer;
+  padding: revert-layer;
+  background-color: revert-layer;
+  color: revert-layer;
+  font-family: revert-layer;
+  font-size: revert-layer;
+  line-height: revert-layer;
+  border-radius: revert-layer;
+  white-space: revert-layer;
+  word-break: revert-layer;
+  overflow: revert-layer;
+}
+
+/* Streamdown renders the document inside one wrapper div, so the base
+ * stylesheet's `.markdown-body > *:first-child` / `:last-child` margin trims
+ * no longer reach the first and last blocks; reapply them one level down. */
+.markdown-body > div > *:first-child {
+  margin-top: 0 !important;
+}
+.markdown-body > div > *:last-child {
+  margin-bottom: 0 !important;
+}
+
+/* Tailwind's preflight resets list markers (list-style: none). The GitHub
+ * stylesheet only declares markers for nested/typed lists and relies on
+ * browser defaults for the base cases, so restore those explicitly. */
+.markdown-body ul {
+  list-style-type: disc;
+}
+.markdown-body ul ul {
+  list-style-type: circle;
+}
+.markdown-body ul ul ul {
+  list-style-type: square;
+}
+.markdown-body ol {
+  list-style-type: decimal;
+}
+
+/* Table layout control for HTML-authored tables and the directive comments
+ * in tableDirectives.ts: standard presentational markup, honored
+ * deliberately (github.com ignores it; its tables are always
+ * content-width). 100% is the only width value honored here.
+ * table-layout: fixed makes the browser enforce col widths and split the
+ * remainder equally; break-word keeps long content inside its cell. */
+.markdown-body table[width="100%"] {
+  display: table;
+  width: 100%;
+}
+.markdown-body table[width="100%"]:has(> colgroup) {
+  table-layout: fixed;
+}
+.markdown-body table[width="100%"]:has(> colgroup) :is(td, th) {
+  overflow-wrap: break-word;
+}
+
+/* GFM alert title icons: the five octicons GitHub inlines as <svg> (info,
+ * light-bulb, report, alert, stop), embedded as data-URI masks painted with
+ * currentColor so each title's hue applies. Masks keep the rehype sanitizer
+ * closed to svg/path elements. Scoped to the five known types so a typeless
+ * .markdown-alert-title never paints an unmasked square. */
+.markdown-body
+  :is(
+    .markdown-alert-note,
+    .markdown-alert-tip,
+    .markdown-alert-important,
+    .markdown-alert-warning,
+    .markdown-alert-caution
+  )
+  > .markdown-alert-title::before {
+  content: "";
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  margin-right: var(--base-size-8, 8px);
+  background-color: currentColor;
+  -webkit-mask-image: var(--alert-icon);
+  mask-image: var(--alert-icon);
+  -webkit-mask-size: 100% 100%;
+  mask-size: 100% 100%;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+}
+.markdown-body .markdown-alert-note > .markdown-alert-title {
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
+}
+.markdown-body .markdown-alert-tip > .markdown-alert-title {
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z'/%3E%3C/svg%3E");
+}
+.markdown-body .markdown-alert-important > .markdown-alert-title {
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
+}
+.markdown-body .markdown-alert-warning > .markdown-alert-title {
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
+}
+.markdown-body .markdown-alert-caution > .markdown-alert-title {
+  --alert-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25a.749.749 0 0 1-.53.22H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
+}
+
+/* GFM alert/status hues (attention, success, done) have no Terax token;
+ * keep GitHub's palette, split by the app's theme class rather than the OS
+ * media query. */
+.light .markdown-body {
+  color-scheme: light;
+  --fgColor-attention: #9a6700;
+  --borderColor-attention-emphasis: #9a6700;
+  --bgColor-attention-muted: #fff8c5;
+  --fgColor-success: #1a7f37;
+  --borderColor-success-emphasis: #1a7f37;
+  --fgColor-done: #8250df;
+  --borderColor-done-emphasis: #8250df;
+}
+
+.dark .markdown-body {
+  color-scheme: dark;
+  --fgColor-attention: #d29922;
+  --borderColor-attention-emphasis: #9e6a03;
+  --bgColor-attention-muted: #bb800926;
+  --fgColor-success: #3fb950;
+  --borderColor-success-emphasis: #238636;
+  --fgColor-done: #ab7df8;
+  --borderColor-done-emphasis: #8957e5;
+}

--- a/src/modules/markdown/markdown-theme.css
+++ b/src/modules/markdown/markdown-theme.css
@@ -1,11 +1,7 @@
-/* markdown-base.css (vendored GitHub markdown styles) provides the layout
- * (spacing, headings, tables) but switches palettes on the OS
- * prefers-color-scheme media query. Terax instead defines semantic tokens on
- * <html> (stylesheet defaults in globals.css, overridden per theme by
- * applyTheme() for non-default and custom themes) and toggles a .light/.dark
- * root class, so this file re-points the base stylesheet's color variables
- * at those tokens. It must load after markdown-base.css (import order in
- * RenderedMarkdown.tsx) to win the cascade over its media-query blocks. */
+/* Re-points the vendored base stylesheet's color variables at Terax's
+ * semantic theme tokens, keyed off the .light/.dark root class rather than
+ * the OS color-scheme query so custom themes win. Must load after
+ * markdown-base.css to beat its media-query blocks in the cascade. */
 .markdown-body {
   --fontStack-sansSerif: var(--font-sans, "Inter Variable", sans-serif);
   --fontStack-monospace: "JetBrains Mono", ui-monospace, SFMono-Regular,

--- a/src/modules/markdown/markdown-theme.css
+++ b/src/modules/markdown/markdown-theme.css
@@ -2,6 +2,13 @@
  * semantic theme tokens, keyed off the .light/.dark root class rather than
  * the OS color-scheme query so custom themes win. Must load after
  * markdown-base.css to beat its media-query blocks in the cascade. */
+
+.markdown-body {
+  max-width: 980px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .markdown-body {
   --fontStack-sansSerif: var(--font-sans, "Inter Variable", sans-serif);
   --fontStack-monospace: "JetBrains Mono", ui-monospace, SFMono-Regular,

--- a/src/modules/markdown/tableDirectives.test.tsx
+++ b/src/modules/markdown/tableDirectives.test.tsx
@@ -19,93 +19,119 @@ const render = (md: string) =>
 
 const PIPE_TABLE = "| a | b | c |\n|---|---|---|\n| 1 | 2 | 3 |";
 
+type DirectiveCase = {
+  name: string;
+  md: string;
+  contains?: string[];
+  absent?: string[];
+  counts?: [RegExp, number][];
+};
+
+const check = ({
+  md,
+  contains = [],
+  absent = [],
+  counts = [],
+}: DirectiveCase) => {
+  const html = render(md);
+  for (const fragment of contains) expect(html).toContain(fragment);
+  for (const fragment of absent) expect(html).not.toContain(fragment);
+  for (const [pattern, count] of counts)
+    expect(html.match(pattern)).toHaveLength(count);
+};
+
+const APPLY_CASES: DirectiveCase[] = [
+  {
+    name: "width stretches the next table and the comment is stripped",
+    md: `<!-- table width="100%" -->\n${PIPE_TABLE}`,
+    contains: ['<table width="100%">'],
+    absent: ["<!--"],
+  },
+  {
+    name: "cols=equal alone equalizes at natural width, no table width attr",
+    md: `<!-- table cols="equal" -->\n${PIPE_TABLE}`,
+    contains: ["<table><colgroup>"],
+    counts: [[/<col width="33\.333%"\/>/g, 3]],
+  },
+  {
+    name: "width and cols combine in one directive",
+    md: `<!-- table width="100%" cols="equal" -->\n${PIPE_TABLE}`,
+    contains: ['<table width="100%"><colgroup>'],
+    counts: [[/<col width="33\.333%"\/>/g, 3]],
+  },
+  {
+    name: "stacked directive comments all apply",
+    md: `<!-- table width="100%" -->\n<!-- table cols="equal" -->\n${PIPE_TABLE}`,
+    contains: ['<table width="100%"><colgroup>'],
+  },
+  {
+    name: "single-quoted attribute values are accepted",
+    md: `<!-- table width='100%' -->\n${PIPE_TABLE}`,
+    contains: ['<table width="100%">'],
+  },
+  {
+    name: "unquoted attribute values are accepted",
+    md: `<!-- table width=100% -->\n${PIPE_TABLE}`,
+    contains: ['<table width="100%">'],
+  },
+  {
+    name: "applies across a blank line before the table",
+    md: `<!-- table width="100%" -->\n\n${PIPE_TABLE}`,
+    contains: ['<table width="100%">'],
+  },
+  {
+    name: "explicit cols set widths, auto stays attributeless, no implied table width",
+    md: `<!-- table cols="12%, auto, 25%" -->\n${PIPE_TABLE}`,
+    contains: ['<col width="12%"/>', '<col width="25%"/>'],
+    absent: ['table width="100%"'],
+    counts: [[/<col\/>/g, 1]],
+  },
+  {
+    name: "cols entries beyond the actual column count are dropped",
+    md: `<!-- table cols="10%, 20%, 30%, 40%, 50%" -->\n${PIPE_TABLE}`,
+    absent: ["40%"],
+    counts: [[/<col width=/g, 3]],
+  },
+];
+
+const NOOP_CASES: DirectiveCase[] = [
+  {
+    name: "a table without a directive gains neither width nor colgroup",
+    md: PIPE_TABLE,
+    absent: ["width=", "colgroup"],
+  },
+  {
+    name: "an ordinary comment does not affect the table",
+    md: `<!-- just a note -->\n${PIPE_TABLE}`,
+    absent: ["width="],
+  },
+  {
+    name: "a directive with no adjacent table does nothing",
+    md: '<!-- table width="100%" -->\n\nJust a paragraph.',
+    contains: ["Just a paragraph."],
+    absent: ["width="],
+  },
+];
+
 describe("rehypeTableDirectives", () => {
-  it("width directive stretches the next table", () => {
-    const html = render(`<!-- table width="100%" -->\n${PIPE_TABLE}`);
-    expect(html).toContain('<table width="100%">');
-    expect(html).not.toContain("<!--");
+  it("applies directives", () => {
+    for (const c of APPLY_CASES) check(c);
   });
 
-  it("cols=equal alone equalizes at natural width, no table width attr", () => {
-    const html = render(`<!-- table cols="equal" -->\n${PIPE_TABLE}`);
-    expect(html).toContain("<table><colgroup>");
-    expect(html.match(/<col width="33\.333%"\/>/g)).toHaveLength(3);
-  });
-
-  it("width and cols combine in one directive", () => {
-    const html = render(
-      `<!-- table width="100%" cols="equal" -->\n${PIPE_TABLE}`,
-    );
-    expect(html).toContain('<table width="100%"><colgroup>');
-    expect(html.match(/<col width="33\.333%"\/>/g)).toHaveLength(3);
-  });
-
-  it("stacked directive comments all apply", () => {
-    const html = render(
-      `<!-- table width="100%" -->\n<!-- table cols="equal" -->\n${PIPE_TABLE}`,
-    );
-    expect(html).toContain('<table width="100%"><colgroup>');
-  });
-
-  it("accepts single-quoted and unquoted attribute values", () => {
-    expect(render(`<!-- table width='100%' -->\n${PIPE_TABLE}`)).toContain(
-      '<table width="100%">',
-    );
-    expect(render(`<!-- table width=100% -->\n${PIPE_TABLE}`)).toContain(
-      '<table width="100%">',
-    );
-  });
-
-  it("applies across a blank line before the table", () => {
-    const html = render(`<!-- table width="100%" -->\n\n${PIPE_TABLE}`);
-    expect(html).toContain('<table width="100%">');
-  });
-
-  it("explicit cols set widths without implying table width", () => {
-    const html = render(`<!-- table cols="12%, auto, 25%" -->\n${PIPE_TABLE}`);
-    expect(html).not.toContain('table width="100%"');
-    expect(html).toContain('<col width="12%"/>');
-    expect(html).toContain('<col width="25%"/>');
-    expect(html.match(/<col\/>/g)).toHaveLength(1);
-  });
-
-  it("drops cols entries beyond the actual column count", () => {
-    const html = render(
-      `<!-- table cols="10%, 20%, 30%, 40%, 50%" -->\n${PIPE_TABLE}`,
-    );
-    expect(html.match(/<col width=/g)).toHaveLength(3);
-    expect(html).not.toContain("40%");
-  });
-
-  it("tables without a directive are untouched", () => {
-    const html = render(PIPE_TABLE);
-    expect(html).not.toContain("width=");
-    expect(html).not.toContain("colgroup");
-  });
-
-  it("ordinary comments do not affect tables", () => {
-    const html = render(`<!-- just a note -->\n${PIPE_TABLE}`);
-    expect(html).not.toContain("width=");
-  });
-
-  it("a directive with no adjacent table is a no-op", () => {
-    const html = render('<!-- table width="100%" -->\n\nJust a paragraph.');
-    expect(html).toContain("Just a paragraph.");
-    expect(html).not.toContain("width=");
+  it("ignores non-directives and directives without a table", () => {
+    for (const c of NOOP_CASES) check(c);
   });
 
   it("directive values cannot inject elements or attributes", () => {
-    const html = render(
+    const injected = render(
       `<!-- table cols="&quot;><img src=x onerror=alert(1)>" -->\n${PIPE_TABLE}`,
     );
-    expect(html).not.toContain("<img");
-  });
+    expect(injected).not.toContain("<img");
 
-  it("dangerous markup in cells is still stripped by the sanitizer", () => {
-    const html = render(
+    const cellMarkup = render(
       `<!-- table cols="equal" -->\n| <script>x()</script> a | b | c |\n|---|---|---|\n| 1 | 2 | 3 |`,
     );
-    expect(html).not.toContain("<script");
-    expect(html).toContain("colgroup");
+    expect(cellMarkup).not.toContain("<script");
+    expect(cellMarkup).toContain("colgroup");
   });
 });

--- a/src/modules/markdown/tableDirectives.test.tsx
+++ b/src/modules/markdown/tableDirectives.test.tsx
@@ -1,0 +1,111 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { Streamdown } from "streamdown";
+import { describe, expect, it } from "vitest";
+import { components, rehypePlugins } from "./RenderedMarkdown";
+
+// Uses the real pipeline exported by RenderedMarkdown, so plugin order and
+// sanitizer schema cannot drift from what the preview actually runs.
+const render = (md: string) =>
+  renderToStaticMarkup(
+    <Streamdown
+      mode="static"
+      parseIncompleteMarkdown={false}
+      rehypePlugins={rehypePlugins}
+      components={components}
+    >
+      {md}
+    </Streamdown>,
+  );
+
+const PIPE_TABLE = "| a | b | c |\n|---|---|---|\n| 1 | 2 | 3 |";
+
+describe("rehypeTableDirectives", () => {
+  it("width directive stretches the next table", () => {
+    const html = render(`<!-- table width="100%" -->\n${PIPE_TABLE}`);
+    expect(html).toContain('<table width="100%">');
+    expect(html).not.toContain("<!--");
+  });
+
+  it("cols=equal alone equalizes at natural width, no table width attr", () => {
+    const html = render(`<!-- table cols="equal" -->\n${PIPE_TABLE}`);
+    expect(html).toContain("<table><colgroup>");
+    expect(html.match(/<col width="33\.333%"\/>/g)).toHaveLength(3);
+  });
+
+  it("width and cols combine in one directive", () => {
+    const html = render(
+      `<!-- table width="100%" cols="equal" -->\n${PIPE_TABLE}`,
+    );
+    expect(html).toContain('<table width="100%"><colgroup>');
+    expect(html.match(/<col width="33\.333%"\/>/g)).toHaveLength(3);
+  });
+
+  it("stacked directive comments all apply", () => {
+    const html = render(
+      `<!-- table width="100%" -->\n<!-- table cols="equal" -->\n${PIPE_TABLE}`,
+    );
+    expect(html).toContain('<table width="100%"><colgroup>');
+  });
+
+  it("accepts single-quoted and unquoted attribute values", () => {
+    expect(render(`<!-- table width='100%' -->\n${PIPE_TABLE}`)).toContain(
+      '<table width="100%">',
+    );
+    expect(render(`<!-- table width=100% -->\n${PIPE_TABLE}`)).toContain(
+      '<table width="100%">',
+    );
+  });
+
+  it("applies across a blank line before the table", () => {
+    const html = render(`<!-- table width="100%" -->\n\n${PIPE_TABLE}`);
+    expect(html).toContain('<table width="100%">');
+  });
+
+  it("explicit cols set widths without implying table width", () => {
+    const html = render(`<!-- table cols="12%, auto, 25%" -->\n${PIPE_TABLE}`);
+    expect(html).not.toContain('table width="100%"');
+    expect(html).toContain('<col width="12%"/>');
+    expect(html).toContain('<col width="25%"/>');
+    expect(html.match(/<col\/>/g)).toHaveLength(1);
+  });
+
+  it("drops cols entries beyond the actual column count", () => {
+    const html = render(
+      `<!-- table cols="10%, 20%, 30%, 40%, 50%" -->\n${PIPE_TABLE}`,
+    );
+    expect(html.match(/<col width=/g)).toHaveLength(3);
+    expect(html).not.toContain("40%");
+  });
+
+  it("tables without a directive are untouched", () => {
+    const html = render(PIPE_TABLE);
+    expect(html).not.toContain("width=");
+    expect(html).not.toContain("colgroup");
+  });
+
+  it("ordinary comments do not affect tables", () => {
+    const html = render(`<!-- just a note -->\n${PIPE_TABLE}`);
+    expect(html).not.toContain("width=");
+  });
+
+  it("a directive with no adjacent table is a no-op", () => {
+    const html = render('<!-- table width="100%" -->\n\nJust a paragraph.');
+    expect(html).toContain("Just a paragraph.");
+    expect(html).not.toContain("width=");
+  });
+
+  it("directive values cannot inject elements or attributes", () => {
+    const html = render(
+      `<!-- table cols="&quot;><img src=x onerror=alert(1)>" -->\n${PIPE_TABLE}`,
+    );
+    expect(html).not.toContain("<img");
+  });
+
+  it("dangerous markup in cells is still stripped by the sanitizer", () => {
+    const html = render(
+      `<!-- table cols="equal" -->\n| <script>x()</script> a | b | c |\n|---|---|---|\n| 1 | 2 | 3 |`,
+    );
+    expect(html).not.toContain("<script");
+    expect(html).toContain("colgroup");
+  });
+});

--- a/src/modules/markdown/tableDirectives.ts
+++ b/src/modules/markdown/tableDirectives.ts
@@ -1,37 +1,14 @@
-/**
- * Table layout directives: an HTML comment immediately before a table
- * translates into the standard markup markdown-theme.css honors
- * (`<table width>` + `<colgroup>`), so authoring stays a plain pipe table.
- *
- *   <!-- table width="100%" -->              full width, content-sized columns
- *   <!-- table cols="equal" -->              equal columns, natural table width
- *   <!-- table width="100%" cols="equal" --> full width, equal columns
- *   <!-- table cols="12%, auto, 25%" -->     per-column widths
- *
- * width and cols are independent; combine them in one comment or stack
- * comments (later ones win on conflicts). Attribute values take double,
- * single, or no quotes. "100%" is the only width value the preview
- * stylesheet honors. cols entries are positional (the Nth entry sizes the
- * Nth column) and accept percentages ("25%") or bare pixel counts ("160");
- * the HTML width attribute takes nothing else, and its legacy parser
- * silently truncates units like "12ch" to pixels. "equal" expands to
- * (100/N)% per column. Entries beyond the actual column count are dropped;
- * missing ones leave columns auto-sized. Without width="100%" the browser's
- * auto layout treats column widths as hints, so strict sizing needs the
- * full-width form. GitHub ignores HTML comments, so files degrade to a
- * normal table there.
- *
- * Runs after rehype-raw (which materializes comment nodes) and before
- * rehype-sanitize: the sanitizer strips the comment itself and vets the
- * injected markup, so directives cannot bypass it.
- */
+// An HTML comment directly above a table, e.g.
+// <!-- table width="100%" cols="12%, auto, 25%" --> ("equal" divides
+// evenly), sets width and column sizing; GitHub ignores it. Runs after
+// rehype-raw and before rehype-sanitize, which strips the comment and vets
+// the injected markup.
 
 const DIRECTIVE = /^\s*table\s+(\S[\s\S]*)$/;
 const ATTR = /(\w+)=(?:"([^"]*)"|'([^']*)'|([^\s"']+))/g;
 
-// Minimal structural view of hast nodes; avoids depending on the transitive
-// @types/hast package. Shared by the other hand-rolled rehype plugins in
-// this module.
+// Minimal structural view of hast nodes, shared by this module's plugins;
+// avoids depending on the transitive @types/hast package.
 export type HNode = {
   type: string;
   tagName?: string;
@@ -102,15 +79,12 @@ function applyToNextTable(
   table.children = [colgroup, ...(table.children ?? [])];
 }
 
-/* (100/N)% per column: equalizes under fixed layout and, as far as content
- * allows, under auto layout. */
 function equalWidths(count: number): string[] {
   if (count === 0) return [];
   const pct = Math.round(100000 / count) / 1000;
   return Array<string>(count).fill(`${pct}%`);
 }
 
-/** Next element sibling; skips comments and whitespace-only text. */
 function nextElement(siblings: HNode[], from: number): HNode | null {
   for (let i = from; i < siblings.length; i++) {
     const n = siblings[i];

--- a/src/modules/markdown/tableDirectives.ts
+++ b/src/modules/markdown/tableDirectives.ts
@@ -1,0 +1,141 @@
+/**
+ * Table layout directives: an HTML comment immediately before a table
+ * translates into the standard markup markdown-theme.css honors
+ * (`<table width>` + `<colgroup>`), so authoring stays a plain pipe table.
+ *
+ *   <!-- table width="100%" -->              full width, content-sized columns
+ *   <!-- table cols="equal" -->              equal columns, natural table width
+ *   <!-- table width="100%" cols="equal" --> full width, equal columns
+ *   <!-- table cols="12%, auto, 25%" -->     per-column widths
+ *
+ * width and cols are independent; combine them in one comment or stack
+ * comments (later ones win on conflicts). Attribute values take double,
+ * single, or no quotes. "100%" is the only width value the preview
+ * stylesheet honors. cols entries are positional (the Nth entry sizes the
+ * Nth column) and accept percentages ("25%") or bare pixel counts ("160");
+ * the HTML width attribute takes nothing else, and its legacy parser
+ * silently truncates units like "12ch" to pixels. "equal" expands to
+ * (100/N)% per column. Entries beyond the actual column count are dropped;
+ * missing ones leave columns auto-sized. Without width="100%" the browser's
+ * auto layout treats column widths as hints, so strict sizing needs the
+ * full-width form. GitHub ignores HTML comments, so files degrade to a
+ * normal table there.
+ *
+ * Runs after rehype-raw (which materializes comment nodes) and before
+ * rehype-sanitize: the sanitizer strips the comment itself and vets the
+ * injected markup, so directives cannot bypass it.
+ */
+
+const DIRECTIVE = /^\s*table\s+(\S[\s\S]*)$/;
+const ATTR = /(\w+)=(?:"([^"]*)"|'([^']*)'|([^\s"']+))/g;
+
+// Minimal structural view of hast nodes; avoids depending on the transitive
+// @types/hast package. Shared by the other hand-rolled rehype plugins in
+// this module.
+export type HNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HNode[];
+};
+
+export function rehypeTableDirectives() {
+  return (tree: unknown) => {
+    visit(tree as HNode);
+  };
+}
+
+function visit(node: HNode): void {
+  const kids = node.children;
+  if (!kids) return;
+  for (let i = 0; i < kids.length; i++) {
+    const child = kids[i];
+    if (child.type === "comment" && typeof child.value === "string") {
+      const m = DIRECTIVE.exec(child.value);
+      if (m) applyToNextTable(kids, i + 1, m[1]);
+    }
+    visit(child);
+  }
+}
+
+function applyToNextTable(
+  siblings: HNode[],
+  from: number,
+  rawAttrs: string,
+): void {
+  const attrs = new Map<string, string>();
+  for (const m of rawAttrs.matchAll(ATTR)) {
+    attrs.set(m[1], m[2] ?? m[3] ?? m[4] ?? "");
+  }
+  const cols = attrs.get("cols");
+  const width = attrs.get("width");
+  if (!width && !cols) return;
+
+  const table = nextElement(siblings, from);
+  if (table?.tagName !== "table") return;
+
+  if (width) table.properties = { ...table.properties, width };
+  if (!cols) return;
+
+  const count = countColumns(table);
+  const widths =
+    cols === "equal"
+      ? equalWidths(count)
+      : cols
+          .split(",")
+          .map((s) => s.trim())
+          .slice(0, count > 0 ? count : undefined);
+  if (widths.length === 0) return;
+
+  const colgroup: HNode = {
+    type: "element",
+    tagName: "colgroup",
+    properties: {},
+    children: widths.map((w) => ({
+      type: "element",
+      tagName: "col",
+      properties: w && w !== "auto" ? { width: w } : {},
+      children: [],
+    })),
+  };
+  table.children = [colgroup, ...(table.children ?? [])];
+}
+
+/* (100/N)% per column: equalizes under fixed layout and, as far as content
+ * allows, under auto layout. */
+function equalWidths(count: number): string[] {
+  if (count === 0) return [];
+  const pct = Math.round(100000 / count) / 1000;
+  return Array<string>(count).fill(`${pct}%`);
+}
+
+/** Next element sibling; skips comments and whitespace-only text. */
+function nextElement(siblings: HNode[], from: number): HNode | null {
+  for (let i = from; i < siblings.length; i++) {
+    const n = siblings[i];
+    if (n.type === "element") return n;
+    if (n.type === "comment") continue;
+    if (n.type === "text" && (n.value ?? "").trim() === "") continue;
+    return null;
+  }
+  return null;
+}
+
+function countColumns(table: HNode): number {
+  const tr = findFirst(table, "tr");
+  if (!tr?.children) return 0;
+  return tr.children.filter(
+    (c) => c.type === "element" && (c.tagName === "th" || c.tagName === "td"),
+  ).length;
+}
+
+function findFirst(node: HNode, tag: string): HNode | null {
+  for (const c of node.children ?? []) {
+    if (c.type !== "element") continue;
+    if (c.tagName === tag) return c;
+    const found = findFirst(c, tag);
+    if (found) return found;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

GitHub-fidelity markdown preview: markdown files render the way GitHub renders them, built entirely on the app's existing Streamdown renderer with a rebuilt rehype pipeline.

**At a glance:** GitHub-fidelity styling on Terax theme tokens, frontmatter tables, table layout directives, GFM alerts, heading anchors with working TOC links, relative image resolution, live refresh on external file changes, hardened sanitization, static-only rendering, and zero dependency changes.

## Why

Closes #434 (markdown "properly viewed as it is on GitHub"); also covers what #518 asked for, without the extension baggage. Everything rides Streamdown's own pipeline, keeping one markdown renderer in the app.

## How

**Look like GitHub**
- Vendored github-markdown-css (MIT, sindresorhus) mapped onto the app's theme tokens, so custom themes keep working in both light and dark
- Frontmatter renders as a table, like GitHub
- Table layout directives: an HTML comment above a table (`<!-- table width="100%" cols="12%, auto, 25%" -->`) controls width and column sizing. Invisible on GitHub, which renders the plain table

**Behave like GitHub**
- GFM alerts, all five types, matching GitHub's semantics (case-insensitive marker on its own first line, unknown types stay blockquotes, no nesting). Icons are CSS mask data URIs, so the sanitizer stays closed to svg
- Heading anchors with GitHub-slug ids (including the `user-content-` clobber GitHub applies). README TOC links scroll within the pane instead of navigating the webview

**Understand the workspace**
- Relative image paths resolve against the document's directory and load zero-copy through `convertFileSrc`, the same asset-protocol path the editor and media viewer use (#314 pattern)
- The preview re-reads when the file changes on disk (agents, scripts, `git checkout`), wired to the #488 watcher, keeping scroll position; no flash through the loading state

**Pipeline design**
- One markdown renderer in the app: Streamdown, `mode="static"` with `parseIncompleteMarkdown={false}`, preserving the #913 invariant. A 7k-line document is a single parse in roughly 0.6 s, guard-tested
- Passing `rehypePlugins` to Streamdown replaces its internal chain wholesale, so the pipeline is rebuilt from Streamdown's own exported defaults with the feature plugins spliced in: raw, table directives, alerts, heading anchors, local images, then sanitize, then harden. Sanitize runs after every plugin; nothing bypasses it
- Sanitizer additions are enumerated only: `colgroup`/`col` tags, the exact `markdown-alert` class values, and the `asset` scheme for `img src`. A test locks the schema against blanket `className` allowances
- Streamdown's link-safety popup is disabled in the preview only (chat untouched); links open in the OS browser, scheme-limited to http(s)/mailto, with the true destination shown on hover

**Where the lines go** (the diff looks heavy for a preview feature; +3,704 lines total)

| Category | Lines | Share | What it is |
|---|---|---|---|
| Vendored stylesheet | ~1,400 | 39% | github-markdown-css checked in as an auditable source rather than added as a dependency |
| Tests | ~1,300 | 34% | Tests outweigh production code 1.7:1: injection fixtures, watcher race coverage, path-traversal edges, sanitizer schema and asset-scope locks |
| Production code | ~740 | 20% | Six small modules; comments are held to short whys on security invariants and pipeline ordering. |
| Review demo | ~230 | 6% | markdown-preview-demo.md, droppable before merge |
| Lockfile / deps | 0 | 0 | package.json and pnpm-lock.yaml are byte-identical to main |

Net: the hand-written program logic is roughly 660 lines; the rest is stylesheet, tests, documentation and the demo.

## Testing

549 tests green; 59 across the markdown module and shared code components cover the directives, alerts, anchors, image resolution, watch sync, frontmatter, link policy and error boundary. Injection fixtures verify script tags, iframes, style tags, inline event handlers and `javascript:` hrefs (including mixed-case) render inert, while GitHub-allowed raw HTML (`kbd`, `details`, `sub`/`sup`) still renders. The load-bearing external assumptions are pinned by tests: the `assetProtocol` scope the image resolver relies on, and the Streamdown internal tuple shapes the pipeline destructures (a minor bump that reshapes them fails loudly). A pathological-nesting fixture (about 2k nested blockquotes) fails soft inside the pane's error boundary, which logs the contained error. A five-agent review pass (code quality, test coverage, comment accuracy, silent failures, testing-guide adherence) preceded this PR; its findings are folded into the final commits.

Manual flows exercised in `pnpm tauri dev` against markdown-preview-demo.md: all five alert types plus reject cases in light and dark themes, TOC fragment links (including bottom-of-document targets, which surfaced and fixed a scroll-container bug), relative and missing images, Raw/Rendered toggle, and the GitHub side-by-side comparison. Live refresh on external edits is verified end to end: unit and race tests, plus a manual pass with an external process editing the previewed file (pane updated in place, scroll held, no loading flash). Note for reviewers trying this in dev: use a file outside the project root, because Vite full-reloads the dev webview for in-root changes and masks the pane-level refresh.

- [x] `pnpm lint` clean (no new warnings; the 103 pre-existing on main are unchanged)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo clippy` clean: N/A, `src-tauri/` untouched
- [x] (If you touched `src-tauri/`) `cargo nextest run` clean: N/A, `src-tauri/` untouched
- [x] (If you changed a `#[tauri::command]` signature) called out below: N/A, no command signatures changed
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [x] Shells tested (if relevant): N/A, no shell interaction

## Screenshots
Referencing the same file from current build (old) vs. PR branch (new) - I chose dark theme as a wild guess that it's more common than light. It makes some of the elements harder to see when the images are smaller sizes - worth clicking to open for a better visual comparison. As noted below, the test file markdown-preview-demo.md is included in the root directory to help with review (can/should be removed before merge).

Old:
<img width="1124" height="769" alt="image" src="https://github.com/user-attachments/assets/169bd83b-35fb-49b5-9b1e-67afa620f836" />
New (front matter table, list indentation, "inline code" formatting, footnote reference formatting, heading underlines, line spacing, consistent page width):
<img width="1123" height="813" alt="image" src="https://github.com/user-attachments/assets/fa68a54d-bc8a-479c-9d6e-abee82301501" />


Old:
<img width="1124" height="983" alt="image" src="https://github.com/user-attachments/assets/2d86ac03-e7b2-4e5e-99be-f41abef8d36c" />
New (alert formatting, list indentation, list spacing, nested list indentation, nested list numbering, task list formatting):
<img width="1123" height="1183" alt="image" src="https://github.com/user-attachments/assets/da247254-51ef-4161-a69c-21c02e197301" />


Old:
<img width="1123" height="981" alt="image" src="https://github.com/user-attachments/assets/5e36cef3-1178-4dda-b347-1beefd68b58b" />
New (table formatting, table contents formatting, custom column width features):
<img width="1121" height="787" alt="image" src="https://github.com/user-attachments/assets/b57d2c93-9366-4491-bf82-d973736b8bde" />


Old:
<img width="1124" height="689" alt="image" src="https://github.com/user-attachments/assets/d914e251-1254-4ec2-ba9e-3da63139f4b7" />
New (removed broken > run button for shell commands, fixed plain fence formatting, added relative path image resolving):
<img width="1121" height="901" alt="image" src="https://github.com/user-attachments/assets/279d0b62-9a5e-40d6-b47a-0173c4980652" />


Old:
<img width="1125" height="632" alt="image" src="https://github.com/user-attachments/assets/39acb299-60a6-4e2f-916b-66bb1a9979eb" />
New (consistent inline html, slug duplicate fix, horizontal rule formatting, footnote formatting):
<img width="1121" height="700" alt="image" src="https://github.com/user-attachments/assets/fdb211c1-032c-4897-a77b-d3ec97a36063" />

## Notes for reviewer

- One deliberate behavior change: bare relative links (`docs/x.md`) render as plain text instead of the dead anchors the preview produced before; `./x.md` and `#fragment` links keep working. Cross-file navigation is a possible follow-up
- Root-absolute image paths (`/assets/x.png`) pass through unresolved for now; GitHub resolves them against the repo root, and resolving them cleanly wants a workspace-root concept this module does not have
- Size gates green: startup 342.84 kB of 540 kB, total client JS 1.48 MB of 1.5 MB; the markdown stack stays a lazy chunk. Math and mermaid are intentionally not here (math is #714's territory)
- I left a `markdown-preview-demo.md` at root in this PR - it exercises every feature with GitHub's rendering. I can drop it before merge (or move to docs). 
- Happy to split any of the feature groups into separate PRs if that makes reviews easier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hardened Markdown preview supporting YAML frontmatter, GitHub-style alerts, task lists, tables (with width/columns directives), fenced code blocks, images, footnotes, HTML, and heading anchors.
  * Enabled local image URL rewriting, fragment navigation (in-preview scrolling), and safer link handling (external open for `https`/`mailto`, ignored/neutralized for unsafe links).
  * Added live file refresh with safer update behavior and a friendly fallback when rendering fails.
  * Made the “Run in active terminal” control optional for command blocks.
* **Documentation**
  * Added a Markdown preview demo documentation file covering supported features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->