### PR TITLE
fix(terminal): enable Ctrl+V paste on Windows outside alternate screen

### DIFF
--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  shouldTerminalPaste,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
+  terminalPasteKind,
   terminalReadlineSequence,
   terminalWordNavigationSequence,
   type TerminalKeyEvent,
@@ -12,6 +14,7 @@ const evt = (partial: Partial<TerminalKeyEvent>): TerminalKeyEvent => ({
   altKey: false,
   ctrlKey: false,
   metaKey: false,
+  shiftKey: false,
   key: "",
   code: "",
   ...partial,
@@ -175,5 +178,63 @@ describe("terminalReadlineSequence", () => {
         isAlternateScreen: true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("terminalPasteKind", () => {
+  const plainCtrlV = evt({ ctrlKey: true, key: "v", code: "KeyV" });
+  const ctrlShiftV = evt({
+    ctrlKey: true,
+    shiftKey: true,
+    key: "V",
+    code: "KeyV",
+  });
+
+  const windows = { isMac: false, isWindows: true };
+  const linux = { isMac: false, isWindows: false };
+  const mac = { isMac: true, isWindows: false };
+
+  it("classifies plain Ctrl+V as a paste on Windows only", () => {
+    expect(terminalPasteKind(plainCtrlV, windows)).toBe("plain");
+    expect(terminalPasteKind(plainCtrlV, linux)).toBeNull();
+    expect(terminalPasteKind(plainCtrlV, mac)).toBeNull();
+  });
+
+  it("classifies Ctrl+Shift+V as a paste on Windows and Linux", () => {
+    expect(terminalPasteKind(ctrlShiftV, windows)).toBe("classic");
+    expect(terminalPasteKind(ctrlShiftV, linux)).toBe("classic");
+    expect(terminalPasteKind(ctrlShiftV, mac)).toBeNull();
+  });
+
+  it("ignores Ctrl+V with extra modifiers", () => {
+    expect(
+      terminalPasteKind(
+        evt({ ctrlKey: true, altKey: true, key: "v", code: "KeyV" }),
+        windows,
+      ),
+    ).toBeNull();
+    expect(
+      terminalPasteKind(
+        evt({ ctrlKey: true, metaKey: true, key: "v", code: "KeyV" }),
+        windows,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("shouldTerminalPaste", () => {
+  it("pastes plain Ctrl+V only outside the alternate screen", () => {
+    expect(shouldTerminalPaste("plain", false)).toBe(true);
+    expect(shouldTerminalPaste("plain", true)).toBe(false);
+  });
+
+  it("pastes Ctrl+Shift+V regardless of alternate-screen state", () => {
+    expect(shouldTerminalPaste("classic", false)).toBe(true);
+    expect(shouldTerminalPaste("classic", true)).toBe(true);
+  });
+
+  it("blocks plain Ctrl+V when the alt screen engages after the async clipboard read", () => {
+    expect(shouldTerminalPaste("plain", false)).toBe(true);
+    expect(shouldTerminalPaste("plain", true)).toBe(false);
   });
 });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -1,6 +1,6 @@
 export type TerminalKeyEvent = Pick<
   KeyboardEvent,
-  "altKey" | "ctrlKey" | "metaKey" | "key" | "code"
+  "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "key" | "code"
 >;
 
 export type PlatformOpts = { isMac: boolean };
@@ -54,4 +54,32 @@ export function terminalReadlineSequence(
     terminalWordNavigationSequence(event) ??
     terminalDeleteSequence(event, opts)
   );
+}
+
+export type TerminalPasteKind = "classic" | "plain";
+
+/** Paste chord classification:
+ *   non-macOS  Ctrl+Shift+V → "classic" (always pastes, even on the alt screen)
+ *   Windows    Ctrl+V       → "plain"   (pastes only outside the alt screen.
+ *                             On Linux Ctrl+V is a native readline shortcut,
+ *                             On macOS Cmd+V is handled natively)
+ */
+export function terminalPasteKind(
+  event: TerminalKeyEvent,
+  opts: PlatformOpts & { isWindows: boolean },
+): TerminalPasteKind | null {
+  const isV = event.code === "KeyV" || event.key === "v" || event.key === "V";
+  if (!isV || !event.ctrlKey || event.altKey || event.metaKey) return null;
+  if (event.shiftKey) return opts.isMac ? null : "classic";
+  return opts.isWindows ? "plain" : null;
+}
+
+/** Plain Ctrl+V must not paste into alt-screen TUIs (vim, htop, ...), where
+ * Ctrl+V has its own meaning. Called both on keydown and again after the
+ * asynchronous clipboard read, since the screen state may change in between. */
+export function shouldTerminalPaste(
+  kind: TerminalPasteKind,
+  isAlternateScreen: boolean,
+): boolean {
+  return kind === "classic" || !isAlternateScreen;
 }

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -15,7 +15,12 @@ import {
   writeTerminalClipboard,
 } from "./terminalClipboard";
 import { pasteIntoTerminal } from "./terminalPaste";
-import { terminalReadlineSequence } from "./keymap";
+import {
+  shouldTerminalPaste,
+  terminalPasteKind,
+  terminalReadlineSequence,
+} from "./keymap";
+import { IS_MAC, IS_WINDOWS } from "@/lib/platform";
 
 export const POOL_MAX_SIZE = 5;
 const FIT_DEBOUNCE_MS = 8;
@@ -287,7 +292,13 @@ function createSlot(): Slot {
       if (event.type === "keydown") {
         const targetLeafId = slot.currentLeafId;
         void readTerminalClipboard().then((text) => {
-          if (text && slot.currentLeafId === targetLeafId) slot.term.paste(text);
+          if (
+            text &&
+            slot.currentLeafId === targetLeafId &&
+            isTerminalPaste(event, slot)
+          ) {
+            slot.term.paste(text);
+          }
         });
       }
       event.preventDefault();
@@ -1044,9 +1055,6 @@ export function getLiveSlotForLeaf(leafId: number): Slot | null {
   );
 }
 
-const IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad/.test(navigator.userAgent);
 
 function isTerminalCopy(e: KeyboardEvent): boolean {
   return (
@@ -1060,20 +1068,8 @@ function isTerminalCopy(e: KeyboardEvent): boolean {
 }
 
 function isTerminalPaste(e: KeyboardEvent, s: Slot): boolean {
-  if (IS_MAC) return false;
-  const classic =
-    e.ctrlKey &&
-    e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyV" || e.key === "v" || e.key === "V");
-  const plainCtrlV =
-    e.ctrlKey &&
-    !e.shiftKey &&
-    !e.altKey &&
-    !e.metaKey &&
-    (e.code === "KeyV" || e.key === "v" || e.key === "V");
-  return classic || (plainCtrlV && !isAltScreen(s));
+  const kind = terminalPasteKind(e, { isMac: IS_MAC, isWindows: IS_WINDOWS });
+  return kind !== null && shouldTerminalPaste(kind, isAltScreen(s));
 }
 
 function isShiftEnter(e: KeyboardEvent): boolean {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -283,7 +283,7 @@ function createSlot(): Slot {
       event.preventDefault();
       return false;
     }
-    if (isTerminalPaste(event)) {
+    if (isTerminalPaste(event, slot)) {
       if (event.type === "keydown") {
         const targetLeafId = slot.currentLeafId;
         void readTerminalClipboard().then((text) => {
@@ -1059,15 +1059,21 @@ function isTerminalCopy(e: KeyboardEvent): boolean {
   );
 }
 
-function isTerminalPaste(e: KeyboardEvent): boolean {
-  return (
-    !IS_MAC &&
+function isTerminalPaste(e: KeyboardEvent, s: Slot): boolean {
+  if (IS_MAC) return false;
+  const classic =
     e.ctrlKey &&
     e.shiftKey &&
     !e.altKey &&
     !e.metaKey &&
-    (e.code === "KeyV" || e.key === "v" || e.key === "V")
-  );
+    (e.code === "KeyV" || e.key === "v" || e.key === "V");
+  const plainCtrlV =
+    e.ctrlKey &&
+    !e.shiftKey &&
+    !e.altKey &&
+    !e.metaKey &&
+    (e.code === "KeyV" || e.key === "v" || e.key === "V");
+  return classic || (plainCtrlV && !isAltScreen(s));
 }
 
 function isShiftEnter(e: KeyboardEvent): boolean {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits - it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
Allow plain Ctrl+V to paste in the terminal grid on Windows when not in
an alternate screen, so interactive prompts (e.g. pi dev) can be pasted
into. Ctrl+Shift+V still works, and TUIs like vim keep Ctrl+V.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

## How
<!-- Brief notes on the approach, only if non-obvious. -->

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own -
     describe the actual flows you exercised. -->

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [x] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [x] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-aware terminal paste shortcuts, including plain Ctrl+V on supported non-Mac platforms.
  * Preserved Ctrl+Shift+V paste behavior in alternate-screen terminals and existing supported environments.

* **Bug Fixes**
  * Paste actions are now revalidated after clipboard access, preventing insertion when the terminal context or paste conditions have changed.
  * Improved handling of modifier keys and alternate-screen paste restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->