### PR TITLE
test(wsl): cover WSL command output decoding

### DIFF
--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -623,6 +623,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn decode_command_output_reads_plain_utf8() {
+        assert_eq!(decode_command_output(b"hello world"), "hello world");
+    }
+
+    #[test]
+    fn decode_command_output_strips_utf16le_bom() {
+        // BOM (FF FE) followed by "hi" as little-endian UTF-16.
+        let bytes = [0xff, 0xfe, 0x68, 0x00, 0x69, 0x00];
+        assert_eq!(decode_command_output(&bytes), "hi");
+    }
+
+    #[test]
+    fn decode_command_output_detects_bomless_utf16le() {
+        // "test" as little-endian UTF-16, no BOM; the odd-position NULs trip the
+        // heuristic.
+        let bytes = [0x74, 0x00, 0x65, 0x00, 0x73, 0x00, 0x74, 0x00];
+        assert_eq!(decode_command_output(&bytes), "test");
+    }
+
+    #[test]
+    fn decode_command_output_keeps_ascii_without_nuls_as_utf8() {
+        assert_eq!(decode_command_output(b"C:\\Users"), "C:\\Users");
+    }
+
+    #[test]
     fn distro_validator_accepts_real_names() {
         assert!(is_safe_distro_name("Ubuntu"));
         assert!(is_safe_distro_name("Ubuntu-22.04"));


### PR DESCRIPTION
## What

Adds unit tests for `decode_command_output` in
`src-tauri/src/modules/workspace.rs`. Test-only: extends the existing
`#[cfg(all(test, windows))]` module.

## Why

`decode_command_output` turns raw WSL command bytes into a `String`, handling
both UTF-8 and the UTF-16LE that Windows tools emit. It had no tests.

## How

Cases added to the existing Windows test module (the function is Windows-only).

Locked behavior:

- Plain UTF-8 passthrough.
- Stripping of a UTF-16LE BOM (FF FE).
- Detection of BOM-less UTF-16LE via the odd-position-NUL heuristic.
- Leaving ASCII without NULs as UTF-8.

## Testing

- [x] `cargo nextest run --locked` on Windows — the 4 new tests pass (verified via
  `cargo test --locked --lib workspace::tests::decode`).
- [x] Change confined to the test module; production code untouched.
- The tests are Windows-gated (matching the function), so they run on the
  `windows-latest` CI job and are compiled out on the Linux job.

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Did not run `cargo fmt` (my local rustfmt version reformats unrelated files);
  the added tests follow the surrounding style. CI does not gate on `cargo fmt`.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only touches a test module; should merge cleanly.
