### PR TITLE
feat(terminal): drag explorer paths into terminal

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -170,7 +170,7 @@ export default function App() {
     useState<GitHistorySearchHandle | null>(null);
   const { zoomIn, zoomOut, zoomReset } = useZoom();
   useApplyEditorFontSize();
-  useTerminalFileDrop();
+  const terminalPathDropTarget = useTerminalFileDrop();
   const explorerRef = useRef<FileExplorerHandle>(null);
 
   // Drives session disposal off the pane tree, not React lifecycles —
@@ -1221,6 +1221,7 @@ export default function App() {
                         onPathDeleted={handlePathDeleted}
                         onRevealInTerminal={cdInNewTab}
                         onAttachToAgent={handleAttachFileToAgent}
+                        pathDropTarget={terminalPathDropTarget}
                       />
                     ) : (
                       <SourceControlPanel

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -44,6 +44,7 @@ import type { GitStatusCode } from "./lib/gitStatusUtils";
 import { useGlobalShortcuts } from "@/modules/shortcuts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { GitStatusSnapshot } from "@/modules/ai/lib/native";
+import type { TerminalPathDropTarget } from "@/modules/terminal";
 
 export type FileExplorerHandle = {
   focus: () => void;
@@ -59,6 +60,7 @@ type Props = {
   onPathDeleted?: (path: string) => void;
   onRevealInTerminal?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
+  pathDropTarget?: TerminalPathDropTarget;
   gitStatus?: GitStatusSnapshot | null;
 };
 
@@ -190,6 +192,7 @@ export const FileExplorer = memo(
       onPathDeleted,
       onRevealInTerminal,
       onAttachToAgent,
+      pathDropTarget,
       gitStatus,
     },
     ref,
@@ -264,6 +267,7 @@ export const FileExplorer = memo(
       rootPath: rootPath ?? "",
       isDir: isDirAt,
       onMove: tree.movePath,
+      pathDropTarget,
     });
 
     const fileDrop = useExplorerFileDrop({

--- a/src/modules/explorer/lib/useExplorerDnd.test.ts
+++ b/src/modules/explorer/lib/useExplorerDnd.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { resolveExplorerMoveTarget } from "./useExplorerDnd";
+import { describe, expect, it, vi } from "vitest";
+import {
+  finishExplorerDrag,
+  resolveExplorerMoveTarget,
+} from "./useExplorerDnd";
 
 const directories = new Set(["/repo/src", "/repo/src/components"]);
 const isDir = (path: string) => directories.has(path);
@@ -72,5 +75,34 @@ describe("resolveExplorerMoveTarget", () => {
         isDir,
       ),
     ).toBeNull();
+  });
+});
+
+describe("finishExplorerDrag", () => {
+  it("uses a terminal-targeted drop without moving the explorer item", () => {
+    const pathDropTarget = {
+      updateTarget: vi.fn(() => true),
+      dropPath: vi.fn(() => true),
+      clearTarget: vi.fn(),
+    };
+    const onMove = vi.fn();
+
+    finishExplorerDrag(
+      true,
+      "/repo/file.ts",
+      100,
+      200,
+      null,
+      pathDropTarget,
+      onMove,
+    );
+
+    expect(pathDropTarget.dropPath).toHaveBeenCalledWith(
+      "/repo/file.ts",
+      100,
+      200,
+    );
+    expect(pathDropTarget.clearTarget).toHaveBeenCalledOnce();
+    expect(onMove).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/explorer/lib/useExplorerDnd.test.ts
+++ b/src/modules/explorer/lib/useExplorerDnd.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { resolveExplorerMoveTarget } from "./useExplorerDnd";
+
+const directories = new Set(["/repo/src", "/repo/src/components"]);
+const isDir = (path: string) => directories.has(path);
+
+describe("resolveExplorerMoveTarget", () => {
+  it("moves onto a hovered directory", () => {
+    expect(
+      resolveExplorerMoveTarget(
+        "/repo/file.ts",
+        "/repo",
+        "/repo/src",
+        true,
+        isDir,
+      ),
+    ).toBe("/repo/src");
+  });
+
+  it("uses the parent when hovering a file", () => {
+    expect(
+      resolveExplorerMoveTarget(
+        "/repo/file.ts",
+        "/repo",
+        "/repo/src/index.ts",
+        true,
+        isDir,
+      ),
+    ).toBe("/repo/src");
+  });
+
+  it("uses the root only over empty explorer space", () => {
+    expect(
+      resolveExplorerMoveTarget(
+        "/repo/src/file.ts",
+        "/repo",
+        null,
+        true,
+        isDir,
+      ),
+    ).toBe("/repo");
+  });
+
+  it("does not turn a terminal hover into a root move", () => {
+    expect(
+      resolveExplorerMoveTarget(
+        "/repo/src/file.ts",
+        "/repo",
+        null,
+        false,
+        isDir,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects no-op and recursive directory moves", () => {
+    expect(
+      resolveExplorerMoveTarget(
+        "/repo/src/file.ts",
+        "/repo",
+        "/repo/src",
+        true,
+        isDir,
+      ),
+    ).toBeNull();
+    expect(
+      resolveExplorerMoveTarget(
+        "/repo/src",
+        "/repo",
+        "/repo/src/components",
+        true,
+        isDir,
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/modules/explorer/lib/useExplorerDnd.ts
+++ b/src/modules/explorer/lib/useExplorerDnd.ts
@@ -5,6 +5,11 @@ type Options = {
   rootPath: string;
   isDir: (path: string) => boolean | undefined;
   onMove: (from: string, toDir: string) => void;
+  pathDropTarget?: {
+    updateTarget: (clientX: number, clientY: number) => boolean;
+    dropPath: (path: string, clientX: number, clientY: number) => boolean;
+    clearTarget: () => void;
+  };
 };
 
 const THRESHOLD = 5;
@@ -14,11 +19,39 @@ function parentDir(path: string): string {
   return i > 0 ? path.slice(0, i) : path;
 }
 
+export function resolveExplorerMoveTarget(
+  source: string,
+  rootPath: string,
+  hoveredPath: string | null,
+  insideExplorer: boolean,
+  isDir: (path: string) => boolean | undefined,
+): string | null {
+  if (!insideExplorer) return null;
+  const target = hoveredPath
+    ? isDir(hoveredPath)
+      ? hoveredPath
+      : parentDir(hoveredPath)
+    : rootPath;
+  if (
+    target === source ||
+    target.startsWith(`${source}/`) ||
+    parentDir(source) === target
+  ) {
+    return null;
+  }
+  return target;
+}
+
 // Pointer-based, delegated on the container (no per-row handlers); sidesteps
 // native HTML5 DnD which Tauri intercepts when dragDropEnabled is on. The ghost
 // follows the cursor via direct DOM writes, so dragging re-renders only when the
 // drop target changes, not on every move.
-export function useExplorerDnd({ rootPath, isDir, onMove }: Options) {
+export function useExplorerDnd({
+  rootPath,
+  isDir,
+  onMove,
+  pathDropTarget,
+}: Options) {
   const [dragLabel, setDragLabel] = useState<string | null>(null);
   const [dropTargetDir, setDropTargetDir] = useState<string | null>(null);
 
@@ -27,8 +60,8 @@ export function useExplorerDnd({ rootPath, isDir, onMove }: Options) {
   const dropTargetRef = useRef<string | null>(null);
   const suppressClickRef = useRef(false);
   const cleanupRef = useRef<(() => void) | null>(null);
-  const optsRef = useRef({ rootPath, isDir, onMove });
-  optsRef.current = { rootPath, isDir, onMove };
+  const optsRef = useRef({ rootPath, isDir, onMove, pathDropTarget });
+  optsRef.current = { rootPath, isDir, onMove, pathDropTarget };
 
   const placeGhost = (x: number, y: number) => {
     lastPosRef.current = { x, y };
@@ -62,16 +95,21 @@ export function useExplorerDnd({ rootPath, isDir, onMove }: Options) {
         setDragLabel(name);
       }
       placeGhost(ev.clientX, ev.clientY);
-      const { rootPath, isDir } = optsRef.current;
-      const hit = document
-        .elementFromPoint(ev.clientX, ev.clientY)
-        ?.closest<HTMLElement>("[data-fs-path]");
+      const { rootPath, isDir, pathDropTarget } = optsRef.current;
+      const element = document.elementFromPoint(ev.clientX, ev.clientY);
+      const terminalTargeted =
+        pathDropTarget?.updateTarget(ev.clientX, ev.clientY) ?? false;
+      const hit = element?.closest<HTMLElement>("[data-fs-path]");
       const p = hit?.getAttribute("data-fs-path");
-      const t = p ? (isDir(p) ? p : parentDir(p)) : rootPath;
-      const valid =
-        t !== source && !t.startsWith(`${source}/`) && parentDir(source) !== t
-          ? t
-          : null;
+      const valid = terminalTargeted
+        ? null
+        : resolveExplorerMoveTarget(
+            source,
+            rootPath,
+            p ?? null,
+            element?.closest("[data-explorer-drop]") != null,
+            isDir,
+          );
       if (dropTargetRef.current !== valid) {
         dropTargetRef.current = valid;
         setDropTargetDir(valid);
@@ -86,8 +124,14 @@ export function useExplorerDnd({ rootPath, isDir, onMove }: Options) {
     const end = (commit: boolean) => {
       detach();
       if (!active) return;
-      if (commit && dropTargetRef.current)
+      const { x, y } = lastPosRef.current;
+      const droppedInTerminal =
+        commit &&
+        (optsRef.current.pathDropTarget?.dropPath(source, x, y) ?? false);
+      if (commit && !droppedInTerminal && dropTargetRef.current) {
         optsRef.current.onMove(source, dropTargetRef.current);
+      }
+      optsRef.current.pathDropTarget?.clearTarget();
       suppressClickRef.current = true;
       setTimeout(() => {
         suppressClickRef.current = false;
@@ -112,7 +156,13 @@ export function useExplorerDnd({ rootPath, isDir, onMove }: Options) {
     }
   }, []);
 
-  useEffect(() => () => cleanupRef.current?.(), []);
+  useEffect(
+    () => () => {
+      cleanupRef.current?.();
+      optsRef.current.pathDropTarget?.clearTarget();
+    },
+    [],
+  );
 
   return { ghostRef, dragLabel, dropTargetDir, onPointerDown, onClickCapture };
 }

--- a/src/modules/explorer/lib/useExplorerDnd.ts
+++ b/src/modules/explorer/lib/useExplorerDnd.ts
@@ -1,15 +1,17 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+export type ExplorerPathDropTarget = {
+  updateTarget: (clientX: number, clientY: number) => boolean;
+  dropPath: (path: string, clientX: number, clientY: number) => boolean;
+  clearTarget: () => void;
+};
+
 type Options = {
   rootPath: string;
   isDir: (path: string) => boolean | undefined;
   onMove: (from: string, toDir: string) => void;
-  pathDropTarget?: {
-    updateTarget: (clientX: number, clientY: number) => boolean;
-    dropPath: (path: string, clientX: number, clientY: number) => boolean;
-    clearTarget: () => void;
-  };
+  pathDropTarget?: ExplorerPathDropTarget;
 };
 
 const THRESHOLD = 5;
@@ -40,6 +42,24 @@ export function resolveExplorerMoveTarget(
     return null;
   }
   return target;
+}
+
+export function finishExplorerDrag(
+  commit: boolean,
+  source: string,
+  clientX: number,
+  clientY: number,
+  moveTarget: string | null,
+  pathDropTarget: ExplorerPathDropTarget | undefined,
+  onMove: (from: string, toDir: string) => void,
+): void {
+  const handledByPathTarget =
+    commit &&
+    (pathDropTarget?.dropPath(source, clientX, clientY) ?? false);
+  if (commit && !handledByPathTarget && moveTarget) {
+    onMove(source, moveTarget);
+  }
+  pathDropTarget?.clearTarget();
 }
 
 // Pointer-based, delegated on the container (no per-row handlers); sidesteps
@@ -125,13 +145,15 @@ export function useExplorerDnd({
       detach();
       if (!active) return;
       const { x, y } = lastPosRef.current;
-      const droppedInTerminal =
-        commit &&
-        (optsRef.current.pathDropTarget?.dropPath(source, x, y) ?? false);
-      if (commit && !droppedInTerminal && dropTargetRef.current) {
-        optsRef.current.onMove(source, dropTargetRef.current);
-      }
-      optsRef.current.pathDropTarget?.clearTarget();
+      finishExplorerDrag(
+        commit,
+        source,
+        x,
+        y,
+        dropTargetRef.current,
+        optsRef.current.pathDropTarget,
+        optsRef.current.onMove,
+      );
       suppressClickRef.current = true;
       setTimeout(() => {
         suppressClickRef.current = false;

--- a/src/modules/terminal/index.ts
+++ b/src/modules/terminal/index.ts
@@ -16,7 +16,10 @@ export {
   tabAgentStatus,
   useAgentActivityStore,
 } from "./lib/agentActivity";
-export { useTerminalFileDrop } from "./lib/useTerminalFileDrop";
+export {
+  type TerminalPathDropTarget,
+  useTerminalFileDrop,
+} from "./lib/useTerminalFileDrop";
 export {
   findLeafCwd,
   hasLeaf,

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -13,6 +13,7 @@ import {
   readTerminalClipboard,
   writeTerminalClipboard,
 } from "./terminalClipboard";
+import { pasteIntoTerminal } from "./terminalPaste";
 import { terminalReadlineSequence } from "./keymap";
 
 export const POOL_MAX_SIZE = 5;
@@ -141,10 +142,7 @@ export function poolSlotStats(): PoolSlotStat[] {
 // dropped path as a real paste while a plain shell gets the literal text.
 export function pasteIntoLeaf(leafId: number, text: string): boolean {
   const slot = slots.find((s) => s.currentLeafId === leafId);
-  if (!slot) return false;
-  slot.term.paste(text);
-  slot.term.focus();
-  return true;
+  return pasteIntoTerminal(slot?.term ?? null, text);
 }
 
 function getRecycler(): HTMLDivElement {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -143,6 +143,7 @@ export function pasteIntoLeaf(leafId: number, text: string): boolean {
   const slot = slots.find((s) => s.currentLeafId === leafId);
   if (!slot) return false;
   slot.term.paste(text);
+  slot.term.focus();
   return true;
 }
 

--- a/src/modules/terminal/lib/terminalPaste.test.ts
+++ b/src/modules/terminal/lib/terminalPaste.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import { pasteIntoTerminal } from "./terminalPaste";
+
+describe("pasteIntoTerminal", () => {
+  it("pastes and focuses the resolved terminal", () => {
+    const terminal = { paste: vi.fn(), focus: vi.fn() };
+
+    expect(pasteIntoTerminal(terminal, "/repo/file.ts ")).toBe(true);
+    expect(terminal.paste).toHaveBeenCalledWith("/repo/file.ts ");
+    expect(terminal.focus).toHaveBeenCalledOnce();
+  });
+
+  it("returns false when no terminal is resolved", () => {
+    expect(pasteIntoTerminal(null, "/repo/file.ts ")).toBe(false);
+  });
+});

--- a/src/modules/terminal/lib/terminalPaste.ts
+++ b/src/modules/terminal/lib/terminalPaste.ts
@@ -1,0 +1,14 @@
+export type TerminalPasteTarget = {
+  paste: (text: string) => void;
+  focus: () => void;
+};
+
+export function pasteIntoTerminal(
+  terminal: TerminalPasteTarget | null,
+  text: string,
+): boolean {
+  if (!terminal) return false;
+  terminal.paste(text);
+  terminal.focus();
+  return true;
+}

--- a/src/modules/terminal/lib/useTerminalFileDrop.test.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/platform", () => ({ IS_WINDOWS: false }));
+
+import { createTerminalPathDropTarget } from "./useTerminalFileDrop";
+
+describe("createTerminalPathDropTarget", () => {
+  it("tracks the terminal leaf under the pointer", () => {
+    const setTarget = vi.fn();
+    const target = createTerminalPathDropTarget({
+      leafIdAtPoint: (x, y) => (x === 20 && y === 30 ? 7 : null),
+      paste: vi.fn(),
+      setTarget,
+    });
+
+    expect(target.updateTarget(20, 30)).toBe(true);
+    expect(setTarget).toHaveBeenLastCalledWith(7);
+    expect(target.updateTarget(1, 2)).toBe(false);
+    expect(setTarget).toHaveBeenLastCalledWith(null);
+  });
+
+  it("clears the target and pastes a shell-quoted path", () => {
+    const paste = vi.fn(() => true);
+    const setTarget = vi.fn();
+    const target = createTerminalPathDropTarget({
+      leafIdAtPoint: () => 11,
+      paste,
+      setTarget,
+    });
+
+    expect(target.dropPath("/repo/My File.ts", 40, 50)).toBe(true);
+    expect(setTarget).toHaveBeenCalledWith(null);
+    expect(paste).toHaveBeenCalledWith(11, "'/repo/My File.ts' ");
+  });
+
+  it("clears stale state when a drop misses every terminal", () => {
+    const paste = vi.fn(() => true);
+    const setTarget = vi.fn();
+    const target = createTerminalPathDropTarget({
+      leafIdAtPoint: () => null,
+      paste,
+      setTarget,
+    });
+
+    expect(target.dropPath("/repo/file.ts", 1, 2)).toBe(false);
+    expect(setTarget).toHaveBeenCalledWith(null);
+    expect(paste).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/terminal/lib/useTerminalFileDrop.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.ts
@@ -4,6 +4,12 @@ import { useTerminalDropStore } from "./dropStore";
 import { formatDroppedPaths } from "./quoteShellPath";
 import { pasteIntoLeaf } from "./rendererPool";
 
+export type TerminalPathDropTarget = {
+  updateTarget: (clientX: number, clientY: number) => boolean;
+  dropPath: (path: string, clientX: number, clientY: number) => boolean;
+  clearTarget: () => void;
+};
+
 // Tauri reports the drop point in physical pixels on some platforms and logical
 // on others; only scale down when it overflows the logical viewport.
 function leafIdAt(x: number, y: number): number | null {
@@ -21,10 +27,28 @@ function leafIdAt(x: number, y: number): number | null {
   return Number.isFinite(id) ? id : null;
 }
 
+const terminalPathDropTarget: TerminalPathDropTarget = {
+  updateTarget(clientX, clientY) {
+    const leafId = leafIdAt(clientX, clientY);
+    useTerminalDropStore.getState().setTarget(leafId);
+    return leafId !== null;
+  },
+  dropPath(path, clientX, clientY) {
+    useTerminalDropStore.getState().setTarget(null);
+    const leafId = leafIdAt(clientX, clientY);
+    if (leafId === null) return false;
+    pasteIntoLeaf(leafId, formatDroppedPaths([path]));
+    return true;
+  },
+  clearTarget() {
+    useTerminalDropStore.getState().setTarget(null);
+  },
+};
+
 /** Wires native OS file drops into the terminal pane under the cursor: shows a
  * drop overlay on that pane while dragging, and bracketed-pastes the
  * shell-quoted path(s) on drop. Drops outside any terminal leaf are ignored. */
-export function useTerminalFileDrop(): void {
+export function useTerminalFileDrop(): TerminalPathDropTarget {
   useEffect(() => {
     let disposed = false;
     let unlisten: (() => void) | null = null;
@@ -62,4 +86,6 @@ export function useTerminalFileDrop(): void {
       unlisten?.();
     };
   }, []);
+
+  return terminalPathDropTarget;
 }

--- a/src/modules/terminal/lib/useTerminalFileDrop.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.ts
@@ -10,6 +10,12 @@ export type TerminalPathDropTarget = {
   clearTarget: () => void;
 };
 
+type TerminalPathDropDeps = {
+  leafIdAtPoint: (clientX: number, clientY: number) => number | null;
+  paste: (leafId: number, text: string) => boolean;
+  setTarget: (leafId: number | null) => void;
+};
+
 // Tauri reports the drop point in physical pixels on some platforms and logical
 // on others; only scale down when it overflows the logical viewport.
 function leafIdAt(x: number, y: number): number | null {
@@ -27,23 +33,35 @@ function leafIdAt(x: number, y: number): number | null {
   return Number.isFinite(id) ? id : null;
 }
 
-const terminalPathDropTarget: TerminalPathDropTarget = {
-  updateTarget(clientX, clientY) {
-    const leafId = leafIdAt(clientX, clientY);
-    useTerminalDropStore.getState().setTarget(leafId);
-    return leafId !== null;
-  },
-  dropPath(path, clientX, clientY) {
-    useTerminalDropStore.getState().setTarget(null);
-    const leafId = leafIdAt(clientX, clientY);
-    if (leafId === null) return false;
-    pasteIntoLeaf(leafId, formatDroppedPaths([path]));
-    return true;
-  },
-  clearTarget() {
-    useTerminalDropStore.getState().setTarget(null);
-  },
-};
+export function createTerminalPathDropTarget({
+  leafIdAtPoint,
+  paste,
+  setTarget,
+}: TerminalPathDropDeps): TerminalPathDropTarget {
+  return {
+    updateTarget(clientX, clientY) {
+      const leafId = leafIdAtPoint(clientX, clientY);
+      setTarget(leafId);
+      return leafId !== null;
+    },
+    dropPath(path, clientX, clientY) {
+      setTarget(null);
+      const leafId = leafIdAtPoint(clientX, clientY);
+      if (leafId === null) return false;
+      paste(leafId, formatDroppedPaths([path]));
+      return true;
+    },
+    clearTarget() {
+      setTarget(null);
+    },
+  };
+}
+
+const terminalPathDropTarget = createTerminalPathDropTarget({
+  leafIdAtPoint: leafIdAt,
+  paste: pasteIntoLeaf,
+  setTarget: (leafId) => useTerminalDropStore.getState().setTarget(leafId),
+});
 
 /** Wires native OS file drops into the terminal pane under the cursor: shows a
  * drop overlay on that pane while dragging, and bracketed-pastes the


### PR DESCRIPTION
## What

Allow files and folders dragged from the built-in explorer to be dropped on any terminal pane, inserting the absolute shell-quoted path through bracketed paste and focusing the destination pane.

## Why

The existing terminal drop integration only handled native OS file drags. Terax explorer drags used a separate pointer-based path and could not reach terminal input. Dragging outside the explorer could also be interpreted as moving a nested item to the workspace root.

## How

The explorer drag hook now delegates terminal hit testing and drop delivery to the existing terminal drop service. Explorer move-target resolution is a pure function with regression coverage, and terminal paste keeps the target ready for keyboard input.

## Testing

- [x] pnpm lint completed without errors
- [x] pnpm check-types clean
- [x] pnpm test clean, 487 tests
- [ ] Manual smoke-test of the affected feature
- [ ] If UI, tested in pnpm tauri dev
- [ ] Platforms tested
- [ ] Shells tested

## Screenshots / GIFs

Not included. This reuses the existing terminal drop overlay without introducing a new visual surface.

## Notes for reviewer

No Rust, IPC, dependency, or bundle-size changes. Native OS file drops continue using the same service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled drag-and-drop between the file explorer and terminal panes, including terminal-specific drop targeting.
  * Dropped paths are bracketed-pasted into the targeted terminal with shell-safe path handling.
  * Explorer drag-and-drop now blocks invalid destinations, including recursive and no-op moves.
  * Terminals automatically focus after a successful paste.

* **Bug Fixes**
  * Improved drag-and-drop drop-target cleanup and state clearing across commit/cancel/unmount paths.

* **Tests**
  * Added coverage for explorer move resolution/commit behavior and terminal paste/drop targeting utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->