### PR TITLE
fix(explorer): preserve sidebar width across window resize

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1231,6 +1231,10 @@ export default function App() {
             <ResizablePanelGroup
               orientation="horizontal"
               className="min-h-0 flex-1"
+              onLayoutChanged={(_, { isUserInteraction }) => {
+                const width = sidebarRef.current?.getSize().inPixels ?? 0;
+                persistSidebarWidth(width, isUserInteraction);
+              }}
             >
               <ResizablePanel
                 id="sidebar"
@@ -1245,7 +1249,6 @@ export default function App() {
                 collapsible
                 collapsedSize={0}
                 onResize={(size) => {
-                  if (size.inPixels > 0) persistSidebarWidth(size.inPixels);
                   persistSidebarCollapsed(size.inPixels <= 0);
                 }}
               >

--- a/src/modules/sidebar/useSidebarPanel.test.ts
+++ b/src/modules/sidebar/useSidebarPanel.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { shouldPersistSidebarWidth } from "./useSidebarPanel";
+
+describe("shouldPersistSidebarWidth", () => {
+  it("only persists a positive width from direct user interaction", () => {
+    expect(shouldPersistSidebarWidth(320, true)).toBe(true);
+    expect(shouldPersistSidebarWidth(320, false)).toBe(false);
+    expect(shouldPersistSidebarWidth(0, true)).toBe(false);
+  });
+});

--- a/src/modules/sidebar/useSidebarPanel.ts
+++ b/src/modules/sidebar/useSidebarPanel.ts
@@ -15,6 +15,13 @@ const SIDEBAR_WIDTH_STORAGE_KEY = "terax.sidebar.width";
 const SIDEBAR_VIEW_STORAGE_KEY = "terax.sidebar.view";
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "terax.sidebar.collapsed";
 
+export function shouldPersistSidebarWidth(
+  width: number,
+  isUserInteraction: boolean,
+): boolean {
+  return isUserInteraction && width > 0;
+}
+
 function clampSidebarWidth(width: number): number {
   return Math.min(
     SIDEBAR_MAX_WIDTH,
@@ -116,20 +123,24 @@ export function useSidebarPanel(
     [persistSidebarView, sidebarView],
   );
 
-  const persistSidebarWidth = useCallback((next: number) => {
-    sidebarWidthRef.current = next;
-    if (sidebarWidthWriteTimerRef.current) {
-      window.clearTimeout(sidebarWidthWriteTimerRef.current);
-    }
-    sidebarWidthWriteTimerRef.current = window.setTimeout(() => {
-      sidebarWidthWriteTimerRef.current = 0;
-      try {
-        window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(next));
-      } catch {
-        // ignore
+  const persistSidebarWidth = useCallback(
+    (next: number, isUserInteraction: boolean) => {
+      if (!shouldPersistSidebarWidth(next, isUserInteraction)) return;
+      sidebarWidthRef.current = next;
+      if (sidebarWidthWriteTimerRef.current) {
+        window.clearTimeout(sidebarWidthWriteTimerRef.current);
       }
-    }, 200);
-  }, []);
+      sidebarWidthWriteTimerRef.current = window.setTimeout(() => {
+        sidebarWidthWriteTimerRef.current = 0;
+        try {
+          window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(next));
+        } catch {
+          // ignore
+        }
+      }, 200);
+    },
+    [],
+  );
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## What

Preserve the user-selected Explorer sidebar width when the application window is restored, maximized, or otherwise resized.

Adds regression coverage for the sidebar width persistence guard.

## Why

`Panel.onResize` also fires for container-driven layout recalculations. Window resizing therefore overwrote the stored user preference with a transient panel width.

Closes #1081.

## How

Move width persistence to `Group.onLayoutChanged` and only save positive widths when `isUserInteraction` is true.

Collapse state remains handled by the panel resize callback, preserving the existing programmatic collapse and expand behavior.

## Testing

The regression test verifies that:

- A completed user resize is persisted.
- Window-driven layout changes are ignored.
- Collapsing the sidebar does not overwrite the last expanded width.

Manually verified on Windows by resizing the Explorer sidebar, restoring the maximized window, and maximizing it again. The selected width remained unchanged.

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): Not applicable

## Screenshots / GIFs

Not included. This is a persistence behavior fix with no visual styling changes.

## Notes for reviewer

Width persistence now relies on the interaction metadata provided by `react-resizable-panels` 4.12.2. Programmatic resize and window constraint recalculation cannot overwrite the stored user width.

No dependencies were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar resizing behavior so manually adjusted widths are saved reliably.
  * Prevented automatic layout changes and collapsed states from overwriting the saved sidebar width.
  * Added safeguards to ensure only valid, user-selected sidebar widths are persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->