### PR TITLE
test(git-history): cover graph rail width

### DIFF
--- a/src/modules/git-history/GraphRail.test.ts
+++ b/src/modules/git-history/GraphRail.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { MAX_VISIBLE_LANES, railWidth } from "./GraphRail";
+
+describe("railWidth", () => {
+  it("uses the same minimum width for zero and one lane", () => {
+    expect(railWidth(0)).toBe(railWidth(1));
+  });
+
+  it("grows as lanes are added", () => {
+    expect(railWidth(2)).toBeGreaterThan(railWidth(1));
+    expect(railWidth(3)).toBeGreaterThan(railWidth(2));
+  });
+
+  it("clamps the width once the visible-lane cap is reached", () => {
+    const capped = railWidth(MAX_VISIBLE_LANES);
+    expect(railWidth(MAX_VISIBLE_LANES + 1)).toBe(capped);
+    expect(railWidth(100)).toBe(capped);
+  });
+});


### PR DESCRIPTION
## What

Adds a unit test for `railWidth` in `git-history/GraphRail.tsx`. Test-only.

## Why

`railWidth` sizes the commit graph rail from the lane count, with a clamp at the
visible-lane cap; that logic was untested. Complements the earlier `layoutGraph`
coverage.

## How

Pure function, tested directly.

Locked behavior:

- Zero and one lane share the same minimum width.
- Width grows as lanes are added.
- Width clamps once the visible-lane cap is reached (extra lanes past the cap do
  not widen the rail).

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify graph rail widths remain consistent for minimal lanes.
  * Confirmed widths increase appropriately with additional lanes.
  * Verified widths are capped when lane counts exceed the visible limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->