### PR TITLE
test(ai): cover session title derivation

### DIFF
--- a/src/modules/ai/lib/sessions.test.ts
+++ b/src/modules/ai/lib/sessions.test.ts
@@ -1,0 +1,61 @@
+import type { UIMessage } from "@ai-sdk/react";
+import { describe, expect, it } from "vitest";
+import { deriveTitle } from "./sessions";
+
+function message(text: string, role: UIMessage["role"] = "user"): UIMessage {
+  return {
+    id: "id",
+    role,
+    parts: [{ type: "text", text }],
+  } as UIMessage;
+}
+
+describe("deriveTitle", () => {
+  it("returns New chat for no messages", () => {
+    expect(deriveTitle([])).toBe("New chat");
+  });
+
+  it("skips non-user messages", () => {
+    expect(deriveTitle([message("assistant reply", "assistant")])).toBe(
+      "New chat",
+    );
+  });
+
+  it("takes the first user text part", () => {
+    expect(deriveTitle([message("what is terax")])).toBe("what is terax");
+  });
+
+  it("uses the first line only", () => {
+    expect(deriveTitle([message("line one\nline two")])).toBe("line one");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(deriveTitle([message("  padded  ")])).toBe("padded");
+  });
+
+  it("strips terminal-context, selection and file blocks", () => {
+    const text =
+      '<terminal-context project="x">code</terminal-context>\nshort title';
+    expect(deriveTitle([message(text)])).toBe("short title");
+  });
+
+  it("strips multiple consecutive blocks", () => {
+    const text = "<selection>a</selection><file>b</file>\ntitle";
+    expect(deriveTitle([message(text)])).toBe("title");
+  });
+
+  it("falls back to New chat when only blocks are present", () => {
+    const text = "<file>path</file>\n";
+    expect(deriveTitle([message(text)])).toBe("New chat");
+  });
+
+  it("truncates titles longer than 40 chars with an ellipsis", () => {
+    const long = "a".repeat(45);
+    expect(deriveTitle([message(long)])).toBe(`${"a".repeat(40)}…`);
+  });
+
+  it("keeps a title of exactly 40 chars intact", () => {
+    const exactly40 = "a".repeat(40);
+    expect(deriveTitle([message(exactly40)])).toBe(exactly40);
+  });
+});

--- a/src/modules/ai/lib/sessions.test.ts
+++ b/src/modules/ai/lib/sessions.test.ts
@@ -58,4 +58,39 @@ describe("deriveTitle", () => {
     const exactly40 = "a".repeat(40);
     expect(deriveTitle([message(exactly40)])).toBe(exactly40);
   });
+
+  it("walks past an assistant reply to the later user question", () => {
+    expect(
+      deriveTitle([
+        message("assistant reply", "assistant"),
+        message("the real question"),
+      ]),
+    ).toBe("the real question");
+  });
+
+  it("skips non-text parts before the first text part", () => {
+    const m: UIMessage = {
+      id: "id",
+      role: "user",
+      parts: [
+        { type: "file" as const, url: "file:///a.png", mediaType: "image/png" },
+        { type: "text", text: "after the attachment" },
+      ],
+    } as unknown as UIMessage;
+    expect(deriveTitle([m])).toBe("after the attachment");
+  });
+
+  it("selects the first of several user messages with multiple parts", () => {
+    const second: UIMessage = {
+      id: "m2",
+      role: "user",
+      parts: [
+        { type: "file" as const, url: "file:///b.txt", mediaType: "text/plain" },
+        { type: "text", text: "second question" },
+      ],
+    } as unknown as UIMessage;
+    expect(
+      deriveTitle([message("first question"), second]),
+    ).toBe("first question");
+  });
 });


### PR DESCRIPTION
## What
Adds unit tests for `deriveTitle` in `src/modules/ai/lib/sessions.ts`.

## Why
`deriveTitle` derives a session title from AI chat messages: it skips non-user roles, strips `<terminal-context>`, `<selection>` and `<file>` blocks, takes the first line, caps at 40 chars, and falls back to "New chat". None of that behavior was covered.

## How
Test-only, new file colocated with the module. Fixtures build minimal `UIMessage` shapes. Covers: empty list, non-user skip, first user text part, first line, trimming, block stripping (including multiple consecutive blocks), fallback, 40-char truncation boundary.

## Testing
- [x] `pnpm test` clean (full suite)
- [x] `pnpm check-types` clean
- [x] `pnpm lint` clean (biome on the new file)
- Platforms tested: n/a (pure logic, node env)

## Notes for reviewer
Test-only, single file. Observed while writing these: an unterminated block tag (truncated AI output) is not stripped because the regex requires the closing tag - the raw tag lands in the title. Noted for a follow-up; not asserted here to avoid locking in the current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for AI-generated session title behavior.
  * Verified text extraction, whitespace handling, context removal, fallback behavior, line selection, and 40-character truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->