### PR TITLE
fix(terminal): correct macOS Hangul/CJK IME input

### DIFF
--- a/src/modules/terminal/lib/ime.test.ts
+++ b/src/modules/terminal/lib/ime.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { imeReconstruct } from "./ime";
+
+// Apply a PTY byte stream (text + DEL erases) to a line buffer the way a line
+// editor would, so a sequence of steps can be asserted against the final line.
+function applyToLine(line: string, send: string): string {
+  const buf = [...line];
+  for (const ch of send) {
+    if (ch === "\x7f") buf.pop();
+    else buf.push(ch);
+  }
+  return buf.join("");
+}
+
+describe("imeReconstruct", () => {
+  it("appends a new unit on insertText", () => {
+    expect(imeReconstruct("", "insertText", "ㅇ")).toEqual({
+      send: "ㅇ",
+      unit: "ㅇ",
+    });
+  });
+
+  it("erases the previous unit and resends on insertReplacementText", () => {
+    expect(imeReconstruct("ㅇ", "insertReplacementText", "아")).toEqual({
+      send: "\x7f아",
+      unit: "아",
+    });
+  });
+
+  it("skips a duplicate replacement with identical data (no flicker)", () => {
+    expect(imeReconstruct("잘", "insertReplacementText", "잘")).toBeNull();
+  });
+
+  it("replaces the previous unit on insertCompositionText (composition model)", () => {
+    // Opening a syllable: nothing to erase yet.
+    expect(imeReconstruct("", "insertCompositionText", "ㅇ")).toEqual({
+      send: "ㅇ",
+      unit: "ㅇ",
+    });
+    // Refining it must erase the leading jamo, not append after it.
+    expect(imeReconstruct("ㅇ", "insertCompositionText", "아")).toEqual({
+      send: "\x7f아",
+      unit: "아",
+    });
+  });
+
+  it("commits composed text without re-writing when already on screen", () => {
+    expect(imeReconstruct("아", "insertFromComposition", "아")).toEqual({
+      send: "",
+      unit: "",
+    });
+  });
+
+  it("ignores deleteCompositionText (the commit reconciles)", () => {
+    expect(imeReconstruct("아 ", "deleteCompositionText", "")).toBeNull();
+  });
+
+  it("erases the previous unit on delete, leaving an empty unit", () => {
+    expect(imeReconstruct("녕", "deleteContentBackward", "")).toEqual({
+      send: "\x7f",
+      unit: "",
+    });
+  });
+
+  it("always erases at least one code point on delete", () => {
+    expect(imeReconstruct("", "deleteContentBackward", "")).toEqual({
+      send: "\x7f",
+      unit: "",
+    });
+  });
+
+  it("ignores empty insert data and unknown input types", () => {
+    expect(imeReconstruct("a", "insertText", "")).toBeNull();
+    expect(imeReconstruct("a", "insertFromPaste", "p")).toBeNull();
+    expect(imeReconstruct("a", "historyUndo", "")).toBeNull();
+  });
+
+  // The end-to-end invariant: replaying the WKWebView event trace for a word
+  // must reconstruct exactly that word on the PTY line, with no leaked jamo.
+  it("reconstructs '안녕' from the WKWebView event trace", () => {
+    const trace: Array<[string, string]> = [
+      ["insertText", "ㅇ"],
+      ["insertReplacementText", "아"],
+      ["insertReplacementText", "안"],
+      ["insertReplacementText", "안"],
+      ["insertText", "ㄴ"],
+      ["insertReplacementText", "녀"],
+      ["insertReplacementText", "녕"],
+      ["insertReplacementText", "녕"],
+    ];
+    let unit = "";
+    let line = "";
+    for (const [type, data] of trace) {
+      const step = imeReconstruct(unit, type, data);
+      if (!step) continue;
+      line = applyToLine(line, step.send);
+      unit = step.unit;
+    }
+    expect(line).toBe("안녕");
+  });
+
+  // The composition-event model (current macOS WKWebView): each step carries the
+  // full preedit, a deleteCompositionText clears it, insertFromComposition
+  // commits. Replaying the real '아 ' trace must yield exactly "아 ".
+  it("reconstructs '아 ' from the composition-event trace", () => {
+    const trace: Array<[string, string]> = [
+      ["insertCompositionText", "ㅇ"],
+      ["insertCompositionText", "아"],
+      ["insertCompositionText", "아 "],
+      ["deleteCompositionText", ""],
+      ["insertFromComposition", "아 "],
+    ];
+    let unit = "";
+    let line = "";
+    for (const [type, data] of trace) {
+      const step = imeReconstruct(unit, type, data);
+      if (!step) continue;
+      line = applyToLine(line, step.send);
+      unit = step.unit;
+    }
+    expect(line).toBe("아 ");
+  });
+});

