### PR TITLE
fix(links): route external links through native opener

### DIFF
--- a/src/components/ai-elements/markdown-link.test.tsx
+++ b/src/components/ai-elements/markdown-link.test.tsx
@@ -5,6 +5,7 @@ const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn() }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl }));
 
 import { openMarkdownLink } from "./markdown-link";
+import { openExternalUrl } from "@/lib/external-link";
 
 describe("MarkdownLink", () => {
   afterEach(() => {
@@ -29,6 +30,15 @@ describe("MarkdownLink", () => {
 
     await openMarkdownLink("https://example.com", onSettled);
 
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("does not invoke the native opener for unsupported schemes", async () => {
+    const onSettled = vi.fn();
+
+    await openExternalUrl("javascript:alert(1)", onSettled);
+
+    expect(openUrl).not.toHaveBeenCalled();
     expect(onSettled).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/ai-elements/markdown-link.test.tsx
+++ b/src/components/ai-elements/markdown-link.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { openUrl } = vi.hoisted(() => ({ openUrl: vi.fn() }));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl }));
+
+import { openMarkdownLink } from "./markdown-link";
+
+describe("MarkdownLink", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens through the native opener and settles after success", async () => {
+    openUrl.mockResolvedValue(undefined);
+    const onSettled = vi.fn();
+
+    await openMarkdownLink("https://chatgpt.com/codex/settings/usage", onSettled);
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://chatgpt.com/codex/settings/usage",
+    );
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("still settles when opening fails", async () => {
+    openUrl.mockRejectedValue(new Error("browser unavailable"));
+    const onSettled = vi.fn();
+
+    await openMarkdownLink("https://example.com", onSettled);
+
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ai-elements/markdown-link.tsx
+++ b/src/components/ai-elements/markdown-link.tsx
@@ -1,0 +1,56 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { ComponentProps, MouseEventHandler } from "react";
+
+export type MarkdownLinkProps = ComponentProps<"a"> & {
+  node?: unknown;
+  /** Called after the external-open attempt settles. */
+  onSettled?: () => void;
+};
+
+function isExternalMarkdownUrl(href: string): boolean {
+  return /^(?:https?:|mailto:|tel:)/i.test(href);
+}
+
+export function openMarkdownLink(
+  href: string,
+  onSettled?: () => void,
+): Promise<void> {
+  return openUrl(href)
+    .catch((error) => {
+      console.error("[terax] failed to open Markdown link:", error);
+    })
+    .finally(() => onSettled?.());
+}
+
+/**
+ * Open rendered Markdown links through the native opener instead of letting
+ * the Tauri webview navigate to an external origin.
+ */
+export function MarkdownLink({
+  children,
+  href,
+  node: _node,
+  onClick,
+  onSettled,
+  ...props
+}: MarkdownLinkProps) {
+  const handleClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
+    onClick?.(event);
+    if (event.defaultPrevented || !href || !isExternalMarkdownUrl(href)) return;
+
+    event.preventDefault();
+    void openMarkdownLink(href, onSettled);
+  };
+
+  return (
+    <a
+      {...props}
+      href={href}
+      onClick={handleClick}
+      rel="noreferrer"
+      target="_blank"
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/ai-elements/markdown-link.tsx
+++ b/src/components/ai-elements/markdown-link.tsx
@@ -1,5 +1,5 @@
-import { openUrl } from "@tauri-apps/plugin-opener";
 import type { ComponentProps, MouseEventHandler } from "react";
+import { isExternalUrl, openExternalUrl } from "@/lib/external-link";
 
 export type MarkdownLinkProps = ComponentProps<"a"> & {
   node?: unknown;
@@ -7,19 +7,11 @@ export type MarkdownLinkProps = ComponentProps<"a"> & {
   onSettled?: () => void;
 };
 
-function isExternalMarkdownUrl(href: string): boolean {
-  return /^(?:https?:|mailto:|tel:)/i.test(href);
-}
-
 export function openMarkdownLink(
   href: string,
   onSettled?: () => void,
 ): Promise<void> {
-  return openUrl(href)
-    .catch((error) => {
-      console.error("[terax] failed to open Markdown link:", error);
-    })
-    .finally(() => onSettled?.());
+  return openExternalUrl(href, onSettled);
 }
 
 /**
@@ -36,7 +28,7 @@ export function MarkdownLink({
 }: MarkdownLinkProps) {
   const handleClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
     onClick?.(event);
-    if (event.defaultPrevented || !href || !isExternalMarkdownUrl(href)) return;
+    if (event.defaultPrevented || !href || !isExternalUrl(href)) return;
 
     event.preventDefault();
     void openMarkdownLink(href, onSettled);

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
+import { useChatStore } from "@/modules/ai/store/chatStore";
 import {
   Tooltip,
   TooltipContent,
@@ -25,6 +26,7 @@ import {
 import { Streamdown } from "streamdown";
 import { ChatStreamingProvider } from "./chat-code";
 import { MarkdownCode } from "./markdown-code";
+import { MarkdownLink, type MarkdownLinkProps } from "./markdown-link";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -321,7 +323,15 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
   streaming?: boolean;
 };
 
-const streamdownComponents = { code: MarkdownCode };
+const streamdownComponents = {
+  a: (props: MarkdownLinkProps) => (
+    <MarkdownLink
+      {...props}
+      onSettled={() => useChatStore.getState().focusInput()}
+    />
+  ),
+  code: MarkdownCode,
+};
 
 export const MessageResponse = memo(
   ({ className, streaming = false, ...props }: MessageResponseProps) => (

--- a/src/lib/external-link.ts
+++ b/src/lib/external-link.ts
@@ -1,0 +1,21 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+export function isExternalUrl(href: string): boolean {
+  return /^(?:https?:|mailto:|tel:)/i.test(href);
+}
+
+export function openExternalUrl(
+  href: string,
+  onSettled?: () => void,
+): Promise<void> {
+  if (!isExternalUrl(href)) {
+    onSettled?.();
+    return Promise.resolve();
+  }
+
+  return openUrl(href)
+    .catch((error) => {
+      console.error("[terax] failed to open external link:", error);
+    })
+    .finally(() => onSettled?.());
+}

--- a/src/modules/markdown/MarkdownPreviewPane.tsx
+++ b/src/modules/markdown/MarkdownPreviewPane.tsx
@@ -1,4 +1,5 @@
 import { MarkdownCode } from "@/components/ai-elements/markdown-code";
+import { MarkdownLink } from "@/components/ai-elements/markdown-link";
 import { cn } from "@/lib/utils";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { invoke } from "@tauri-apps/api/core";
@@ -24,7 +25,7 @@ type Props = {
   onSetView: (mode: "rendered" | "raw") => void;
 };
 
-const components = { code: MarkdownCode };
+const components = { a: MarkdownLink, code: MarkdownCode };
 
 export function MarkdownPreviewPane({ path, visible, onSetView }: Props) {
   const [status, setStatus] = useState<Status>({ kind: "loading" });

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,7 +1,7 @@
 import { resolveFontFamily } from "@/lib/fonts";
+import { openExternalUrl } from "@/lib/external-link";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import { SerializeAddon } from "@xterm/addon-serialize";
@@ -191,7 +191,19 @@ export function applyBackgroundActive(active: boolean): void {
 }
 
 function createSlot(): Slot {
-  const term = new Terminal(termOptions());
+  let focusTerminal = () => {};
+  const term = new Terminal({
+    ...termOptions(),
+    // xterm's default OSC 8 handler uses window.confirm/window.open. In the
+    // Tauri webview that shows the navigation warning and can leave the
+    // terminal without focus after confirmation.
+    linkHandler: {
+      activate: (_event, uri) => {
+        void openExternalUrl(uri, focusTerminal);
+      },
+    },
+  });
+  focusTerminal = () => term.focus();
   const fitAddon = new FitAddon();
   const searchAddon = new SearchAddon();
   const serializeAddon = new SerializeAddon();
@@ -199,7 +211,9 @@ function createSlot(): Slot {
   term.loadAddon(searchAddon);
   term.loadAddon(serializeAddon);
   term.loadAddon(
-    new WebLinksAddon((_e, uri) => openUrl(uri).catch(console.error)),
+    new WebLinksAddon((_e, uri) => {
+      void openExternalUrl(uri, () => term.focus());
+    }),
   );
 
   const host = document.createElement("div");


### PR DESCRIPTION
## What

Route external links in AI Markdown, Markdown preview, and terminal output through Tauri's native opener, then restore focus to the originating input.

## Why

Streamdown and xterm's default OSC 8 link handler use `window.open`/webview navigation. In Terax, confirming the resulting security warning can open nothing and leave terminal or composer input unresponsive.

Closes #773

## How

Added a shared external-link helper that validates `http`, `https`, `mailto`, and `tel` URLs, calls `openUrl`, logs failures, and runs a focus callback after the attempt settles. AI/Markdown links use it directly; xterm's OSC 8 handler and URL link addon now use it instead of their webview/browser defaults.

## Testing

- [ ] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs

Not included: this is a behavior-only UI fix with no visual layout change.

## Notes for reviewer

- `pnpm check-types`, the full frontend test suite (67 files / 511 tests), `pnpm build`, and the focused external-link tests passed.
- `pnpm lint` exits successfully but reports 103 pre-existing repository warnings; the changed files add no warnings. It is intentionally left unchecked because the repository-wide output is not warning-free.
- `cargo test --locked` passed in an isolated target (248 tests). `src-tauri` was not changed, so the conditional Rust checklist items do not apply; `cargo clippy -D warnings` still finds the existing unused `window` warning in `src-tauri/src/lib.rs:129`.
- Manual Windows smoke-test confirmed both a Codex `/status` terminal link and a Markdown-file link open successfully without a warning dialog or loss of terminal input.
- No Tauri command signatures were changed.
