### PR TITLE
test(git): cover upstream and path normalization helpers

### DIFF
--- a/src-tauri/src/modules/git/utils.rs
+++ b/src-tauri/src/modules/git/utils.rs
@@ -128,6 +128,33 @@ mod tests {
     use super::*;
 
     #[test]
+    fn split_upstream_separates_remote_and_branch() {
+        assert_eq!(
+            split_upstream("origin/main"),
+            (Some("origin".to_string()), Some("main".to_string()))
+        );
+    }
+
+    #[test]
+    fn split_upstream_splits_on_the_first_slash_only() {
+        assert_eq!(
+            split_upstream("origin/feature/x"),
+            (Some("origin".to_string()), Some("feature/x".to_string()))
+        );
+    }
+
+    #[test]
+    fn split_upstream_without_slash_yields_branch_only() {
+        assert_eq!(split_upstream("main"), (None, Some("main".to_string())));
+    }
+
+    #[test]
+    fn normalize_git_path_converts_backslashes_to_slashes() {
+        assert_eq!(normalize_git_path("a\\b\\c"), "a/b/c");
+        assert_eq!(normalize_git_path("a/b"), "a/b");
+    }
+
+    #[test]
     fn safe_pathspec_accepts_normal_paths() {
         assert!(is_safe_pathspec("src/main.rs"));
         assert!(is_safe_pathspec("a/b/c-d_e.txt"));


### PR DESCRIPTION
## What

Adds unit tests for the pure `split_upstream` and `normalize_git_path` helpers in
`src-tauri/src/modules/git/utils.rs`. Test-only: extends the existing
`#[cfg(test)]` module.

## Why

`split_upstream` parses `remote/branch` for the branch/upstream display and
`normalize_git_path` normalizes separators; both are pure and were untested.

## How

Cases added to the existing test module.

Locked behavior:

- `split_upstream`: separates `origin/main` into remote and branch; splits on the
  first slash only, so `origin/feature/x` keeps `feature/x` as the branch; and
  returns `(None, Some(branch))` when there is no slash.
- `normalize_git_path`: converts backslashes to forward slashes and leaves an
  already-forward-slash path unchanged.

## Testing

- [x] `cargo nextest run --locked` — the 4 new tests pass (verified via
  `cargo test --locked --lib git::utils::tests`).
- [x] Change confined to the test module; production code untouched.
- [ ] Frontend `pnpm` checks — N/A, Rust-only change.

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Did not run `cargo fmt` (my local rustfmt version reformats unrelated files);
  the added tests follow the surrounding style. CI does not gate on `cargo fmt`.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only touches a test module; should merge cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Git upstream parsing, including remote and branch separation.
  * Added coverage ensuring Windows-style Git paths are normalized to forward slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->