### PR TITLE
fix(terminal): render wide emoji at correct cell width

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@xterm/addon-serialize':
         specifier: ^0.14.0
         version: 0.14.0
+      '@xterm/addon-unicode11':
+        specifier: ^0.9.0
+        version: 0.9.0
       '@xterm/addon-web-links':
         specifier: ^0.12.0
         version: 0.12.0
@@ -3035,6 +3038,9 @@ packages:
 
   '@xterm/addon-serialize@0.14.0':
     resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
+
+  '@xterm/addon-unicode11@0.9.0':
+    resolution: {integrity: sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==}
 
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
@@ -8732,6 +8738,8 @@ snapshots:
   '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-serialize@0.14.0': {}
+
+  '@xterm/addon-unicode11@0.9.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
 

--- a/src/modules/terminal/lib/emojiWidth.test.ts
+++ b/src/modules/terminal/lib/emojiWidth.test.ts
@@ -1,0 +1,100 @@
+import type {
+  ITerminalAddon,
+  IUnicodeVersionProvider,
+  Terminal,
+} from "@xterm/xterm";
+import { describe, expect, it } from "vitest";
+import { activateUnicode11 } from "./unicodeWidth";
+
+// Drive real activation through a DOM-free fake terminal that dispatches width by
+// the active version, so the width assertions fail too if the wiring regresses.
+function activate() {
+  let addonLoaded = false;
+  // Start on a stub V6 like real xterm: a run that never switches to "11" widths
+  // nothing wide, failing the assertions below instead of silently passing.
+  const providers = new Map<string, IUnicodeVersionProvider>([
+    ["6", { version: "6", wcwidth: () => 1, charProperties: () => 0 }],
+  ]);
+  const state = { activeVersion: "6" };
+  const term = {
+    loadAddon(addon: ITerminalAddon) {
+      addonLoaded = true;
+      addon.activate(term as unknown as Terminal);
+    },
+    unicode: {
+      get versions() {
+        return [...providers.keys()];
+      },
+      register(p: IUnicodeVersionProvider) {
+        providers.set(p.version, p);
+      },
+      get activeVersion() {
+        return state.activeVersion;
+      },
+      set activeVersion(v: string) {
+        // Match real xterm: activating an unregistered version throws, which
+        // locks the register-before-activate order in activateUnicode11.
+        if (!providers.has(v)) throw new Error(`unknown Unicode version "${v}"`);
+        state.activeVersion = v;
+      },
+    },
+  };
+  activateUnicode11(term as Pick<Terminal, "loadAddon" | "unicode">);
+  const width = (cp: number) => {
+    const provider = providers.get(state.activeVersion);
+    if (!provider) throw new Error("no active provider");
+    return provider.wcwidth(cp);
+  };
+  return {
+    addonLoaded,
+    activeVersion: state.activeVersion,
+    activeProvider: providers.get(state.activeVersion),
+    width,
+  };
+}
+
+describe("terminal emoji width", () => {
+  const { addonLoaded, activeVersion, activeProvider, width } = activate();
+
+  it("loads the addon and activates Unicode version 11", () => {
+    expect(addonLoaded).toBe(true);
+    expect(activeVersion).toBe("11");
+    expect(activeProvider?.version).toBe("11");
+  });
+
+  it("counts the large green circle as two cells", () => {
+    expect(width(0x1f7e2)).toBe(2);
+  });
+
+  it("counts the whole colored circle/square block as two cells", () => {
+    for (let cp = 0x1f7e0; cp <= 0x1f7eb; cp++) {
+      expect(width(cp)).toBe(2);
+    }
+  });
+
+  it("stays targeted: codepoints bracketing the block are one cell", () => {
+    expect(width(0x1f7df)).toBe(1); // just below the block
+    expect(width(0x1f7ec)).toBe(1); // just above the block
+  });
+
+  it("counts emoji-presentation triangles as two cells", () => {
+    expect(width(0x23eb)).toBe(2); // fast up (double triangle)
+    expect(width(0x23ec)).toBe(2); // fast down
+    expect(width(0x1f53a)).toBe(2); // red triangle up
+  });
+
+  it("leaves text-presentation triangles one cell", () => {
+    // Triangle glyphs used as menu/tree/prompt carets are text-default and must
+    // stay narrow, or every TUI that draws them as one cell would shear instead.
+    expect(width(0x25b2)).toBe(1); // black up-pointing triangle
+    expect(width(0x25b6)).toBe(1); // black right-pointing triangle
+    expect(width(0x25bc)).toBe(1); // black down-pointing triangle
+  });
+
+  it("keeps already-correct widths intact", () => {
+    expect(width(0x41)).toBe(1); // "A"
+    expect(width(0x1f534)).toBe(2); // red circle
+    expect(width(0x1f9ca)).toBe(2); // ice cube
+    expect(width(0x1fa90)).toBe(2); // ringed planet
+  });
+});

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -17,6 +17,7 @@ import {
 import { pasteIntoTerminal } from "./terminalPaste";
 import { terminalReadlineSequence } from "./keymap";
 import { createTerminalLinkHandler } from "./terminalLinks";
+import { activateUnicode11 } from "./unicodeWidth";
 
 export const POOL_MAX_SIZE = 5;
 const FIT_DEBOUNCE_MS = 8;
@@ -222,6 +223,7 @@ function createSlot(): Slot {
       void openExternalUrl(uri, () => term.focus());
     }),
   );
