### PR TITLE
test(ai): cover model preference dedup and toggle logic

### DIFF
--- a/src/modules/ai/lib/modelPrefs.test.ts
+++ b/src/modules/ai/lib/modelPrefs.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prefsMock = vi.hoisted(() => ({
+  favoriteModelIds: [] as string[],
+  recentModelIds: [] as string[],
+}));
+
+const storeMock = vi.hoisted(() => ({
+  setFavoriteModelIds: vi.fn(),
+  setRecentModelIds: vi.fn(),
+}));
+
+vi.mock("@/modules/settings/preferences", () => ({
+  usePreferencesStore: {
+    getState: () => ({
+      favoriteModelIds: prefsMock.favoriteModelIds,
+      recentModelIds: prefsMock.recentModelIds,
+    }),
+  },
+}));
+
+vi.mock("@/modules/settings/store", () => storeMock);
+
+import { pushRecentModel, toggleFavoriteModel } from "./modelPrefs";
+
+beforeEach(() => {
+  prefsMock.favoriteModelIds = [];
+  prefsMock.recentModelIds = [];
+  storeMock.setFavoriteModelIds.mockClear();
+  storeMock.setRecentModelIds.mockClear();
+});
+
+describe("toggleFavoriteModel", () => {
+  it("adds an id when absent", async () => {
+    prefsMock.favoriteModelIds = ["a"];
+    await toggleFavoriteModel("b");
+    expect(storeMock.setFavoriteModelIds).toHaveBeenCalledWith(["a", "b"]);
+  });
+
+  it("removes an id when already present", async () => {
+    prefsMock.favoriteModelIds = ["a", "b"];
+    await toggleFavoriteModel("a");
+    expect(storeMock.setFavoriteModelIds).toHaveBeenCalledWith(["b"]);
+  });
+
+  it("propagates a write failure", async () => {
+    storeMock.setFavoriteModelIds.mockRejectedValueOnce(new Error("ipc down"));
+    await expect(toggleFavoriteModel("a")).rejects.toThrow("ipc down");
+  });
+});
+
+describe("pushRecentModel", () => {
+  it("appends a new id to an empty list", async () => {
+    prefsMock.recentModelIds = [];
+    await pushRecentModel("a");
+    expect(storeMock.setRecentModelIds).toHaveBeenCalledWith(["a"]);
+  });
+
+  it("moves an existing id to the front", async () => {
+    prefsMock.recentModelIds = ["a", "b", "c"];
+    await pushRecentModel("b");
+    expect(storeMock.setRecentModelIds).toHaveBeenCalledWith(["b", "a", "c"]);
+  });
+
+  it("deduplicates before capping a full list", async () => {
+    prefsMock.recentModelIds = ["a", "b", "c", "d", "e"];
+    await pushRecentModel("c");
+    expect(storeMock.setRecentModelIds).toHaveBeenCalledWith([
+      "c",
+      "a",
+      "b",
+      "d",
+      "e",
+    ]);
+  });
+
+  it("caps the list at five entries", async () => {
+    prefsMock.recentModelIds = ["e", "d", "c", "b", "a"];
+    await pushRecentModel("x");
+    expect(storeMock.setRecentModelIds).toHaveBeenCalledWith([
+      "x",
+      "e",
+      "d",
+      "c",
+      "b",
+    ]);
+  });
+
+  it("is a no-op when the id is already most recent", async () => {
+    prefsMock.recentModelIds = ["a", "b"];
+    await pushRecentModel("a");
+    expect(storeMock.setRecentModelIds).not.toHaveBeenCalled();
+  });
+
+  it("propagates a write failure", async () => {
+    storeMock.setRecentModelIds.mockRejectedValueOnce(new Error("ipc down"));
+    await expect(pushRecentModel("a")).rejects.toThrow("ipc down");
+  });
+});


### PR DESCRIPTION
## What
Adds a vitest unit test for `src/modules/ai/lib/modelPrefs.ts`.

## Why
`toggleFavoriteModel` and `pushRecentModel` carry real logic (dedup, move-to-front, cap at 5, no-op guard) and had no coverage. Pulls together the dedup-before-cap ordering and the failure propagation path.

## How
Test-only. Mocks the preferences store and the persistence setters with the repos established `vi.hoisted` + `vi.mock` pattern (see `src/modules/shortcuts/lib/shortcutLabel.test.ts`). No production file touched.

## Testing
- [x] `pnpm lint` clean (biome check on the new file)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (full suite, 568 pass)
- [ ] Manual smoke-test of the affected feature
- Platforms tested: n/a (logic-only, node env)

## Notes for reviewer
Test-only, single file, mirrors the merged coverage series. New cases lock the dedup-before-cap ordering (would regress as a lost entry) and the IPC failure propagation (the prod module has no try/catch, so an error reaches the caller).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for AI model preference updates, including favorites and recently used model ordering.
  * Verified list limits, no-op behavior, store writes, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->