### PR TITLE
fix(tabs): keep "Open With" files from being wiped by session restore

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -130,6 +130,7 @@ export default function App() {
     activeId,
     setActiveId,
     allocId,
+    booted,
     replaceTabs,
     moveTabToSpace,
     reorderTab,
@@ -623,22 +624,44 @@ export default function App() {
     [openFileTab, newMarkdownTab],
   );
 
-  // "Open With" files arrive via the event (warm start) and get_launch_files
-  // (cold start, before this listener attaches). Backend already authorized
-  // each parent; openFileTab dedupes by path, so both paths can't double-open.
+  const openLaunchFiles = useCallback(
+    (paths: string[]) => {
+      for (const path of paths) handleOpenFile(path, true);
+    },
+    [handleOpenFile],
+  );
+
+  // Warm start: the backend emits once the window already exists. Attach on
+  // mount so an "Open With" that lands mid-restore isn't dropped — the backend
+  // also seeds the drain-once state, so the boot drain below is the safety net.
   useEffect(() => {
     let unlisten: (() => void) | undefined;
-    const openAll = (paths: string[]) => {
-      for (const path of paths) handleOpenFile(path, true);
-    };
+    let disposed = false;
     (async () => {
-      unlisten = await listen<string[]>("terax:open-file", (e) => {
-        openAll(e.payload);
+      const off = await listen<string[]>("terax:open-file", (e) => {
+        openLaunchFiles(e.payload);
       });
-      openAll(await consumeLaunchFiles());
+      if (disposed) off();
+      else unlisten = off;
     })();
-    return () => unlisten?.();
-  }, [handleOpenFile]);
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [openLaunchFiles]);
+
+  // Cold start: files arrive as CLI args (Linux/Windows) or the macOS open-files
+  // event, and get_launch_files drains them once. Wait for `booted` — the spaces
+  // restore ends in replaceTabs(), which overwrites the whole tab list and would
+  // discard a launch tab opened before it, making the file flash open and vanish.
+  // Booting first also lands the tab in the restored active space, and lets
+  // openFileTab dedupe against a session that already had the file open.
+  useEffect(() => {
+    if (!booted) return;
+    void (async () => {
+      openLaunchFiles(await consumeLaunchFiles());
+    })();
+  }, [booted, openLaunchFiles]);
 
   const handlePathRenamed = useCallback(
     (from: string, to: string) => {

--- a/src/modules/tabs/lib/planFileTabOpen.test.ts
+++ b/src/modules/tabs/lib/planFileTabOpen.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   type EditorTab,
   planFileTabOpen,
+  planMarkdownTabOpen,
   type Tab,
   type TerminalTab,
 } from "./useTabs";
@@ -99,6 +100,64 @@ describe("planFileTabOpen", () => {
         spaceId: "one",
         preview: true,
       }),
+    );
+  });
+});
+
+describe("planMarkdownTabOpen", () => {
+  it("reuses markdown tabs only within the requested space", () => {
+    const tabs: Tab[] = [
+      terminal,
+      {
+        id: 3,
+        kind: "markdown",
+        spaceId: "two",
+        title: "README.md",
+        path: "/repo/README.md",
+      },
+    ];
+
+    const reused = planMarkdownTabOpen(tabs, "/repo/README.md", "two", () => {
+      throw new Error("should not allocate");
+    });
+    const plan = planMarkdownTabOpen(tabs, "/repo/README.md", "one", () => 4);
+
+    expect(reused).toEqual({ tabs, tabId: 3 });
+    expect(plan.tabId).toBe(4);
+    expect(plan.tabs).toContainEqual(
+      expect.objectContaining({
+        id: 4,
+        kind: "markdown",
+        path: "/repo/README.md",
+        spaceId: "one",
+      }),
+    );
+    expect(plan.tabs).toContain(tabs[1]);
+  });
+
+  it("preserves markdown and regular files in a mixed launch batch", () => {
+    const markdownPlan = planMarkdownTabOpen(
+      [terminal],
+      "/repo/README.md",
+      "one",
+      () => 3,
+    );
+    const filePlan = planFileTabOpen(
+      markdownPlan.tabs,
+      "/repo/main.rs",
+      true,
+      "one",
+      () => 4,
+    );
+
+    expect(filePlan.tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "markdown",
+          path: "/repo/README.md",
+        }),
+        expect.objectContaining({ kind: "editor", path: "/repo/main.rs" }),
+      ]),
     );
   });
 });

