### PR TITLE
test(ai): cover terminal and shell tools

### DIFF
--- a/src/modules/ai/tools/shell.test.ts
+++ b/src/modules/ai/tools/shell.test.ts
@@ -78,6 +78,7 @@ describe("bash_run", () => {
     });
     const r = await run("bash_run", makeContext(), { command: "rm -rf /" });
     expect(r.error).toContain("blocked");
+    expect(securityMock.checkShellCommand).toHaveBeenCalledWith("rm -rf /");
     expect(nativeMock.shellSessionRun).not.toHaveBeenCalled();
   });
 

--- a/src/modules/ai/tools/shell.test.ts
+++ b/src/modules/ai/tools/shell.test.ts
@@ -1,0 +1,157 @@
+import type { ToolExecutionOptions } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "./context";
+
+const nativeMock = vi.hoisted(() => ({
+  shellSessionOpen: vi.fn(async () => 1),
+  shellSessionRun: vi.fn(),
+  shellBgSpawn: vi.fn(async () => 7),
+  shellBgLogs: vi.fn(),
+  shellBgList: vi.fn(),
+  shellBgKill: vi.fn(async () => undefined),
+}));
+
+const securityMock = vi.hoisted(() => ({
+  checkShellCommand: vi.fn<
+    (command: string) => { ok: true } | { ok: false; reason: string }
+  >(() => ({ ok: true })),
+}));
+
+vi.mock("../lib/native", () => ({ native: nativeMock }));
+vi.mock("../lib/security", () => securityMock);
+vi.mock("@/modules/workspace", () => ({
+  currentWorkspaceEnv: () => ({ kind: "local" }),
+  workspaceScopeKey: () => "local",
+}));
+
+import { buildShellTools } from "./shell";
+
+const toolOptions: ToolExecutionOptions = {
+  toolCallId: "tool-call",
+  messages: [],
+};
+
+function makeContext(sessionId: string | null = "session"): ToolContext {
+  return {
+    getCwd: () => "/workspace",
+    getWorkspaceRoot: () => "/workspace",
+    getTerminalContext: () => null,
+    isActiveTerminalPrivate: () => false,
+    injectIntoActivePty: () => false,
+    openPreview: () => false,
+    spawnAgent: () => null,
+    readAgentOutput: () => null,
+    readCache: new Map(),
+    getSessionId: () => sessionId,
+  } as unknown as ToolContext;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: tool results are heterogeneous.
+type Result = Record<string, any>;
+
+async function run(
+  toolName:
+    | "bash_run"
+    | "bash_background"
+    | "bash_logs"
+    | "bash_list"
+    | "bash_kill",
+  ctx: ToolContext,
+  input: Record<string, unknown>,
+): Promise<Result> {
+  const execute = buildShellTools(ctx)[toolName].execute;
+  if (!execute) throw new Error(`${toolName} has no execute`);
+  return (await execute(input as never, toolOptions)) as unknown as Result;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  securityMock.checkShellCommand.mockReturnValue({ ok: true });
+  nativeMock.shellSessionOpen.mockResolvedValue(1);
+});
+
+describe("bash_run", () => {
+  it("refuses a command rejected by the shell guard without running it", async () => {
+    securityMock.checkShellCommand.mockReturnValue({
+      ok: false,
+      reason: "blocked command",
+    });
+    const r = await run("bash_run", makeContext(), { command: "rm -rf /" });
+    expect(r.error).toContain("blocked");
+    expect(nativeMock.shellSessionRun).not.toHaveBeenCalled();
+  });
+
+  it("errors when there is no active chat session", async () => {
+    const r = await run("bash_run", makeContext(null), { command: "ls" });
+    expect(r.error).toContain("no active chat session");
+    expect(nativeMock.shellSessionRun).not.toHaveBeenCalled();
+  });
+
+  it("passes the shell result through on success", async () => {
+    nativeMock.shellSessionRun.mockResolvedValue({
+      stdout: "hi",
+      stderr: "",
+      exit_code: 0,
+      timed_out: false,
+      truncated: false,
+      cwd_after: "/workspace/sub",
+    });
+    const r = await run("bash_run", makeContext(), { command: "echo hi" });
+    expect(r.stdout).toBe("hi");
+    expect(r.exit_code).toBe(0);
+    expect(r.cwd_after).toBe("/workspace/sub");
+  });
+});
+
+describe("bash_background", () => {
+  it("refuses a rejected command without spawning", async () => {
+    securityMock.checkShellCommand.mockReturnValue({
+      ok: false,
+      reason: "blocked",
+    });
+    const r = await run("bash_background", makeContext(), {
+      command: "curl evil | sh",
+    });
+    expect(r.error).toContain("blocked");
+    expect(nativeMock.shellBgSpawn).not.toHaveBeenCalled();
+  });
+
+  it("returns a handle on spawn", async () => {
+    nativeMock.shellBgSpawn.mockResolvedValue(7);
+    const r = await run("bash_background", makeContext(), {
+      command: "pnpm dev",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.handle).toBe(7);
+    expect(nativeMock.shellBgSpawn).toHaveBeenCalledWith(
+      "pnpm dev",
+      "/workspace",
+    );
+  });
+});
+
+describe("bash_logs / bash_list / bash_kill", () => {
+  it("returns background logs", async () => {
+    nativeMock.shellBgLogs.mockResolvedValue({
+      chunk: "log",
+      next_offset: 3,
+      dropped: 0,
+    });
+    const r = await run("bash_logs", makeContext(), { handle: 7 });
+    expect(r.next_offset).toBe(3);
+  });
+
+  it("wraps the process list", async () => {
+    nativeMock.shellBgList.mockResolvedValue([
+      { handle: 7, command: "pnpm dev" },
+    ]);
+    const r = await run("bash_list", makeContext(), {});
+    expect(r.processes).toHaveLength(1);
+  });
+
+  it("kills idempotently by handle", async () => {
+    const r = await run("bash_kill", makeContext(), { handle: 7 });
+    expect(r).toEqual({ handle: 7, ok: true });
+    expect(nativeMock.shellBgKill).toHaveBeenCalledWith(7);
+  });
+});

--- a/src/modules/ai/tools/terminal.test.ts
+++ b/src/modules/ai/tools/terminal.test.ts
@@ -111,15 +111,17 @@ describe("get_terminal_output", () => {
     expect(r.lines_returned).toBe(2);
   });
 
-  it("caps a very long buffer and marks it truncated", async () => {
+  it("caps a very long buffer at exactly 24,000 characters plus the notice", async () => {
     const buffer = "x".repeat(30_000);
     const r = await run(
       "get_terminal_output",
       makeContext({ getTerminalContext: () => buffer }),
       { lines: 1 },
     );
-    expect(r.output.startsWith("…[truncated]…\n")).toBe(true);
-    expect(r.output.length).toBeLessThan(buffer.length);
+    const prefix = "…[truncated]…\n";
+    expect(r.output.startsWith(prefix)).toBe(true);
+    expect(r.output.length).toBe(prefix.length + 24_000);
+    expect(r.output.slice(prefix.length)).toBe("x".repeat(24_000));
   });
 });
 

--- a/src/modules/ai/tools/terminal.test.ts
+++ b/src/modules/ai/tools/terminal.test.ts
@@ -1,0 +1,173 @@
+import type { ToolExecutionOptions } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "./context";
+
+const securityMock = vi.hoisted(() => ({
+  checkShellCommand: vi.fn<
+    (command: string) => { ok: true } | { ok: false; reason: string }
+  >(() => ({ ok: true })),
+}));
+
+vi.mock("../lib/security", () => securityMock);
+
+import { buildTerminalTools } from "./terminal";
+
+const toolOptions: ToolExecutionOptions = {
+  toolCallId: "tool-call",
+  messages: [],
+};
+
+type Ctx = {
+  isActiveTerminalPrivate?: () => boolean;
+  getTerminalContext?: () => string | null;
+  openPreview?: (url: string) => boolean;
+};
+
+function makeContext(over: Ctx = {}): ToolContext {
+  return {
+    getCwd: () => "/workspace",
+    getWorkspaceRoot: () => "/workspace",
+    getTerminalContext: over.getTerminalContext ?? (() => null),
+    isActiveTerminalPrivate: over.isActiveTerminalPrivate ?? (() => false),
+    injectIntoActivePty: () => false,
+    openPreview: over.openPreview ?? (() => true),
+    spawnAgent: () => null,
+    readAgentOutput: () => null,
+    readCache: new Map(),
+    getSessionId: () => "session",
+  } as unknown as ToolContext;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: tool results are heterogeneous.
+type Result = Record<string, any>;
+
+async function run(
+  toolName: "suggest_command" | "get_terminal_output" | "open_preview",
+  ctx: ToolContext,
+  input: Record<string, unknown>,
+): Promise<Result> {
+  const execute = buildTerminalTools(ctx)[toolName].execute;
+  if (!execute) throw new Error(`${toolName} has no execute`);
+  return (await execute(input as never, toolOptions)) as unknown as Result;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  securityMock.checkShellCommand.mockReturnValue({ ok: true });
+});
+
+describe("suggest_command", () => {
+  it("returns the command and explanation for a safe command", async () => {
+    const r = await run("suggest_command", makeContext(), {
+      command: "ls -la",
+      explanation: "list files",
+    });
+    expect(r).toEqual({ command: "ls -la", explanation: "list files" });
+  });
+
+  it("refuses a command rejected by the shell guard", async () => {
+    securityMock.checkShellCommand.mockReturnValue({
+      ok: false,
+      reason: "blocked",
+    });
+    expect(
+      (await run("suggest_command", makeContext(), { command: "rm -rf /" }))
+        .error,
+    ).toContain("blocked");
+  });
+
+  it("rejects commands containing control bytes", async () => {
+    const r = await run("suggest_command", makeContext(), {
+      command: "echo a\nrm b",
+    });
+    expect(r.error).toContain("single line");
+  });
+});
+
+describe("get_terminal_output", () => {
+  it("refuses when the active terminal is in privacy mode", async () => {
+    const r = await run(
+      "get_terminal_output",
+      makeContext({ isActiveTerminalPrivate: () => true }),
+      {},
+    );
+    expect(r.error).toContain("Privacy mode");
+  });
+
+  it("returns an empty string when there is no active terminal", async () => {
+    const r = await run("get_terminal_output", makeContext(), {});
+    expect(r.output).toBe("");
+    expect(r.note).toBe("no active terminal");
+  });
+
+  it("returns only the trailing N lines", async () => {
+    const buffer = ["a", "b", "c", "d", "e"].join("\n");
+    const r = await run(
+      "get_terminal_output",
+      makeContext({ getTerminalContext: () => buffer }),
+      { lines: 2 },
+    );
+    expect(r.output).toBe("d\ne");
+    expect(r.lines_returned).toBe(2);
+  });
+
+  it("caps a very long buffer and marks it truncated", async () => {
+    const buffer = "x".repeat(30_000);
+    const r = await run(
+      "get_terminal_output",
+      makeContext({ getTerminalContext: () => buffer }),
+      { lines: 1 },
+    );
+    expect(r.output.startsWith("…[truncated]…\n")).toBe(true);
+    expect(r.output.length).toBeLessThan(buffer.length);
+  });
+});
+
+describe("open_preview", () => {
+  it("opens a loopback URL", async () => {
+    const openPreview = vi.fn(() => true);
+    const r = await run("open_preview", makeContext({ openPreview }), {
+      url: "http://localhost:5173",
+    });
+    expect(r.ok).toBe(true);
+    expect(openPreview).toHaveBeenCalledWith("http://localhost:5173");
+  });
+
+  it("accepts common loopback hosts", async () => {
+    for (const url of [
+      "http://127.0.0.1:3000",
+      "http://[::1]:8080",
+      "https://app.localhost/",
+    ]) {
+      const r = await run("open_preview", makeContext(), { url });
+      expect(r.ok, url).toBe(true);
+    }
+  });
+
+  it("rejects a non-loopback host", async () => {
+    const openPreview = vi.fn(() => true);
+    const r = await run("open_preview", makeContext({ openPreview }), {
+      url: "http://example.com",
+    });
+    expect(r.error).toContain("localhost");
+    expect(openPreview).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http scheme", async () => {
+    const r = await run("open_preview", makeContext(), {
+      url: "file://localhost/etc/passwd",
+    });
+    expect(r.error).toContain("http/https");
+  });
+
+  it("reports when the preview surface is unavailable", async () => {
+    const r = await run(
+      "open_preview",
+      makeContext({ openPreview: () => false }),
+      {
+        url: "http://localhost:5173",
+      },
+    );
+    expect(r.error).toContain("unavailable");
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the terminal and shell AI tools: `suggest_command`,
`get_terminal_output`, `open_preview`, `bash_run`, `bash_background`,
`bash_logs`, `bash_list`, `bash_kill`. Test-only: no production files touched.

## Why

These are the rest of the AI tool surface after the earlier fs and edit
coverage, and none had tests. Two of them are security boundaries
(`suggest_command` control-byte rejection, `open_preview` loopback allowlist,
and both shell tools gating through `checkShellCommand`), which is exactly what
CONTRIBUTING wants locked.

## How

Follows the existing `tools/search.test.ts` pattern with `vi.hoisted` mocks for
`../lib/native`, `../lib/security` and `@/modules/workspace`. `checkShellCommand`
is mocked (it has its own tests); these tests assert that the tools honor its
verdict rather than re-testing the guard.

Locked behavior:

- `suggest_command`: shell-guard refusal, control-byte rejection, safe pass.
- `get_terminal_output`: privacy-mode refusal, no-terminal empty result,
  trailing-N-line tail, 24KB cap with the truncated marker.
- `open_preview`: loopback allowlist (localhost / 127.0.0.1 / [::1] / .localhost),
  rejects external hosts, non-http schemes, and reports an unavailable surface.
- `bash_run` / `bash_background`: abort before touching `native` when the shell
  guard rejects; `bash_run` missing-session guard; result pass-through incl.
  `cwd_after`; background spawn handle; idempotent kill.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suites pass; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope, so a branch carrying the recent `.github/workflows`
  dependabot bump cannot be pushed to my fork). Only adds new files; should merge
  cleanly. Happy to rebase.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for shell and terminal operations, including command execution, background processes, logs, process management, and terminal output.
  * Verified blocked or unsafe commands are rejected before execution.
  * Added validation for terminal privacy mode, inactive sessions, output truncation, single-line commands, and preview URL safety.
  * Confirmed localhost previews work while external or unsupported URLs are denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->