### PR TITLE
feat(agents): recognize GJC as a status-reporting agent

### DIFF
--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -5,10 +5,10 @@ const ST_FINAL: u8 = b'\\';
 
 const OSC_MAX: usize = 2048;
 
-const DEFAULT_AGENTS: &[&str] = &["claude", "codex", "gemini", "pi", "opencode", "grok"];
+const DEFAULT_AGENTS: &[&str] = &["claude", "codex", "gemini", "pi", "gjc", "opencode", "grok"];
 
 // OSC 777 marker our agent hooks emit. Legacy 3-field `notify;Terax;<event>`
-// (Claude) or 4-field `notify;Terax;<agent>;<event>` (Codex/Gemini/Pi).
+// (Claude) or 4-field `notify;Terax;<agent>;<event>` (Codex/Gemini/Pi/GJC).
 const TERAX_MARKER: &[u8] = b"notify;Terax;";
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -376,6 +376,19 @@ mod tests {
         );
         assert_eq!(
             run(&mut d, &osc("777;notify;Terax;pi;finished")),
+            vec![Transition::Finished]
+        );
+    }
+
+    #[test]
+    fn gjc_marker_self_arms_and_drives_status() {
+        let mut d = AgentDetector::new();
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;gjc;working")),
+            vec![started("gjc")]
+        );
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;gjc;finished")),
             vec![Transition::Finished]
         );
     }

