### PR TITLE
fix(terminal): default to non-WebGL rendering on Linux

### DIFF
--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_AGENT_LAUNCH_COMMANDS,
   normalizeAgentLaunchCommands,
 } from "@/modules/agents/lib/launcher";
+import { IS_LINUX } from "@/lib/platform";
 import type { KeyBinding, ShortcutId } from "@/modules/shortcuts/shortcuts";
 import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
@@ -30,6 +31,10 @@ export const DEFAULT_THEME_ID = "terax-default";
 export type BackgroundKind = "none" | "image";
 
 export type TerminalCursorStyle = "bar" | "block" | "underline";
+
+export function defaultTerminalWebglEnabled(isLinux: boolean): boolean {
+  return !isLinux;
+}
 
 export const EDITOR_THEMES = [
   "kanagawa",
@@ -329,7 +334,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   editorWordWrap: false,
   showHidden: false,
   explorerGitDecorations: true,
-  terminalWebglEnabled: true,
+  terminalWebglEnabled: defaultTerminalWebglEnabled(IS_LINUX),
   terminalCursorBlink: false,
   terminalCursorStyle: "bar",
   terminalFontFamily: "",

--- a/src/modules/settings/terminalWebglDefault.test.ts
+++ b/src/modules/settings/terminalWebglDefault.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { defaultTerminalWebglEnabled } from "./store";
+
+describe("defaultTerminalWebglEnabled", () => {
+  it("uses the DOM renderer by default on Linux", () => {
+    expect(defaultTerminalWebglEnabled(true)).toBe(false);
+  });
+
+  it("keeps WebGL enabled by default on other platforms", () => {
+    expect(defaultTerminalWebglEnabled(false)).toBe(true);
+  });
+});

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./osc-handlers";
 
 // git-bash path mapping is Windows-only; exercise that branch.
-vi.mock("@/lib/platform", () => ({ IS_WINDOWS: true }));
+vi.mock("@/lib/platform", () => ({ IS_LINUX: false, IS_WINDOWS: true }));
 
 /**
  * Minimal in-memory fake of the xterm `Terminal` surface we touch — just

--- a/src/modules/terminal/lib/quoteShellPath.test.ts
+++ b/src/modules/terminal/lib/quoteShellPath.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/platform", () => ({ IS_WINDOWS: false }));
+vi.mock("@/lib/platform", () => ({ IS_LINUX: false, IS_WINDOWS: false }));
 
 import { formatDroppedPaths, quoteShellPath } from "./quoteShellPath";
 

--- a/src/modules/terminal/lib/rendererPool.test.ts
+++ b/src/modules/terminal/lib/rendererPool.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vitest";
+import { refreshAfterWebglDispose } from "./rendererPool";
+
+describe("refreshAfterWebglDispose", () => {
+  it("repaints every terminal row after WebGL disposal", () => {
+    const refresh = vi.fn();
+
+    refreshAfterWebglDispose({ rows: 42, refresh });
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledWith(0, 41);
+  });
+});

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -874,6 +874,9 @@ export function applyWebglPreference(enabled: boolean): void {
     } else if (slot.webglAddon) {
       cancelWebglReap(slot);
       disposeSlotWebgl(slot);
+      try {
+        slot.term.refresh(0, slot.term.rows - 1);
+      } catch {}
     }
   }
 }

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -874,11 +874,17 @@ export function applyWebglPreference(enabled: boolean): void {
     } else if (slot.webglAddon) {
       cancelWebglReap(slot);
       disposeSlotWebgl(slot);
-      try {
-        slot.term.refresh(0, slot.term.rows - 1);
-      } catch {}
+      refreshAfterWebglDispose(slot.term);
     }
   }
+}
+
+export function refreshAfterWebglDispose(
+  term: Pick<Terminal, "refresh" | "rows">,
+): void {
+  try {
+    term.refresh(0, term.rows - 1);
+  } catch {}
 }
 
 // Parked and retained slots can't be measured (display:none); poison lastW

--- a/src/modules/terminal/lib/useTerminalFileDrop.test.ts
+++ b/src/modules/terminal/lib/useTerminalFileDrop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/platform", () => ({ IS_WINDOWS: false }));
+vi.mock("@/lib/platform", () => ({ IS_LINUX: false, IS_WINDOWS: false }));
 
 import { createTerminalPathDropTarget } from "./useTerminalFileDrop";
 

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -234,16 +234,15 @@ export function GeneralSection() {
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-65 text-[11px]">
                     xterm's WebGL renderer caches glyphs in a GPU texture atlas.
-                    On some macOS setups (especially with Nerd Fonts), the atlas
-                    corrupts and terminal text becomes unreadable. Turn this off
-                    as a fallback — performance dips slightly, but text renders
-                    correctly via the DOM renderer.
+                    Some Linux graphics stacks can miss a terminal repaint, making
+                    input appear one keystroke behind. Turn this off to use the
+                    reliable DOM renderer. It may be slightly less performant.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             </span>
           }
-          description="Hardware-accelerated rendering. Turn off if text shows corruption or blank tiles."
+          description="Hardware-accelerated rendering. Turn off if text lags, corrupts, or shows blank tiles."
         >
           <Switch
             checked={terminalWebglEnabled}


### PR DESCRIPTION
## What users saw

On some Linux systems, terminal input looked like it was always one keystroke behind. For example, after typing `a`, nothing appeared. After typing `b`, only `a` appeared. The newest character showed up only after pressing another key.

## What was actually wrong

The terminal was receiving keyboard input correctly. The problem was only visual: xterm's WebGL renderer, which uses the GPU, sometimes did not repaint the latest terminal character on some Linux graphics setups. A later keypress caused another repaint, which made the previous character appear.

## What this PR changes

Terax now uses the more reliable non-WebGL terminal renderer by default on Linux. This avoids the missed repaint and makes every typed character appear immediately.

WebGL is still available in Settings for users who want hardware-accelerated rendering and whose system works well with it. Turning WebGL off also refreshes any terminal panes that are already open.

## Verification

- `pnpm check-types` passed.
- `pnpm test` passed: 78 test files and 550 tests.
- Built and upgraded the Debian package locally.
- Confirmed that terminal input no longer appears one keystroke behind after the upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal WebGL is now disabled by default on Linux and remains enabled on other platforms.
  * Terminals refresh automatically after WebGL is disabled to keep displayed content current.

* **Bug Fixes**
  * Improved Linux terminal rendering to prevent input from appearing one keystroke behind.
  * Updated WebGL guidance to recommend the DOM renderer as a more reliable Linux fallback.

* **Tests**
  * Added coverage for platform-specific defaults and terminal refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->