### PR TITLE
fix(spaces): honor explicit launch directory on boot

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,11 @@ import {
 } from "@/components/ui/resizable";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { consumeLaunchFiles, getLaunchDir } from "@/lib/launchDir";
+import {
+  consumeLaunchFiles,
+  getExplicitLaunchDir,
+  getLaunchDir,
+} from "@/lib/launchDir";
 import { quoteShellArg } from "@/lib/shellQuote";
 import { usePresence } from "@/lib/usePresence";
 import { useZoom } from "@/lib/useZoom";
@@ -219,6 +223,7 @@ export default function App() {
   useSpacesBoot({
     ready: launchCwdResolved,
     launchCwd,
+    explicitLaunchDir: getExplicitLaunchDir() ?? null,
     home,
     allocId,
     replaceTabs,

--- a/src/lib/launchDir.ts
+++ b/src/lib/launchDir.ts
@@ -1,16 +1,28 @@
 import { invoke } from "@tauri-apps/api/core";
 
 let cached: string | undefined;
+let explicitCached: string | undefined;
 
 export async function initLaunchDir(): Promise<void> {
-  const dir =
-    (await invoke<string | null>("get_launch_dir").catch(() => null)) ??
-    (await invoke<string>("workspace_current_dir").catch(() => null));
+  const explicit = await invoke<string | null>("get_launch_dir").catch(
+    () => null,
+  );
+  if (explicit) {
+    explicitCached = explicit.replace(/\\/g, "/");
+    cached = explicitCached;
+    return;
+  }
+
+  const dir = await invoke<string>("workspace_current_dir").catch(() => null);
   cached = dir ? dir.replace(/\\/g, "/") : undefined;
 }
 
 export function getLaunchDir(): string | undefined {
   return cached;
+}
+
+export function getExplicitLaunchDir(): string | undefined {
+  return explicitCached;
 }
 
 /**

--- a/src/modules/spaces/lib/activeSpace.test.ts
+++ b/src/modules/spaces/lib/activeSpace.test.ts
@@ -1,6 +1,12 @@
 import type { WorkspaceEnv } from "@/modules/workspace";
 import { describe, expect, it } from "vitest";
-import { activeSpaceEnv, findActiveSpace, freshTabCwd } from "./activeSpace";
+import type { Tab } from "@/modules/tabs/lib/useTabs";
+import {
+  activeSpaceEnv,
+  applyExplicitLaunchDir,
+  findActiveSpace,
+  freshTabCwd,
+} from "./activeSpace";
 import type { SpaceMeta } from "./store";
 
 function space(over: Partial<SpaceMeta>): SpaceMeta {
@@ -75,5 +81,135 @@ describe("freshTabCwd", () => {
     expect(freshTabCwd(local, null, "C:/work", "C:/Users/me")).toBe("C:/work");
     expect(freshTabCwd(local, null, null, "C:/Users/me")).toBe("C:/Users/me");
     expect(freshTabCwd(local, null, null, null)).toBeNull();
+  });
+});
+
+describe("applyExplicitLaunchDir", () => {
+  function ids(start = 10): () => number {
+    let n = start;
+    return () => n++;
+  }
+
+  function term(
+    over: Partial<Extract<Tab, { kind: "terminal" }>>,
+  ): Extract<Tab, { kind: "terminal" }> {
+    return {
+      id: 1,
+      kind: "terminal",
+      spaceId: "s1",
+      title: "shell",
+      cwd: "C:/old",
+      paneTree: { kind: "leaf", id: 2, cwd: "C:/old" },
+      activeLeafId: 2,
+      ...over,
+    };
+  }
+
+  it("activates an existing local space whose root matches the explicit launch dir", () => {
+    const spaces = [
+      space({ id: "old", root: "C:/old" }),
+      space({ id: "repo", root: "c:\\work\\repo\\" }),
+    ];
+    const tabs: Tab[] = [
+      term({ id: 1, spaceId: "old", cwd: "C:/old" }),
+      term({
+        id: 3,
+        spaceId: "repo",
+        cwd: "C:/work/repo",
+        paneTree: { kind: "leaf", id: 4, cwd: "C:/work/repo" },
+        activeLeafId: 4,
+      }),
+    ];
+
+    const result = applyExplicitLaunchDir({
+      spaces,
+      tabs,
+      launchDir: "C:/work/repo",
+      allocId: ids(),
+      now: () => 100,
+      newSpaceId: () => "new",
+    });
+
+    expect(result.activeSpaceId).toBe("repo");
+    expect(result.activeTabId).toBe(3);
+    expect(result.spaces).toHaveLength(2);
+    expect(result.tabs).toHaveLength(2);
+  });
+
+  it("creates a local space when no existing local root matches", () => {
+    const result = applyExplicitLaunchDir({
+      spaces: [space({ id: "old", root: "C:/old" })],
+      tabs: [term({ id: 1, spaceId: "old" })],
+      launchDir: "D:/work/new-repo",
+      allocId: ids(20),
+      now: () => 123,
+      newSpaceId: () => "sp-new",
+    });
+
+    expect(result.activeSpaceId).toBe("sp-new");
+    const created = result.spaces[result.spaces.length - 1];
+    const createdTab = result.tabs[result.tabs.length - 1];
+    expect(created).toMatchObject({
+      id: "sp-new",
+      name: "new-repo",
+      root: "D:/work/new-repo",
+      env: { kind: "local" },
+      createdAt: 123,
+      updatedAt: 123,
+    });
+    expect(createdTab).toMatchObject({
+      kind: "terminal",
+      spaceId: "sp-new",
+      cwd: "D:/work/new-repo",
+    });
+    expect(result.activeTabId).toBe(createdTab?.id);
+  });
+
+  it("does not match a WSL space for a local explicit launch dir", () => {
+    const result = applyExplicitLaunchDir({
+      spaces: [
+        space({
+          id: "wsl",
+          root: "C:/work/repo",
+          env: { kind: "wsl", distro: "Ubuntu" },
+        }),
+      ],
+      tabs: [],
+      launchDir: "C:/work/repo",
+      allocId: ids(30),
+      now: () => 456,
+      newSpaceId: () => "local",
+    });
+
+    expect(result.activeSpaceId).toBe("local");
+    expect(result.spaces.map((s) => s.id)).toEqual(["wsl", "local"]);
+  });
+
+  it("adds and activates a terminal when the matched space has no launch-dir tab", () => {
+    const result = applyExplicitLaunchDir({
+      spaces: [space({ id: "repo", root: "C:/work/repo" })],
+      tabs: [
+        term({
+          id: 1,
+          spaceId: "repo",
+          cwd: "C:/work/repo/subdir",
+          paneTree: { kind: "leaf", id: 2, cwd: "C:/work/repo/subdir" },
+        }),
+      ],
+      launchDir: "C:/work/repo",
+      allocId: ids(40),
+      now: () => 789,
+      newSpaceId: () => "new",
+    });
+
+    expect(result.activeSpaceId).toBe("repo");
+    expect(result.tabs).toHaveLength(2);
+    const added = result.tabs[result.tabs.length - 1];
+    expect(added).toMatchObject({
+      kind: "terminal",
+      spaceId: "repo",
+      cwd: "C:/work/repo",
+    });
+    expect(result.activeTabId).toBe(added?.id);
   });
 });

--- a/src/modules/spaces/lib/activeSpace.ts
+++ b/src/modules/spaces/lib/activeSpace.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceEnv } from "@/modules/workspace";
 import type { Tab } from "@/modules/tabs/lib/useTabs";
-import { freshTerminalTab } from "./serialize";
+import { basename, freshTerminalTab } from "./serialize";
 import { newSpaceId as makeDefaultSpaceId, type SpaceMeta } from "./store";
 
 export function findActiveSpace(
@@ -30,11 +30,6 @@ export function freshTabCwd(
   home: string | null,
 ): string | null {
   return restoredHome ?? (env.kind === "local" ? (launchCwd ?? home) : null);
-}
-
-function basename(path: string): string {
-  const parts = path.split(/[\\/]/).filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : path;
 }
 
 function localPathKey(path: string | null): string | null {

--- a/src/modules/spaces/lib/activeSpace.ts
+++ b/src/modules/spaces/lib/activeSpace.ts
@@ -1,5 +1,7 @@
 import type { WorkspaceEnv } from "@/modules/workspace";
-import type { SpaceMeta } from "./store";
+import type { Tab } from "@/modules/tabs/lib/useTabs";
+import { freshTerminalTab } from "./serialize";
+import { newSpaceId as makeDefaultSpaceId, type SpaceMeta } from "./store";
 
 export function findActiveSpace(
   spaces: SpaceMeta[],
@@ -28,4 +30,85 @@ export function freshTabCwd(
   home: string | null,
 ): string | null {
   return restoredHome ?? (env.kind === "local" ? (launchCwd ?? home) : null);
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : path;
+}
+
+function localPathKey(path: string | null): string | null {
+  if (!path) return null;
+  let normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  normalized = normalized.replace(
+    /^([a-z]):/,
+    (_, drive: string) => `${drive.toUpperCase()}:`,
+  );
+  return normalized || path;
+}
+
+type ExplicitLaunchDirInput = {
+  spaces: SpaceMeta[];
+  tabs: Tab[];
+  launchDir: string;
+  allocId: () => number;
+  now?: () => number;
+  newSpaceId?: () => string;
+};
+
+export function applyExplicitLaunchDir({
+  spaces,
+  tabs,
+  launchDir,
+  allocId,
+  now = Date.now,
+  newSpaceId: makeSpaceId = makeDefaultSpaceId,
+}: ExplicitLaunchDirInput): {
+  spaces: SpaceMeta[];
+  activeSpaceId: string;
+  tabs: Tab[];
+  activeTabId: number;
+} {
+  const launchKey = localPathKey(launchDir);
+  const existing = spaces.find(
+    (s) => s.env.kind === "local" && localPathKey(s.root) === launchKey,
+  );
+  const nextSpaces = [...spaces];
+  let target = existing;
+
+  if (!target) {
+    const timestamp = now();
+    target = {
+      id: makeSpaceId(),
+      name: basename(launchDir),
+      root: launchDir,
+      env: { kind: "local" },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    nextSpaces.push(target);
+  }
+
+  const existingTab = tabs.find(
+    (t) =>
+      t.kind === "terminal" &&
+      t.spaceId === target.id &&
+      localPathKey(t.cwd ?? null) === launchKey,
+  );
+  if (existingTab) {
+    return {
+      spaces: nextSpaces,
+      activeSpaceId: target.id,
+      tabs,
+      activeTabId: existingTab.id,
+    };
+  }
+
+  const tab = freshTerminalTab(target.id, launchDir, allocId);
+  return {
+    spaces: nextSpaces,
+    activeSpaceId: target.id,
+    tabs: [...tabs, tab],
+    activeTabId: tab.id,
+  };
 }

--- a/src/modules/spaces/lib/serialize.ts
+++ b/src/modules/spaces/lib/serialize.ts
@@ -26,7 +26,7 @@ export type SerializedTab =
   | { kind: "preview"; url: string }
   | { kind: "markdown"; path: string };
 
-function basename(path: string): string {
+export function basename(path: string): string {
   const parts = path.split(/[\\/]/).filter(Boolean);
   return parts.length ? parts[parts.length - 1] : path;
 }

--- a/src/modules/spaces/lib/useSpacesBoot.test.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.test.ts
@@ -1,0 +1,140 @@
+import type { Tab } from "@/modules/tabs/lib/useTabs";
+import { describe, expect, it, vi } from "vitest";
+import type { SpaceMeta, SpaceState } from "./store";
+import { bootSpaces } from "./useSpacesBoot";
+
+function space(over: Partial<SpaceMeta> = {}): SpaceMeta {
+  return {
+    id: "repo",
+    name: "Repo",
+    root: "C:/work/repo",
+    env: { kind: "local" },
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  };
+}
+
+function state(cwd: string): SpaceState {
+  return {
+    tabs: [
+      {
+        kind: "terminal",
+        tree: { kind: "leaf", cwd, active: true },
+      },
+    ],
+    activeTabIndex: 0,
+  };
+}
+
+function ids(start = 10): () => number {
+  let next = start;
+  return () => next++;
+}
+
+function setup(overrides: Record<string, unknown> = {}) {
+  const events: string[] = [];
+  const spaces = [
+    space(),
+    space({ id: "other", name: "Other", root: "C:/work/other" }),
+  ];
+  const deps = {
+    loadAll: vi.fn().mockResolvedValue({
+      spaces,
+      activeId: "repo",
+      states: new Map([
+        ["repo", state("C:/work/repo")],
+        ["other", state("C:/work/other")],
+      ]),
+    }),
+    saveSpacesList: vi.fn(async () => {
+      events.push("save-spaces");
+    }),
+    saveActiveId: vi.fn(async () => {
+      events.push("save-active");
+    }),
+    workspaceAuthorize: vi.fn(async (cwd: string) => {
+      events.push(`authorize:${cwd}`);
+      return cwd;
+    }),
+    hydrate: vi.fn(() => {
+      events.push("hydrate");
+    }),
+    ...overrides,
+  };
+  const params = {
+    launchCwd: "C:/fallback",
+    explicitLaunchDir: "C:/work/repo",
+    home: "C:/Users/test",
+    allocId: ids(),
+    replaceTabs: vi.fn((_: Tab[], __: number) => {
+      events.push("replace-tabs");
+    }),
+    setActiveSpaceForNewTabs: vi.fn(),
+    adoptWorkspaceEnv: vi.fn(async () => {
+      events.push("adopt-local");
+      return "C:/Users/test";
+    }),
+  };
+  return { deps, events, params, spaces };
+}
+
+describe("bootSpaces explicit launch", () => {
+  it("adopts local workspace and hydrates before replacing tabs", async () => {
+    const { deps, events, params, spaces } = setup();
+
+    await bootSpaces(params, deps);
+
+    expect(params.adoptWorkspaceEnv).toHaveBeenCalledWith({ kind: "local" });
+    expect(params.setActiveSpaceForNewTabs).toHaveBeenCalledWith("repo");
+    expect(deps.saveSpacesList).toHaveBeenCalledWith(spaces);
+    expect(deps.saveActiveId).toHaveBeenCalledWith("repo");
+    expect(deps.workspaceAuthorize.mock.calls).toEqual([
+      ["C:/work/repo"],
+      ["C:/work/other"],
+    ]);
+    expect(events.indexOf("adopt-local")).toBeLessThan(
+      events.indexOf("authorize:C:/work/repo"),
+    );
+    expect(events.indexOf("authorize:C:/work/other")).toBeLessThan(
+      events.indexOf("hydrate"),
+    );
+    expect(events.indexOf("save-active")).toBeLessThan(
+      events.indexOf("hydrate"),
+    );
+    expect(events.indexOf("hydrate")).toBeLessThan(
+      events.indexOf("replace-tabs"),
+    );
+    expect(params.replaceTabs).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "terminal",
+          spaceId: "repo",
+          cwd: "C:/work/repo",
+        }),
+      ]),
+      11,
+    );
+  });
+
+  it("hydrates and replaces tabs when external operations fail", async () => {
+    const { deps, events, params, spaces } = setup({
+      saveSpacesList: vi.fn().mockRejectedValue(new Error("save spaces")),
+      saveActiveId: vi.fn().mockRejectedValue(new Error("save active")),
+      workspaceAuthorize: vi.fn().mockRejectedValue(new Error("authorize")),
+    });
+    params.adoptWorkspaceEnv.mockRejectedValue(new Error("adopt"));
+
+    await bootSpaces(params, deps);
+
+    expect(deps.saveSpacesList).toHaveBeenCalledWith(spaces);
+    expect(deps.saveActiveId).toHaveBeenCalledWith("repo");
+    expect(deps.workspaceAuthorize).toHaveBeenCalledWith("C:/work/repo");
+    expect(deps.hydrate).toHaveBeenCalledWith(spaces, "repo", {
+      repo: 0,
+      other: 0,
+    });
+    expect(params.replaceTabs).toHaveBeenCalledOnce();
+    expect(events).toEqual(["hydrate", "replace-tabs"]);
+  });
+});

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -26,6 +26,20 @@ type Params = {
   adoptWorkspaceEnv: (env: WorkspaceEnv) => Promise<string | null>;
 };
 
+type BootParams = Omit<Params, "ready" | "markBooted">;
+
+type BootDependencies = {
+  loadAll: typeof loadAll;
+  saveSpacesList: typeof saveSpacesList;
+  saveActiveId: typeof saveActiveId;
+  workspaceAuthorize: typeof native.workspaceAuthorize;
+  hydrate: (
+    spaces: SpaceMeta[],
+    activeId: string | null,
+    initialActiveIndex?: Record<string, number>,
+  ) => void;
+};
+
 function uniqueCwds(tabs: Tab[]): string[] {
   const set = new Set<string>();
   const walk = (n: PaneNode) => {
@@ -37,6 +51,122 @@ function uniqueCwds(tabs: Tab[]): string[] {
   };
   for (const t of tabs) if (t.kind === "terminal") walk(t.paneTree);
   return [...set];
+}
+
+const defaultBootDependencies: BootDependencies = {
+  loadAll,
+  saveSpacesList,
+  saveActiveId,
+  workspaceAuthorize: (path) => native.workspaceAuthorize(path),
+  hydrate: (spaces, activeId, initialActiveIndex) =>
+    useSpaces.getState().hydrate(spaces, activeId, initialActiveIndex),
+};
+
+export async function bootSpaces(
+  {
+    launchCwd,
+    explicitLaunchDir,
+    home,
+    allocId,
+    replaceTabs,
+    setActiveSpaceForNewTabs,
+    adoptWorkspaceEnv,
+  }: BootParams,
+  deps: BootDependencies = defaultBootDependencies,
+): Promise<void> {
+  const { spaces, activeId, states } = await deps.loadAll();
+
+  if (spaces.length === 0) {
+    const root = launchCwd ?? home ?? null;
+    // Hydrate prefs before reading the saved workspace env.
+    await usePreferencesStore
+      .getState()
+      .init()
+      .catch(() => {});
+    const meta: SpaceMeta = {
+      id: DEFAULT_SPACE_ID,
+      name: "Default",
+      root,
+      env: explicitLaunchDir
+        ? { kind: "local" }
+        : parseWorkspaceScopeKey(
+            usePreferencesStore.getState().defaultWorkspaceEnv,
+          ),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    await deps.saveSpacesList([meta]);
+    await deps.saveActiveId(DEFAULT_SPACE_ID);
+    setActiveSpaceForNewTabs(DEFAULT_SPACE_ID);
+    deps.hydrate([meta], DEFAULT_SPACE_ID);
+    return;
+  }
+
+  const restored: Tab[] = [];
+  for (const space of spaces) {
+    const st = states.get(space.id);
+    if (!st) continue;
+    restored.push(...hydrateTabs(st.tabs, space.id, allocId));
+  }
+
+  const active =
+    activeId && spaces.some((s) => s.id === activeId)
+      ? activeId
+      : spaces[0].id;
+
+  const initialActiveIndex: Record<string, number> = {};
+  for (const [id, st] of states)
+    initialActiveIndex[id] = st.activeTabIndex;
+
+  if (explicitLaunchDir) {
+    const launched = applyExplicitLaunchDir({
+      spaces,
+      tabs: restored,
+      launchDir: explicitLaunchDir,
+      allocId,
+    });
+    setActiveSpaceForNewTabs(launched.activeSpaceId);
+    await adoptWorkspaceEnv({ kind: "local" }).catch(() => null);
+    const authorizeCwds = [
+      ...new Set([explicitLaunchDir, ...uniqueCwds(launched.tabs)]),
+    ];
+    await Promise.allSettled([
+      deps.saveSpacesList(launched.spaces),
+      deps.saveActiveId(launched.activeSpaceId),
+      ...authorizeCwds.map((cwd) => deps.workspaceAuthorize(cwd)),
+    ]);
+    deps.hydrate(
+      launched.spaces,
+      launched.activeSpaceId,
+      initialActiveIndex,
+    );
+    replaceTabs(launched.tabs, launched.activeTabId);
+    return;
+  }
+
+  setActiveSpaceForNewTabs(active);
+
+  // Apply the space's env+home before the fresh-tab fallback and spawns
+  // below; env is set synchronously so cwd resolution picks WSL vs local.
+  const env = activeSpaceEnv(spaces, active);
+  const restoredHome = await adoptWorkspaceEnv(env);
+
+  // Active space must never be empty, else its tab list shows nothing.
+  if (!restored.some((t) => t.spaceId === active)) {
+    const cwd = freshTabCwd(env, restoredHome, launchCwd, home);
+    restored.push(freshTerminalTab(active, cwd, allocId));
+  }
+
+  await Promise.allSettled(
+    uniqueCwds(restored).map((cwd) => deps.workspaceAuthorize(cwd)),
+  );
+
+  deps.hydrate(spaces, active, initialActiveIndex);
+
+  const inActive = restored.filter((t) => t.spaceId === active);
+  const idx = states.get(active)?.activeTabIndex ?? 0;
+  const activeTab = inActive[idx] ?? inActive[0] ?? restored[0];
+  replaceTabs(restored, activeTab.id);
 }
 
 export function useSpacesBoot({
@@ -56,109 +186,19 @@ export function useSpacesBoot({
     if (!ready || done.current) return;
     done.current = true;
 
-    void (async () => {
-      try {
-        const { spaces, activeId, states } = await loadAll();
-
-        if (spaces.length === 0) {
-          const root = launchCwd ?? home ?? null;
-          // Hydrate prefs before reading the saved workspace env.
-          await usePreferencesStore
-            .getState()
-            .init()
-            .catch(() => {});
-          const meta: SpaceMeta = {
-            id: DEFAULT_SPACE_ID,
-            name: "Default",
-            root,
-            env: explicitLaunchDir
-              ? { kind: "local" }
-              : parseWorkspaceScopeKey(
-                  usePreferencesStore.getState().defaultWorkspaceEnv,
-                ),
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          };
-          await saveSpacesList([meta]);
-          await saveActiveId(DEFAULT_SPACE_ID);
-          setActiveSpaceForNewTabs(DEFAULT_SPACE_ID);
-          useSpaces.getState().hydrate([meta], DEFAULT_SPACE_ID);
-          return;
-        }
-
-        const restored: Tab[] = [];
-        for (const space of spaces) {
-          const st = states.get(space.id);
-          if (!st) continue;
-          restored.push(...hydrateTabs(st.tabs, space.id, allocId));
-        }
-
-        const active =
-          activeId && spaces.some((s) => s.id === activeId)
-            ? activeId
-            : spaces[0].id;
-
-        const initialActiveIndex: Record<string, number> = {};
-        for (const [id, st] of states)
-          initialActiveIndex[id] = st.activeTabIndex;
-
-        if (explicitLaunchDir) {
-          const launched = applyExplicitLaunchDir({
-            spaces,
-            tabs: restored,
-            launchDir: explicitLaunchDir,
-            allocId,
-          });
-          setActiveSpaceForNewTabs(launched.activeSpaceId);
-          await adoptWorkspaceEnv({ kind: "local" });
-          await saveSpacesList(launched.spaces);
-          await saveActiveId(launched.activeSpaceId);
-          await native.workspaceAuthorize(explicitLaunchDir);
-          await Promise.allSettled(
-            uniqueCwds(launched.tabs).map((cwd) =>
-              native.workspaceAuthorize(cwd),
-            ),
-          );
-          useSpaces
-            .getState()
-            .hydrate(
-              launched.spaces,
-              launched.activeSpaceId,
-              initialActiveIndex,
-            );
-          replaceTabs(launched.tabs, launched.activeTabId);
-          return;
-        }
-
-        setActiveSpaceForNewTabs(active);
-
-        // Apply the space's env+home before the fresh-tab fallback and spawns
-        // below; env is set synchronously so cwd resolution picks WSL vs local.
-        const env = activeSpaceEnv(spaces, active);
-        const restoredHome = await adoptWorkspaceEnv(env);
-
-        // Active space must never be empty, else its tab list shows nothing.
-        if (!restored.some((t) => t.spaceId === active)) {
-          const cwd = freshTabCwd(env, restoredHome, launchCwd, home);
-          restored.push(freshTerminalTab(active, cwd, allocId));
-        }
-
-        await Promise.allSettled(
-          uniqueCwds(restored).map((cwd) => native.workspaceAuthorize(cwd)),
-        );
-
-        useSpaces.getState().hydrate(spaces, active, initialActiveIndex);
-
-        const inActive = restored.filter((t) => t.spaceId === active);
-        const idx = states.get(active)?.activeTabIndex ?? 0;
-        const activeTab = inActive[idx] ?? inActive[0] ?? restored[0];
-        replaceTabs(restored, activeTab.id);
-      } catch (e) {
+    void bootSpaces({
+      launchCwd,
+      explicitLaunchDir,
+      home,
+      allocId,
+      replaceTabs,
+      setActiveSpaceForNewTabs,
+      adoptWorkspaceEnv,
+    })
+      .catch((e) => {
         console.error("[terax] spaces boot failed:", e);
-      } finally {
-        markBooted();
-      }
-    })();
+      })
+      .finally(markBooted);
   }, [
     ready,
     launchCwd,

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -5,7 +5,11 @@ import { DEFAULT_SPACE_ID } from "@/modules/tabs/lib/useTabs";
 import { isLeaf, type PaneNode } from "@/modules/terminal/lib/panes";
 import { parseWorkspaceScopeKey, type WorkspaceEnv } from "@/modules/workspace";
 import { useEffect, useRef } from "react";
-import { activeSpaceEnv, freshTabCwd } from "./activeSpace";
+import {
+  activeSpaceEnv,
+  applyExplicitLaunchDir,
+  freshTabCwd,
+} from "./activeSpace";
 import { freshTerminalTab, hydrateTabs } from "./serialize";
 import { loadAll, type SpaceMeta, saveActiveId, saveSpacesList } from "./store";
 import { useSpaces } from "./useSpaces";
@@ -13,6 +17,7 @@ import { useSpaces } from "./useSpaces";
 type Params = {
   ready: boolean;
   launchCwd: string | null;
+  explicitLaunchDir: string | null;
   home: string | null;
   allocId: () => number;
   replaceTabs: (tabs: Tab[], activeId: number) => void;
@@ -37,6 +42,7 @@ function uniqueCwds(tabs: Tab[]): string[] {
 export function useSpacesBoot({
   ready,
   launchCwd,
+  explicitLaunchDir,
   home,
   allocId,
   replaceTabs,
@@ -65,9 +71,11 @@ export function useSpacesBoot({
             id: DEFAULT_SPACE_ID,
             name: "Default",
             root,
-            env: parseWorkspaceScopeKey(
-              usePreferencesStore.getState().defaultWorkspaceEnv,
-            ),
+            env: explicitLaunchDir
+              ? { kind: "local" }
+              : parseWorkspaceScopeKey(
+                  usePreferencesStore.getState().defaultWorkspaceEnv,
+                ),
             createdAt: Date.now(),
             updatedAt: Date.now(),
           };
@@ -89,6 +97,39 @@ export function useSpacesBoot({
           activeId && spaces.some((s) => s.id === activeId)
             ? activeId
             : spaces[0].id;
+
+        const initialActiveIndex: Record<string, number> = {};
+        for (const [id, st] of states)
+          initialActiveIndex[id] = st.activeTabIndex;
+
+        if (explicitLaunchDir) {
+          const launched = applyExplicitLaunchDir({
+            spaces,
+            tabs: restored,
+            launchDir: explicitLaunchDir,
+            allocId,
+          });
+          setActiveSpaceForNewTabs(launched.activeSpaceId);
+          await adoptWorkspaceEnv({ kind: "local" });
+          await saveSpacesList(launched.spaces);
+          await saveActiveId(launched.activeSpaceId);
+          await native.workspaceAuthorize(explicitLaunchDir);
+          await Promise.allSettled(
+            uniqueCwds(launched.tabs).map((cwd) =>
+              native.workspaceAuthorize(cwd),
+            ),
+          );
+          useSpaces
+            .getState()
+            .hydrate(
+              launched.spaces,
+              launched.activeSpaceId,
+              initialActiveIndex,
+            );
+          replaceTabs(launched.tabs, launched.activeTabId);
+          return;
+        }
+
         setActiveSpaceForNewTabs(active);
 
         // Apply the space's env+home before the fresh-tab fallback and spawns
@@ -106,9 +147,6 @@ export function useSpacesBoot({
           uniqueCwds(restored).map((cwd) => native.workspaceAuthorize(cwd)),
         );
 
-        const initialActiveIndex: Record<string, number> = {};
-        for (const [id, st] of states)
-          initialActiveIndex[id] = st.activeTabIndex;
         useSpaces.getState().hydrate(spaces, active, initialActiveIndex);
 
         const inActive = restored.filter((t) => t.spaceId === active);
@@ -124,6 +162,7 @@ export function useSpacesBoot({
   }, [
     ready,
     launchCwd,
+    explicitLaunchDir,
     home,
     allocId,
     replaceTabs,


### PR DESCRIPTION
## What
Fix Spaces boot behavior when Terax is launched with an explicit directory. The app now treats the explicit launch directory as the active local workspace, reuses a matching local Space when possible, and opens or activates a terminal tab rooted at that directory.

## Why
Launching Terax for a specific folder could fall back to restored/default Space state instead of honoring the requested launch directory. That could activate the wrong Space, keep a WSL/default env, or miss the intended cwd tab.

## How
Added explicit launch-dir tracking separate from the workspace-current-dir fallback, then routed Spaces boot through a pure helper that matches local Space roots, creates a local Space when needed, and selects a terminal tab for the launch cwd.

## Testing
- [ ] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [ ] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows, unit/static checks only
- [ ] Shells tested (if relevant): N/A

Additional checks:
- [x] `pnpm exec vitest run src/modules/spaces/lib/activeSpace.test.ts --reporter=verbose` passes, 13 tests.
- [x] `git diff --check` exits 0.

Notes on unchecked items:
- `pnpm lint` exits 0, but reports existing warnings outside this PR's touched files.
- `pnpm test -- src/modules/spaces/lib/activeSpace.test.ts` and `pnpm exec vitest run src/app/eager-budget.test.ts --reporter=verbose` hit an existing `src/app/eager-budget.test.ts` `SyntaxError: Invalid or unexpected token`; this file is not modified by this PR.
- Manual app smoke test was not run in this session.

## Screenshots / GIFs
N/A, no visual UI change.

## Notes for reviewer
This keeps the change focused to launch directory handling and Spaces boot logic. It intentionally does not alter restored Spaces for normal launches without an explicit launch directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for launching directly into a specified directory, including explicit directory handling during space boot.
  - Automatically opens or creates the matching local space and terminal tab, reusing existing ones when available.
  - Applies the local workspace environment for explicit launches and persists/restores launched spaces and active selections.

- **Bug Fixes**
  - Prevents incorrect workspace matches by normalizing explicit launch directory paths.
  - Ignores WSL spaces for local explicit launches and creates/activates the required terminal tab when missing.

- **Tests**
  - Added coverage for explicit-launch boot behavior and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->