### PR TITLE
fix(pty): avoid fish conda prompt recursion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            fish \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             librsvg2-dev \
@@ -94,6 +95,9 @@ jobs:
       - name: cargo nextest
         working-directory: src-tauri
         run: cargo nextest run --locked
+
+      - name: fish shell integration
+        run: fish --no-config src-tauri/src/modules/pty/scripts/init.test.fish
 
   rust-platforms:
     name: rust-test (${{ matrix.os }})

--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -54,6 +54,13 @@ end
 # where a framework prompt (starship etc.) would otherwise override fish_prompt
 # and drop our markers.
 function __terax_install_prompt
+    # ponytail: cover Conda's named wrapper; generalize if another prompt
+    # framework preserves Terax indirectly.
+    if not set -q TERAX_BLOCKS
+        and functions -q __fish_prompt_orig
+        and functions __fish_prompt_orig | string match -q '*__terax_user_prompt*'
+        return
+    end
     __terax_capture_user_prompt
     if set -q TERAX_BLOCKS
         function fish_right_prompt

--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -58,6 +58,7 @@ function __terax_install_prompt
     # framework preserves Terax indirectly.
     if not set -q TERAX_BLOCKS
         and functions -q __fish_prompt_orig
+        and functions fish_prompt | string match -q '*__fish_prompt_orig*'
         and functions __fish_prompt_orig | string match -q '*__terax_user_prompt*'
         return
     end

--- a/src-tauri/src/modules/pty/scripts/init.test.fish
+++ b/src-tauri/src/modules/pty/scripts/init.test.fish
@@ -1,10 +1,11 @@
 set -gx TERAX_TERMINAL 1
+set -l script_dir (dirname (status filename))
 
 function fish_prompt
     printf base
 end
 
-source (path dirname (status filename))/init.fish
+source "$script_dir/init.fish"
 
 # Conda preserves the prompt installed from conf.d before wrapping it.
 functions -c fish_prompt __fish_prompt_orig
@@ -18,18 +19,21 @@ __terax_install_prompt
 set -l rendered (fish_prompt)
 test (string match -ra conda -- "$rendered" | count) -eq 1; or exit 1
 test (string match -ra base -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '133;D;' -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '133;A' -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '133;B' -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '7;file://' -- "$rendered" | count) -eq 1; or exit 1
 
-# Replacements that do not preserve Terax still need the post-config rewrap.
-functions -e __fish_prompt_orig __terax_user_prompt fish_prompt
-set -e __TERAX_HOOKS_LOADED
-function fish_prompt
-    printf base
-end
-source (path dirname (status filename))/init.fish
+# Replacements that preserve Conda's helper but do not delegate to it still
+# need the post-config rewrap.
+functions -e __terax_user_prompt fish_prompt
 function fish_prompt
     printf replacement
 end
 __terax_install_prompt
 set rendered (fish_prompt)
 test (string match -ra replacement -- "$rendered" | count) -eq 1; or exit 1
-string match -q '*]133;A*' -- "$rendered"; or exit 1
+test (string match -ra '133;D;' -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '133;A' -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '133;B' -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra '7;file://' -- "$rendered" | count) -eq 1; or exit 1

--- a/src-tauri/src/modules/pty/scripts/init.test.fish
+++ b/src-tauri/src/modules/pty/scripts/init.test.fish
@@ -1,0 +1,35 @@
+set -gx TERAX_TERMINAL 1
+
+function fish_prompt
+    printf base
+end
+
+source (path dirname (status filename))/init.fish
+
+# Conda preserves the prompt installed from conf.d before wrapping it.
+functions -c fish_prompt __fish_prompt_orig
+function fish_prompt
+    printf conda
+    __fish_prompt_orig
+end
+
+__terax_install_prompt
+
+set -l rendered (fish_prompt)
+test (string match -ra conda -- "$rendered" | count) -eq 1; or exit 1
+test (string match -ra base -- "$rendered" | count) -eq 1; or exit 1
+
+# Replacements that do not preserve Terax still need the post-config rewrap.
+functions -e __fish_prompt_orig __terax_user_prompt fish_prompt
+set -e __TERAX_HOOKS_LOADED
+function fish_prompt
+    printf base
+end
+source (path dirname (status filename))/init.fish
+function fish_prompt
+    printf replacement
+end
+__terax_install_prompt
+set rendered (fish_prompt)
+test (string match -ra replacement -- "$rendered" | count) -eq 1; or exit 1
+string match -q '*]133;A*' -- "$rendered"; or exit 1


### PR DESCRIPTION
## What

Avoid reinstalling the Terax Fish prompt wrapper when Conda has preserved the earlier wrapper as `__fish_prompt_orig`. Add an executable Fish regression to Linux CI.

## Why

Closes #1056. Reinstalling after `config.fish` currently creates `Terax -> Conda -> old Terax -> Conda`, so Fish aborts at its call-stack limit.

## How

Detect the narrow Conda-style preserved wrapper before recapturing it. Other prompt replacements still take the existing post-config rewrap path.

## Testing

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (543 tests)
- [x] Manual smoke-test of the affected feature through the executable Fish harness
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] `cargo nextest run --locked` clean (269 tests)
- [ ] (If you changed a `#[tauri::command]` signature) not applicable
- [ ] (If UI) not applicable
- [x] Platforms tested: macOS host; Linux CI exercises the Fish harness
- [x] Shells tested: fish

RED before the fix: the harness exited 1 at Fish call-stack exhaustion. GREEN after the fix: it exits 0 and verifies both the Conda-preserved prompt and the normal replacement path.

## Screenshots / GIFs

Not applicable; no UI change.

## Notes for reviewer

The guard is intentionally limited to the named wrapper shape reported by Conda; the existing behavior remains unchanged for other prompt frameworks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fish shell prompt integration to preserve existing custom prompts while adding Terax prompt features.
  * Prevented unnecessary prompt reinstallation, reducing potential prompt conflicts.
  * Ensured prompts are correctly restored after configuration is reloaded, including support for Conda output and Terax escape sequences.

* **Tests**
  * Added coverage for Fish prompt installation, preservation, and reconfiguration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->