### PR TITLE
test(ai): cover run_subagent tool

### DIFF
--- a/src/modules/ai/tools/subagent.test.ts
+++ b/src/modules/ai/tools/subagent.test.ts
@@ -1,0 +1,78 @@
+import type { ToolExecutionOptions } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "./context";
+
+const runSubagentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/runSubagent", () => ({ runSubagent: runSubagentMock }));
+vi.mock("../store/chatStore", () => ({
+  useChatStore: {
+    getState: () => ({
+      apiKeys: {},
+      selectedModelId: "model",
+      patchAgentMeta: vi.fn(),
+    }),
+  },
+}));
+
+import { buildSubagentTools } from "./subagent";
+
+const toolOptions: ToolExecutionOptions = {
+  toolCallId: "tool-call",
+  messages: [],
+};
+
+function makeContext(): ToolContext {
+  return {
+    getCwd: () => "/workspace",
+    getWorkspaceRoot: () => "/workspace",
+    getTerminalContext: () => null,
+    isActiveTerminalPrivate: () => false,
+    injectIntoActivePty: () => false,
+    openPreview: () => false,
+    spawnAgent: () => null,
+    readAgentOutput: () => null,
+    readCache: new Map(),
+    getSessionId: () => "session",
+  } as unknown as ToolContext;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: tool results are heterogeneous.
+type Result = Record<string, any>;
+
+async function run(input: Record<string, unknown>): Promise<Result> {
+  const execute = buildSubagentTools(makeContext()).run_subagent.execute;
+  if (!execute) throw new Error("run_subagent has no execute");
+  return (await execute(input as never, toolOptions)) as unknown as Result;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("run_subagent", () => {
+  it("maps the subagent result fields on success", async () => {
+    runSubagentMock.mockResolvedValue({
+      summary: "done",
+      stepCount: 4,
+      durationMs: 1200,
+    });
+    const r = await run({
+      type: "reviewer",
+      prompt: "review it",
+      description: "card",
+    });
+    expect(r).toEqual({
+      type: "reviewer",
+      description: "card",
+      summary: "done",
+      stepCount: 4,
+      durationMs: 1200,
+    });
+  });
+
+  it("returns an error result instead of throwing when the subagent fails", async () => {
+    runSubagentMock.mockRejectedValue(new Error("boom"));
+    const r = await run({ type: "reviewer", prompt: "review it" });
+    expect(r.type).toBe("reviewer");
+    expect(r.error).toContain("boom");
+  });
+});


### PR DESCRIPTION
## What

Adds a unit test for the `run_subagent` AI tool, the last untested tool on the AI
tool surface. Test-only.

## Why

With the earlier fs, edit, terminal, shell, agent, context and todo tool PRs,
`run_subagent` was the only tool in `src/modules/ai/tools/` without a test.

## How

Follows the established `vi.hoisted` mock pattern: `runSubagent` and the chat
store are mocked so the test exercises the tool's result mapping and error
handling.

Locked behavior:

- Success maps the subagent result fields (summary, stepCount, durationMs)
  alongside the requested type and description.
- A failing subagent yields an error result carrying the type, instead of
  throwing.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.
