### PR TITLE
test(shortcuts): cover command palette MRU ranking

### DIFF
--- a/src/modules/command-palette/lib/mru.test.ts
+++ b/src/modules/command-palette/lib/mru.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { mruRank, mruSnapshot, recordUse } from "./mru";
+
+describe("mruRank", () => {
+  it("returns the recorded timestamp for a known id", () => {
+    expect(mruRank({ a: 5, b: 9 }, "b")).toBe(9);
+  });
+
+  it("returns 0 for an id not in the snapshot", () => {
+    expect(mruRank({ a: 5 }, "missing")).toBe(0);
+  });
+
+  it("returns 0 against an empty snapshot", () => {
+    expect(mruRank({}, "anything")).toBe(0);
+  });
+});
+
+describe("mru persistence without localStorage", () => {
+  // The vitest node environment has no localStorage; the store must degrade
+  // gracefully rather than throw.
+  it("returns an empty snapshot when storage is unavailable", () => {
+    expect(mruSnapshot()).toEqual({});
+  });
+
+  it("does not throw when recording a use", () => {
+    expect(() => recordUse("some.command")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the command-palette MRU helpers in
`command-palette/lib/mru.ts`. Test-only.

## Why

`mruRank` ranks palette entries by recency and the store is backed by
localStorage; neither the ranking nor the graceful-degradation path was tested.

## How

`mruRank` is pure and tested directly. The persistence tests run in the vitest
node environment, which has no localStorage, so they also lock that the store
degrades gracefully rather than throwing.

Locked behavior:

- `mruRank`: recorded timestamp for a known id, 0 for a missing id or an empty
  snapshot.
- Without localStorage: `mruSnapshot` returns an empty object and `recordUse`
  does not throw.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.
