### PR TITLE
Update isKnownModelId to accept compat-* model IDs

### DIFF
--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -670,7 +670,7 @@ export function getModel(id: ModelId): ModelInfo {
 }
 
 export function isKnownModelId(id: string): id is ModelId {
-  return MODELS.some((x) => x.id === id);
+  return isCompatModelId(id) || MODELS.some((x) => x.id === id);
 }
 
 const FREEFORM_PROVIDERS: ReadonlySet<ProviderId> = new Set([


### PR DESCRIPTION
## Summary
Expands `isKnownModelId()` to accept `compat-*` model IDs in addition to the MODELS registry entries, enabling custom OpenAI-compatible endpoints to be used as the default chat model.

## Change
- `src/modules/ai/config.ts`: Added `isCompatModelId(id)` check to `isKnownModelId()`

## Testing
- Confirmed settings persistence with `defaultModelId: "compat-bf94417d"`
- API key storage works via keychain
- Model dropdown correctly shows custom endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model recognition to support additional compatibility model IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->