--- a/src/modules/tabs/lib/planFileTabOpen.test.ts
+++ b/src/modules/tabs/lib/planFileTabOpen.test.ts
@@ -160,4 +160,23 @@ describe("planMarkdownTabOpen", () => {
       ]),
     );
   });
+
+  it("normalizes path separators when reusing a markdown tab", () => {
+    const tabs: Tab[] = [
+      terminal,
+      {
+        id: 3,
+        kind: "markdown",
+        spaceId: "one",
+        title: "README.md",
+        path: "C:\\repo\\README.md",
+      },
+    ];
+
+    const plan = planMarkdownTabOpen(tabs, "C:/repo/README.md", "one", () => {
+      throw new Error("should not allocate");
+    });
+
+    expect(plan).toEqual({ tabs, tabId: 3 });
+  });
 });

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -1280,6 +1280,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     activeId,
     setActiveId,
     allocId,
+    booted,
     replaceTabs,
     moveTabToSpace,
     reorderTab,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -153,6 +153,34 @@ export type OpenFileTabOptions = {
   activate?: boolean;
 };
 
+export function planMarkdownTabOpen(
+  tabs: Tab[],
+  path: string,
+  spaceId: string,
+  allocId: () => number,
+): { tabs: Tab[]; tabId: number } {
+  const existing = tabs.find(
+    (tab) =>
+      tab.kind === "markdown" && tab.spaceId === spaceId && tab.path === path,
+  );
+  if (existing) return { tabs, tabId: existing.id };
+
+  const tabId = allocId();
+  return {
+    tabs: [
+      ...tabs,
+      {
+        id: tabId,
+        kind: "markdown",
+        spaceId,
+        title: basename(path),
+        path,
+      },
+    ],
+    tabId,
+  };
+}
+
 export function planFileTabOpen(
   tabs: Tab[],
   path: string,
@@ -845,26 +873,18 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   // openFileTab's setTabs(plan.tabs), which is built from the stale ref.
   const newMarkdownTab = useCallback((path: string) => {
     const curr = tabsRef.current;
-    const existing = curr.find((t) => t.kind === "markdown" && t.path === path);
-    if (existing) {
-      setActiveId(existing.id);
-      return existing.id;
+    const plan = planMarkdownTabOpen(
+      curr,
+      path,
+      activeSpaceIdRef.current,
+      () => nextIdRef.current++,
+    );
+    if (plan.tabs !== curr) {
+      tabsRef.current = plan.tabs;
+      setTabs(plan.tabs);
     }
-    const id = nextIdRef.current++;
-    const next: Tab[] = [
-      ...curr,
-      {
-        id,
-        kind: "markdown",
-        spaceId: activeSpaceIdRef.current,
-        title: basename(path),
-        path,
-      },
-    ];
-    tabsRef.current = next;
-    setTabs(next);
-    setActiveId(id);
-    return id;
+    setActiveId(plan.tabId);
+    return plan.tabId;
   }, []);
 
   const setOverrideLanguage = useCallback((id: number, lang: string | null) => {

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -839,31 +839,32 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     return id;
   }, []);
 
+  // Mirrors tabsRef like openFileTab instead of using a functional update: a
+  // batch that opens a markdown file before a regular one (multi-file "Open
+  // With") would otherwise have the queued markdown update clobbered by
+  // openFileTab's setTabs(plan.tabs), which is built from the stale ref.
   const newMarkdownTab = useCallback((path: string) => {
-    let targetId: number | null = null;
-    setTabs((curr) => {
-      const existing = curr.find(
-        (t) => t.kind === "markdown" && t.path === path,
-      );
-      if (existing) {
-        targetId = existing.id;
-        return curr;
-      }
-      const id = nextIdRef.current++;
-      targetId = id;
-      return [
-        ...curr,
-        {
-          id,
-          kind: "markdown",
-          spaceId: activeSpaceIdRef.current,
-          title: basename(path),
-          path,
-        },
-      ];
-    });
-    if (targetId !== null) setActiveId(targetId);
-    return targetId;
+    const curr = tabsRef.current;
+    const existing = curr.find((t) => t.kind === "markdown" && t.path === path);
+    if (existing) {
+      setActiveId(existing.id);
+      return existing.id;
+    }
+    const id = nextIdRef.current++;
+    const next: Tab[] = [
+      ...curr,
+      {
+        id,
+        kind: "markdown",
+        spaceId: activeSpaceIdRef.current,
+        title: basename(path),
+        path,
+      },
+    ];
+    tabsRef.current = next;
+    setTabs(next);
+    setActiveId(id);
+    return id;
   }, []);
 
   const setOverrideLanguage = useCallback((id: number, lang: string | null) => {

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -159,9 +159,12 @@ export function planMarkdownTabOpen(
   spaceId: string,
   allocId: () => number,
 ): { tabs: Tab[]; tabId: number } {
+  const pathKey = path.replace(/\\/g, "/");
   const existing = tabs.find(
     (tab) =>
-      tab.kind === "markdown" && tab.spaceId === spaceId && tab.path === path,
+      tab.kind === "markdown" &&
+      tab.spaceId === spaceId &&
+      tab.path.replace(/\\/g, "/") === pathKey,
   );
   if (existing) return { tabs, tabId: existing.id };
 
@@ -527,6 +530,8 @@ export function useTabs(initial?: Partial<TerminalTab>) {
 
   const replaceTabs = useCallback((next: Tab[], nextActiveId: number) => {
     if (next.length === 0) return;
+    tabsRef.current = next;
+    activeIdRef.current = nextActiveId;
     setTabs(next);
     setActiveId(nextActiveId);
   }, []);


### PR DESCRIPTION
Opening a file via the OS "Open With" action made it flash into view and vanish. The launch-file would get closed because of the tab restore kicking in after the launch.

## What
Files opened through the OS "Open With" action flashed into view and immediately vanished. The launch-file tab is no longer discarded by the session restore.

## Why
The launch-file effect drained `get_launch_files` on mount and opened an editor tab right away, while `useSpacesBoot` was still awaiting `loadAll()`, `adoptWorkspaceEnv()` and one `workspaceAuthorize()` per restored cwd. Boot then finished with `replaceTabs()`, a flat `setTabs()` overwrite that doesn't contain the launch tab, so the tab was dropped. The `terax:open-file` re-delivery event is macOS-only, so Windows and Linux lost the file outright. Only the launch directory survived, since it's read through a path that never touches the tab list.

## How
Split the single effect in two. The warm-start listener still attaches on mount, but the cold-start drain now waits for `booted` (newly exposed from `useTabs`). `replaceTabs` has exactly one caller, so gating on `booted` closes the race fully. Two fixes fall out of ordering the drain after restore: the tab lands in the restored active space instead of `DEFAULT_SPACE_ID`, and `openFileTab`'s path dedupe finally works against a session that already had the file open — which the old comment claimed
but couldn't deliver.


## Testing
Reproduced with the official release, then verified with the local build swapped into install directory.

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean - 612 passes, 91 files
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --no rust changes
- [ ] (If you touched `src-tauri/`) `cargo nextest run --no rust changes
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested via a real release build rather than `pnpm tauri dev`
- [x] Platforms tested: Windows 11
- [ ] Shells tested (if relevant): none


## Screenshots / GIFs
None Captured.

## Notes for reviewer
Following notes are from Claude:

- The fix is frontend-only, but the root cause spans the Rust drain-once state in `src-tauri/src/lib.rs` and the React boot order — worth reading together.
- `RunEvent::Opened` re-delivery is still macOS-only. Windows/Linux now depend entirely on the post-boot drain. That's correct today, but if `replaceTabs` ever gains a second caller the gate needs revisiting.
- Unrelated, spotted while debugging and **not** addressed here:
  1. `dirs::cache_dir()` on Windows is `%LOCALAPPDATA%`, so `control.json` and the `run\` launcher dirs are written into `%LOCALAPPDATA%\terax` — case-insensitively, the same folder as the install dir. Runtime state lands next to `terax.exe`.
  2. My installed build had no `terax-cli.exe` beside `terax.exe`, so `find_bundled_cli()` silently disabled the shell alias. Possible `externalBin` packaging gap in the release workflow..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch-file handling during app startup.
  * Files opened while the workspace is restoring are now processed reliably.
  * Improved handling of files opened after the app has already started.
  * Prevented launch-file events from being processed after the app is closed.
  * Opening a Markdown file now reuses an existing tab when possible and keeps the correct tab active.
  * Improved reliability when opening multiple files across different workspaces and when paths use different separators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->