### PR TITLE
test(explorer): cover file icon resolution chain

### DIFF
--- a/src/modules/explorer/lib/iconResolver.test.ts
+++ b/src/modules/explorer/lib/iconResolver.test.ts
@@ -39,4 +39,20 @@ describe("folderIconUrl", () => {
   it("returns an inline svg data url", () => {
     expect(folderIconUrl("src", false)).toContain("data:image/svg");
   });
+
+  it("uses distinct open and closed icons for a mapped folder", () => {
+    const closed = folderIconUrl("src", false);
+    const expanded = folderIconUrl("src", true);
+    expect(expanded).toContain("data:image/svg");
+    expect(expanded).not.toBe(closed);
+  });
+
+  it("differs from the confirmed unknown-folder fallback when mapped", () => {
+    const fallback = folderIconUrl("qzxwv-dir", false);
+    const fallbackExpanded = folderIconUrl("qzxwv-dir", true);
+    expect(fallback).toContain("data:image/svg");
+    expect(fallbackExpanded).toContain("data:image/svg");
+    expect(fallbackExpanded).not.toBe(fallback);
+    expect(folderIconUrl("src", false)).not.toBe(fallback);
+  });
 });

--- a/src/modules/explorer/lib/iconResolver.test.ts
+++ b/src/modules/explorer/lib/iconResolver.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { fileIconUrl, folderIconUrl } from "./iconResolver";
+
+// These assertions lock the resolution chain (by-name, extension, compound
+// extension, and default fallback) rather than the icon SVGs themselves, so
+// they stay valid when the underlying icon set changes.
+const DEFAULT = fileIconUrl("file-with-no-known-extension");
+
+describe("fileIconUrl resolution chain", () => {
+  it("returns an inline svg data url", () => {
+    expect(fileIconUrl("a.ts")).toContain("data:image/svg");
+  });
+
+  it("is deterministic for the same extension", () => {
+    expect(fileIconUrl("a.ts")).toBe(fileIconUrl("b.ts"));
+  });
+
+  it("resolves a known extension to something other than the default", () => {
+    expect(fileIconUrl("a.ts")).not.toBe(DEFAULT);
+  });
+
+  it("distinguishes a compound extension from its base", () => {
+    // .test.tsx should resolve differently from a plain .tsx.
+    expect(fileIconUrl("component.test.tsx")).not.toBe(
+      fileIconUrl("component.tsx"),
+    );
+  });
+
+  it("resolves a by-name match (no extension) to a non-default icon", () => {
+    expect(fileIconUrl("Dockerfile")).not.toBe(DEFAULT);
+  });
+
+  it("falls back to the default for an unknown extension", () => {
+    expect(fileIconUrl("mystery.qzxwv")).toBe(DEFAULT);
+  });
+});
+
+describe("folderIconUrl", () => {
+  it("returns an inline svg data url", () => {
+    expect(folderIconUrl("src", false)).toContain("data:image/svg");
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for the file/folder icon resolution chain in
`explorer/lib/iconResolver.ts`. Test-only.

## Why

`fileIconUrl` resolves which icon a file gets through a by-name -> extension ->
compound-extension -> default fallback chain, and that resolution logic was
untested.

## How

The assertions lock the resolution *algorithm*, not the icon SVGs: they compare
outputs relationally (known vs default, base vs compound extension, by-name vs
default), so they stay valid when the underlying icon set changes.

Locked behavior:

- Returns an inline svg data url.
- Deterministic per extension.
- A known extension resolves to something other than the default.
- A compound extension (.test.tsx) resolves differently from its base (.tsx).
- A by-name match (Dockerfile) is non-default.
- An unknown extension falls back to the default.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (unchanged: 103 pre-existing warnings, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (the new suite passes; see reviewer note on one
  pre-existing suite)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched a couple of commits behind current `main` on purpose (my token lacks
  the `workflow` scope). Only adds a new file; should merge cleanly.
- Same unrelated pre-existing failure noted before: `src/app/eager-budget.test.ts`
  fails locally under Windows with `git core.autocrlf=true`; the committed blob is
  LF and it passes on CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for file and folder icon resolution.
  * Verified consistent icon generation, support for known and compound file extensions, filename-based matches, and fallback behavior for unknown types.
  * Confirmed that generated icons are available as inline SVG data URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->