### PR TITLE
test(git): cover GitError display formatting

### DIFF
--- a/src-tauri/src/modules/git/errors.rs
+++ b/src-tauri/src/modules/git/errors.rs
@@ -107,3 +107,73 @@ impl From<GitError> for String {
 }
 
 pub type Result<T> = std::result::Result<T, GitError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_builds_command_failed() {
+        let err = GitError::command("git status", "fatal: not a repo");
+        match &err {
+            GitError::CommandFailed { context, detail } => {
+                assert_eq!(*context, "git status");
+                assert_eq!(detail, "fatal: not a repo");
+            }
+            other => panic!("expected CommandFailed, got {other:?}"),
+        }
+        assert_eq!(err.to_string(), "git status: fatal: not a repo");
+    }
+
+    #[test]
+    fn command_failed_without_detail_omits_the_colon() {
+        let err = GitError::command("git status", "");
+        assert_eq!(err.to_string(), "git status");
+    }
+
+    #[test]
+    fn too_old_names_found_and_required_versions() {
+        let msg = GitError::TooOld {
+            found: "2.20.0".into(),
+            required: "2.23",
+        }
+        .to_string();
+        assert!(msg.contains("2.20.0"));
+        assert!(msg.contains("2.23"));
+    }
+
+    #[test]
+    fn file_too_large_reports_size_max_and_path() {
+        let msg = GitError::FileTooLarge {
+            path: PathBuf::from("/repo/big.bin"),
+            size: 999,
+            max: 100,
+        }
+        .to_string();
+        assert!(msg.contains("999"));
+        assert!(msg.contains("100"));
+        assert!(msg.contains("big.bin"));
+    }
+
+    #[test]
+    fn timed_out_includes_the_operation() {
+        assert_eq!(
+            GitError::TimedOut("git fetch").to_string(),
+            "git fetch timed out"
+        );
+    }
+
+    #[test]
+    fn empty_commit_message_is_fixed() {
+        assert_eq!(
+            GitError::EmptyCommitMessage.to_string(),
+            "commit message cannot be empty"
+        );
+    }
+
+    #[test]
+    fn converts_into_string_via_display() {
+        let s: String = GitError::NoUpstream.into();
+        assert_eq!(s, GitError::NoUpstream.to_string());
+    }
+}


### PR DESCRIPTION
## What

Adds unit tests for `GitError`'s `Display` implementation and the
`From<GitError> for String` conversion. Test-only: only adds a `#[cfg(test)]`
module to `src-tauri/src/modules/git/errors.rs`.

## Why

The `Display` impl produces the user-facing git error strings shown in the
source-control UI, and one branch has real logic (the `CommandFailed`
empty-detail case that omits the trailing colon). None of it was tested.

## How

Pure formatting tests in an inline `#[cfg(test)] mod tests`.

Locked behavior:

- `GitError::command(..)` builds `CommandFailed`; Display renders `context: detail`.
- `CommandFailed` with empty detail renders just `context` (no trailing colon).
- `TooOld` interpolates the found and required versions.
- `FileTooLarge` reports size, max, and path.
- `TimedOut` and `EmptyCommitMessage` render their fixed text.
- `From<GitError> for String` goes through `Display`.

## Testing

- [x] `cargo nextest run --locked` — the 7 new tests pass (verified via
  `cargo test --locked --lib errors::`).
- [x] The change is confined to a test module; production code is untouched.
- [ ] Frontend `pnpm` checks — N/A, Rust-only change.

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change. No production
  code touched.
- I did not run `cargo fmt` because my local rustfmt version reformats unrelated
  files across the tree; the new test module is written in standard rustfmt style.
  CI does not gate on `cargo fmt`, and clippy/nextest are unaffected.
- Local-only note (not caused by this change): `cargo clippy` fails on my Windows
  checkout with `unused variable: window` at `src/lib.rs:129`, because that
  binding is only consumed under `#[cfg(target_os = "linux")]`. It is present on
  `main` independently of this PR and passes on the Linux CI clippy job.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a test module; should merge cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify Git error messages and formatting.
  * Confirmed consistent handling of command failures, missing details, timeouts, oversized files, outdated versions, empty commit messages, and missing upstream branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->