### PR TITLE
test(shortcuts): cover command palette availability logic

### DIFF
--- a/src/modules/command-palette/commands.test.ts
+++ b/src/modules/command-palette/commands.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "@/modules/tabs";
+import {
+  type CommandPaletteActionContext,
+  createCommandItems,
+} from "./commands";
+
+function terminalTab(id: number): Tab {
+  return {
+    id,
+    kind: "terminal",
+    spaceId: "s",
+    title: "shell",
+    paneTree: { kind: "leaf", id: id * 10 },
+    activeLeafId: id * 10,
+  } as unknown as Tab;
+}
+
+function baseContext(
+  over: Partial<CommandPaletteActionContext> = {},
+): CommandPaletteActionContext {
+  const noop = () => {};
+  return {
+    tabs: [terminalTab(1)],
+    activeId: 1,
+    searchTarget: "content" as never,
+    explorerRoot: "/workspace",
+    home: "/home/me",
+    spaces: [],
+    activeSpaceId: null,
+    openNewTab: noop,
+    openNewBlock: noop,
+    openNewPrivate: noop,
+    openNewEditor: noop,
+    openNewPreview: noop,
+    openGitGraph: noop,
+    toggleSourceControl: noop,
+    closeActiveTabOrPane: noop,
+    splitPaneRight: noop,
+    splitPaneDown: noop,
+    focusSearch: noop,
+    focusExplorerSearch: noop,
+    toggleSidebar: noop,
+    toggleAi: noop,
+    askAiSelection: noop,
+    openSettings: noop,
+    openKeyboardShortcuts: noop,
+    openSpacesOverview: noop,
+    newSpace: noop,
+    switchSpace: noop,
+    ...over,
+  };
+}
+
+function reasonById(over: Partial<CommandPaletteActionContext>, id: string) {
+  const item = createCommandItems(baseContext(over)).find((i) => i.id === id);
+  if (!item) throw new Error(`no command item ${id}`);
+  return item.disabledReason;
+}
+
+describe("createCommandItems", () => {
+  it("enables split on a terminal tab below the pane limit", () => {
+    expect(reasonById({}, "pane.splitRight")).toBeUndefined();
+    expect(reasonById({}, "pane.splitDown")).toBeUndefined();
+  });
+
+  it("disables split when there is no terminal tab", () => {
+    const editorTab = { ...terminalTab(1), kind: "editor" } as unknown as Tab;
+    expect(reasonById({ tabs: [editorTab] }, "pane.splitRight")).toBe(
+      "No terminal tab",
+    );
+  });
+
+  it("disables close on the last tab with a single pane", () => {
+    expect(reasonById({}, "tab.close")).toBe("Last tab");
+  });
+
+  it("enables close when more than one tab is open", () => {
+    expect(
+      reasonById({ tabs: [terminalTab(1), terminalTab(2)] }, "tab.close"),
+    ).toBeUndefined();
+  });
+
+  it("disables content search when there is no searchable view", () => {
+    expect(reasonById({ searchTarget: null as never }, "search.focus")).toBe(
+      "No searchable view",
+    );
+  });
+
+  it("disables explorer search when there is no workspace root", () => {
+    expect(reasonById({ explorerRoot: null }, "explorer.search")).toBe(
+      "No workspace root",
+    );
+  });
+
+  it("marks the active space as the current one", () => {
+    const reason = reasonById(
+      { spaces: [{ id: "sp1", name: "One" }], activeSpaceId: "sp1" },
+      "spaces.switch.sp1",
+    );
+    expect(reason).toBe("Current space");
+  });
+});


### PR DESCRIPTION
## What

Adds a unit test for `createCommandItems` in `command-palette/commands.ts`,
covering the availability (disabledReason) logic. Test-only.

## Why

The command palette gates several actions on the current state (pane count,
tab count, searchable view, workspace root, active space) and that logic was
untested.

## How

Pure function, tested by building an action context and asserting each gated
item's `disabledReason`.

Locked behavior:

- Split enabled on a terminal tab below the pane limit; disabled ("No terminal
  tab") when there is no terminal tab.
- Close disabled ("Last tab") on the last single-pane tab; enabled with more
  tabs.
- Content search disabled ("No searchable view") without a searchable view.
- Explorer search disabled ("No workspace root") without a workspace root.
- The active space is marked as the current one.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.
