### PR TITLE
test(agents): cover agent label formatting

### DIFF
--- a/src/modules/agents/lib/format.test.ts
+++ b/src/modules/agents/lib/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { displayAgent } from "./format";
+
+describe("displayAgent", () => {
+  it("maps known agent ids to their display labels", () => {
+    expect(displayAgent("claude")).toBe("Claude Code");
+    expect(displayAgent("codex")).toBe("Codex");
+    expect(displayAgent("pi")).toBe("Pi");
+  });
+
+  it("looks the label up case-insensitively", () => {
+    expect(displayAgent("CLAUDE")).toBe("Claude Code");
+    expect(displayAgent("gEmInI")).toBe("Gemini");
+  });
+
+  it("capitalizes an unknown agent id", () => {
+    expect(displayAgent("foobar")).toBe("Foobar");
+  });
+
+  it("falls back to 'Agent' for an empty id", () => {
+    expect(displayAgent("")).toBe("Agent");
+  });
+});


### PR DESCRIPTION
## What

Adds a unit test for `displayAgent` in `agents/lib/format.ts`. Test-only.

## Why

`displayAgent` renders the agent name shown in agent notifications and status,
but had no test.

## How

Pure function, tested directly.

Locked behavior: known-id label lookup (claude -> "Claude Code"), case-insensitive
lookup, capitalization of an unknown id, and the empty-id fallback to "Agent".

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for agent display labels, including known agents, case-insensitive IDs, unknown IDs, and empty-value fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->