### PR TITLE
test(editor): cover LSP server preset resolution

### DIFF
--- a/src/modules/lsp/lib/presets.test.ts
+++ b/src/modules/lsp/lib/presets.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { LspCustomServer } from "@/modules/settings/store";
+import {
+  allServers,
+  LSP_PRESETS,
+  serverById,
+  serverForLanguage,
+  serversForLanguage,
+} from "./presets";
+
+const customPy: LspCustomServer = {
+  id: "my-py",
+  name: "Mine",
+  command: "x",
+  args: [],
+  languages: { py: "python" },
+  rootMarkers: [],
+};
+
+describe("serversForLanguage", () => {
+  it("returns the built-in servers that claim a language", () => {
+    expect(serversForLanguage("py", []).map((p) => p.id)).toEqual([
+      "pyright",
+      "ruff",
+    ]);
+  });
+
+  it("includes matching custom servers after the presets", () => {
+    expect(serversForLanguage("py", [customPy]).map((p) => p.id)).toEqual([
+      "pyright",
+      "ruff",
+      "my-py",
+    ]);
+  });
+
+  it("returns nothing for a null or unknown language", () => {
+    expect(serversForLanguage(null, [])).toEqual([]);
+    expect(serversForLanguage("cobol", [])).toEqual([]);
+  });
+});
+
+describe("serverForLanguage", () => {
+  it("returns the first candidate when no activation is given", () => {
+    expect(serverForLanguage("py", [])?.id).toBe("pyright");
+  });
+
+  it("prefers the enabled server over preset order", () => {
+    expect(serverForLanguage("py", [], { ruff: "enabled" })?.id).toBe("ruff");
+  });
+
+  it("skips a dismissed server and offers the next fresh one", () => {
+    expect(serverForLanguage("py", [], { pyright: "dismissed" })?.id).toBe(
+      "ruff",
+    );
+  });
+
+  it("returns null when nothing claims the language", () => {
+    expect(serverForLanguage("cobol", [])).toBeNull();
+  });
+});
+
+describe("serverById", () => {
+  it("finds a preset by id", () => {
+    expect(serverById("pyright", [])?.id).toBe("pyright");
+  });
+
+  it("finds a custom server by id", () => {
+    expect(serverById("my-py", [customPy])?.name).toBe("Mine");
+  });
+
+  it("returns null for an unknown id", () => {
+    expect(serverById("nope", [])).toBeNull();
+  });
+});
+
+describe("allServers", () => {
+  it("appends custom servers to the presets", () => {
+    expect(allServers([customPy])).toHaveLength(LSP_PRESETS.length + 1);
+  });
+});

--- a/src/modules/lsp/lib/presets.test.ts
+++ b/src/modules/lsp/lib/presets.test.ts
@@ -75,6 +75,11 @@ describe("serverById", () => {
 
 describe("allServers", () => {
   it("appends custom servers to the presets", () => {
-    expect(allServers([customPy])).toHaveLength(LSP_PRESETS.length + 1);
+    const servers = allServers([customPy]);
+    expect(servers).toHaveLength(LSP_PRESETS.length + 1);
+    expect(servers.map((s) => s.id)).toEqual([
+      ...LSP_PRESETS.map((p) => p.id),
+      "my-py",
+    ]);
   });
 });


### PR DESCRIPTION
## What

Adds unit tests for the LSP preset resolvers in `lsp/lib/presets.ts`. Test-only:
no production files touched.

## Why

`serversForLanguage`, `serverForLanguage`, `serverById` and `allServers` decide
which language server handles a file, and the activation precedence in
`serverForLanguage` is non-obvious. None had tests.

## How

Pure functions, tested directly against the built-in `LSP_PRESETS`.

Locked behavior:

- `serversForLanguage`: the built-in servers that claim a language (py -> pyright,
  ruff), custom servers appended after presets, and nothing for a null or unknown
  language.
- `serverForLanguage` precedence: first candidate by default, an `enabled` server
  wins over preset order, and a `dismissed` server is skipped for the next fresh
  candidate.
- `serverById`: preset and custom lookup, null for an unknown id.
- `allServers`: presets plus custom servers.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly. Happy to
  rebase.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for language server preset selection, including built-in and custom servers.
  * Verified language matching, custom-server ordering, and activation states.
  * Added checks for server lookup by ID and combined listings, including count and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->