### PR TITLE
test(ai): cover todo validation and the todo tool

### DIFF
--- a/src/modules/ai/lib/todos.test.ts
+++ b/src/modules/ai/lib/todos.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { type Todo, validateTodos } from "./todos";
+
+function todo(over: Partial<Todo> = {}): Todo {
+  return { id: "t1", title: "task", status: "pending", ...over };
+}
+
+describe("validateTodos", () => {
+  it("accepts an empty list", () => {
+    expect(validateTodos([])).toBeNull();
+  });
+
+  it("accepts a list with a single in_progress item", () => {
+    expect(
+      validateTodos([
+        todo({ id: "a", status: "in_progress" }),
+        todo({ id: "b", status: "pending" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("rejects an empty or whitespace title", () => {
+    expect(validateTodos([todo({ title: "" })])).toContain("title");
+    expect(validateTodos([todo({ title: "   " })])).toContain("title");
+  });
+
+  it("rejects more than one in_progress item", () => {
+    const err = validateTodos([
+      todo({ id: "a", status: "in_progress" }),
+      todo({ id: "b", status: "in_progress" }),
+    ]);
+    expect(err).toContain("in_progress");
+    expect(err).toContain("2");
+  });
+});

--- a/src/modules/ai/tools/todo.test.ts
+++ b/src/modules/ai/tools/todo.test.ts
@@ -1,0 +1,88 @@
+import type { ToolExecutionOptions } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "./context";
+
+const storeMock = vi.hoisted(() => ({ setTodos: vi.fn() }));
+
+vi.mock("../store/todoStore", () => ({
+  useTodosStore: { getState: () => ({ setTodos: storeMock.setTodos }) },
+}));
+
+import { buildTodoTools } from "./todo";
+
+const toolOptions: ToolExecutionOptions = {
+  toolCallId: "tool-call",
+  messages: [],
+};
+
+function makeContext(sessionId: string | null = "session"): ToolContext {
+  return {
+    getCwd: () => "/workspace",
+    getWorkspaceRoot: () => "/workspace",
+    getTerminalContext: () => null,
+    isActiveTerminalPrivate: () => false,
+    injectIntoActivePty: () => false,
+    openPreview: () => false,
+    spawnAgent: () => null,
+    readAgentOutput: () => null,
+    readCache: new Map(),
+    getSessionId: () => sessionId,
+  } as unknown as ToolContext;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: tool results are heterogeneous.
+type Result = Record<string, any>;
+
+async function run(
+  ctx: ToolContext,
+  input: Record<string, unknown>,
+): Promise<Result> {
+  const execute = buildTodoTools(ctx).todo_write.execute;
+  if (!execute) throw new Error("todo_write has no execute");
+  return (await execute(input as never, toolOptions)) as unknown as Result;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("todo_write", () => {
+  it("errors when there is no active session", async () => {
+    const r = await run(makeContext(null), { todos: [] });
+    expect(r.error).toContain("no active session");
+    expect(storeMock.setTodos).not.toHaveBeenCalled();
+  });
+
+  it("persists todos and reports the count and current item", async () => {
+    const r = await run(makeContext(), {
+      todos: [
+        { id: "a", title: "first", status: "in_progress" },
+        { id: "b", title: "second", status: "pending" },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.count).toBe(2);
+    expect(r.inProgress).toBe("first");
+    expect(storeMock.setTodos).toHaveBeenCalledWith(
+      "session",
+      expect.any(Array),
+    );
+  });
+
+  it("assigns an id to a todo that lacks one", async () => {
+    await run(makeContext(), {
+      todos: [{ title: "no id yet", status: "pending" }],
+    });
+    const persisted = storeMock.setTodos.mock.calls[0][1];
+    expect(persisted[0].id).toBeTruthy();
+  });
+
+  it("rejects an invalid batch without persisting", async () => {
+    const r = await run(makeContext(), {
+      todos: [
+        { id: "a", title: "x", status: "in_progress" },
+        { id: "b", title: "y", status: "in_progress" },
+      ],
+    });
+    expect(r.error).toContain("in_progress");
+    expect(storeMock.setTodos).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for `validateTodos` and the `todo_write` AI tool. Test-only.

## Why

`validateTodos` guards the agent's todo list and `todo_write` persists it (part
of the AI tool surface); neither had tests.

## How

`validateTodos` is pure, tested directly. `todo_write` is tested against the real
validator with only the todos store mocked.

Locked behavior:

- `validateTodos`: empty-list and single-in_progress accept paths, empty/whitespace
  title rejection, and rejection when more than one item is in_progress (count in
  the message).
- `todo_write`: no-session guard, persistence with the reported count and current
  in_progress title, id assignment for a todo that lacks one, and rejection of an
  invalid batch before anything is persisted.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suites pass; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds new files; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.