--- a/src/modules/terminal/lib/ime.ts
+++ b/src/modules/terminal/lib/ime.ts
@@ -1,0 +1,44 @@
+// Pure core for the macOS IME reconstruction (see attachImeInput). Maps the
+// last on-screen unit + an InputEvent to the PTY bytes and the new unit.
+// Handles both WKWebView input models: the composition one
+// (insertCompositionText/insertFromComposition) and the plain replacement one
+// (insertText/insertReplacementText).
+export type ImeStep = { send: string; unit: string };
+
+const DEL = "\x7f";
+const cpLen = (s: string): number => [...s].length;
+
+export function imeReconstruct(
+  unit: string,
+  inputType: string,
+  data: string,
+): ImeStep | null {
+  // Replacement-style events carry the full current composing text, which
+  // supersedes the previous on-screen unit (erase it, write the new one).
+  if (
+    inputType === "insertReplacementText" ||
+    inputType === "insertCompositionText"
+  ) {
+    if (!data || data === unit) return null;
+    return { send: DEL.repeat(cpLen(unit)) + data, unit: data };
+  }
+  // Commit: the composed text is finalized. Reconcile against what's on screen
+  // (usually already equal), then clear the unit for the next syllable.
+  if (inputType === "insertFromComposition") {
+    if (data === unit) return { send: "", unit: "" };
+    return { send: DEL.repeat(cpLen(unit)) + (data ?? ""), unit: "" };
+  }
+  // Preedit cleared just before a commit — ignore; insertFromComposition
+  // reconciles. Handling it would flicker on every commit.
+  if (inputType === "deleteCompositionText") return null;
+  // A fresh standalone unit (non-composition input, e.g. other webviews).
+  if (inputType === "insertText") {
+    if (!data) return null;
+    return { send: data, unit: data };
+  }
+  // Backspace and other deletions erase the current unit.
+  if (inputType.startsWith("delete")) {
+    return { send: DEL.repeat(Math.max(1, cpLen(unit))), unit: "" };
+  }
+  return null;
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -8,6 +8,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type FontWeight, Terminal } from "@xterm/xterm";
+import { imeReconstruct } from "./ime";
 import { shouldCursorBlink } from "./cursorBlink";
 import {
   readTerminalClipboard,
@@ -67,6 +68,10 @@ export type Slot = {
   lastW: number;
   lastH: number;
   lastUsedAt: number;
+  imeUnit: string; // last uncommitted macOS IME syllable (see attachImeInput)
+  // Set once a compositionstart is seen: this webview fires real composition
+  // events, so xterm handles IME natively and our reconstruction must defer.
+  imeNative: boolean;
 };
 
 const slots: Slot[] = [];
@@ -202,6 +207,44 @@ export function applyBackgroundActive(active: boolean): void {
   }
 }
 
