### PR TITLE
test(shortcuts): cover shortcut label override resolution

### DIFF
--- a/src/modules/shortcuts/lib/shortcutLabel.test.ts
+++ b/src/modules/shortcuts/lib/shortcutLabel.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { KeyBinding } from "../shortcuts";
+
+const prefsMock = vi.hoisted(() => ({
+  shortcuts: {} as Record<string, KeyBinding[]>,
+}));
+
+vi.mock("@/modules/settings/preferences", () => ({
+  usePreferencesStore: {
+    getState: () => ({ shortcuts: prefsMock.shortcuts }),
+  },
+}));
+
+import { shortcutLabel } from "./shortcutLabel";
+
+beforeEach(() => {
+  prefsMock.shortcuts = {};
+});
+
+describe("shortcutLabel", () => {
+  it("formats the default binding when there is no user override", () => {
+    // commandPalette.open defaults to Ctrl+P.
+    expect(shortcutLabel("commandPalette.open")).toBe("Ctrl P");
+  });
+
+  it("prefers a user override over the default binding", () => {
+    prefsMock.shortcuts = {
+      "commandPalette.open": [{ ctrl: true, shift: true, key: "k" }],
+    };
+    expect(shortcutLabel("commandPalette.open")).toBe("Ctrl Shift K");
+  });
+});


### PR DESCRIPTION
## What

Adds a unit test for `shortcutLabel` in `shortcuts/lib/shortcutLabel.ts`.
Test-only.

## Why

`shortcutLabel` renders a shortcut's display tokens for imperative callers (e.g.
toasts) and resolves user overrides over the default binding; that resolution
was untested.

## How

The preferences store is mocked so overrides can be controlled; `SHORTCUTS` and
`getBindingTokens` stay real.

Locked behavior:

- Formats the default binding when there is no user override (commandPalette.open
  -> "Ctrl P" in the test environment).
- A user override wins over the default binding.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change. The token
  branch is deterministic in the vitest node environment (no Tauri OS plugin, so
  `IS_MAC` is false), matching the earlier shortcuts test.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify shortcut labels display default keybindings correctly.
  * Added coverage to confirm customized keybindings are formatted and displayed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->