### PR TITLE
fix(tabs): improve tab interaction handling

### DIFF
--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { AgentIcon } from "@/modules/agents/lib/agentIcon";
 import type { AgentLaunchRequest } from "@/modules/agents/lib/launcher";
 import {
   ALL_LANGUAGES,
@@ -21,7 +22,6 @@ import {
 } from "@/modules/editor/lib/languageDefinitions";
 import { resolveDisplayName } from "@/modules/editor/lib/languageResolver";
 import { fileIconUrl } from "@/modules/explorer/lib/iconResolver";
-import { AgentIcon } from "@/modules/agents/lib/agentIcon";
 import {
   leafIds,
   ptyIdForLeaf,
@@ -367,6 +367,11 @@ export function TabBar({
                             role="button"
                             tabIndex={-1}
                             data-no-drag
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
                             className="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-sm p-1 -m-1 transition-all hover:bg-accent hover:text-accent-foreground hover:ring-1 hover:ring-primary/30 hover:shadow-[0_0_4px_var(--color-popover-foreground)]"
                           >
                             <TabIcon tab={t} />
@@ -469,6 +474,14 @@ export function TabBar({
                       role="button"
                       aria-label="Close tab"
                       data-no-drag
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
                       onClick={(e) => {
                         e.stopPropagation();
                         onClose(t.id);
@@ -667,7 +680,9 @@ export function TabIcon({ tab }: { tab: Tab }) {
     );
   }
   if (agentStatus.state === "working" && agentStatus.agent) {
-    return <AgentIcon agent={agentStatus.agent} size={14} className="shrink-0" />;
+    return (
+      <AgentIcon agent={agentStatus.agent} size={14} className="shrink-0" />
+    );
   }
   return (
     <HugeiconsIcon


### PR DESCRIPTION
## What
Closing an unfocused tab no longer activates it first, and choosing a language override no longer leaves a blue focus border.

## Why
The nested controls were allowing pointer and mouse events to reach the parent tab trigger, causing unwanted focus changes and visual focus styling.

## How
Pointer and mouse events on the close button and language override control are stopped or prevented before they reach the parent tab trigger.

## Testing
Manual testing confirmed that closing an unfocused tab preserves focus on the currently active tab, and selecting a language override no longer leaves a blue focus border.

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [ ] ~~(If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean~~
- [ ] ~~(If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)~~
- [ ] ~~(If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep~~
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS
- [ ] ~~Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactions with editor language selectors and tab close controls.
  * Prevented these controls from unintentionally selecting, dragging, or activating tabs.
* **Style**
  * Standardized formatting for the working-agent icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->