### PR TITLE
feat(fs): natural (numeric-aware) sort for the file tree

### DIFF
--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
@@ -58,10 +59,56 @@ fn git_non_ignored_names(dir: &Path, show_hidden: bool) -> HashSet<String> {
         .collect()
 }
 
+/// Natural (numeric-aware) case-insensitive ordering, so `"file10"` sorts after
+/// `"file9"` instead of after `"file1"`. Runs of ASCII digits compare as numbers
+/// (leading zeros ignored, then original length breaks the tie for stability);
+/// everything else compares one char at a time, lowercased. Non-ASCII (e.g.
+/// Hangul) falls back to code-point order, matching the previous behavior.
+fn natural_cmp(a: &str, b: &str) -> Ordering {
+    let mut ai = a.chars().peekable();
+    let mut bi = b.chars().peekable();
+    loop {
+        match (ai.peek().copied(), bi.peek().copied()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(ca), Some(cb)) => {
+                if ca.is_ascii_digit() && cb.is_ascii_digit() {
+                    let na: String =
+                        std::iter::from_fn(|| ai.next_if(char::is_ascii_digit)).collect();
+                    let nb: String =
+                        std::iter::from_fn(|| bi.next_if(char::is_ascii_digit)).collect();
+                    let ta = na.trim_start_matches('0');
+                    let tb = nb.trim_start_matches('0');
+                    // Longer significant run = larger number; same length -> lexical.
+                    let ord = ta.len().cmp(&tb.len()).then_with(|| ta.cmp(tb));
+                    if ord != Ordering::Equal {
+                        return ord;
+                    }
+                    // Equal value: fewer leading zeros first, for a stable total order.
+                    let ord = na.len().cmp(&nb.len());
+                    if ord != Ordering::Equal {
+                        return ord;
+                    }
+                } else {
+                    let la = ca.to_ascii_lowercase();
+                    let lb = cb.to_ascii_lowercase();
+                    if la != lb {
+                        return la.cmp(&lb);
+                    }
+                    ai.next();
+                    bi.next();
+                }
+            }
+        }
+    }
+}
+
 /// Lists immediate children of `path`. Dirs first, then files, each sorted
-/// case-insensitively. Dot-prefixed entries (files and dirs) are hidden unless
-/// `show_hidden` is set. `git_decorations` opts into the per-entry `gitignored`
-/// flag; off by default so non-explorer callers pay nothing.
+/// with `natural_cmp` (numeric-aware, case-insensitive). Dot-prefixed entries
+/// (files and dirs) are hidden unless `show_hidden` is set. `git_decorations`
+/// opts into the per-entry `gitignored` flag; off by default so non-explorer
+/// callers pay nothing.
 #[tauri::command]
 pub fn fs_read_dir(
     path: String,
@@ -139,7 +186,7 @@ pub fn fs_read_dir(
         };
         rank(&a.kind)
             .cmp(&rank(&b.kind))
-            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+            .then_with(|| natural_cmp(&a.name, &b.name))
     });
 
     Ok(entries)
