### PR TITLE
test(theme): cover builtin theme registry

### DIFF
--- a/src/modules/theme/themes/index.test.ts
+++ b/src/modules/theme/themes/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_THEME_ID } from "../types";
-import { getBuiltinTheme, getDefaultTheme, listBuiltinThemes } from "./index";
+import { DEFAULT_THEME_ID } from "@/modules/theme/types";
+import {
+  getBuiltinTheme,
+  getDefaultTheme,
+  listBuiltinThemes,
+} from "@/modules/theme/themes/index";
 
 describe("builtin theme registry", () => {
   it("exposes a non-empty list of themes", () => {
@@ -22,9 +26,14 @@ describe("builtin theme registry", () => {
     expect(getBuiltinTheme("no-such-theme")).toBeUndefined();
   });
 
-  it("resolves the default theme to a registered theme, not the fallback", () => {
+  it("resolves the default theme through the registered-theme lookup", () => {
+    expect(getDefaultTheme()).toBe(getBuiltinTheme(DEFAULT_THEME_ID));
+  });
+
+  it("falls back to the first registered theme if the default is missing", () => {
     const ids = listBuiltinThemes().map((t) => t.id);
-    expect(ids).toContain(DEFAULT_THEME_ID);
-    expect(getDefaultTheme().id).toBe(DEFAULT_THEME_ID);
+    expect(ids).not.toContain("__fallback__");
+    expect(getBuiltinTheme("__fallback__")).toBeUndefined();
+    expect(getDefaultTheme()).toBe(listBuiltinThemes()[0]);
   });
 });

--- a/src/modules/theme/themes/index.test.ts
+++ b/src/modules/theme/themes/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_THEME_ID } from "../types";
+import { getBuiltinTheme, getDefaultTheme, listBuiltinThemes } from "./index";
+
+describe("builtin theme registry", () => {
+  it("exposes a non-empty list of themes", () => {
+    expect(listBuiltinThemes().length).toBeGreaterThan(0);
+  });
+
+  it("has a unique id per theme", () => {
+    const ids = listBuiltinThemes().map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("resolves every listed theme by its id", () => {
+    for (const theme of listBuiltinThemes()) {
+      expect(getBuiltinTheme(theme.id)).toBe(theme);
+    }
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getBuiltinTheme("no-such-theme")).toBeUndefined();
+  });
+
+  it("resolves the default theme to a registered theme, not the fallback", () => {
+    const ids = listBuiltinThemes().map((t) => t.id);
+    expect(ids).toContain(DEFAULT_THEME_ID);
+    expect(getDefaultTheme().id).toBe(DEFAULT_THEME_ID);
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the builtin theme registry in `theme/themes/index.ts`.
Test-only.

## Why

`listBuiltinThemes`, `getBuiltinTheme` and `getDefaultTheme` back the theme
system, and a registration mistake (a duplicate theme id, or a `DEFAULT_THEME_ID`
that no theme actually uses) would silently degrade the default without any
compile error. Nothing tested those invariants.

## How

Pure registry functions, tested directly.

Locked behavior:

- A non-empty theme list with a unique id per theme.
- Every listed theme is resolvable by its id via `getBuiltinTheme`, and an
  unknown id returns undefined.
- `getDefaultTheme` resolves to a registered theme: `DEFAULT_THEME_ID` is present
  in the registry, so the result is the real default and not the `BUILTIN[0]`
  fallback.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the built-in theme registry.
  * Verified theme IDs are unique, themes resolve correctly, unknown IDs are handled safely, and the default theme is registered properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->