### PR TITLE
feat(git): support nested repository targeting

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/modules/sidebar";
 import {
   SourceControlPanel,
+  useRepositoryTargeting,
   useSourceControlContext,
 } from "@/modules/source-control";
 import {
@@ -95,7 +96,11 @@ import {
 } from "@/modules/terminal";
 import { ThemeProvider, useThemeFileEditing } from "@/modules/theme";
 import { UpdaterDialog } from "@/modules/updater";
-import { useWorkspaceEnvStore, type WorkspaceEnv } from "@/modules/workspace";
+import {
+  useWorkspaceEnvStore,
+  workspaceScopeKey,
+  type WorkspaceEnv,
+} from "@/modules/workspace";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -213,6 +218,7 @@ export default function App() {
 
   const activeSpaceId = useSpaces((s) => s.activeId);
   const spacesHydrated = useSpaces((s) => s.hydrated);
+  const sourceControlSpaceId = activeSpaceId ?? DEFAULT_SPACE_ID;
 
   const handleWorkspaceChange = useCallback(
     async (env: WorkspaceEnv) => {
@@ -284,6 +290,7 @@ export default function App() {
     persistSidebarCollapsed,
     toggleSidebar,
     cycleSidebarView,
+    openSidebarView,
     persistSidebarWidth,
     toggleExplorerFocus,
   } = useSidebarPanel(explorerRef);
@@ -666,6 +673,32 @@ export default function App() {
     activeTab?.kind === "editor" || activeTab?.kind === "markdown"
       ? activeTab.path
       : null;
+  const isRepositoryContextCurrent = useCallback(
+    (spaceId: string, workspaceKey: string) => {
+      const currentSpaceId =
+        useSpaces.getState().activeId ?? DEFAULT_SPACE_ID;
+      const currentWorkspaceKey = workspaceScopeKey(
+        useWorkspaceEnvStore.getState().env,
+      );
+      return spaceId === currentSpaceId && workspaceKey === currentWorkspaceKey;
+    },
+    [],
+  );
+  const openSourceControl = useCallback(() => {
+    openSidebarView("source-control");
+  }, [openSidebarView]);
+  const {
+    repositoryTarget: sourceControlRepositoryTarget,
+    openInSourceControl: handleOpenRepositoryInSourceControl,
+    openGitHistory: handleOpenGitHistoryForPath,
+    followActiveContext: handleFollowRepositoryContext,
+  } = useRepositoryTargeting({
+    spaceId: sourceControlSpaceId,
+    workspaceKey: workspaceScopeKey(workspaceEnv),
+    isContextCurrent: isRepositoryContextCurrent,
+    openSourceControl,
+    openCommitHistoryTab,
+  });
   const { sourceControl, toggleSourceControl, openGitGraphFromContext } =
     useSourceControlContext({
       activeTab,
@@ -676,6 +709,7 @@ export default function App() {
       launchCwdResolved,
       home,
       sidebarView,
+      repositoryTarget: sourceControlRepositoryTarget,
       cycleSidebarView,
       openCommitHistoryTab,
     });
@@ -1281,6 +1315,10 @@ export default function App() {
                         onPathRenamed={handlePathRenamed}
                         onPathDeleted={handlePathDeleted}
                         onRevealInTerminal={cdInNewTab}
+                        onOpenInSourceControl={
+                          handleOpenRepositoryInSourceControl
+                        }
+                        onOpenGitHistory={handleOpenGitHistoryForPath}
                         onAttachToAgent={handleAttachFileToAgent}
                         pathDropTarget={terminalPathDropTarget}
                       />
@@ -1292,6 +1330,10 @@ export default function App() {
                         onOpenGitGraph={openGitGraphFromContext}
                         onOpenFile={handleOpenFile}
                         onNavigateToPath={cdInNewTab}
+                        repositoryTarget={sourceControlRepositoryTarget}
+                        onFollowRepositoryContext={
+                          handleFollowRepositoryContext
+                        }
                       />
                     )}
                   </div>

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -50,6 +50,8 @@ type Props = {
   onRequestClose: () => void;
   onActiveChange?: (active: boolean) => void;
   onRevealInTerminal?: (path: string) => void;
+  onOpenInSourceControl?: (path: string) => void;
+  onOpenGitHistory?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
 };
 
@@ -65,6 +67,8 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
   onRequestClose,
   onActiveChange,
   onRevealInTerminal,
+  onOpenInSourceControl,
+  onOpenGitHistory,
   onAttachToAgent,
 }: Props,
   ref,
@@ -284,6 +288,22 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
                           onSelect={() => onRevealInTerminal(hit.path)}
                         >
                           Open in Terminal
+                        </ContextMenuItem>
+                      )}
+                      {hit.is_dir && onOpenInSourceControl && (
+                        <ContextMenuItem
+                          className={COMPACT_ITEM}
+                          onSelect={() => onOpenInSourceControl(hit.path)}
+                        >
+                          Open in Source Control
+                        </ContextMenuItem>
+                      )}
+                      {hit.is_dir && onOpenGitHistory && (
+                        <ContextMenuItem
+                          className={COMPACT_ITEM}
+                          onSelect={() => onOpenGitHistory(hit.path)}
+                        >
+                          Open Git History
                         </ContextMenuItem>
                       )}
                       <ContextMenuItem

--- a/src/modules/explorer/FileExplorer.tsx
+++ b/src/modules/explorer/FileExplorer.tsx
@@ -59,6 +59,8 @@ type Props = {
   onPathRenamed?: (from: string, to: string) => void;
   onPathDeleted?: (path: string) => void;
   onRevealInTerminal?: (path: string) => void;
+  onOpenInSourceControl?: (path: string) => void;
+  onOpenGitHistory?: (path: string) => void;
   onAttachToAgent?: (path: string) => void;
   pathDropTarget?: TerminalPathDropTarget;
   gitStatus?: GitStatusSnapshot | null;
@@ -191,6 +193,8 @@ export const FileExplorer = memo(
       onPathRenamed,
       onPathDeleted,
       onRevealInTerminal,
+      onOpenInSourceControl,
+      onOpenGitHistory,
       onAttachToAgent,
       pathDropTarget,
       gitStatus,
@@ -557,6 +561,8 @@ export const FileExplorer = memo(
           onRequestClose={() => setIsSearchOpen(false)}
           onActiveChange={setIsSearchActive}
           onRevealInTerminal={onRevealInTerminal}
+          onOpenInSourceControl={onOpenInSourceControl}
+          onOpenGitHistory={onOpenGitHistory}
           onAttachToAgent={onAttachToAgent}
         />
 
@@ -686,6 +692,22 @@ export const FileExplorer = memo(
                       Open in Terminal
                     </ContextMenuItem>
                   )}
+                  {menuTarget.isDir && onOpenInSourceControl && (
+                    <ContextMenuItem
+                      className={COMPACT_ITEM}
+                      onSelect={() => onOpenInSourceControl(menuTarget.path)}
+                    >
+                      Open in Source Control
+                    </ContextMenuItem>
+                  )}
+                  {menuTarget.isDir && onOpenGitHistory && (
+                    <ContextMenuItem
+                      className={COMPACT_ITEM}
+                      onSelect={() => onOpenGitHistory(menuTarget.path)}
+                    >
+                      Open Git History
+                    </ContextMenuItem>
+                  )}
                   <ContextMenuItem
                     className={COMPACT_ITEM}
                     onSelect={() => void revealInFinder(menuTarget.path)}
@@ -767,6 +789,22 @@ export const FileExplorer = memo(
                       onSelect={() => onRevealInTerminal(rootPath)}
                     >
                       Open in Terminal
+                    </ContextMenuItem>
+                  )}
+                  {onOpenInSourceControl && (
+                    <ContextMenuItem
+                      className={COMPACT_ITEM}
+                      onSelect={() => onOpenInSourceControl(rootPath)}
+                    >
+                      Open in Source Control
+                    </ContextMenuItem>
+                  )}
+                  {onOpenGitHistory && (
+                    <ContextMenuItem
+                      className={COMPACT_ITEM}
+                      onSelect={() => onOpenGitHistory(rootPath)}
+                    >
+                      Open Git History
                     </ContextMenuItem>
                   )}
                   <ContextMenuItem

--- a/src/modules/sidebar/useSidebarPanel.ts
+++ b/src/modules/sidebar/useSidebarPanel.ts
@@ -123,6 +123,17 @@ export function useSidebarPanel(
     [persistSidebarView, sidebarView],
   );
 
+  const openSidebarView = useCallback(
+    (view: SidebarViewId) => {
+      const panel = sidebarRef.current;
+      if (panel && panel.getSize().asPercentage <= 0) {
+        panel.resize(`${sidebarWidthRef.current}px`);
+      }
+      if (view !== sidebarView) persistSidebarView(view);
+    },
+    [persistSidebarView, sidebarView],
+  );
+
   const persistSidebarWidth = useCallback(
     (next: number, isUserInteraction: boolean) => {
       if (!shouldPersistSidebarWidth(next, isUserInteraction)) return;
@@ -191,6 +202,7 @@ export function useSidebarPanel(
     persistSidebarCollapsed,
     toggleSidebar,
     cycleSidebarView,
+    openSidebarView,
     persistSidebarWidth,
     toggleExplorerFocus,
   };

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -76,6 +76,10 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import {
+  repositoryTargetIsPending,
+  type SourceControlRepositoryTarget,
+} from "./repositoryTarget";
 import type { SourceControlSummary } from "./useSourceControl";
 import {
   useSourceControlPanel,
@@ -96,6 +100,8 @@ type Props = {
   }) => void;
   onOpenFile?: (absolutePath: string) => void;
   onNavigateToPath?: (path: string) => void;
+  repositoryTarget: SourceControlRepositoryTarget;
+  onFollowRepositoryContext: () => void;
 };
 
 const SOURCE_CONTROL_TOOLTIP_CLASS =
@@ -160,11 +166,17 @@ function checkboxValue(state: CheckState): boolean | "indeterminate" {
 function BranchDropdown({
   repoRoot,
   repoLabel,
+  displayRepoRoot,
+  repositoryTarget,
+  onFollowRepositoryContext,
   onNavigateToPath,
   onRefresh,
 }: {
   repoRoot: string | null;
   repoLabel: string;
+  displayRepoRoot: string | null;
+  repositoryTarget: SourceControlRepositoryTarget;
+  onFollowRepositoryContext: () => void;
   onNavigateToPath?: (path: string) => void;
   onRefresh: () => void;
 }) {
@@ -242,6 +254,7 @@ function BranchDropdown({
         <button
           type="button"
           disabled={checkingOut}
+          title={displayRepoRoot ?? repoLabel}
           className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[11.5px] font-medium leading-none text-foreground transition-colors hover:bg-foreground/10 disabled:cursor-default disabled:opacity-70"
         >
           <HugeiconsIcon
@@ -250,10 +263,43 @@ function BranchDropdown({
             strokeWidth={1.9}
             className="shrink-0 text-muted-foreground"
           />
-          <span className="max-w-35 truncate">{repoLabel}</span>
+          {displayRepoRoot ? (
+            <>
+              <span className="max-w-22 truncate">
+                {basename(displayRepoRoot)}
+              </span>
+              <span className="text-muted-foreground/60">/</span>
+            </>
+          ) : null}
+          <span className="max-w-24 truncate">{repoLabel}</span>
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
+        {displayRepoRoot ? (
+          <>
+            <DropdownMenuLabel className="text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/85">
+              Repository
+            </DropdownMenuLabel>
+            <div
+              className="truncate px-2 pb-1.5 text-[11px] text-muted-foreground"
+              title={displayRepoRoot}
+            >
+              {displayRepoRoot}
+            </div>
+            {repositoryTarget.mode === "fixed" ? (
+              <DropdownMenuItem
+                onSelect={() => {
+                  onFollowRepositoryContext();
+                  setOpen(false);
+                }}
+                className="cursor-pointer text-[12px]"
+              >
+                Follow Active Context
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
         {loading ? (
           <div className="flex items-center gap-2 px-3 py-3 text-[11px] text-muted-foreground">
             <Spinner className="size-3" />
@@ -348,6 +394,8 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   onOpenDiff,
   onOpenFile,
   onNavigateToPath,
+  repositoryTarget,
+  onFollowRepositoryContext,
 }: Props) {
   const scm = useSourceControlPanel(open, sourceControl, onOpenDiff);
   const refreshAnimationRef = useRef<number | null>(null);
@@ -364,17 +412,26 @@ export const SourceControlPanel = memo(function SourceControlPanel({
     };
   }, []);
 
-  const isRefreshing = scm.panelState === "loading";
+  const fixedTargetPending = repositoryTargetIsPending({
+    target: repositoryTarget,
+    loadedContextPath: sourceControl.contextPath,
+    loadedRepoRoot: sourceControl.repo?.repoRoot ?? null,
+    isLoading: sourceControl.isLoading,
+  });
+  const panelState = fixedTargetPending ? "loading" : scm.panelState;
+  const isRefreshing = panelState === "loading";
   const repoLabel = useMemo(() => {
+    if (fixedTargetPending) return "Loading";
     if (!scm.status) return "Source Control";
     return scm.status.isDetached ? "detached" : scm.status.branch;
-  }, [scm.status]);
+  }, [fixedTargetPending, scm.status]);
 
   const commitShortcut = IS_MAC ? "⌘↩" : "Ctrl+Enter";
   const generateShortcut = IS_MAC ? "⌘G" : "Ctrl+G";
   const canCommit =
     scm.stagedEntries.length > 0 &&
     scm.commitMessage.trim().length > 0 &&
+    !fixedTargetPending &&
     !scm.actionBusy;
   const commitDisabledReason = scm.actionBusy
     ? "Wait for the current Git action to finish."
@@ -387,9 +444,11 @@ export const SourceControlPanel = memo(function SourceControlPanel({
     ? `Commit with ${commitShortcut}.`
     : (commitDisabledReason ?? `Commit with ${commitShortcut}.`);
   const pushHint = scm.pushHint ?? "Push is unavailable right now.";
-  const pushDisabledReason = scm.actionBusy
-    ? "Wait for the current Git action to finish."
-    : pushHint;
+  const pushDisabledReason = fixedTargetPending
+    ? "Wait for the selected repository to finish loading."
+    : scm.actionBusy
+      ? "Wait for the current Git action to finish."
+      : pushHint;
   const stagedCount = scm.stagedEntries.length;
   const changedCount = scm.fileEntries.length;
   const pushStatusLabel = upstreamBadgeLabel(scm.status?.upstream);
@@ -402,9 +461,14 @@ export const SourceControlPanel = memo(function SourceControlPanel({
     !!scm.status &&
     scm.status.behind > 0 &&
     !isDiverged &&
+    !fixedTargetPending &&
     !scm.actionBusy &&
     !sourceControl.busyAction;
-  const canFetch = hasUpstream && !scm.actionBusy && !sourceControl.busyAction;
+  const canFetch =
+    hasUpstream &&
+    !fixedTargetPending &&
+    !scm.actionBusy &&
+    !sourceControl.busyAction;
 
   const footerFeedback = useMemo(() => {
     if (scm.actionError)
@@ -619,8 +683,17 @@ export const SourceControlPanel = memo(function SourceControlPanel({
         <header className="flex shrink-0 items-center justify-between gap-2 border-b border-border/50 px-3 pb-2.5 pt-3">
           <div className="flex min-w-0 items-center gap-1.5">
             <BranchDropdown
-              repoRoot={scm.repo?.repoRoot ?? null}
+              repoRoot={
+                fixedTargetPending ? null : (scm.repo?.repoRoot ?? null)
+              }
               repoLabel={repoLabel}
+              displayRepoRoot={
+                repositoryTarget.mode === "fixed"
+                  ? repositoryTarget.repoRoot
+                  : (scm.repo?.repoRoot ?? null)
+              }
+              repositoryTarget={repositoryTarget}
+              onFollowRepositoryContext={onFollowRepositoryContext}
               onNavigateToPath={onNavigateToPath}
               onRefresh={handleRefresh}
             />
@@ -739,18 +812,18 @@ export const SourceControlPanel = memo(function SourceControlPanel({
           </button>
         ) : null}
 
-        {scm.panelState === "loading" ? (
+        {panelState === "loading" ? (
           <PanelCenter title="Loading repository" />
         ) : null}
 
-        {scm.panelState === "no-repo" ? (
+        {panelState === "no-repo" ? (
           <PanelCenter
             title="No repository"
             body="The active workspace is not inside a Git repository."
           />
         ) : null}
 
-        {scm.panelState === "error" ? (
+        {panelState === "error" ? (
           <PanelCenter
             title="Source control error"
             body={scm.statusError ?? "Unknown source control error"}
@@ -762,7 +835,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
           />
         ) : null}
 
-        {scm.panelState === "ready" && scm.status ? (
+        {panelState === "ready" && scm.status ? (
           <>
             <div className="relative shrink-0 space-y-2 border-b border-border/40 bg-gradient-to-b from-card/65 to-card/30 px-2.5 pb-2.5 pt-2.5">
               <div
@@ -880,7 +953,9 @@ export const SourceControlPanel = memo(function SourceControlPanel({
                       size="xs"
                       variant="secondary"
                       className="h-7 cursor-pointer text-[11.5px] font-medium disabled:cursor-not-allowed"
-                      disabled={!scm.canPush || !!scm.actionBusy}
+                      disabled={
+                        !scm.canPush || fixedTargetPending || !!scm.actionBusy
+                      }
                       onClick={() => void scm.push()}
                     >
                       {scm.actionBusy === "push" ? "Pushing…" : "Push"}

--- a/src/modules/source-control/index.ts
+++ b/src/modules/source-control/index.ts
@@ -1,4 +1,6 @@
 export { SourceControlPanel } from "./SourceControlPanelLazy";
+export type { SourceControlRepositoryTarget } from "./repositoryTarget";
+export { useRepositoryTargeting } from "./useRepositoryTargeting";
 export {
   getSourceControlRemoteIndicator,
   useSourceControl,

--- a/src/modules/source-control/repositoryTarget.test.ts
+++ b/src/modules/source-control/repositoryTarget.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "@/modules/tabs";
+import {
+  activeRepositoryContextPath,
+  clearRepositoryTargetForSpace,
+  gitGraphRepositoryPath,
+  repositoryTargetForSpace,
+  repositoryTargetIsPending,
+  setRepositoryTargetForSpace,
+  sourceControlRepositoryPath,
+} from "./repositoryTarget";
+
+const terminalTab: Tab = {
+  id: 1,
+  kind: "terminal",
+  spaceId: "space-a",
+  title: "shell",
+  paneTree: { kind: "leaf", id: 10 },
+  activeLeafId: 10,
+};
+
+const editorTab: Tab = {
+  id: 2,
+  kind: "editor",
+  spaceId: "space-a",
+  title: "main.ts",
+  path: "C:\\repo\\src\\main.ts",
+  dirty: false,
+  preview: false,
+};
+
+const historyTab: Tab = {
+  id: 3,
+  kind: "git-history",
+  spaceId: "space-a",
+  title: "History",
+  repoRoot: "/repos/history",
+};
+
+describe("repository targets", () => {
+  it("keeps fixed repositories isolated by Space", () => {
+    const targets = setRepositoryTargetForSpace(
+      {},
+      "space-a",
+      "local",
+      "/repos/a",
+    );
+
+    expect(repositoryTargetForSpace(targets, "space-a", "local")).toEqual({
+      mode: "fixed",
+      repoRoot: "/repos/a",
+    });
+    expect(repositoryTargetForSpace(targets, "space-b", "local")).toEqual({
+      mode: "follow-context",
+    });
+    expect(
+      setRepositoryTargetForSpace(
+        targets,
+        "space-a",
+        "local",
+        "/repos/a",
+      ),
+    ).toBe(targets);
+  });
+
+  it("keeps repository paths isolated by workspace environment", () => {
+    const localTargets = setRepositoryTargetForSpace(
+      {},
+      "space-a",
+      "local",
+      "C:/repos/a",
+    );
+    const targets = setRepositoryTargetForSpace(
+      localTargets,
+      "space-a",
+      "wsl:Ubuntu",
+      "/repos/a",
+    );
+
+    expect(repositoryTargetForSpace(targets, "space-a", "local")).toEqual({
+      mode: "fixed",
+      repoRoot: "C:/repos/a",
+    });
+    expect(repositoryTargetForSpace(targets, "space-a", "wsl:Ubuntu")).toEqual({
+      mode: "fixed",
+      repoRoot: "/repos/a",
+    });
+  });
+
+  it("returns to context-following without changing other Spaces", () => {
+    const otherSpace = setRepositoryTargetForSpace(
+      {},
+      "space-b",
+      "local",
+      "/repos/b",
+    );
+    const targets = setRepositoryTargetForSpace(
+      otherSpace,
+      "space-a",
+      "local",
+      "/repos/a",
+    );
+    const next = clearRepositoryTargetForSpace(targets, "space-a", "local");
+
+    expect(repositoryTargetForSpace(next, "space-a", "local")).toEqual({
+      mode: "follow-context",
+    });
+    expect(repositoryTargetForSpace(next, "space-b", "local")).toEqual({
+      mode: "fixed",
+      repoRoot: "/repos/b",
+    });
+  });
+});
+
+describe("activeRepositoryContextPath", () => {
+  it("prefers the focused terminal leaf cwd", () => {
+    expect(
+      activeRepositoryContextPath({
+        activeTab: terminalTab,
+        activeTerminalLeafCwd: "/repos/terminal/packages/app",
+        explorerRoot: "/repos/explorer",
+        workspaceFallbackPath: "/fallback",
+      }),
+    ).toBe("/repos/terminal/packages/app");
+  });
+
+  it("uses the editor parent directory across Windows paths", () => {
+    expect(
+      activeRepositoryContextPath({
+        activeTab: editorTab,
+        activeTerminalLeafCwd: null,
+        explorerRoot: "/repos/explorer",
+        workspaceFallbackPath: "/fallback",
+      }),
+    ).toBe("C:/repo/src");
+  });
+
+  it("preserves Unix and Windows filesystem roots", () => {
+    expect(
+      activeRepositoryContextPath({
+        activeTab: { ...editorTab, path: "/main.ts" },
+        activeTerminalLeafCwd: null,
+        explorerRoot: null,
+        workspaceFallbackPath: null,
+      }),
+    ).toBe("/");
+    expect(
+      activeRepositoryContextPath({
+        activeTab: { ...editorTab, path: "C:\\main.ts" },
+        activeTerminalLeafCwd: null,
+        explorerRoot: null,
+        workspaceFallbackPath: null,
+      }),
+    ).toBe("C:/");
+  });
+
+  it("keeps a Git tab bound to its own repository", () => {
+    expect(
+      activeRepositoryContextPath({
+        activeTab: historyTab,
+        activeTerminalLeafCwd: null,
+        explorerRoot: "/repos/explorer",
+        workspaceFallbackPath: "/fallback",
+      }),
+    ).toBe("/repos/history");
+  });
+});
+
+describe("sourceControlRepositoryPath", () => {
+  const fixed = { mode: "fixed", repoRoot: "/repos/fixed" } as const;
+
+  it("applies a fixed target inside Source Control", () => {
+    expect(
+      sourceControlRepositoryPath({
+        contextPath: "/repos/active",
+        badgeContextPath: "/repos/explorer",
+        sidebarView: "source-control",
+        hasOpenGitTab: false,
+        target: fixed,
+      }),
+    ).toBe("/repos/fixed");
+  });
+
+  it("does not leak a fixed target into Explorer decorations or badges", () => {
+    expect(
+      sourceControlRepositoryPath({
+        contextPath: "/repos/active",
+        badgeContextPath: "/repos/explorer",
+        sidebarView: "explorer",
+        hasOpenGitTab: false,
+        target: fixed,
+      }),
+    ).toBe("/repos/explorer");
+  });
+
+  it("keeps open Git tabs on their active repository outside Source Control", () => {
+    expect(
+      sourceControlRepositoryPath({
+        contextPath: "/repos/history",
+        badgeContextPath: "/repos/explorer",
+        sidebarView: "explorer",
+        hasOpenGitTab: true,
+        target: fixed,
+      }),
+    ).toBe("/repos/history");
+  });
+
+  it("uses the fixed target for graph routing only from Source Control", () => {
+    expect(
+      gitGraphRepositoryPath({
+        contextPath: "/repos/active",
+        sidebarView: "source-control",
+        target: fixed,
+      }),
+    ).toBe("/repos/fixed");
+    expect(
+      gitGraphRepositoryPath({
+        contextPath: "/repos/active",
+        sidebarView: "explorer",
+        target: fixed,
+      }),
+    ).toBe("/repos/active");
+  });
+});
+
+describe("repositoryTargetIsPending", () => {
+  const fixed = { mode: "fixed", repoRoot: "/repos/fixed" } as const;
+
+  it("masks state loaded for a previous repository", () => {
+    expect(
+      repositoryTargetIsPending({
+        target: fixed,
+        loadedContextPath: "/repos/previous",
+        loadedRepoRoot: "/repos/previous",
+        isLoading: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps loading masked until the selected repository is loaded", () => {
+    expect(
+      repositoryTargetIsPending({
+        target: fixed,
+        loadedContextPath: "/repos/fixed",
+        loadedRepoRoot: null,
+        isLoading: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("reveals a completed error or no-repository state", () => {
+    expect(
+      repositoryTargetIsPending({
+        target: fixed,
+        loadedContextPath: "/repos/fixed",
+        loadedRepoRoot: null,
+        isLoading: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/modules/source-control/repositoryTarget.ts
+++ b/src/modules/source-control/repositoryTarget.ts
@@ -1,0 +1,136 @@
+import type { SidebarViewId } from "@/modules/sidebar";
+import type { Tab } from "@/modules/tabs";
+
+export type SourceControlRepositoryTarget =
+  | { mode: "follow-context" }
+  | { mode: "fixed"; repoRoot: string };
+
+export type SourceControlRepositoryTargets = Readonly<
+  Record<string, string>
+>;
+
+const FOLLOW_CONTEXT: SourceControlRepositoryTarget = {
+  mode: "follow-context",
+};
+
+function targetScopeKey(spaceId: string, workspaceKey: string): string {
+  return `${spaceId}\0${workspaceKey}`;
+}
+
+function dirname(path: string | null): string | null {
+  if (!path) return null;
+  const normalized = path.replace(/\\/g, "/");
+  const index = normalized.lastIndexOf("/");
+  if (index < 0) return normalized;
+  if (index === 0) return "/";
+  if (index === 2 && /^[A-Za-z]:\//.test(normalized)) {
+    return normalized.slice(0, 3);
+  }
+  return normalized.slice(0, index);
+}
+
+export function repositoryTargetForSpace(
+  targets: SourceControlRepositoryTargets,
+  spaceId: string,
+  workspaceKey: string,
+): SourceControlRepositoryTarget {
+  const repoRoot = targets[targetScopeKey(spaceId, workspaceKey)];
+  return repoRoot
+    ? { mode: "fixed", repoRoot }
+    : FOLLOW_CONTEXT;
+}
+
+export function setRepositoryTargetForSpace(
+  targets: SourceControlRepositoryTargets,
+  spaceId: string,
+  workspaceKey: string,
+  repoRoot: string,
+): SourceControlRepositoryTargets {
+  const key = targetScopeKey(spaceId, workspaceKey);
+  if (targets[key] === repoRoot) return targets;
+  return { ...targets, [key]: repoRoot };
+}
+
+export function clearRepositoryTargetForSpace(
+  targets: SourceControlRepositoryTargets,
+  spaceId: string,
+  workspaceKey: string,
+): SourceControlRepositoryTargets {
+  const key = targetScopeKey(spaceId, workspaceKey);
+  if (!(key in targets)) return targets;
+  const next = { ...targets };
+  delete next[key];
+  return next;
+}
+
+export function activeRepositoryContextPath({
+  activeTab,
+  activeTerminalLeafCwd,
+  explorerRoot,
+  workspaceFallbackPath,
+}: {
+  activeTab: Tab | undefined;
+  activeTerminalLeafCwd: string | null;
+  explorerRoot: string | null;
+  workspaceFallbackPath: string | null;
+}): string | null {
+  if (activeTab?.kind === "terminal") {
+    return activeTerminalLeafCwd ?? explorerRoot ?? workspaceFallbackPath;
+  }
+  if (activeTab?.kind === "editor") return dirname(activeTab.path);
+  if (activeTab?.kind === "git-diff") return activeTab.repoRoot;
+  if (activeTab?.kind === "git-commit-file") return activeTab.repoRoot;
+  if (activeTab?.kind === "git-history") return activeTab.repoRoot;
+  return explorerRoot ?? workspaceFallbackPath;
+}
+
+export function sourceControlRepositoryPath({
+  contextPath,
+  badgeContextPath,
+  sidebarView,
+  hasOpenGitTab,
+  target,
+}: {
+  contextPath: string | null;
+  badgeContextPath: string | null;
+  sidebarView: SidebarViewId;
+  hasOpenGitTab: boolean;
+  target: SourceControlRepositoryTarget;
+}): string | null {
+  if (sidebarView === "source-control" && target.mode === "fixed") {
+    return target.repoRoot;
+  }
+  return hasOpenGitTab || sidebarView === "source-control"
+    ? contextPath
+    : badgeContextPath;
+}
+
+export function gitGraphRepositoryPath({
+  contextPath,
+  sidebarView,
+  target,
+}: {
+  contextPath: string | null;
+  sidebarView: SidebarViewId;
+  target: SourceControlRepositoryTarget;
+}): string | null {
+  return sidebarView === "source-control" && target.mode === "fixed"
+    ? target.repoRoot
+    : contextPath;
+}
+
+export function repositoryTargetIsPending({
+  target,
+  loadedContextPath,
+  loadedRepoRoot,
+  isLoading,
+}: {
+  target: SourceControlRepositoryTarget;
+  loadedContextPath: string | null;
+  loadedRepoRoot: string | null;
+  isLoading: boolean;
+}): boolean {
+  if (target.mode !== "fixed") return false;
+  if (loadedContextPath !== target.repoRoot) return true;
+  return isLoading && loadedRepoRoot !== target.repoRoot;
+}

--- a/src/modules/source-control/useRepositoryTargeting.ts
+++ b/src/modules/source-control/useRepositoryTargeting.ts
@@ -1,0 +1,117 @@
+import { native } from "@/modules/ai/lib/native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  clearRepositoryTargetForSpace,
+  repositoryTargetForSpace,
+  setRepositoryTargetForSpace,
+  type SourceControlRepositoryTargets,
+} from "./repositoryTarget";
+
+type RequestCounter = { current: number };
+
+type Params = {
+  spaceId: string;
+  workspaceKey: string;
+  isContextCurrent: (spaceId: string, workspaceKey: string) => boolean;
+  openSourceControl: () => void;
+  openCommitHistoryTab: (input: {
+    repoRoot: string;
+    branch: string | null;
+  }) => void;
+};
+
+export function useRepositoryTargeting({
+  spaceId,
+  workspaceKey,
+  isContextCurrent,
+  openSourceControl,
+  openCommitHistoryTab,
+}: Params) {
+  const [targets, setTargets] = useState<SourceControlRepositoryTargets>({});
+  const sourceControlRequestRef = useRef(0);
+  const historyRequestRef = useRef(0);
+  const requestScope = `${spaceId}\0${workspaceKey}`;
+  const requestScopeRef = useRef(requestScope);
+  const repositoryTarget = useMemo(
+    () => repositoryTargetForSpace(targets, spaceId, workspaceKey),
+    [spaceId, targets, workspaceKey],
+  );
+
+  useEffect(() => {
+    if (requestScopeRef.current === requestScope) return;
+    requestScopeRef.current = requestScope;
+    sourceControlRequestRef.current += 1;
+    historyRequestRef.current += 1;
+  }, [requestScope]);
+
+  const resolveRepository = useCallback(
+    async (path: string, requestRef: RequestCounter) => {
+      const requestId = ++requestRef.current;
+      try {
+        const repo = await native.gitResolveRepo(path);
+        if (
+          requestId !== requestRef.current ||
+          !isContextCurrent(spaceId, workspaceKey)
+        ) {
+          return null;
+        }
+        if (!repo) {
+          toast.info("No Git repository contains this folder.");
+        }
+        return repo;
+      } catch (error) {
+        if (
+          requestId === requestRef.current &&
+          isContextCurrent(spaceId, workspaceKey)
+        ) {
+          toast.error("Could not resolve Git repository", {
+            description: String(error),
+          });
+        }
+        return null;
+      }
+    },
+    [isContextCurrent, spaceId, workspaceKey],
+  );
+
+  const openInSourceControl = useCallback(
+    async (path: string) => {
+      const repo = await resolveRepository(path, sourceControlRequestRef);
+      if (!repo) return;
+      setTargets((current) =>
+        setRepositoryTargetForSpace(
+          current,
+          spaceId,
+          workspaceKey,
+          repo.repoRoot,
+        ),
+      );
+      openSourceControl();
+    },
+    [openSourceControl, resolveRepository, spaceId, workspaceKey],
+  );
+
+  const openGitHistory = useCallback(
+    async (path: string) => {
+      const repo = await resolveRepository(path, historyRequestRef);
+      if (!repo) return;
+      openCommitHistoryTab({ repoRoot: repo.repoRoot, branch: repo.branch });
+    },
+    [openCommitHistoryTab, resolveRepository],
+  );
+
+  const followActiveContext = useCallback(() => {
+    sourceControlRequestRef.current += 1;
+    setTargets((current) =>
+      clearRepositoryTargetForSpace(current, spaceId, workspaceKey),
+    );
+  }, [spaceId, workspaceKey]);
+
+  return {
+    repositoryTarget,
+    openInSourceControl,
+    openGitHistory,
+    followActiveContext,
+  };
+}

--- a/src/modules/source-control/useSourceControl.test.ts
+++ b/src/modules/source-control/useSourceControl.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginSourceControlRefresh,
+  repositoryContainsContext,
+} from "./useSourceControl";
+
+describe("repositoryContainsContext", () => {
+  it("matches a repository root and its descendants", () => {
+    expect(repositoryContainsContext("/repo", "/repo")).toBe(true);
+    expect(repositoryContainsContext("/repo", "/repo/packages/app")).toBe(
+      true,
+    );
+  });
+
+  it("rejects sibling paths that only share a string prefix", () => {
+    expect(repositoryContainsContext("/repo", "/repo-other/app")).toBe(false);
+    expect(repositoryContainsContext("/Repo", "/repo/app")).toBe(false);
+  });
+
+  it("normalizes Windows separators and drive-letter casing", () => {
+    expect(
+      repositoryContainsContext("C:\\Repo", "c:/repo/packages/app"),
+    ).toBe(true);
+  });
+
+  it("normalizes UNC server and share casing", () => {
+    expect(
+      repositoryContainsContext(
+        "\\\\SERVER\\Share\\Repo",
+        "//server/share/repo/packages/app",
+      ),
+    ).toBe(true);
+  });
+
+  it("handles filesystem roots", () => {
+    expect(repositoryContainsContext("/", "/workspace")).toBe(true);
+    expect(repositoryContainsContext("C:/", "C:/workspace")).toBe(true);
+  });
+});
+
+describe("beginSourceControlRefresh", () => {
+  const loaded = {
+    contextPath: "/old/repo",
+    repo: {
+      repoRoot: "/old/repo",
+      branch: "main",
+      upstream: null,
+      isDetached: false,
+    },
+    status: {
+      repoRoot: "/old/repo",
+      branch: "main",
+      upstream: null,
+      ahead: 0,
+      behind: 0,
+      isDetached: false,
+      truncated: false,
+      changedFiles: [],
+    },
+    hasRepo: true,
+    isLoading: false,
+    localError: "old error",
+    lastRemoteError: "old remote error",
+    untouched: 42,
+  };
+
+  it("clears stale repository data when the context changes repositories", () => {
+    expect(beginSourceControlRefresh(loaded, "/new/repo", false)).toEqual({
+      contextPath: "/new/repo",
+      repo: null,
+      status: null,
+      hasRepo: false,
+      isLoading: true,
+      localError: null,
+      lastRemoteError: null,
+      untouched: 42,
+    });
+  });
+
+  it("preserves fresh repository data for a context inside the same repo", () => {
+    expect(
+      beginSourceControlRefresh(loaded, "/old/repo/packages/app", true),
+    ).toEqual({
+      ...loaded,
+      contextPath: "/old/repo/packages/app",
+      isLoading: true,
+      localError: null,
+    });
+  });
+});

--- a/src/modules/source-control/useSourceControl.ts
+++ b/src/modules/source-control/useSourceControl.ts
@@ -27,6 +27,7 @@ export type SourceControlRemoteActionResult = {
 };
 
 export type SourceControlSummary = {
+  contextPath: string | null;
   repo: GitRepoInfo | null;
   status: GitStatusSnapshot | null;
   changedCount: number;
@@ -58,6 +59,7 @@ export type SourceControlRemoteIndicator = {
 };
 
 type SourceControlSummaryState = {
+  contextPath: string | null;
   repo: GitRepoInfo | null;
   status: GitStatusSnapshot | null;
   hasRepo: boolean;
@@ -66,6 +68,71 @@ type SourceControlSummaryState = {
   busyAction: SourceControlRemoteAction | null;
   lastRemoteError: string | null;
 };
+
+type RefreshableSourceControlState = Pick<
+  SourceControlSummaryState,
+  | "contextPath"
+  | "repo"
+  | "status"
+  | "hasRepo"
+  | "isLoading"
+  | "localError"
+  | "lastRemoteError"
+>;
+
+type InflightRefresh = {
+  contextKey: string;
+  mode: SourceControlRefreshMode;
+  promise: Promise<void>;
+};
+
+function sourceControlContextKey(
+  workspaceKey: string,
+  contextPath: string | null,
+): string {
+  return `${workspaceKey}\0${contextPath ?? ""}`;
+}
+
+function normalizedContextPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized === "/" || /^[A-Za-z]:\/$/.test(normalized)) {
+    return normalized;
+  }
+  return normalized.replace(/\/+$/, "");
+}
+
+export function repositoryContainsContext(
+  repoRoot: string | null,
+  contextPath: string | null,
+): boolean {
+  if (!repoRoot || !contextPath) return false;
+  let root = normalizedContextPath(repoRoot);
+  let context = normalizedContextPath(contextPath);
+  const windowsPaths =
+    (/^[A-Za-z]:\//.test(root) && /^[A-Za-z]:\//.test(context)) ||
+    (root.startsWith("//") && context.startsWith("//"));
+  if (windowsPaths) {
+    root = root.toLowerCase();
+    context = context.toLowerCase();
+  }
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return context === root || context.startsWith(prefix);
+}
+
+export function beginSourceControlRefresh<
+  T extends RefreshableSourceControlState,
+>(current: T, contextPath: string, reuseCurrentRepository: boolean): T {
+  return {
+    ...current,
+    contextPath,
+    repo: reuseCurrentRepository ? current.repo : null,
+    status: reuseCurrentRepository ? current.status : null,
+    hasRepo: reuseCurrentRepository ? current.hasRepo : false,
+    isLoading: true,
+    localError: null,
+    lastRemoteError: reuseCurrentRepository ? current.lastRemoteError : null,
+  };
+}
 
 function normalizeError(error: unknown): string {
   if (typeof error === "string") return error;
@@ -153,6 +220,7 @@ export function useSourceControl(
   const workspaceEnv = useWorkspaceEnvStore((s) => s.env);
   const workspaceKey = workspaceScopeKey(workspaceEnv);
   const [state, setState] = useState<SourceControlSummaryState>({
+    contextPath: null,
     repo: null,
     status: null,
     hasRepo: false,
@@ -163,11 +231,14 @@ export function useSourceControl(
   });
   const stateRef = useRef(state);
   const requestIdRef = useRef(0);
-  const inflightRef = useRef<Promise<void> | null>(null);
-  const inflightModeRef = useRef<SourceControlRefreshMode>("never");
+  const inflightRef = useRef<InflightRefresh | null>(null);
   const autoFetchByRepoRef = useRef(new Map<string, number>());
   const enabledRef = useRef(enabled);
   const lastRefreshAtRef = useRef(0);
+  const resetWorkspaceKeyRef = useRef(workspaceKey);
+  const contextKey = sourceControlContextKey(workspaceKey, contextPath);
+  const contextKeyRef = useRef(contextKey);
+  contextKeyRef.current = contextKey;
 
   useEffect(() => {
     stateRef.current = state;
@@ -178,11 +249,13 @@ export function useSourceControl(
   }, [enabled]);
 
   useEffect(() => {
+    if (resetWorkspaceKeyRef.current === workspaceKey) return;
+    resetWorkspaceKeyRef.current = workspaceKey;
     requestIdRef.current++;
     inflightRef.current = null;
-    inflightModeRef.current = "never";
     autoFetchByRepoRef.current.clear();
     setState({
+      contextPath: null,
       repo: null,
       status: null,
       hasRepo: false,
@@ -207,11 +280,22 @@ export function useSourceControl(
 
   const doRefresh = useCallback(
     async (remoteMode: SourceControlRefreshMode): Promise<void> => {
-      if (!enabledRef.current) return;
+      const refreshContextKey = contextKey;
+      if (
+        !enabledRef.current ||
+        refreshContextKey !== contextKeyRef.current
+      ) {
+        return;
+      }
       const requestId = ++requestIdRef.current;
+      const isCurrentRequest = () =>
+        requestId === requestIdRef.current &&
+        refreshContextKey === contextKeyRef.current;
 
       if (!contextPath) {
+        if (!isCurrentRequest()) return;
         setState({
+          contextPath: null,
           repo: null,
           status: null,
           hasRepo: false,
@@ -224,13 +308,13 @@ export function useSourceControl(
       }
 
       const activeRoot = stateRef.current.repo?.repoRoot ?? null;
-      const reusableRoot =
-        activeRoot &&
-        (contextPath === activeRoot || contextPath.startsWith(`${activeRoot}/`))
-          ? activeRoot
-          : undefined;
+      const reusableRoot = repositoryContainsContext(activeRoot, contextPath)
+        ? activeRoot
+        : null;
 
-      setState((current) => ({ ...current, isLoading: true, localError: null }));
+      setState((current) =>
+        beginSourceControlRefresh(current, contextPath, !!reusableRoot),
+      );
 
       try {
         let repo: GitRepoInfo | null;
@@ -240,7 +324,7 @@ export function useSourceControl(
           try {
             repo = stateRef.current.repo ?? null;
             status = await native.gitStatus(reusableRoot);
-            if (requestId !== requestIdRef.current) return;
+            if (!isCurrentRequest()) return;
             if (!repo || repo.repoRoot !== reusableRoot) {
               repo = {
                 repoRoot: reusableRoot,
@@ -251,7 +335,7 @@ export function useSourceControl(
             }
           } catch {
             const snapshot = await native.gitPanelSnapshot(contextPath);
-            if (requestId !== requestIdRef.current) return;
+            if (!isCurrentRequest()) return;
             if (!snapshot.repo) {
               setState((current) => ({
                 ...current,
@@ -268,7 +352,7 @@ export function useSourceControl(
           }
         } else {
           const snapshot = await native.gitPanelSnapshot(contextPath);
-          if (requestId !== requestIdRef.current) return;
+          if (!isCurrentRequest()) return;
           if (!snapshot.repo) {
             setState((current) => ({
               ...current,
@@ -310,14 +394,15 @@ export function useSourceControl(
             await native.gitFetch(repo.repoRoot);
             touchAutoFetch(autoFetchByRepoRef.current, repo.repoRoot);
             nextRemoteError = null;
-            if (requestId !== requestIdRef.current) return;
+            if (!isCurrentRequest()) return;
             status = await native.gitStatus(repo.repoRoot);
-            if (requestId !== requestIdRef.current) return;
+            if (!isCurrentRequest()) return;
           } catch (error) {
             nextRemoteError = normalizeError(error);
           }
         }
 
+        if (!isCurrentRequest()) return;
         setState((current) => ({
           ...current,
           repo,
@@ -328,7 +413,7 @@ export function useSourceControl(
           lastRemoteError: nextRemoteError,
         }));
       } catch (error) {
-        if (requestId !== requestIdRef.current) return;
+        if (!isCurrentRequest()) return;
         setState((current) => ({
           ...current,
           repo: null,
@@ -338,34 +423,34 @@ export function useSourceControl(
           localError: normalizeError(error),
         }));
       } finally {
-        lastRefreshAtRef.current = Date.now();
+        if (isCurrentRequest()) {
+          lastRefreshAtRef.current = Date.now();
+        }
       }
     },
-    [contextPath, workspaceKey],
+    [contextKey, contextPath],
   );
 
   const refresh = useCallback(
     async (options?: { remote?: SourceControlRefreshMode }) => {
       const remoteMode = options?.remote ?? "never";
       const inflight = inflightRef.current;
-      if (inflight) {
-        const cur = inflightModeRef.current;
+      if (inflight?.contextKey === contextKey) {
+        const cur = inflight.mode;
         const upgrade =
           (cur === "never" && remoteMode !== "never") ||
           (cur === "auto" && remoteMode === "always");
-        if (!upgrade) return inflight;
+        if (!upgrade) return inflight.promise;
       }
-      inflightModeRef.current = remoteMode;
       const run = doRefresh(remoteMode).finally(() => {
-        if (inflightRef.current === run) {
+        if (inflightRef.current?.promise === run) {
           inflightRef.current = null;
-          inflightModeRef.current = "never";
         }
       });
-      inflightRef.current = run;
+      inflightRef.current = { contextKey, mode: remoteMode, promise: run };
       return run;
     },
-    [doRefresh],
+    [contextKey, doRefresh],
   );
 
   const runRemoteAction = useCallback(
@@ -386,6 +471,9 @@ export function useSourceControl(
       }
 
       setState((current) => ({ ...current, busyAction: action }));
+      const actionContextKey = contextKeyRef.current;
+      const isCurrentContext = () =>
+        actionContextKey === contextKeyRef.current;
 
       try {
         if (action === "fetch") {
@@ -398,13 +486,17 @@ export function useSourceControl(
         } else {
           await native.gitPush(repo.repoRoot);
         }
-        setState((current) => ({ ...current, lastRemoteError: null }));
-        await refresh({ remote: "never" });
+        if (isCurrentContext()) {
+          setState((current) => ({ ...current, lastRemoteError: null }));
+          await refresh({ remote: "never" });
+        }
         return { ok: true, action };
       } catch (error) {
         const message = normalizeError(error);
-        setState((current) => ({ ...current, lastRemoteError: message }));
-        await refresh({ remote: "never" }).catch(() => {});
+        if (isCurrentContext()) {
+          setState((current) => ({ ...current, lastRemoteError: message }));
+          await refresh({ remote: "never" }).catch(() => {});
+        }
         return { ok: false, action, error: message };
       } finally {
         setState((current) => ({ ...current, busyAction: null }));
@@ -417,6 +509,7 @@ export function useSourceControl(
     if (!enabled) {
       requestIdRef.current++;
       setState({
+        contextPath: null,
         repo: null,
         status: null,
         hasRepo: false,
@@ -430,12 +523,16 @@ export function useSourceControl(
     setState((current) => ({ ...current, lastRemoteError: null }));
     const run = () => {
       const root = stateRef.current.repo?.repoRoot;
-      const sameRepo =
-        !!root &&
-        !!contextPath &&
-        (contextPath === root || contextPath.startsWith(`${root}/`));
+      const sameRepo = repositoryContainsContext(root ?? null, contextPath);
       const fresh = Date.now() - lastRefreshAtRef.current < SC_STATUS_TTL_MS;
-      if (fresh && sameRepo && stateRef.current.hasRepo) return;
+      if (fresh && sameRepo && stateRef.current.hasRepo) {
+        setState((current) =>
+          current.contextPath === contextPath
+            ? current
+            : { ...current, contextPath },
+        );
+        return;
+      }
       void refresh({ remote: "never" });
     };
     const idle =
@@ -453,7 +550,7 @@ export function useSourceControl(
         window.clearTimeout(idle as number);
       }
     };
-  }, [refresh, contextPath, enabled, workspaceKey]);
+  }, [refresh, contextPath, enabled]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -476,6 +573,7 @@ export function useSourceControl(
 
   return useMemo<SourceControlSummary>(
     () => ({
+      contextPath: state.contextPath,
       repo: state.repo,
       status: state.status,
       changedCount: state.status?.changedFiles.length ?? 0,

--- a/src/modules/source-control/useSourceControlContext.ts
+++ b/src/modules/source-control/useSourceControlContext.ts
@@ -2,15 +2,13 @@ import { useCallback, useMemo } from "react";
 import { native } from "@/modules/ai/lib/native";
 import type { SidebarViewId } from "@/modules/sidebar";
 import type { Tab } from "@/modules/tabs";
+import {
+  activeRepositoryContextPath,
+  gitGraphRepositoryPath,
+  sourceControlRepositoryPath,
+  type SourceControlRepositoryTarget,
+} from "./repositoryTarget";
 import { useSourceControl } from "./useSourceControl";
-
-function dirname(path: string | null): string | null {
-  if (!path) return null;
-  const normalized = path.replace(/\\/g, "/");
-  const idx = normalized.lastIndexOf("/");
-  if (idx <= 0) return normalized;
-  return normalized.slice(0, idx);
-}
 
 type Params = {
   activeTab: Tab | undefined;
@@ -21,6 +19,7 @@ type Params = {
   launchCwdResolved: boolean;
   home: string | null;
   sidebarView: SidebarViewId;
+  repositoryTarget: SourceControlRepositoryTarget;
   cycleSidebarView: (view: SidebarViewId) => void;
   openCommitHistoryTab: (args: {
     repoRoot: string;
@@ -42,22 +41,19 @@ export function useSourceControlContext({
   launchCwdResolved,
   home,
   sidebarView,
+  repositoryTarget,
   cycleSidebarView,
   openCommitHistoryTab,
 }: Params) {
   const workspaceFallbackPath = launchCwdResolved
     ? (launchCwd ?? home ?? null)
     : null;
-  const sourceControlContextPath = (() => {
-    if (activeTab?.kind === "terminal") {
-      return activeTerminalLeafCwd ?? explorerRoot ?? workspaceFallbackPath;
-    }
-    if (activeTab?.kind === "editor") return dirname(activeTab.path);
-    if (activeTab?.kind === "git-diff") return activeTab.repoRoot;
-    if (activeTab?.kind === "git-commit-file") return activeTab.repoRoot;
-    if (activeTab?.kind === "git-history") return activeTab.repoRoot;
-    return explorerRoot ?? workspaceFallbackPath;
-  })();
+  const sourceControlContextPath = activeRepositoryContextPath({
+    activeTab,
+    activeTerminalLeafCwd,
+    explorerRoot,
+    workspaceFallbackPath,
+  });
   const hasOpenGitTab = useMemo(
     () =>
       tabs.some(
@@ -68,14 +64,22 @@ export function useSourceControlContext({
       ),
     [tabs],
   );
-  const sourceControlActive = hasOpenGitTab || sidebarView === "source-control";
   // Ambient path tracks the explorer root so the rail badge and explorer git
   // decorations reflect the repo you are actually looking at. cd-within-repo
   // churn is absorbed by the status TTL + reusable-root path in useSourceControl.
   const badgeContextPath = explorerRoot ?? workspaceFallbackPath;
-  const sourceControlPath = sourceControlActive
-    ? sourceControlContextPath
-    : badgeContextPath;
+  const sourceControlPath = sourceControlRepositoryPath({
+    contextPath: sourceControlContextPath,
+    badgeContextPath,
+    sidebarView,
+    hasOpenGitTab,
+    target: repositoryTarget,
+  });
+  const graphContextPath = gitGraphRepositoryPath({
+    contextPath: sourceControlContextPath,
+    sidebarView,
+    target: repositoryTarget,
+  });
   const sourceControl = useSourceControl(sourceControlPath, true);
 
   const toggleSourceControl = useCallback(() => {
@@ -84,16 +88,20 @@ export function useSourceControlContext({
 
   const openGitGraphFromContext = useCallback(async () => {
     const known = sourceControl.hasRepo ? sourceControl.repo : null;
-    if (known) {
+    const fixedTargetIsLoaded =
+      sidebarView !== "source-control" ||
+      repositoryTarget.mode !== "fixed" ||
+      known?.repoRoot === repositoryTarget.repoRoot;
+    if (known && fixedTargetIsLoaded) {
       openCommitHistoryTab({
         repoRoot: known.repoRoot,
         branch: sourceControl.status?.branch ?? null,
       });
       return;
     }
-    if (!sourceControlContextPath) return;
+    if (!graphContextPath) return;
     try {
-      const repo = await native.gitResolveRepo(sourceControlContextPath);
+      const repo = await native.gitResolveRepo(graphContextPath);
       if (!repo) return;
       openCommitHistoryTab({ repoRoot: repo.repoRoot, branch: repo.branch });
     } catch {
@@ -104,7 +112,9 @@ export function useSourceControlContext({
     sourceControl.hasRepo,
     sourceControl.repo,
     sourceControl.status?.branch,
-    sourceControlContextPath,
+    graphContextPath,
+    repositoryTarget,
+    sidebarView,
   ]);
 
   return { sourceControl, toggleSourceControl, openGitGraphFromContext };

--- a/src/modules/tabs/lib/planCommitHistoryOpen.test.ts
+++ b/src/modules/tabs/lib/planCommitHistoryOpen.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { planCommitHistoryOpen, type GitHistoryTab, type Tab } from "./useTabs";
+
+function history(
+  id: number,
+  repoRoot: string,
+  spaceId = "space-a",
+): GitHistoryTab {
+  return {
+    id,
+    kind: "git-history",
+    spaceId,
+    title: "Git History",
+    repoRoot,
+  };
+}
+
+describe("planCommitHistoryOpen", () => {
+  it("reuses a repository history tab within the active Space", () => {
+    const existing = history(1, "/repos/a");
+    let allocations = 0;
+    const result = planCommitHistoryOpen(
+      [existing],
+      { repoRoot: "/repos/a", branch: "main" },
+      "space-a",
+      () => {
+        allocations += 1;
+        return 2;
+      },
+    );
+
+    expect(result.targetId).toBe(1);
+    expect(result.tabs[0]).toMatchObject({ title: "History · main" });
+    expect(allocations).toBe(0);
+
+    const repeated = planCommitHistoryOpen(
+      result.tabs,
+      { repoRoot: "/repos/a", branch: "main" },
+      "space-a",
+      () => 2,
+    );
+    expect(repeated.tabs).toBe(result.tabs);
+  });
+
+  it("opens separate tabs for separate repositories", () => {
+    const existing = history(1, "/repos/a");
+    const result = planCommitHistoryOpen(
+      [existing],
+      { repoRoot: "/repos/b", branch: "feature" },
+      "space-a",
+      () => 2,
+    );
+
+    expect(result.targetId).toBe(2);
+    expect(result.tabs).toEqual([
+      existing,
+      expect.objectContaining({
+        id: 2,
+        repoRoot: "/repos/b",
+        spaceId: "space-a",
+        title: "History · feature",
+      }),
+    ]);
+  });
+
+  it("does not activate a matching repository tab from another Space", () => {
+    const otherSpace = history(1, "/repos/shared", "space-b");
+    const tabs: Tab[] = [otherSpace];
+    const result = planCommitHistoryOpen(
+      tabs,
+      { repoRoot: "/repos/shared" },
+      "space-a",
+      () => 2,
+    );
+
+    expect(result.targetId).toBe(2);
+    expect(result.tabs).toEqual([
+      otherSpace,
+      expect.objectContaining({
+        id: 2,
+        repoRoot: "/repos/shared",
+        spaceId: "space-a",
+      }),
+    ]);
+  });
+});

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -276,6 +276,45 @@ export function planGitDiffOpen(
   return { tabs: next, targetId: id };
 }
 
+export function planCommitHistoryOpen(
+  tabs: Tab[],
+  input: { repoRoot: string; branch?: string | null },
+  spaceId: string,
+  allocId: () => number,
+): { tabs: Tab[]; targetId: number } {
+  const existing = tabs.find(
+    (tab) =>
+      tab.kind === "git-history" &&
+      tab.spaceId === spaceId &&
+      tab.repoRoot === input.repoRoot,
+  );
+  const title = input.branch ? `History · ${input.branch}` : "Git History";
+  if (existing) {
+    if (existing.title === title) return { tabs, targetId: existing.id };
+    return {
+      tabs: tabs.map((tab) =>
+        tab.id === existing.id ? { ...existing, title } : tab,
+      ),
+      targetId: existing.id,
+    };
+  }
+
+  const id = allocId();
+  return {
+    tabs: [
+      ...tabs,
+      {
+        id,
+        kind: "git-history",
+        spaceId,
+        title,
+        repoRoot: input.repoRoot,
+      } satisfies GitHistoryTab,
+    ],
+    targetId: id,
+  };
+}
+
 function coldTerminalTab(
   tabId: number,
   leafId: number,
@@ -873,34 +912,18 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   const openCommitHistoryTab = useCallback(
     (input: { repoRoot: string; branch?: string | null }) => {
       const curr = tabsRef.current;
-      const existing = curr.find(
-        (t) => t.kind === "git-history" && t.repoRoot === input.repoRoot,
+      const plan = planCommitHistoryOpen(
+        curr,
+        input,
+        activeSpaceIdRef.current,
+        () => nextIdRef.current++,
       );
-      const title = input.branch ? `History · ${input.branch}` : "Git History";
-      if (existing) {
-        const nextTabs = curr.map((t) =>
-          t.id === existing.id ? { ...t, title } : t,
-        );
-        tabsRef.current = nextTabs;
-        setTabs(nextTabs);
-        setActiveId(existing.id);
-        return existing.id;
+      if (plan.tabs !== curr) {
+        tabsRef.current = plan.tabs;
+        setTabs(plan.tabs);
       }
-      const id = nextIdRef.current++;
-      const nextTabs = [
-        ...curr,
-        {
-          id,
-          kind: "git-history",
-          spaceId: activeSpaceIdRef.current,
-          title,
-          repoRoot: input.repoRoot,
-        } satisfies GitHistoryTab,
-      ];
-      tabsRef.current = nextTabs;
-      setTabs(nextTabs);
-      setActiveId(id);
-      return id;
+      setActiveId(plan.targetId);
+      return plan.targetId;
     },
     [],
   );


### PR DESCRIPTION
## Summary

- open the Git repository containing any Explorer directory directly in Source Control
- open repository-bound Git History tabs for nested repositories, submodules, and independent repositories inside a workspace
- keep repository targeting isolated by Space and workspace environment, with an explicit return to active-context following

## Engineering approach

This uses the existing native `git_resolve_repo` boundary only after an explicit user action. Git resolves the actual top-level repository, so `.git` directories, submodule `.git` files, and worktrees follow Git's own semantics.

The implementation deliberately avoids recursive repository discovery, background scans, watchers, polling, and startup IPC. Async resolution and Source Control refreshes are context-scoped so stale requests cannot replace a newer selection. Git History tab identity is scoped by both repository and Space.

This is a focused replacement for the implementation approach in #1034. Shaurya Gangrade is credited as a co-author on the feature commit.

## Performance and size

- no new dependencies
- no Rust or size-budget changes
- main window startup JS: 342,026 / 540,000 bytes
- total client JS: 1,488,783 / 1,500,000 bytes
- measured delta from current `main`: +1,117 startup bytes and +1,855 total bytes
- runtime Git work occurs only when the user invokes a repository action

## Validation

- `pnpm lint`
- `pnpm check-types`
- `pnpm test` (583 tests)
- `pnpm build`
- `pnpm size --json`
- React Compiler healthcheck (425/425 components)
- `cargo check --all-targets --locked`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo nextest run --locked` (276 tests)

Closes #952