@@ -175,6 +222,49 @@ pub fn list_subdirs(
         .filter(|name| show_hidden || !name.starts_with('.'))
         .collect();
 
-    dirs.sort_by_key(|a| a.to_lowercase());
+    dirs.sort_by(|a, b| natural_cmp(a, b));
     Ok(dirs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::natural_cmp;
+    use std::cmp::Ordering;
+
+    fn sorted(mut v: Vec<&str>) -> Vec<&str> {
+        v.sort_by(|a, b| natural_cmp(a, b));
+        v
+    }
+
+    #[test]
+    fn numbers_sort_as_values_not_lexically() {
+        assert_eq!(
+            sorted(vec!["17", "170", "18", "3", "20", "171", "9"]),
+            vec!["3", "9", "17", "18", "20", "170", "171"],
+        );
+    }
+
+    #[test]
+    fn numbers_embedded_in_names() {
+        assert_eq!(
+            sorted(vec!["10-x-plan.md", "2-x-plan.md", "1-x-plan.md"]),
+            vec!["1-x-plan.md", "2-x-plan.md", "10-x-plan.md"],
+        );
+    }
+
+    #[test]
+    fn case_insensitive_and_hangul_stable() {
+        assert_eq!(natural_cmp("Apple", "apple"), Ordering::Equal);
+        assert_eq!(sorted(vec!["b", "A", "c"]), vec!["A", "b", "c"]);
+        // Hangul falls back to code-point order, deterministic.
+        assert_eq!(sorted(vec!["나", "가", "다"]), vec!["가", "나", "다"]);
+    }
+
+    #[test]
+    fn leading_zeros_are_a_total_order() {
+        // Same value, differing zero padding: never Equal, and antisymmetric.
+        assert_eq!(natural_cmp("007", "7"), Ordering::Greater);
+        assert_eq!(natural_cmp("7", "007"), Ordering::Less);
+        assert_eq!(sorted(vec!["v007", "v7", "v08"]), vec!["v7", "v007", "v08"]);
+    }
 }

--- a/src-tauri/src/modules/fs/tree.rs
+++ b/src-tauri/src/modules/fs/tree.rs
@@ -59,49 +59,70 @@ fn git_non_ignored_names(dir: &Path, show_hidden: bool) -> HashSet<String> {
         .collect()
 }
 
-/// Natural (numeric-aware) case-insensitive ordering, so `"file10"` sorts after
-/// `"file9"` instead of after `"file1"`. Runs of ASCII digits compare as numbers
-/// (leading zeros ignored, then original length breaks the tie for stability);
-/// everything else compares one char at a time, lowercased. Non-ASCII (e.g.
-/// Hangul) falls back to code-point order, matching the previous behavior.
-fn natural_cmp(a: &str, b: &str) -> Ordering {
-    let mut ai = a.chars().peekable();
-    let mut bi = b.chars().peekable();
+fn natural_cmp_inner(a: &str, b: &str) -> Ordering {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    let mut ai = 0;
+    let mut bi = 0;
+
     loop {
-        match (ai.peek().copied(), bi.peek().copied()) {
+        match (a.get(ai).copied(), b.get(bi).copied()) {
             (None, None) => return Ordering::Equal,
             (None, Some(_)) => return Ordering::Less,
             (Some(_), None) => return Ordering::Greater,
-            (Some(ca), Some(cb)) => {
-                if ca.is_ascii_digit() && cb.is_ascii_digit() {
-                    let na: String =
-                        std::iter::from_fn(|| ai.next_if(char::is_ascii_digit)).collect();
-                    let nb: String =
-                        std::iter::from_fn(|| bi.next_if(char::is_ascii_digit)).collect();
-                    let ta = na.trim_start_matches('0');
-                    let tb = nb.trim_start_matches('0');
-                    // Longer significant run = larger number; same length -> lexical.
-                    let ord = ta.len().cmp(&tb.len()).then_with(|| ta.cmp(tb));
+            (Some(ac), Some(bc)) => {
+                if ac.is_ascii_digit() && bc.is_ascii_digit() {
+                    let a_end = ai
+                        + a[ai..]
+                            .iter()
+                            .take_while(|byte| byte.is_ascii_digit())
+                            .count();
+                    let b_end = bi
+                        + b[bi..]
+                            .iter()
+                            .take_while(|byte| byte.is_ascii_digit())
+                            .count();
+                    let a_run = &a[ai..a_end];
+                    let b_run = &b[bi..b_end];
+                    let a_zeros = a_run.iter().take_while(|byte| **byte == b'0').count();
+                    let b_zeros = b_run.iter().take_while(|byte| **byte == b'0').count();
+                    let a_number = &a_run[a_zeros..];
+                    let b_number = &b_run[b_zeros..];
+
+                    let ord = a_number.len().cmp(&b_number.len());
                     if ord != Ordering::Equal {
                         return ord;
                     }
-                    // Equal value: fewer leading zeros first, for a stable total order.
-                    let ord = na.len().cmp(&nb.len());
+                    let ord = a_number.cmp(b_number);
                     if ord != Ordering::Equal {
                         return ord;
                     }
+                    let ord = a_run.len().cmp(&b_run.len());
+                    if ord != Ordering::Equal {
+                        return ord;
+                    }
+                    ai = a_end;
+                    bi = b_end;
                 } else {
-                    let la = ca.to_ascii_lowercase();
-                    let lb = cb.to_ascii_lowercase();
-                    if la != lb {
-                        return la.cmp(&lb);
+                    let ord = ac.to_ascii_lowercase().cmp(&bc.to_ascii_lowercase());
+                    if ord != Ordering::Equal {
+                        return ord;
                     }
-                    ai.next();
-                    bi.next();
+                    ai += 1;
+                    bi += 1;
                 }
             }
         }
     }
+}
+
+fn natural_cmp(a: &str, b: &str) -> Ordering {
+    let a_folded = (!a.is_ascii()).then(|| a.to_lowercase());
+    let b_folded = (!b.is_ascii()).then(|| b.to_lowercase());
+    natural_cmp_inner(
+        a_folded.as_deref().unwrap_or(a),
+        b_folded.as_deref().unwrap_or(b),
+    )
 }
 
 /// Lists immediate children of `path`. Dirs first, then files, each sorted
@@ -253,10 +274,16 @@ mod tests {
     }
 
     #[test]
-    fn case_insensitive_and_hangul_stable() {
+    fn case_insensitive() {
         assert_eq!(natural_cmp("Apple", "apple"), Ordering::Equal);
+        assert_eq!(natural_cmp("École", "école"), Ordering::Equal);
+        assert_eq!(natural_cmp("Б2", "б2"), Ordering::Equal);
         assert_eq!(sorted(vec!["b", "A", "c"]), vec!["A", "b", "c"]);
-        // Hangul falls back to code-point order, deterministic.
+        assert_eq!(sorted(vec!["École", "éclair"]), vec!["éclair", "École"]);
+    }
+
+    #[test]
+    fn non_cased_unicode_keeps_code_point_order() {
         assert_eq!(sorted(vec!["나", "가", "다"]), vec!["가", "나", "다"]);
     }
 
@@ -266,5 +293,33 @@ mod tests {
         assert_eq!(natural_cmp("007", "7"), Ordering::Greater);
         assert_eq!(natural_cmp("7", "007"), Ordering::Less);
         assert_eq!(sorted(vec!["v007", "v7", "v08"]), vec!["v7", "v007", "v08"]);
+    }
+
+    #[test]
+    fn long_numbers_compare_without_overflow() {
+        assert_eq!(
+            natural_cmp("file99999999999999999999", "file100000000000000000000"),
+            Ordering::Less,
+        );
+    }
+
+    #[test]
+    fn comparator_is_antisymmetric_and_transitive() {
+        let names = [
+            "", "A", "a", "É", "é", "Б", "б", "0", "00", "1", "file2", "file02", "file10", "가",
+        ];
+
+        for a in names {
+            for b in names {
+                assert_eq!(natural_cmp(a, b), natural_cmp(b, a).reverse());
+                for c in names {
+                    if natural_cmp(a, b) != Ordering::Greater
+                        && natural_cmp(b, c) != Ordering::Greater
+                    {
+                        assert_ne!(natural_cmp(a, c), Ordering::Greater);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src-tauri/tests/fs_search.rs
+++ b/src-tauri/tests/fs_search.rs
@@ -243,14 +243,30 @@ fn read_dir_orders_dirs_before_files_then_alpha() {
     let fx = FsFixture::new();
     fx.mkdir("zdir");
     fx.mkdir("adir");
+    fx.mkdir("dir10");
+    fx.mkdir("dir2");
     fx.write("zfile.txt", "");
     fx.write("afile.txt", "");
+    fx.write("file10.txt", "");
+    fx.write("file2.txt", "");
 
     let entries = fs_read_dir(fx.root_str(), false, None, None).expect("read_dir");
     let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
-    assert_eq!(names, vec!["adir", "zdir", "afile.txt", "zfile.txt"]);
+    assert_eq!(
+        names,
+        vec![
+            "adir",
+            "dir2",
+            "dir10",
+            "zdir",
+            "afile.txt",
+            "file2.txt",
+            "file10.txt",
+            "zfile.txt",
+        ],
+    );
     assert!(matches!(entries[0].kind, EntryKind::Dir));
-    assert!(matches!(entries[2].kind, EntryKind::File));
+    assert!(matches!(entries[4].kind, EntryKind::File));
 }
 
 #[test]
@@ -319,12 +335,12 @@ fn read_dir_returns_size_for_files() {
 #[test]
 fn list_subdirs_returns_only_directories() {
     let fx = FsFixture::new();
-    fx.mkdir("dir_a");
-    fx.mkdir("dir_b");
+    fx.mkdir("dir_10");
+    fx.mkdir("dir_2");
     fx.write("not_a_dir.txt", "");
 
     let dirs = list_subdirs(fx.root_str(), false, None).expect("list_subdirs");
-    assert_eq!(dirs, vec!["dir_a", "dir_b"]);
+    assert_eq!(dirs, vec!["dir_2", "dir_10"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The file explorer sorted entries lexically, so numbered files and folders came out in the wrong order — `17, 170, 171, 18, 19` instead of `17, 18, 19, ... 170, 171`.

## Fix

`fs_read_dir` (and `list_subdirs`) now order names with a small `natural_cmp`:

- runs of ASCII digits compare as **numbers** (leading zeros ignored; original length breaks ties for a stable total order),
- everything else compares char-by-char, lowercased (unchanged from before),
- non-ASCII (e.g. Hangul) keeps code-point order.

Folder/file grouping (`rank`) is untouched — only the within-group order changes. No new dependency.

## Testing

- `cargo test` — added unit tests covering numeric ordering, embedded numbers, case-insensitivity, Hangul, and leading-zero total-order.
- `cargo clippy --all-targets -- -D warnings` — clean.

## Before / After

Given `3, 9, 17, 18, 20, 170, 171` on disk:

| Before | After |
|--------|-------|
| `17, 170, 171, 18, 20, 3, 9` | `3, 9, 17, 18, 20, 170, 171` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Directory and subdirectory listings now use natural sorting, placing numbered names in intuitive numeric order.
  * Sorting is case-insensitive and provides consistent ordering for leading zeros and non-ASCII characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->