### PR TITLE
test(ai): cover composer slash commands

### DIFF
--- a/src/modules/ai/lib/slashCommands.test.ts
+++ b/src/modules/ai/lib/slashCommands.test.ts
@@ -6,7 +6,7 @@ const planMock = vi.hoisted(() => ({
   toggle: vi.fn(),
 }));
 
-vi.mock("../store/planStore", () => ({
+vi.mock("@/modules/ai/store/planStore", () => ({
   usePlanStore: {
     getState: () => ({
       active: planMock.active,
@@ -88,9 +88,12 @@ describe("tryRunSlashCommand", () => {
   });
 
   it("toggles plan mode with a bare /plan", () => {
-    planMock.active = true; // reflects the state after toggle()
+    planMock.toggle.mockImplementation(() => {
+      planMock.active = true;
+    });
     const out = tryRunSlashCommand("/plan");
     expect(out).toEqual({ kind: "handled", toast: "Plan mode on" });
     expect(planMock.toggle).toHaveBeenCalled();
+    expect(planMock.active).toBe(true);
   });
 });

--- a/src/modules/ai/lib/slashCommands.test.ts
+++ b/src/modules/ai/lib/slashCommands.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const planMock = vi.hoisted(() => ({
+  active: false,
+  disable: vi.fn(),
+  toggle: vi.fn(),
+}));
+
+vi.mock("../store/planStore", () => ({
+  usePlanStore: {
+    getState: () => ({
+      active: planMock.active,
+      disable: planMock.disable,
+      toggle: planMock.toggle,
+    }),
+  },
+}));
+
+import {
+  TERAX_CMD_RE,
+  tryRunSlashCommand,
+  wrapWithCommandMarker,
+} from "./slashCommands";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  planMock.active = false;
+});
+
+describe("wrapWithCommandMarker / TERAX_CMD_RE", () => {
+  it("wraps a prompt with a command marker", () => {
+    expect(wrapWithCommandMarker("hi", "init")).toBe(
+      '<terax-command name="init" />\n\nhi',
+    );
+  });
+
+  it("parses the marker the wrapper emits", () => {
+    const match = wrapWithCommandMarker("body", "plan").match(TERAX_CMD_RE);
+    expect(match?.[1]).toBe("plan");
+  });
+
+  it("captures an optional state attribute", () => {
+    const match = '<terax-command name="plan" state="on" />\n\nx'.match(
+      TERAX_CMD_RE,
+    );
+    expect([match?.[1], match?.[2]]).toEqual(["plan", "on"]);
+  });
+});
+
+describe("tryRunSlashCommand", () => {
+  it("ignores text that is not a slash or hash command", () => {
+    expect(tryRunSlashCommand("hello world")).toEqual({ kind: "none" });
+  });
+
+  it("expands /init into a send-prompt outcome", () => {
+    const out = tryRunSlashCommand("/init");
+    expect(out).toMatchObject({ kind: "send-prompt", commandName: "init" });
+  });
+
+  it("shows usage for /claude-code with no request", () => {
+    expect(tryRunSlashCommand("/claude-code")).toEqual({
+      kind: "handled",
+      toast: "Usage: /claude-code <request>",
+    });
+  });
+
+  it("wraps a /claude-code request into a send-prompt outcome", () => {
+    const out = tryRunSlashCommand("/claude-code fix the bug");
+    expect(out).toMatchObject({
+      kind: "send-prompt",
+      commandName: "claude-code",
+    });
+  });
+
+  it("accepts a known command with the # prefix", () => {
+    expect(tryRunSlashCommand("#init").kind).toBe("send-prompt");
+  });
+
+  it("ignores an unknown # command", () => {
+    expect(tryRunSlashCommand("#nope")).toEqual({ kind: "none" });
+  });
+
+  it("turns plan mode off with /plan off", () => {
+    const out = tryRunSlashCommand("/plan off");
+    expect(out).toEqual({ kind: "handled", toast: "Plan mode off" });
+    expect(planMock.disable).toHaveBeenCalled();
+    expect(planMock.toggle).not.toHaveBeenCalled();
+  });
+
+  it("toggles plan mode with a bare /plan", () => {
+    planMock.active = true; // reflects the state after toggle()
+    const out = tryRunSlashCommand("/plan");
+    expect(out).toEqual({ kind: "handled", toast: "Plan mode on" });
+    expect(planMock.toggle).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the composer slash-command helpers in
`ai/lib/slashCommands.ts`. Test-only.

## Why

`wrapWithCommandMarker`, `TERAX_CMD_RE` and `tryRunSlashCommand` drive the
composer's `/` and `#handle` commands but had no tests.

## How

Pure logic tested directly; the plan store is mocked so the `/plan` branch can be
exercised without touching global state.

Locked behavior:

- `wrapWithCommandMarker` / `TERAX_CMD_RE`: the marker wrap and its round-trip
  through the regex, including the optional `state` attribute.
- `tryRunSlashCommand`: `none` for plain text, `/init` and `/claude-code`
  expansion (with the usage message when no request follows), acceptance of a
  known `#` command, rejection of an unknown one, and `/plan off` vs a bare
  `/plan` toggle.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for slash command handling, including `/init`, `/claude-code`, `/plan`, and `#init`.
  * Verified command markers are generated and parsed correctly, including optional state information.
  * Confirmed appropriate responses for invalid, unknown, and incomplete commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->