--- a/src-tauri/src/modules/pty/agent_detect.rs
+++ b/src-tauri/src/modules/pty/agent_detect.rs
@@ -11,6 +11,24 @@ const DEFAULT_AGENTS: &[&str] = &["claude", "codex", "gemini", "pi", "gjc", "ope
 // (Claude) or 4-field `notify;Terax;<agent>;<event>` (Codex/Gemini/Pi/GJC).
 const TERAX_MARKER: &[u8] = b"notify;Terax;";
 
+// Agent ids carried by the 4-field marker become UI labels, so they are bounded
+// to a short lowercase slug. This is the only check on that field: any agent
+// that emits the marker is reported, whether or not Terax knows it.
+const AGENT_NAME_MAX: usize = 32;
+
+fn is_agent_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > AGENT_NAME_MAX {
+        return false;
+    }
+    let mut chars = name.chars();
+    let first = chars.next().unwrap();
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum State {
     Ground,
@@ -162,13 +180,16 @@ impl AgentDetector {
 
     fn handle_osc777<F: FnMut(Transition)>(&mut self, pt: &[u8], emit: &mut F) {
         if let Some(tail) = pt.strip_prefix(TERAX_MARKER) {
-            // PTY output is untrusted: only self-arm for known agents.
+            // PTY output is untrusted, so the name is bounded to a plausible
+            // agent id rather than checked against a list: any agent that opts
+            // into the marker works without a Terax release. `agents` still
+            // gates OSC 133 arming, where we match arbitrary command lines.
             let (agent, event) = match tail.iter().position(|&c| c == b';') {
                 Some(i) => {
                     let Ok(name) = std::str::from_utf8(&tail[..i]) else {
                         return;
                     };
-                    if !self.agents.iter().any(|a| a == name) {
+                    if !is_agent_name(name) {
                         return;
                     }
                     (name, &tail[i + 1..])
@@ -394,10 +415,25 @@ mod tests {
     }
 
     #[test]
-    fn four_field_marker_ignores_unknown_agent() {
+    fn four_field_marker_reports_agents_terax_does_not_know() {
         let mut d = AgentDetector::new();
-        assert!(run(&mut d, &osc("777;notify;Terax;evil;attention")).is_empty());
-        // A known agent in the same chunk still works.
+        assert_eq!(
+            run(&mut d, &osc("777;notify;Terax;my-agent-9;attention")),
+            vec![started("my-agent-9"), Transition::Attention]
+        );
+    }
+
+    #[test]
+    fn four_field_marker_rejects_implausible_agent_names() {
+        for name in ["", "-lead", "Upper", "with space", &"x".repeat(33)] {
+            let mut d = AgentDetector::new();
+            assert!(
+                run(&mut d, &osc(&format!("777;notify;Terax;{name};attention"))).is_empty(),
+                "accepted {name:?}"
+            );
+        }
+        // A well-formed name in the same chunk still works.
+        let mut d = AgentDetector::new();
         assert_eq!(
             run(&mut d, &osc("777;notify;Terax;codex;attention")),
             vec![started("codex"), Transition::Attention]

--- a/src/modules/agents/lib/format.ts
+++ b/src/modules/agents/lib/format.ts
@@ -3,6 +3,7 @@ const LABELS: Record<string, string> = {
   codex: "Codex",
   gemini: "Gemini",
   pi: "Pi",
+  gjc: "GJC",
   opencode: "OpenCode",
   grok: "Grok",
   terax: "Terax",

--- a/src/modules/agents/lib/launcher.test.ts
+++ b/src/modules/agents/lib/launcher.test.ts
@@ -54,6 +54,7 @@ describe("agent launch commands", () => {
       codex: "codex",
       gemini: "gemini",
       pi: "pi --provider local",
+      gjc: "gjc",
       opencode: "opencode",
       grok: "grok",
     });

--- a/src/modules/agents/lib/launcher.ts
+++ b/src/modules/agents/lib/launcher.ts
@@ -26,6 +26,13 @@ export const AGENT_LAUNCHERS = [
     supportsHooks: true,
   },
   {
+    id: "gjc",
+    label: "GJC",
+    defaultCommand: "gjc",
+    // GJC emits the OSC 777 marker itself; nothing to install.
+    supportsHooks: false,
+  },
+  {
     id: "opencode",
     label: "OpenCode",
     defaultCommand: "opencode",


### PR DESCRIPTION
## What

Adds `gjc` ([gajae-code](https://github.com/Yeachan-Heo/gajae-code)) to the agent status detector and the launcher list, so agent tabs running GJC drive the header bell / tab status like Claude, Codex, Gemini and Pi already do.

## Why the launcher entry declares `supportsHooks: false`

GJC is a Pi fork, so the obvious route was the existing Pi path: install `terax-notifications.ts` into the user's extension dir and let the extension emit the marker. That cannot work. GJC quarantines filesystem extension discovery:

```ts
// gajae-code src/sdk/session.ts
// Extension/module discovery is quarantined; retain only the private
// runtime needed for bundled product extensions ... Filesystem extension
// paths remain ignored here even when options.additionalExtensionPaths is supplied.
```

Verified empirically against the released 0.12.10 binary: an extension dropped in `~/.gjc/agent/extensions/` and one passed via `-e` both fail to load. `discoverAndLoadHooks` has no callers either, so the hook-config route is dead as well.

GJC therefore emits the marker itself, gated on `TERAX_TERMINAL`:

```
\033]777;notify;Terax;gjc;working|attention|finished\007
```

`agent_start` -> working, `agent_end` -> finished, approval/ask selector -> attention. That is a companion change in gajae-code; this PR is only the Terax side, and it is inert until a GJC build that emits the marker is installed.

Without the whitelist entry the marker is silently dropped, since `handle_osc777` only self-arms for known agent names.

## Changes

- `agent_detect.rs`: `gjc` added to `DEFAULT_AGENTS` + a test covering `working`/`finished` self-arming
- `launcher.ts`: launcher entry, `supportsHooks: false` (nothing to install)
- `format.ts`: `GJC` display label
- `launcher.test.ts`: normalization expectation updated

## Verification

- `cargo test --lib agent_detect` - 20 passed
- `pnpm vitest run src/modules/agents` - 14 passed
- `tsc --noEmit` clean, biome introduces no new findings
- Release build verified to carry the name: `strings target/release/terax | grep claudecodexgeminipigjc` matches, the shipped 0.8.6 binary does not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for launching and detecting the GJC agent.
  * GJC activity now displays working and finished status transitions automatically.
  * Added GJC to agent labels and default command settings.
  * Improved activity detection for compatible agents, including valid agent identifiers not previously configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->