+  activateUnicode11(term);
 
   const host = document.createElement("div");
   host.style.cssText = "width:100%;height:100%;";

--- a/src/modules/terminal/lib/unicodeWidth.ts
+++ b/src/modules/terminal/lib/unicodeWidth.ts
@@ -1,0 +1,11 @@
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import type { Terminal } from "@xterm/xterm";
+
+// xterm defaults to Unicode 6 widths, which undercount modern wide emoji
+// (colored circles/squares U+1F7E0..1F7EB, etc.) as one cell and shear the row.
+export function activateUnicode11(
+  term: Pick<Terminal, "loadAddon" | "unicode">,
+): void {
+  term.loadAddon(new Unicode11Addon());
+  term.unicode.activeVersion = "11";
+}


### PR DESCRIPTION
## What
Activate xterm's Unicode 11 provider on every pooled terminal so modern wide emoji occupy two cells instead of one. Covers the colored circle/square block (U+1F7E0..1F7EB, e.g. the reported 🟢 U+1F7E2), the ringed planet (U+1FA90), and the playback triangles (U+23E9..23EC).

## Why
xterm v6 defaults to its Unicode 6 width tables, which predate these codepoints and count them as a single cell. Because the font renders them two cells wide, every occurrence sheared the rest of the terminal row one column to the left. Reported case: typing a green circle misaligned the whole line.

## How
Adds the official `@xterm/addon-unicode11` (ships Unicode 12 width data) and activates it via a small helper `activateUnicode11(term)` in `src/modules/terminal/lib/unicodeWidth.ts`, called once per terminal in `rendererPool.ts` `createSlot`. `allowProposedApi: true` (already set) is required for `term.unicode.activeVersion`.

Text-presentation glyphs are intentionally left at width 1: geometric arrow triangles (▲ ▶ ▼ ◀, U+25B2..25C0) and similar are text-default and drawn as one cell by TUIs, prompts, and the git graph; widening them would cause shearing rather than fix it. This is locked with a test.

Known out of scope (planned follow-up PR): the VS16 emoji-variation class (base char + U+FE0F, e.g. warning / play / sun symbols) still counts width 1. Neither the addon nor xterm core promotes VS16 to width 2; a fix needs a custom width provider and is deliberately kept separate.

## Testing
- `pnpm lint`, `pnpm check-types`, `pnpm test` all clean (581 tests).
- New `src/modules/terminal/lib/emojiWidth.test.ts` drives the real helper through a DOM-free fake terminal and locks both halves of the contract: the wiring (addon loaded + Unicode version 11 active, via a fake unicode service that dispatches width by the active version) and the widths (the reported codepoint, the whole block, both block boundaries, emoji vs text-presentation triangles, and already-correct glyphs held intact). Mutation-checked: dropping the version switch fails the width tests, not just one assertion.
- Manual: launched `pnpm tauri dev` and confirmed the colored circles/squares and playback triangles align with a two-cell reference column, while arrow triangles stay one cell.

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo clippy ...` clean - N/A, no Rust changes
- [x] (If you touched `src-tauri/`) `cargo nextest run ...` clean - N/A, no Rust changes
- [x] (If you changed a `#[tauri::command]` signature) - N/A
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [x] Shells tested (if relevant): pwsh

## Screenshots / GIFs
Before:
<img width="416" height="281" alt="image" src="https://github.com/user-attachments/assets/0539d211-8084-4e3c-b041-c9eb52242922" />

After:
<img width="409" height="279" alt="image" src="https://github.com/user-attachments/assets/009bc9ca-a98c-4a6a-9950-9ac71e33c439" />


## Notes for reviewer
- Dependency size: `@xterm/addon-unicode11` is ~11.4 KB gzip (ESM build), well under the 50 KB threshold. It is an official xterm addon and is loaded eagerly on the terminal-first path, consistent with xterm being intentionally eager; it does not trip `src/app/eager-budget.test.ts`.
- `pnpm-lock.yaml` contains only the three minimal entries for the new addon (importers + packages + snapshots). A plain `pnpm add` re-resolves an unrelated `react-scan -> bippy` registry drift, so the entries were added by hand and verified with `pnpm install --frozen-lockfile`.
- The width-1 behavior of arrow triangles (▲ ▶ ▼ ◀) is intentional, not a missed case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal rendering for modern emoji and Unicode characters.
  * Added support for accurate widths of wide, narrow, and text-presentation emoji.

* **Bug Fixes**
  * Fixed terminal alignment issues caused by incorrect emoji character widths.

* **Tests**
  * Added coverage for Unicode 11 activation and emoji width handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->