+// macOS WKWebView sends no composition events for Hangul/CJK, only `input`
+// events; reconstruct them here (the sole PTY writer for typed text on macOS).
+function attachImeInput(slot: Slot): void {
+  if (!IS_MAC) return;
+  const ta = slot.host.querySelector(
+    ".xterm-helper-textarea",
+  ) as HTMLTextAreaElement | null;
+  if (!ta) return;
+  const write = (data: string) => {
+    const leafId = slot.currentLeafId;
+    if (leafId === null) return;
+    adapter?.resolveLeaf(leafId)?.writeToPty(data);
+  };
+  // A real compositionstart means this webview delivers proper composition
+  // events, so xterm assembles the syllable itself and emits the committed text
+  // through onData — defer to it and stop reconstructing.
+  ta.addEventListener("compositionstart", () => {
+    slot.imeNative = true;
+  });
+  ta.addEventListener("input", (e) => {
+    if (slot.imeNative) return;
+    const ev = e as InputEvent;
+    const step = imeReconstruct(slot.imeUnit, ev.inputType, ev.data ?? "");
+    if (!step) return;
+    if (step.send) write(step.send);
+    slot.imeUnit = step.unit;
+  });
+}
+
+function isPrintableOnly(data: string): boolean {
+  if (!data) return false;
+  for (const ch of data) {
+    const c = ch.codePointAt(0) ?? 0;
+    if (c < 0x20 || c === 0x7f) return false;
+  }
+  return true;
+}
+
 function createSlot(): Slot {
   const term = new Terminal(termOptions());
   const fitAddon = new FitAddon();
@@ -244,17 +287,15 @@ function createSlot(): Slot {
     lastW: 0,
     lastH: 0,
     lastUsedAt: 0,
+    imeUnit: "",
+    imeNative: false,
   };
 
+  attachImeInput(slot);
+
   term.attachCustomKeyEventHandler((event) => {
-    // During IME composition the browser is assembling a multi-keystroke
-    // character (Chinese pinyin → hanzi, Korean jamo → syllable, etc.).
-    // Raw keydown events — including the Enter that commits a candidate —
-    // must NOT be forwarded to the PTY; xterm will receive the final
-    // composed string through its own compositionend handler instead.
-    // keyCode 229 ("Process") is what Chromium reports for every key
-    // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // macOS: attachImeInput handles composition; elsewhere xterm does.
+    if (event.isComposing || event.keyCode === 229) return !IS_MAC;
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;
@@ -296,6 +337,12 @@ function createSlot(): Slot {
   });
 
   term.onData((data) => {
+    // Only when the webview does NOT fire composition events (imeNative false)
+    // do we reconstruct — and there we drop xterm's spurious re-delivered
+    // printable so it can't double the jamo. When composition events DO fire,
+    // xterm's onData IS the correct committed text; let it through.
+    if (IS_MAC && !slot.imeNative && isPrintableOnly(data)) return;
+    slot.imeUnit = "";
     const leafId = slot.currentLeafId;
     if (leafId === null) return;
     adapter?.resolveLeaf(leafId)?.writeToPty(data);


### PR DESCRIPTION
## Summary

Fixes Hangul/CJK IME input in the terminal on macOS. Composed text now reaches the PTY correctly, and Latin / symbols / IME switching keep working.

Closes #813.

## Problem

macOS WKWebView surfaces IME input in **two different ways** depending on the OS / webview build, and the terminal only worked in neither:

1. **Composition events fire** (`compositionstart/update/end`). Here xterm's own `CompositionHelper` assembles the syllable and emits the committed text through `onData` — it works, and anything extra we do corrupts it.
2. **No composition events** — the composed stream arrives only as textarea `input` events (`insertText` / `insertReplacementText` / `insertCompositionText`) with `isComposing` false. xterm can't assemble a syllable from that, so Hangul reached the PTY broken.

Reproduction of case 2 (Korean 2-beolsik):

| Typed | Before | After |
|-------|--------|-------|
| `안녕` | `ㅇ아...` (leading jamo split off) | `안녕` |
| `사과` | `ㅅ사과` | `사과` |

## Fix

Detect the mode at runtime and never fight xterm:

- On the first `compositionstart`, mark the slot **native** and get out of the way entirely — xterm owns IME, Latin, and symbols.
- Until/unless that happens, reconstruct the committed stream from the `input` events (`ime.ts`), and drop xterm's spurious re-delivered *printable* `onData` so it can't double the leading jamo. Control sequences and bracketed paste carry control bytes and pass through.

Everything is gated on `IS_MAC` **and** the native flag, so non-macOS and composition-capable webviews run exactly xterm's normal path — zero behavior change there.

## Testing

- `pnpm check-types`, `pnpm lint` — clean.
- `pnpm test` — full suite green; `ime.test.ts` covers the reconstruction core for both the replacement-event trace (`안녕`) and the composition-event trace (`아 `).
- Manual on macOS (WKWebView, 2-beolsik): Hangul composition, spacing, no doubled jamo; Latin, digits, symbols (`!@#$%^&*()_+-=~|?/`), bracketed paste, IME language switching, and Enter / arrows / Backspace all correct.

## Relationship to prior PRs

Builds on the input-reconstruction idea in #623 / #718. Those reconstruct unconditionally, which breaks on webview builds that DO fire composition events (double / scrambled output) and don't dedup xterm's re-delivery. This detects the mode and defers to xterm when it can handle IME itself, reconstructing only when it can't.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS terminal input handling for IME-based languages.
  * Composition, replacement, deletion, and committed text now render correctly without duplicated characters or leaked intermediate symbols.
  * Supports more reliable Unicode-aware editing during terminal input.

* **Bug Fixes**
  * Prevented duplicate IME text and visual flicker during composition.
  * Fixed deletion behavior for composed text, including edge cases involving empty input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->