### PR TITLE
fix(pty): avoid exiting ordinary fish shells

### DIFF
--- a/src-tauri/src/modules/pty/scripts/init.fish
+++ b/src-tauri/src/modules/pty/scripts/init.fish
@@ -7,10 +7,10 @@
 # Installed into conf.d, which every fish session sources; only Terax-spawned
 # shells (TERAX_TERMINAL=1) may get their prompt wrapped.
 if not set -q TERAX_TERMINAL
-    exit 0
+    return
 end
 if set -q __TERAX_HOOKS_LOADED
-    exit 0
+    return
 end
 set -g __TERAX_HOOKS_LOADED 1
 

--- a/src-tauri/src/modules/pty/scripts/init.test.fish
+++ b/src-tauri/src/modules/pty/scripts/init.test.fish
@@ -1,6 +1,6 @@
 set -l script_dir (dirname (status filename))
 
-set -l ordinary (env -u TERAX_TERMINAL fish --no-config -c 'source $argv[1]; echo ordinary-shell-survived' -- "$script_dir/init.fish")
+set -l ordinary (env -u TERAX_TERMINAL fish --no-config -c 'source $argv[1]; or exit 1; echo ordinary-shell-survived' -- "$script_dir/init.fish")
 test "$ordinary" = ordinary-shell-survived; or exit 1
 
 set -gx TERAX_TERMINAL 1

--- a/src-tauri/src/modules/pty/scripts/init.test.fish
+++ b/src-tauri/src/modules/pty/scripts/init.test.fish
@@ -1,5 +1,9 @@
-set -gx TERAX_TERMINAL 1
 set -l script_dir (dirname (status filename))
+
+set -l ordinary (env -u TERAX_TERMINAL fish --no-config -c 'source $argv[1]; echo ordinary-shell-survived' -- "$script_dir/init.fish")
+test "$ordinary" = ordinary-shell-survived; or exit 1
+
+set -gx TERAX_TERMINAL 1
 
 function fish_prompt
     printf base


### PR DESCRIPTION
## What

Return from the globally sourced Fish integration file instead of exiting the whole shell when Terax integration is not active.

## Why

Opening a Terax Fish terminal installs `terax.fish` in Fish's global `conf.d` directory. A later ordinary Fish shell sources that file without `TERAX_TERMINAL`; the former `exit 0` terminates that shell before it can run user commands or configuration.

## How

Use Fish's `return` in the two guard branches, then exercise an ordinary `fish --no-config` process in the existing Fish harness.

## Testing

- [x] `pnpm lint` exits successfully; the repository reports 103 existing warnings in untouched frontend files
- [x] `pnpm check-types`
- [x] `pnpm test` (547 tests)
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] `cargo nextest run --locked` (276 tests)
- [x] `git diff --check`
- [x] Added Fish regression harness; Linux CI executes it with Fish installed

## Screenshots / GIFs

Not applicable. No UI change.

## Notes for reviewer

The guards still skip all Terax prompt setup outside a Terax terminal. They now leave the calling Fish shell running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shell initialization so sourcing the configuration no longer closes ordinary Fish sessions.
  * Improved handling when terminal-specific settings are unavailable or have already been loaded.

* **Tests**
  * Added coverage confirming standard shell sessions remain active during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->