### PR TITLE
feat(tabs): close tabs to the right and other tabs

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -74,8 +74,7 @@ import {
 import { StatusBar } from "@/modules/statusbar";
 import {
   TabSwitcherHud,
-  planCloseOtherTabs,
-  planCloseTabsToRight,
+  type CloseTabsPlan,
   useTabSwitcher,
   useTabs,
   useWindowTitle,
@@ -158,8 +157,7 @@ export default function App() {
     openCommitHistoryTab,
     openCommitFileDiffTab,
     closeTab,
-    closeTabsToRight,
-    closeOtherTabs,
+    closeTabs,
     updateTab,
     selectByIndex,
     setLeafCwd,
@@ -384,36 +382,15 @@ export default function App() {
     [closeTab],
   );
 
-  const disposeTabsToRight = useCallback(
-    (anchorId: number) => {
-      const { closeIds } = planCloseTabsToRight(
-        tabsRef.current,
-        anchorId,
-        activeIdRef.current,
-      );
-      for (const id of closeIds) {
+  const disposeTabs = useCallback(
+    (anchorId: number, plan: CloseTabsPlan) => {
+      const closedIds = closeTabs(anchorId, plan);
+      for (const id of closedIds) {
         editorRefs.current.delete(id);
         previewRefs.current.delete(id);
       }
-      closeTabsToRight(anchorId);
     },
-    [closeTabsToRight],
-  );
-
-  const disposeOtherTabs = useCallback(
-    (anchorId: number) => {
-      const { closeIds } = planCloseOtherTabs(
-        tabsRef.current,
-        anchorId,
-        activeIdRef.current,
-      );
-      for (const id of closeIds) {
-        editorRefs.current.delete(id);
-        previewRefs.current.delete(id);
-      }
-      closeOtherTabs(anchorId);
-    },
-    [closeOtherTabs],
+    [closeTabs],
   );
 
   const {
@@ -421,6 +398,7 @@ export default function App() {
     pendingTerminalCloseTab,
     pendingDeleteTabs,
     pendingCloseMany,
+    closeManyConfirming,
     handleClose,
     handleCloseTabsToRight,
     handleCloseOtherTabs,
@@ -437,8 +415,7 @@ export default function App() {
     tabs,
     activeId,
     disposeTab,
-    disposeTabsToRight,
-    disposeOtherTabs,
+    disposeTabs,
   });
 
   const { pendingAppClose, confirmAppClose, cancelAppClose } =
@@ -1595,6 +1572,7 @@ export default function App() {
             onCancelDeleteClose={cancelDeleteClose}
             onConfirmDeleteClose={confirmDeleteClose}
             pendingCloseMany={pendingCloseMany}
+            closeManyConfirming={closeManyConfirming}
             onCancelCloseMany={cancelCloseMany}
             onConfirmCloseMany={confirmCloseMany}
             pendingAppClose={pendingAppClose}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -74,6 +74,8 @@ import {
 import { StatusBar } from "@/modules/statusbar";
 import {
   TabSwitcherHud,
+  planCloseOtherTabs,
+  planCloseTabsToRight,
   useTabSwitcher,
   useTabs,
   useWindowTitle,
@@ -156,6 +158,8 @@ export default function App() {
     openCommitHistoryTab,
     openCommitFileDiffTab,
     closeTab,
+    closeTabsToRight,
+    closeOtherTabs,
     updateTab,
     selectByIndex,
     setLeafCwd,
@@ -380,19 +384,62 @@ export default function App() {
     [closeTab],
   );
 
+  const disposeTabsToRight = useCallback(
+    (anchorId: number) => {
+      const { closeIds } = planCloseTabsToRight(
+        tabsRef.current,
+        anchorId,
+        activeIdRef.current,
+      );
+      for (const id of closeIds) {
+        editorRefs.current.delete(id);
+        previewRefs.current.delete(id);
+      }
+      closeTabsToRight(anchorId);
+    },
+    [closeTabsToRight],
+  );
+
+  const disposeOtherTabs = useCallback(
+    (anchorId: number) => {
+      const { closeIds } = planCloseOtherTabs(
+        tabsRef.current,
+        anchorId,
+        activeIdRef.current,
+      );
+      for (const id of closeIds) {
+        editorRefs.current.delete(id);
+        previewRefs.current.delete(id);
+      }
+      closeOtherTabs(anchorId);
+    },
+    [closeOtherTabs],
+  );
+
   const {
     pendingCloseTab,
     pendingTerminalCloseTab,
     pendingDeleteTabs,
+    pendingCloseMany,
     handleClose,
+    handleCloseTabsToRight,
+    handleCloseOtherTabs,
     confirmClose,
     cancelClose,
     confirmTerminalClose,
     cancelTerminalClose,
     confirmDeleteClose,
     cancelDeleteClose,
+    confirmCloseMany,
+    cancelCloseMany,
     handlePathDeleted,
-  } = useTabCloseGuards({ tabs, disposeTab });
+  } = useTabCloseGuards({
+    tabs,
+    activeId,
+    disposeTab,
+    disposeTabsToRight,
+    disposeOtherTabs,
+  });
 
   const { pendingAppClose, confirmAppClose, cancelAppClose } =
     useAppCloseGuard(tabsRef);
@@ -712,8 +759,7 @@ export default function App() {
       : null;
   const isRepositoryContextCurrent = useCallback(
     (spaceId: string, workspaceKey: string) => {
-      const currentSpaceId =
-        useSpaces.getState().activeId ?? DEFAULT_SPACE_ID;
+      const currentSpaceId = useSpaces.getState().activeId ?? DEFAULT_SPACE_ID;
       const currentWorkspaceKey = workspaceScopeKey(
         useWorkspaceEnvStore.getState().env,
       );
@@ -1338,6 +1384,8 @@ export default function App() {
               onNewGitGraph={openGitGraphFromContext}
               onLaunchAgents={launchAgentGroup}
               onClose={handleClose}
+              onCloseTabsToRight={handleCloseTabsToRight}
+              onCloseOtherTabs={handleCloseOtherTabs}
               onPin={pinTab}
               onRename={handleRenameTab}
               onReorder={reorderTabByGap}
@@ -1546,6 +1594,9 @@ export default function App() {
             pendingDeleteTabs={pendingDeleteTabs}
             onCancelDeleteClose={cancelDeleteClose}
             onConfirmDeleteClose={confirmDeleteClose}
+            pendingCloseMany={pendingCloseMany}
+            onCancelCloseMany={cancelCloseMany}
+            onConfirmCloseMany={confirmCloseMany}
             pendingAppClose={pendingAppClose}
             onCancelAppClose={cancelAppClose}
             onConfirmAppClose={confirmAppClose}

--- a/src/app/components/CloseDialogs.tsx
+++ b/src/app/components/CloseDialogs.tsx
@@ -1,3 +1,5 @@
+import type { CloseManyPending } from "@/app/hooks/tabCloseGuards";
+import type { AppCloseBlocker } from "@/app/hooks/useAppCloseGuard";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,15 +10,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import type { AppCloseBlocker } from "@/app/hooks/useAppCloseGuard";
 import type { Tab } from "@/modules/tabs";
-
-type CloseManyPending = {
-  kind: "right" | "other";
-  closeIds: number[];
-  dirtyCount: number;
-  busy: boolean;
-};
 
 type Props = {
   tabs: Tab[];
@@ -30,6 +24,7 @@ type Props = {
   onCancelDeleteClose: () => void;
   onConfirmDeleteClose: () => void;
   pendingCloseMany: CloseManyPending | null;
+  closeManyConfirming: boolean;
   onCancelCloseMany: () => void;
   onConfirmCloseMany: () => void;
   pendingAppClose: AppCloseBlocker | null;
@@ -52,24 +47,33 @@ function appCloseMessage(blocker: AppCloseBlocker): string {
 }
 
 function closeManyMessage(pending: CloseManyPending, tabs: Tab[]): string {
-  const { kind, dirtyCount, busy, closeIds } = pending;
-  if (dirtyCount === 1 && !busy) {
+  const { kind, dirtyIds, busyLeafIds } = pending;
+  const dirtyCount = dirtyIds.length;
+  const busyCount = busyLeafIds.length;
+  if (dirtyCount === 1 && busyCount === 0) {
     const dirty = tabs.find(
-      (t) => t.kind === "editor" && t.dirty && closeIds.includes(t.id),
+      (tab) => tab.kind === "editor" && dirtyIds.includes(tab.id),
     );
     return dirty?.title
       ? `"${dirty.title}" has unsaved changes. Close it anyway?`
       : "1 tab has unsaved changes. Close it anyway?";
   }
-  if (dirtyCount > 0 && busy) {
-    return `${dirtyCount} tab${dirtyCount === 1 ? "" : "s"} have unsaved changes and a process is running. Closing will discard the changes and terminate the process. Close anyway?`;
+  if (dirtyCount > 0 && busyCount > 0) {
+    const dirty = `${dirtyCount} tab${dirtyCount === 1 ? " has" : "s have"} unsaved changes`;
+    const busy =
+      busyCount === 1
+        ? "a process is running"
+        : `${busyCount} processes are running`;
+    return `${dirty} and ${busy}. Closing will discard the changes and terminate the ${busyCount === 1 ? "process" : "processes"}. Close anyway?`;
   }
   if (dirtyCount > 0) {
     return `${dirtyCount} tabs have unsaved changes. Closing will discard them. Close anyway?`;
   }
+  const process =
+    busyCount === 1 ? "A process is" : `${busyCount} processes are`;
   return kind === "right"
-    ? "A process is running in a tab to the right. Closing it will terminate the process. Close anyway?"
-    : "A process is running in another tab. Closing it will terminate the process. Close anyway?";
+    ? `${process} running in ${busyCount === 1 ? "a tab" : "tabs"} to the right. Closing will terminate ${busyCount === 1 ? "it" : "them"}. Close anyway?`
+    : `${process} running in ${busyCount === 1 ? "another tab" : "other tabs"}. Closing will terminate ${busyCount === 1 ? "it" : "them"}. Close anyway?`;
 }
 
 /** Confirmation dialogs for closing dirty editors and terminals with live processes. */
@@ -85,6 +89,7 @@ export function CloseDialogs({
   onCancelDeleteClose,
   onConfirmDeleteClose,
   pendingCloseMany,
+  closeManyConfirming,
   onCancelCloseMany,
   onConfirmCloseMany,
   pendingAppClose,
@@ -191,8 +196,14 @@ export function CloseDialogs({
             <AlertDialogCancel onClick={onCancelCloseMany}>
               Cancel
             </AlertDialogCancel>
-            <AlertDialogAction onClick={onConfirmCloseMany}>
-              Close Anyway
+            <AlertDialogAction
+              disabled={closeManyConfirming}
+              onClick={(event) => {
+                event.preventDefault();
+                onConfirmCloseMany();
+              }}
+            >
+              {closeManyConfirming ? "Checking..." : "Close Anyway"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/components/CloseDialogs.tsx
+++ b/src/app/components/CloseDialogs.tsx
@@ -11,6 +11,13 @@ import {
 import type { AppCloseBlocker } from "@/app/hooks/useAppCloseGuard";
 import type { Tab } from "@/modules/tabs";
 
+type CloseManyPending = {
+  kind: "right" | "other";
+  closeIds: number[];
+  dirtyCount: number;
+  busy: boolean;
+};
+
 type Props = {
   tabs: Tab[];
   pendingCloseTab: number | null;
@@ -22,6 +29,9 @@ type Props = {
   pendingDeleteTabs: number[] | null;
   onCancelDeleteClose: () => void;
   onConfirmDeleteClose: () => void;
+  pendingCloseMany: CloseManyPending | null;
+  onCancelCloseMany: () => void;
+  onConfirmCloseMany: () => void;
   pendingAppClose: AppCloseBlocker | null;
   onCancelAppClose: () => void;
   onConfirmAppClose: () => void;
@@ -41,6 +51,27 @@ function appCloseMessage(blocker: AppCloseBlocker): string {
   return "A process is still running in a terminal. Quitting will terminate it.";
 }
 
+function closeManyMessage(pending: CloseManyPending, tabs: Tab[]): string {
+  const { kind, dirtyCount, busy, closeIds } = pending;
+  if (dirtyCount === 1 && !busy) {
+    const dirty = tabs.find(
+      (t) => t.kind === "editor" && t.dirty && closeIds.includes(t.id),
+    );
+    return dirty?.title
+      ? `"${dirty.title}" has unsaved changes. Close it anyway?`
+      : "1 tab has unsaved changes. Close it anyway?";
+  }
+  if (dirtyCount > 0 && busy) {
+    return `${dirtyCount} tab${dirtyCount === 1 ? "" : "s"} have unsaved changes and a process is running. Closing will discard the changes and terminate the process. Close anyway?`;
+  }
+  if (dirtyCount > 0) {
+    return `${dirtyCount} tabs have unsaved changes. Closing will discard them. Close anyway?`;
+  }
+  return kind === "right"
+    ? "A process is running in a tab to the right. Closing it will terminate the process. Close anyway?"
+    : "A process is running in another tab. Closing it will terminate the process. Close anyway?";
+}
+
 /** Confirmation dialogs for closing dirty editors and terminals with live processes. */
 export function CloseDialogs({
   tabs,
@@ -53,6 +84,9 @@ export function CloseDialogs({
   pendingDeleteTabs,
   onCancelDeleteClose,
   onConfirmDeleteClose,
+  pendingCloseMany,
+  onCancelCloseMany,
+  onConfirmCloseMany,
   pendingAppClose,
   onCancelAppClose,
   onConfirmAppClose,
@@ -132,6 +166,32 @@ export function CloseDialogs({
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction onClick={onConfirmDeleteClose}>
+              Close Anyway
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={pendingCloseMany !== null}
+        onOpenChange={(open) => !open && onCancelCloseMany()}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingCloseMany?.kind === "right"
+                ? "Close Tabs to the Right"
+                : "Close Other Tabs"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingCloseMany ? closeManyMessage(pendingCloseMany, tabs) : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={onCancelCloseMany}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={onConfirmCloseMany}>
               Close Anyway
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/app/hooks/tabCloseGuards.test.ts
+++ b/src/app/hooks/tabCloseGuards.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CloseManyHazards,
+  hasCloseManyHazards,
+  hasNewCloseManyHazards,
+} from "./tabCloseGuards";
+
+function hazards(
+  dirtyIds: number[] = [],
+  busyLeafIds: number[] = [],
+): CloseManyHazards {
+  return { dirtyIds, busyLeafIds };
+}
+
+describe("close-many hazards", () => {
+  it("requires a guard for dirty editors or busy terminal leaves", () => {
+    expect(hasCloseManyHazards(hazards())).toBe(false);
+    expect(hasCloseManyHazards(hazards([2]))).toBe(true);
+    expect(hasCloseManyHazards(hazards([], [20]))).toBe(true);
+  });
+
+  it("accepts confirmation when the acknowledged hazards are unchanged", () => {
+    const acknowledged = hazards([2], [20]);
+    expect(hasNewCloseManyHazards(acknowledged, hazards([2], [20]))).toBe(
+      false,
+    );
+  });
+
+  it("accepts confirmation when acknowledged hazards have cleared", () => {
+    const acknowledged = hazards([2, 3], [20, 30]);
+    expect(hasNewCloseManyHazards(acknowledged, hazards([2], [30]))).toBe(
+      false,
+    );
+  });
+
+  it("requires another confirmation for a newly dirty editor", () => {
+    expect(hasNewCloseManyHazards(hazards([2]), hazards([2, 3]))).toBe(true);
+  });
+
+  it("requires another confirmation for a newly busy terminal leaf", () => {
+    expect(
+      hasNewCloseManyHazards(hazards([], [20]), hazards([], [20, 30])),
+    ).toBe(true);
+  });
+});

--- a/src/app/hooks/tabCloseGuards.ts
+++ b/src/app/hooks/tabCloseGuards.ts
@@ -1,0 +1,28 @@
+import type { CloseTabsPlan } from "@/modules/tabs";
+
+export type CloseManyKind = "right" | "other";
+
+export type CloseManyHazards = {
+  dirtyIds: number[];
+  busyLeafIds: number[];
+};
+
+export type CloseManyPending = CloseManyHazards & {
+  kind: CloseManyKind;
+  anchorId: number;
+  plan: CloseTabsPlan;
+};
+
+export function hasCloseManyHazards(hazards: CloseManyHazards): boolean {
+  return hazards.dirtyIds.length > 0 || hazards.busyLeafIds.length > 0;
+}
+
+export function hasNewCloseManyHazards(
+  acknowledged: CloseManyHazards,
+  current: CloseManyHazards,
+): boolean {
+  const dirty = new Set(acknowledged.dirtyIds);
+  if (current.dirtyIds.some((id) => !dirty.has(id))) return true;
+  const busy = new Set(acknowledged.busyLeafIds);
+  return current.busyLeafIds.some((id) => !busy.has(id));
+}

--- a/src/app/hooks/useTabCloseGuards.ts
+++ b/src/app/hooks/useTabCloseGuards.ts
@@ -1,18 +1,42 @@
 import { useCallback, useState } from "react";
 import { leafHasForegroundProcess, leafIds } from "@/modules/terminal";
-import { nextActiveInSpace, type Tab } from "@/modules/tabs";
+import {
+  nextActiveInSpace,
+  planCloseOtherTabs,
+  planCloseTabsToRight,
+  type Tab,
+} from "@/modules/tabs";
+
+type CloseManyKind = "right" | "other";
 
 type Params = {
   tabs: Tab[];
+  activeId: number;
   disposeTab: (id: number) => void;
+  disposeTabsToRight: (anchorId: number) => void;
+  disposeOtherTabs: (anchorId: number) => void;
+};
+
+type CloseManyPending = {
+  kind: CloseManyKind;
+  anchorId: number;
+  closeIds: number[];
+  dirtyCount: number;
+  busy: boolean;
 };
 
 /**
  * Guards tab closing: dirty editors and terminals with a live foreground
  * process route through a confirmation dialog instead of closing immediately.
- * Owns the three pending-close states the dialogs render from.
+ * Owns the pending-close states the dialogs render from.
  */
-export function useTabCloseGuards({ tabs, disposeTab }: Params) {
+export function useTabCloseGuards({
+  tabs,
+  activeId,
+  disposeTab,
+  disposeTabsToRight,
+  disposeOtherTabs,
+}: Params) {
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
   const [pendingTerminalCloseTab, setPendingTerminalCloseTab] = useState<
     number | null
@@ -20,6 +44,8 @@ export function useTabCloseGuards({ tabs, disposeTab }: Params) {
   const [pendingDeleteTabs, setPendingDeleteTabs] = useState<number[] | null>(
     null,
   );
+  const [pendingCloseMany, setPendingCloseMany] =
+    useState<CloseManyPending | null>(null);
 
   const handleClose = useCallback(
     async (id: number) => {
@@ -43,6 +69,63 @@ export function useTabCloseGuards({ tabs, disposeTab }: Params) {
     },
     [tabs, disposeTab],
   );
+
+  const handleCloseMany = useCallback(
+    async (kind: CloseManyKind, closeIds: number[], anchorId: number) => {
+      if (closeIds.length === 0) return;
+      const affected = tabs.filter((t) => closeIds.includes(t.id));
+      const dirty = affected.some((t) => t.kind === "editor" && t.dirty);
+      const leaves = affected
+        .filter((t) => t.kind === "terminal")
+        .flatMap((t) => leafIds(t.paneTree));
+      const busy =
+        leaves.length > 0 &&
+        (await Promise.all(leaves.map(leafHasForegroundProcess))).some(Boolean);
+      if (dirty || busy) {
+        setPendingCloseMany({
+          kind,
+          anchorId,
+          closeIds,
+          dirtyCount: affected.filter((t) => t.kind === "editor" && t.dirty)
+            .length,
+          busy,
+        });
+        return;
+      }
+      if (kind === "right") disposeTabsToRight(anchorId);
+      else disposeOtherTabs(anchorId);
+    },
+    [tabs, disposeTabsToRight, disposeOtherTabs],
+  );
+
+  const handleCloseTabsToRight = useCallback(
+    async (anchorId: number) => {
+      const { closeIds } = planCloseTabsToRight(tabs, anchorId, activeId);
+      handleCloseMany("right", closeIds, anchorId);
+    },
+    [tabs, activeId, handleCloseMany],
+  );
+
+  const handleCloseOtherTabs = useCallback(
+    async (anchorId: number) => {
+      const { closeIds } = planCloseOtherTabs(tabs, anchorId, activeId);
+      handleCloseMany("other", closeIds, anchorId);
+    },
+    [tabs, activeId, handleCloseMany],
+  );
+
+  const confirmCloseMany = useCallback(() => {
+    if (pendingCloseMany !== null) {
+      const { kind, anchorId } = pendingCloseMany;
+      if (kind === "right") disposeTabsToRight(anchorId);
+      else disposeOtherTabs(anchorId);
+      setPendingCloseMany(null);
+    }
+  }, [pendingCloseMany, disposeTabsToRight, disposeOtherTabs]);
+
+  const cancelCloseMany = useCallback(() => {
+    setPendingCloseMany(null);
+  }, []);
 
   const confirmClose = useCallback(() => {
     if (pendingCloseTab !== null) {
@@ -96,13 +179,18 @@ export function useTabCloseGuards({ tabs, disposeTab }: Params) {
     pendingCloseTab,
     pendingTerminalCloseTab,
     pendingDeleteTabs,
+    pendingCloseMany,
     handleClose,
+    handleCloseTabsToRight,
+    handleCloseOtherTabs,
     confirmClose,
     cancelClose,
     confirmTerminalClose,
     cancelTerminalClose,
     confirmDeleteClose,
     cancelDeleteClose,
+    confirmCloseMany,
+    cancelCloseMany,
     handlePathDeleted,
   };
 }

--- a/src/app/hooks/useTabCloseGuards.ts
+++ b/src/app/hooks/useTabCloseGuards.ts
@@ -70,9 +70,8 @@ export function useTabCloseGuards({
     [tabs, disposeTab],
   );
 
-  const handleCloseMany = useCallback(
-    async (kind: CloseManyKind, closeIds: number[], anchorId: number) => {
-      if (closeIds.length === 0) return;
+  const evaluateCloseMany = useCallback(
+    async (closeIds: number[]) => {
       const affected = tabs.filter((t) => closeIds.includes(t.id));
       const dirty = affected.some((t) => t.kind === "editor" && t.dirty);
       const leaves = affected
@@ -81,21 +80,28 @@ export function useTabCloseGuards({
       const busy =
         leaves.length > 0 &&
         (await Promise.all(leaves.map(leafHasForegroundProcess))).some(Boolean);
+      return {
+        dirty,
+        busy,
+        dirtyCount: affected.filter((t) => t.kind === "editor" && t.dirty)
+          .length,
+      };
+    },
+    [tabs],
+  );
+
+  const handleCloseMany = useCallback(
+    async (kind: CloseManyKind, closeIds: number[], anchorId: number) => {
+      if (closeIds.length === 0) return;
+      const { dirty, busy, dirtyCount } = await evaluateCloseMany(closeIds);
       if (dirty || busy) {
-        setPendingCloseMany({
-          kind,
-          anchorId,
-          closeIds,
-          dirtyCount: affected.filter((t) => t.kind === "editor" && t.dirty)
-            .length,
-          busy,
-        });
+        setPendingCloseMany({ kind, anchorId, closeIds, dirtyCount, busy });
         return;
       }
       if (kind === "right") disposeTabsToRight(anchorId);
       else disposeOtherTabs(anchorId);
     },
-    [tabs, disposeTabsToRight, disposeOtherTabs],
+    [evaluateCloseMany, disposeTabsToRight, disposeOtherTabs],
   );
 
   const handleCloseTabsToRight = useCallback(
@@ -114,14 +120,37 @@ export function useTabCloseGuards({
     [tabs, activeId, handleCloseMany],
   );
 
-  const confirmCloseMany = useCallback(() => {
-    if (pendingCloseMany !== null) {
-      const { kind, anchorId } = pendingCloseMany;
-      if (kind === "right") disposeTabsToRight(anchorId);
-      else disposeOtherTabs(anchorId);
+  const confirmCloseMany = useCallback(async () => {
+    if (pendingCloseMany === null) return;
+    const { kind, anchorId } = pendingCloseMany;
+    const { closeIds } =
+      kind === "right"
+        ? planCloseTabsToRight(tabs, anchorId, activeId)
+        : planCloseOtherTabs(tabs, anchorId, activeId);
+    if (closeIds.length === 0) {
       setPendingCloseMany(null);
+      return;
     }
-  }, [pendingCloseMany, disposeTabsToRight, disposeOtherTabs]);
+    // Re-run the guard against the current tab set: a tab can enter the
+    // anchor's close range (new tab opened, tab moved) while the dialog is
+    // open, and it needs its own dirty/foreground-process check before it's
+    // swept into a close the user never saw.
+    const { dirty, busy, dirtyCount } = await evaluateCloseMany(closeIds);
+    if (dirty || busy) {
+      setPendingCloseMany({ kind, anchorId, closeIds, dirtyCount, busy });
+      return;
+    }
+    if (kind === "right") disposeTabsToRight(anchorId);
+    else disposeOtherTabs(anchorId);
+    setPendingCloseMany(null);
+  }, [
+    pendingCloseMany,
+    tabs,
+    activeId,
+    evaluateCloseMany,
+    disposeTabsToRight,
+    disposeOtherTabs,
+  ]);
 
   const cancelCloseMany = useCallback(() => {
     setPendingCloseMany(null);

--- a/src/app/hooks/useTabCloseGuards.ts
+++ b/src/app/hooks/useTabCloseGuards.ts
@@ -1,29 +1,30 @@
-import { useCallback, useState } from "react";
-import { leafHasForegroundProcess, leafIds } from "@/modules/terminal";
 import {
+  type CloseManyHazards,
+  type CloseManyKind,
+  type CloseManyPending,
+  hasCloseManyHazards,
+  hasNewCloseManyHazards,
+} from "@/app/hooks/tabCloseGuards";
+import {
+  type CloseTabsPlan,
   nextActiveInSpace,
   planCloseOtherTabs,
   planCloseTabsToRight,
   type Tab,
 } from "@/modules/tabs";
-
-type CloseManyKind = "right" | "other";
+import { leafHasForegroundProcess, leafIds } from "@/modules/terminal";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 type Params = {
   tabs: Tab[];
   activeId: number;
   disposeTab: (id: number) => void;
-  disposeTabsToRight: (anchorId: number) => void;
-  disposeOtherTabs: (anchorId: number) => void;
+  disposeTabs: (anchorId: number, plan: CloseTabsPlan) => void;
 };
 
-type CloseManyPending = {
-  kind: CloseManyKind;
-  anchorId: number;
-  closeIds: number[];
-  dirtyCount: number;
-  busy: boolean;
-};
+function sameIds(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
 
 /**
  * Guards tab closing: dirty editors and terminals with a live foreground
@@ -34,9 +35,14 @@ export function useTabCloseGuards({
   tabs,
   activeId,
   disposeTab,
-  disposeTabsToRight,
-  disposeOtherTabs,
+  disposeTabs,
 }: Params) {
+  const tabsRef = useRef(tabs);
+  const activeIdRef = useRef(activeId);
+  useLayoutEffect(() => {
+    tabsRef.current = tabs;
+    activeIdRef.current = activeId;
+  }, [tabs, activeId]);
   const [pendingCloseTab, setPendingCloseTab] = useState<number | null>(null);
   const [pendingTerminalCloseTab, setPendingTerminalCloseTab] = useState<
     number | null
@@ -46,6 +52,8 @@ export function useTabCloseGuards({
   );
   const [pendingCloseMany, setPendingCloseMany] =
     useState<CloseManyPending | null>(null);
+  const [closeManyConfirming, setCloseManyConfirming] = useState(false);
+  const closeManyRequestRef = useRef(0);
 
   const handleClose = useCallback(
     async (id: number) => {
@@ -70,90 +78,110 @@ export function useTabCloseGuards({
     [tabs, disposeTab],
   );
 
+  const captureCloseMany = useCallback((closeIds: number[]) => {
+    const close = new Set(closeIds);
+    const affected = tabsRef.current.filter((tab) => close.has(tab.id));
+    return {
+      dirtyIds: affected
+        .filter((tab) => tab.kind === "editor" && tab.dirty)
+        .map((tab) => tab.id),
+      leafIds: affected
+        .filter((tab) => tab.kind === "terminal")
+        .flatMap((tab) => leafIds(tab.paneTree)),
+    };
+  }, []);
+
   const evaluateCloseMany = useCallback(
-    async (closeIds: number[]) => {
-      const affected = tabs.filter((t) => closeIds.includes(t.id));
-      const dirty = affected.some((t) => t.kind === "editor" && t.dirty);
-      const leaves = affected
-        .filter((t) => t.kind === "terminal")
-        .flatMap((t) => leafIds(t.paneTree));
-      const busy =
-        leaves.length > 0 &&
-        (await Promise.all(leaves.map(leafHasForegroundProcess))).some(Boolean);
-      return {
-        dirty,
-        busy,
-        dirtyCount: affected.filter((t) => t.kind === "editor" && t.dirty)
-          .length,
-      };
+    async (closeIds: number[]): Promise<CloseManyHazards> => {
+      let { leafIds: checkedLeafIds } = captureCloseMany(closeIds);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const checks = await Promise.all(
+          checkedLeafIds.map(leafHasForegroundProcess),
+        );
+        const latest = captureCloseMany(closeIds);
+        if (sameIds(checkedLeafIds, latest.leafIds)) {
+          return {
+            dirtyIds: latest.dirtyIds,
+            busyLeafIds: checkedLeafIds.filter((_, index) => checks[index]),
+          };
+        }
+        checkedLeafIds = latest.leafIds;
+      }
+      const latest = captureCloseMany(closeIds);
+      return { dirtyIds: latest.dirtyIds, busyLeafIds: latest.leafIds };
     },
-    [tabs],
+    [captureCloseMany],
+  );
+
+  const planCloseMany = useCallback(
+    (kind: CloseManyKind, anchorId: number) =>
+      kind === "right"
+        ? planCloseTabsToRight(tabsRef.current, anchorId, activeIdRef.current)
+        : planCloseOtherTabs(tabsRef.current, anchorId, activeIdRef.current),
+    [],
+  );
+
+  const withCurrentActive = useCallback(
+    (plan: CloseTabsPlan): CloseTabsPlan => ({
+      closeIds: plan.closeIds,
+      nextActiveId: activeIdRef.current,
+    }),
+    [],
   );
 
   const handleCloseMany = useCallback(
-    async (kind: CloseManyKind, closeIds: number[], anchorId: number) => {
-      if (closeIds.length === 0) return;
-      const { dirty, busy, dirtyCount } = await evaluateCloseMany(closeIds);
-      if (dirty || busy) {
-        setPendingCloseMany({ kind, anchorId, closeIds, dirtyCount, busy });
+    async (kind: CloseManyKind, anchorId: number) => {
+      const plan = planCloseMany(kind, anchorId);
+      if (plan.closeIds.length === 0) return;
+      const requestId = ++closeManyRequestRef.current;
+      const hazards = await evaluateCloseMany(plan.closeIds);
+      if (requestId !== closeManyRequestRef.current) return;
+      if (hasCloseManyHazards(hazards)) {
+        setPendingCloseMany({ kind, anchorId, plan, ...hazards });
         return;
       }
-      if (kind === "right") disposeTabsToRight(anchorId);
-      else disposeOtherTabs(anchorId);
+      disposeTabs(anchorId, withCurrentActive(plan));
     },
-    [evaluateCloseMany, disposeTabsToRight, disposeOtherTabs],
+    [disposeTabs, evaluateCloseMany, planCloseMany, withCurrentActive],
   );
 
   const handleCloseTabsToRight = useCallback(
-    async (anchorId: number) => {
-      const { closeIds } = planCloseTabsToRight(tabs, anchorId, activeId);
-      handleCloseMany("right", closeIds, anchorId);
+    (anchorId: number) => {
+      void handleCloseMany("right", anchorId);
     },
-    [tabs, activeId, handleCloseMany],
+    [handleCloseMany],
   );
 
   const handleCloseOtherTabs = useCallback(
-    async (anchorId: number) => {
-      const { closeIds } = planCloseOtherTabs(tabs, anchorId, activeId);
-      handleCloseMany("other", closeIds, anchorId);
+    (anchorId: number) => {
+      void handleCloseMany("other", anchorId);
     },
-    [tabs, activeId, handleCloseMany],
+    [handleCloseMany],
   );
 
   const confirmCloseMany = useCallback(async () => {
     if (pendingCloseMany === null) return;
-    const { kind, anchorId } = pendingCloseMany;
-    const { closeIds } =
-      kind === "right"
-        ? planCloseTabsToRight(tabs, anchorId, activeId)
-        : planCloseOtherTabs(tabs, anchorId, activeId);
-    if (closeIds.length === 0) {
-      setPendingCloseMany(null);
+    const requestId = ++closeManyRequestRef.current;
+    setCloseManyConfirming(true);
+    const hazards = await evaluateCloseMany(pendingCloseMany.plan.closeIds);
+    if (requestId !== closeManyRequestRef.current) return;
+    if (hasNewCloseManyHazards(pendingCloseMany, hazards)) {
+      setPendingCloseMany({ ...pendingCloseMany, ...hazards });
+      setCloseManyConfirming(false);
       return;
     }
-    // Re-run the guard against the current tab set: a tab can enter the
-    // anchor's close range (new tab opened, tab moved) while the dialog is
-    // open, and it needs its own dirty/foreground-process check before it's
-    // swept into a close the user never saw.
-    const { dirty, busy, dirtyCount } = await evaluateCloseMany(closeIds);
-    if (dirty || busy) {
-      setPendingCloseMany({ kind, anchorId, closeIds, dirtyCount, busy });
-      return;
-    }
-    if (kind === "right") disposeTabsToRight(anchorId);
-    else disposeOtherTabs(anchorId);
+    disposeTabs(
+      pendingCloseMany.anchorId,
+      withCurrentActive(pendingCloseMany.plan),
+    );
     setPendingCloseMany(null);
-  }, [
-    pendingCloseMany,
-    tabs,
-    activeId,
-    evaluateCloseMany,
-    disposeTabsToRight,
-    disposeOtherTabs,
-  ]);
+    setCloseManyConfirming(false);
+  }, [pendingCloseMany, disposeTabs, evaluateCloseMany, withCurrentActive]);
 
   const cancelCloseMany = useCallback(() => {
+    closeManyRequestRef.current += 1;
     setPendingCloseMany(null);
+    setCloseManyConfirming(false);
   }, []);
 
   const confirmClose = useCallback(() => {
@@ -209,6 +237,7 @@ export function useTabCloseGuards({
     pendingTerminalCloseTab,
     pendingDeleteTabs,
     pendingCloseMany,
+    closeManyConfirming,
     handleClose,
     handleCloseTabsToRight,
     handleCloseOtherTabs,

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -36,6 +36,10 @@ type Props = {
   onNewGitGraph: () => void;
   onLaunchAgents: (request: AgentLaunchRequest) => void;
   onClose: (id: number) => void;
+  /** Chrome-style: close every tab to the right of the given tab. */
+  onCloseTabsToRight: (id: number) => void;
+  /** Chrome-style: close every tab except the given tab. */
+  onCloseOtherTabs: (id: number) => void;
   /** Promote a preview (transient) tab to persistent. */
   onPin: (id: number) => void;
   /** Set a terminal tab's custom label; empty string resets to default. */
@@ -67,6 +71,8 @@ export function Header({
   onNewGitGraph,
   onLaunchAgents,
   onClose,
+  onCloseTabsToRight,
+  onCloseOtherTabs,
   onPin,
   onRename,
   onReorder,
@@ -164,6 +170,8 @@ export function Header({
           onNewGitGraph={onNewGitGraph}
           onLaunchAgents={onLaunchAgents}
           onClose={onClose}
+          onCloseTabsToRight={onCloseTabsToRight}
+          onCloseOtherTabs={onCloseOtherTabs}
           onPin={onPin}
           onRename={onRename}
           onReorder={onReorder}

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -29,7 +29,9 @@ import {
   useAgentActivityStore,
 } from "@/modules/terminal";
 import {
+  ArrowRight01Icon,
   Cancel01Icon,
+  CancelCircleIcon,
   CheckmarkCircle01Icon,
   Clock01Icon,
   ComputerTerminal02Icon,
@@ -65,6 +67,10 @@ type Props = {
   onNewGitGraph: () => void;
   onLaunchAgents: (request: AgentLaunchRequest) => void;
   onClose: (id: number) => void;
+  /** Chrome-style: close every tab to the right of the given tab. */
+  onCloseTabsToRight: (id: number) => void;
+  /** Chrome-style: close every tab except the given tab. */
+  onCloseOtherTabs: (id: number) => void;
   /** Pin (promote) a preview tab to persistent on double-click. */
   onPin: (id: number) => void;
   /** Set a terminal tab's custom label; empty string resets to default. */
@@ -87,6 +93,8 @@ export function TabBar({
   onNewGitGraph,
   onLaunchAgents,
   onClose,
+  onCloseTabsToRight,
+  onCloseOtherTabs,
   onPin,
   onRename,
   onReorder,
@@ -498,46 +506,73 @@ export function TabBar({
                 </TabsTrigger>
               );
 
-              const tabNode =
-                t.kind === "terminal" ? (
-                  <ContextMenu>
-                    <ContextMenuTrigger asChild>{trigger}</ContextMenuTrigger>
-                    <ContextMenuContent
-                      className="min-w-32 p-1"
-                      onCloseAutoFocus={(e) => e.preventDefault()}
+              const hasTabsToRight = i < tabs.length - 1;
+
+              const tabNode = (
+                <ContextMenu>
+                  <ContextMenuTrigger asChild>{trigger}</ContextMenuTrigger>
+                  <ContextMenuContent
+                    className="min-w-32 p-1"
+                    onCloseAutoFocus={(e) => e.preventDefault()}
+                  >
+                    {t.kind === "terminal" && (
+                      <>
+                        <ContextMenuItem
+                          className="gap-2 rounded-xl px-2.5 py-1.5 text-[13px]"
+                          onSelect={() => setEditingId(t.id)}
+                        >
+                          <HugeiconsIcon
+                            icon={PencilEdit02Icon}
+                            size={13}
+                            strokeWidth={1.75}
+                          />
+                          <span className="flex-1">Rename</span>
+                        </ContextMenuItem>
+                        {tabs.length > 1 && (
+                          <>
+                            <ContextMenuSeparator />
+                            <ContextMenuItem
+                              className="gap-2 rounded-xl px-2.5 py-1.5 text-[13px]"
+                              onSelect={() => onClose(t.id)}
+                            >
+                              <HugeiconsIcon
+                                icon={Cancel01Icon}
+                                size={13}
+                                strokeWidth={1.75}
+                              />
+                              <span className="flex-1">Close</span>
+                            </ContextMenuItem>
+                          </>
+                        )}
+                      </>
+                    )}
+                    <ContextMenuItem
+                      className="gap-2 rounded-xl px-2.5 py-1.5 text-[13px]"
+                      disabled={!hasTabsToRight}
+                      onSelect={() => onCloseTabsToRight(t.id)}
                     >
-                      <ContextMenuItem
-                        className="gap-2 rounded-xl px-2.5 py-1.5 text-[13px]"
-                        onSelect={() => setEditingId(t.id)}
-                      >
-                        <HugeiconsIcon
-                          icon={PencilEdit02Icon}
-                          size={13}
-                          strokeWidth={1.75}
-                        />
-                        <span className="flex-1">Rename</span>
-                      </ContextMenuItem>
-                      {tabs.length > 1 && (
-                        <>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            className="gap-2 rounded-xl px-2.5 py-1.5 text-[13px]"
-                            onSelect={() => onClose(t.id)}
-                          >
-                            <HugeiconsIcon
-                              icon={Cancel01Icon}
-                              size={13}
-                              strokeWidth={1.75}
-                            />
-                            <span className="flex-1">Close</span>
-                          </ContextMenuItem>
-                        </>
-                      )}
-                    </ContextMenuContent>
-                  </ContextMenu>
-                ) : (
-                  trigger
-                );
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        size={13}
+                        strokeWidth={1.75}
+                      />
+                      <span className="flex-1">Close tabs to the right</span>
+                    </ContextMenuItem>
+                    <ContextMenuItem
+                      className="gap-2 rounded-xl px-2.5 py-1.5 text-[13px]"
+                      disabled={tabs.length <= 1}
+                      onSelect={() => onCloseOtherTabs(t.id)}
+                    >
+                      <HugeiconsIcon
+                        icon={CancelCircleIcon}
+                        size={13}
+                        strokeWidth={1.75}
+                      />
+                      <span className="flex-1">Close other tabs</span>
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
+              );
 
               return (
                 <Fragment key={t.id}>

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -12,6 +12,7 @@ export {
   nextActiveInSpace,
   planCloseTabsToRight,
   planCloseOtherTabs,
+  type CloseTabsPlan,
   type Tab,
   type TerminalTab,
   type EditorTab,

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -10,6 +10,8 @@ export {
   DEFAULT_SPACE_ID,
   useTabs,
   nextActiveInSpace,
+  planCloseTabsToRight,
+  planCloseOtherTabs,
   type Tab,
   type TerminalTab,
   type EditorTab,

--- a/src/modules/tabs/lib/applyCloseTabsPlan.test.ts
+++ b/src/modules/tabs/lib/applyCloseTabsPlan.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { applyCloseTabsPlan, planCloseTabsToRight, type Tab } from "./useTabs";
+
+function editor(id: number, spaceId = "a"): Tab {
+  return {
+    id,
+    kind: "editor",
+    spaceId,
+    title: `file-${id}`,
+    path: `/file-${id}`,
+    dirty: false,
+    preview: false,
+  };
+}
+
+function terminal(id: number, leafId: number, spaceId = "a"): Tab {
+  return {
+    id,
+    kind: "terminal",
+    spaceId,
+    title: "shell",
+    paneTree: { kind: "leaf", id: leafId },
+    activeLeafId: leafId,
+  };
+}
+
+describe("applyCloseTabsPlan", () => {
+  it("closes exactly the planned tabs and returns terminal leaves to dispose", () => {
+    const tabs = [terminal(1, 10), terminal(2, 20), editor(3), editor(4)];
+    const result = applyCloseTabsPlan(tabs, 1, {
+      closeIds: [2, 3],
+      nextActiveId: 1,
+    });
+
+    expect(result?.tabs.map((tab) => tab.id)).toEqual([1, 4]);
+    expect(result?.closeIds).toEqual([2, 3]);
+    expect(result?.disposeLeafIds).toEqual([20]);
+    expect(result?.nextActiveId).toBe(1);
+  });
+
+  it("does not sweep in a tab added after the close range was planned", () => {
+    const original = [editor(1), editor(2), editor(3)];
+    const plan = planCloseTabsToRight(original, 1, 1);
+    const current = [...original, editor(4)];
+
+    expect(
+      applyCloseTabsPlan(current, 1, plan)?.tabs.map((tab) => tab.id),
+    ).toEqual([1, 4]);
+  });
+
+  it("does not close a planned tab that moved to another space", () => {
+    const tabs = [editor(1), editor(2), editor(3, "b")];
+    const result = applyCloseTabsPlan(tabs, 1, {
+      closeIds: [2, 3],
+      nextActiveId: 1,
+    });
+
+    expect(result?.tabs.map((tab) => tab.id)).toEqual([1, 3]);
+    expect(result?.closeIds).toEqual([2]);
+  });
+
+  it("falls back to the anchor when the planned active tab is unavailable", () => {
+    const result = applyCloseTabsPlan([editor(1), editor(2)], 1, {
+      closeIds: [2],
+      nextActiveId: 2,
+    });
+
+    expect(result?.nextActiveId).toBe(1);
+  });
+
+  it("does nothing when the anchor no longer exists", () => {
+    expect(
+      applyCloseTabsPlan([editor(2)], 1, {
+        closeIds: [2],
+        nextActiveId: 1,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/modules/tabs/lib/planCloseOtherTabs.test.ts
+++ b/src/modules/tabs/lib/planCloseOtherTabs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { planCloseOtherTabs, type Tab } from "./useTabs";
+
+function tab(id: number, spaceId: string, kind: Tab["kind"] = "editor"): Tab {
+  return {
+    id,
+    kind,
+    spaceId,
+    title: `tab-${id}`,
+    path: `/file-${id}`,
+    dirty: false,
+    preview: false,
+  } as Tab;
+}
+
+describe("planCloseOtherTabs", () => {
+  it("collects every other tab within the same space", () => {
+    const tabs = [tab(1, "a"), tab(2, "a"), tab(3, "a")];
+    expect(planCloseOtherTabs(tabs, 2, 2)).toEqual({
+      closeIds: [1, 3],
+      nextActiveId: 2,
+    });
+  });
+
+  it("skips tabs in other spaces", () => {
+    const tabs = [tab(1, "a"), tab(2, "b"), tab(3, "a")];
+    expect(planCloseOtherTabs(tabs, 3, 2)).toEqual({
+      closeIds: [1],
+      nextActiveId: 2,
+    });
+  });
+
+  it("returns nothing when the anchor is the only tab of its space", () => {
+    const tabs = [tab(1, "a"), tab(2, "b")];
+    expect(planCloseOtherTabs(tabs, 1, 2)).toEqual({
+      closeIds: [],
+      nextActiveId: 2,
+    });
+  });
+
+  it("falls back to the anchor when the active tab is being closed", () => {
+    const tabs = [tab(1, "a"), tab(2, "a"), tab(3, "a")];
+    expect(planCloseOtherTabs(tabs, 1, 3)).toEqual({
+      closeIds: [2, 3],
+      nextActiveId: 1,
+    });
+  });
+
+  it("keeps the active tab when it is not among the closed", () => {
+    const tabs = [tab(1, "a"), tab(2, "a"), tab(3, "a")];
+    expect(planCloseOtherTabs(tabs, 2, 2)).toEqual({
+      closeIds: [1, 3],
+      nextActiveId: 2,
+    });
+  });
+
+  it("returns nothing for an unknown anchor", () => {
+    const tabs = [tab(1, "a")];
+    expect(planCloseOtherTabs(tabs, 99, 1)).toEqual({
+      closeIds: [],
+      nextActiveId: 1,
+    });
+  });
+});

--- a/src/modules/tabs/lib/planCloseTabsToRight.test.ts
+++ b/src/modules/tabs/lib/planCloseTabsToRight.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { planCloseTabsToRight, type Tab } from "./useTabs";
+
+function tab(id: number, spaceId: string, kind: Tab["kind"] = "editor"): Tab {
+  return {
+    id,
+    kind,
+    spaceId,
+    title: `tab-${id}`,
+    path: `/file-${id}`,
+    dirty: false,
+    preview: false,
+  } as Tab;
+}
+
+describe("planCloseTabsToRight", () => {
+  it("collects tabs strictly to the right within the same space", () => {
+    const tabs = [tab(1, "a"), tab(2, "a"), tab(3, "a")];
+    expect(planCloseTabsToRight(tabs, 1, 1)).toEqual({
+      closeIds: [2, 3],
+      nextActiveId: 1,
+    });
+  });
+
+  it("skips tabs in other spaces", () => {
+    const tabs = [tab(1, "a"), tab(2, "b"), tab(3, "a")];
+    expect(planCloseTabsToRight(tabs, 1, 2)).toEqual({
+      closeIds: [3],
+      nextActiveId: 2,
+    });
+  });
+
+  it("returns nothing when the anchor is the last tab of its space", () => {
+    const tabs = [tab(1, "a"), tab(2, "a")];
+    expect(planCloseTabsToRight(tabs, 2, 1)).toEqual({
+      closeIds: [],
+      nextActiveId: 1,
+    });
+  });
+
+  it("falls back to the anchor when the active tab is being closed", () => {
+    const tabs = [tab(1, "a"), tab(2, "a"), tab(3, "a")];
+    expect(planCloseTabsToRight(tabs, 1, 3)).toEqual({
+      closeIds: [2, 3],
+      nextActiveId: 1,
+    });
+  });
+
+  it("keeps the active tab when it is not among the closed", () => {
+    const tabs = [tab(1, "a"), tab(2, "a"), tab(3, "a")];
+    expect(planCloseTabsToRight(tabs, 2, 1)).toEqual({
+      closeIds: [3],
+      nextActiveId: 1,
+    });
+  });
+
+  it("returns nothing for an unknown anchor", () => {
+    const tabs = [tab(1, "a")];
+    expect(planCloseTabsToRight(tabs, 99, 1)).toEqual({
+      closeIds: [],
+      nextActiveId: 1,
+    });
+  });
+});

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -19,7 +19,13 @@ import {
   swapLeafInDirection,
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 // Matches the renderer slot pool size — over this we'd evict an active leaf.
 export const MAX_PANES_PER_TAB = 4;
@@ -151,6 +157,18 @@ export type GitDiffOpenInput = {
 export type OpenFileTabOptions = {
   spaceId?: string;
   activate?: boolean;
+};
+
+export type CloseTabsPlan = {
+  closeIds: number[];
+  nextActiveId: number;
+};
+
+type CloseTabsPlanResult = {
+  tabs: Tab[];
+  closeIds: number[];
+  disposeLeafIds: number[];
+  nextActiveId: number;
 };
 
 export function planMarkdownTabOpen(
@@ -334,7 +352,7 @@ export function planCloseTabsToRight(
   tabs: Tab[],
   anchorId: number,
   activeId: number,
-): { closeIds: number[]; nextActiveId: number } {
+): CloseTabsPlan {
   const anchor = tabs.find((t) => t.id === anchorId);
   if (!anchor) return { closeIds: [], nextActiveId: activeId };
   const sameSpace = tabs.filter((t) => t.spaceId === anchor.spaceId);
@@ -356,7 +374,7 @@ export function planCloseOtherTabs(
   tabs: Tab[],
   anchorId: number,
   activeId: number,
-): { closeIds: number[]; nextActiveId: number } {
+): CloseTabsPlan {
   const anchor = tabs.find((t) => t.id === anchorId);
   if (!anchor) return { closeIds: [], nextActiveId: activeId };
   const sameSpace = tabs.filter((t) => t.spaceId === anchor.spaceId);
@@ -366,6 +384,36 @@ export function planCloseOtherTabs(
     closeIds,
     nextActiveId: closeIds.includes(activeId) ? anchorId : activeId,
   };
+}
+
+export function applyCloseTabsPlan(
+  tabs: Tab[],
+  anchorId: number,
+  plan: CloseTabsPlan,
+): CloseTabsPlanResult | null {
+  const anchor = tabs.find((tab) => tab.id === anchorId);
+  if (!anchor) return null;
+
+  const requested = new Set(plan.closeIds);
+  const closing = tabs.filter(
+    (tab) =>
+      tab.id !== anchorId &&
+      tab.spaceId === anchor.spaceId &&
+      requested.has(tab.id),
+  );
+  if (closing.length === 0) return null;
+
+  const closeIds = closing.map((tab) => tab.id);
+  const close = new Set(closeIds);
+  const next = tabs.filter((tab) => !close.has(tab.id));
+  const nextActiveId = next.some((tab) => tab.id === plan.nextActiveId)
+    ? plan.nextActiveId
+    : anchorId;
+  const disposeLeafIds = closing
+    .filter((tab) => tab.kind === "terminal")
+    .flatMap((tab) => leafIds(tab.paneTree));
+
+  return { tabs: next, closeIds, disposeLeafIds, nextActiveId };
 }
 
 export function planGitDiffOpen(
@@ -547,11 +595,11 @@ export function useTabs(initial?: Partial<TerminalTab>) {
   const tabsRef = useRef(tabs);
   const activeIdRef = useRef(activeId);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     tabsRef.current = tabs;
   }, [tabs]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     activeIdRef.current = activeId;
   }, [activeId]);
 
@@ -1098,35 +1146,19 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     for (const lid of toDispose) disposeSession(lid);
   }, []);
 
-  const closeTabsToRight = useCallback((anchorId: number) => {
-    let toDispose: number[] = [];
-    setTabs((curr) => {
-      const plan = planCloseTabsToRight(curr, anchorId, activeIdRef.current);
-      if (plan.closeIds.length === 0) return curr;
-      const close = new Set(plan.closeIds);
-      toDispose = curr
-        .filter((t) => close.has(t.id) && t.kind === "terminal")
-        .flatMap((t) => leafIds((t as TerminalTab).paneTree));
-      setActiveId(plan.nextActiveId);
-      return curr.filter((t) => !close.has(t.id));
-    });
-    for (const lid of toDispose) disposeSession(lid);
-  }, []);
-
-  const closeOtherTabs = useCallback((anchorId: number) => {
-    let toDispose: number[] = [];
-    setTabs((curr) => {
-      const plan = planCloseOtherTabs(curr, anchorId, activeIdRef.current);
-      if (plan.closeIds.length === 0) return curr;
-      const close = new Set(plan.closeIds);
-      toDispose = curr
-        .filter((t) => close.has(t.id) && t.kind === "terminal")
-        .flatMap((t) => leafIds((t as TerminalTab).paneTree));
-      setActiveId(plan.nextActiveId);
-      return curr.filter((t) => !close.has(t.id));
-    });
-    for (const lid of toDispose) disposeSession(lid);
-  }, []);
+  const closeTabs = useCallback(
+    (anchorId: number, plan: CloseTabsPlan): number[] => {
+      const result = applyCloseTabsPlan(tabsRef.current, anchorId, plan);
+      if (!result) return [];
+      tabsRef.current = result.tabs;
+      activeIdRef.current = result.nextActiveId;
+      setTabs(result.tabs);
+      setActiveId(result.nextActiveId);
+      for (const leafId of result.disposeLeafIds) disposeSession(leafId);
+      return result.closeIds;
+    },
+    [],
+  );
 
   const updateTab = useCallback((id: number, patch: TabPatch) => {
     setTabs((t) =>
@@ -1403,8 +1435,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setAiDiffStatus,
     closeAiDiffTab,
     closeTab,
-    closeTabsToRight,
-    closeOtherTabs,
+    closeTabs,
     updateTab,
     selectByIndex,
     setLeafCwd,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -325,6 +325,49 @@ export function reorderTabsByGap(
   return next;
 }
 
+/**
+ * Plans a Chrome-style "close tabs to the right" within the anchor's space.
+ * Returns the ids strictly to the right of the anchor plus the id to keep
+ * active: the anchor when the active tab is being closed, unchanged otherwise.
+ */
+export function planCloseTabsToRight(
+  tabs: Tab[],
+  anchorId: number,
+  activeId: number,
+): { closeIds: number[]; nextActiveId: number } {
+  const anchor = tabs.find((t) => t.id === anchorId);
+  if (!anchor) return { closeIds: [], nextActiveId: activeId };
+  const sameSpace = tabs.filter((t) => t.spaceId === anchor.spaceId);
+  const idx = sameSpace.findIndex((t) => t.id === anchorId);
+  const closeIds = sameSpace.slice(idx + 1).map((t) => t.id);
+  if (closeIds.length === 0) return { closeIds, nextActiveId: activeId };
+  return {
+    closeIds,
+    nextActiveId: closeIds.includes(activeId) ? anchorId : activeId,
+  };
+}
+
+/**
+ * Plans a Chrome-style "close other tabs" within the anchor's space.
+ * Returns every other tab's id in the anchor's space plus the id to keep
+ * active: the anchor when the active tab is being closed, unchanged otherwise.
+ */
+export function planCloseOtherTabs(
+  tabs: Tab[],
+  anchorId: number,
+  activeId: number,
+): { closeIds: number[]; nextActiveId: number } {
+  const anchor = tabs.find((t) => t.id === anchorId);
+  if (!anchor) return { closeIds: [], nextActiveId: activeId };
+  const sameSpace = tabs.filter((t) => t.spaceId === anchor.spaceId);
+  const closeIds = sameSpace.filter((t) => t.id !== anchorId).map((t) => t.id);
+  if (closeIds.length === 0) return { closeIds, nextActiveId: activeId };
+  return {
+    closeIds,
+    nextActiveId: closeIds.includes(activeId) ? anchorId : activeId,
+  };
+}
+
 export function planGitDiffOpen(
   tabs: Tab[],
   input: GitDiffOpenInput,
@@ -341,8 +384,7 @@ export function planGitDiffOpen(
     tab.path === input.path &&
     tab.mode === input.mode;
   const matchingTabs = tabs.filter(matches);
-  const existing =
-    matchingTabs.find((tab) => !tab.preview) ?? matchingTabs[0];
+  const existing = matchingTabs.find((tab) => !tab.preview) ?? matchingTabs[0];
 
   if (existing) {
     const preview = pin ? false : existing.preview;
@@ -468,7 +510,10 @@ export function planSpaceRemoval(
   let activeId = currentActiveId;
   if (!next.some((t) => t.spaceId === fallbackSpaceId)) {
     const tabId = allocId();
-    next = [...next, coldTerminalTab(tabId, allocId(), fallbackSpaceId, fallbackCwd)];
+    next = [
+      ...next,
+      coldTerminalTab(tabId, allocId(), fallbackSpaceId, fallbackCwd),
+    ];
     activeId = tabId;
   } else if (!next.some((t) => t.id === currentActiveId)) {
     const inFallback = next.filter((t) => t.spaceId === fallbackSpaceId);
@@ -943,25 +988,22 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     [],
   );
 
-  const openGitDiffTab = useCallback(
-    (input: GitDiffOpenInput, pin = false) => {
-      const curr = tabsRef.current;
-      const plan = planGitDiffOpen(
-        curr,
-        input,
-        activeSpaceIdRef.current,
-        pin,
-        () => nextIdRef.current++,
-      );
-      if (plan.tabs !== curr) {
-        tabsRef.current = plan.tabs;
-        setTabs(plan.tabs);
-      }
-      setActiveId(plan.targetId);
-      return plan.targetId;
-    },
-    [],
-  );
+  const openGitDiffTab = useCallback((input: GitDiffOpenInput, pin = false) => {
+    const curr = tabsRef.current;
+    const plan = planGitDiffOpen(
+      curr,
+      input,
+      activeSpaceIdRef.current,
+      pin,
+      () => nextIdRef.current++,
+    );
+    if (plan.tabs !== curr) {
+      tabsRef.current = plan.tabs;
+      setTabs(plan.tabs);
+    }
+    setActiveId(plan.targetId);
+    return plan.targetId;
+  }, []);
 
   const openCommitHistoryTab = useCallback(
     (input: { repoRoot: string; branch?: string | null }) => {
@@ -1056,6 +1098,36 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     for (const lid of toDispose) disposeSession(lid);
   }, []);
 
+  const closeTabsToRight = useCallback((anchorId: number) => {
+    let toDispose: number[] = [];
+    setTabs((curr) => {
+      const plan = planCloseTabsToRight(curr, anchorId, activeIdRef.current);
+      if (plan.closeIds.length === 0) return curr;
+      const close = new Set(plan.closeIds);
+      toDispose = curr
+        .filter((t) => close.has(t.id) && t.kind === "terminal")
+        .flatMap((t) => leafIds((t as TerminalTab).paneTree));
+      setActiveId(plan.nextActiveId);
+      return curr.filter((t) => !close.has(t.id));
+    });
+    for (const lid of toDispose) disposeSession(lid);
+  }, []);
+
+  const closeOtherTabs = useCallback((anchorId: number) => {
+    let toDispose: number[] = [];
+    setTabs((curr) => {
+      const plan = planCloseOtherTabs(curr, anchorId, activeIdRef.current);
+      if (plan.closeIds.length === 0) return curr;
+      const close = new Set(plan.closeIds);
+      toDispose = curr
+        .filter((t) => close.has(t.id) && t.kind === "terminal")
+        .flatMap((t) => leafIds((t as TerminalTab).paneTree));
+      setActiveId(plan.nextActiveId);
+      return curr.filter((t) => !close.has(t.id));
+    });
+    for (const lid of toDispose) disposeSession(lid);
+  }, []);
+
   const updateTab = useCallback((id: number, patch: TabPatch) => {
     setTabs((t) =>
       t.map((x) => {
@@ -1108,9 +1180,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
 
   const selectByIndex = useCallback(
     (idx: number, spaceId?: string) => {
-      const t = spaceId
-        ? pickTabBySpaceIndex(tabs, idx, spaceId)
-        : tabs[idx];
+      const t = spaceId ? pickTabBySpaceIndex(tabs, idx, spaceId) : tabs[idx];
       if (t) setActiveId(t.id);
     },
     [tabs],
@@ -1333,6 +1403,8 @@ export function useTabs(initial?: Partial<TerminalTab>) {
     setAiDiffStatus,
     closeAiDiffTab,
     closeTab,
+    closeTabsToRight,
+    closeOtherTabs,
     updateTab,
     selectByIndex,
     setLeafCwd,


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits - it becomes the squash commit message.
Examples: feat(terminal): add split panes / fix(explorer): close button alignment
-->

## What
<!-- One or two sentences describing the change. -->

Closes #1133

Adds Chrome-style "Close tabs to the right" and "Close other tabs" actions to the tab context menu, with confirmation dialogs for dirty editors and terminals running a live process.

## Why
<!-- The problem you're solving. Link to the issue if there is one (e.g. "Closes #42"). -->

Tab strip lacked bulk-close actions; closing tabs one at a time is tedious. Both actions scope to the tab's space so cross-space tabs survive.

## How
<!-- Brief notes on the approach, only if non-obvious. -->

- `planCloseTabsToRight` / `planCloseOtherTabs` in `useTabs.ts` compute which tab ids close (and the next active id) within the anchor's space; `closeTabsToRight` / `closeOtherTabs` apply them and dispose terminal sessions.
- `useTabCloseGuards` was refactored into a shared `handleCloseMany` / `pendingCloseMany` / `confirmCloseMany` path so both bulk actions reuse the same dirty-editor + foreground-process guard and confirmation dialog (title/wording keyed on a kind: "right" | "other").
- `Close other tabs` disabled when the space has a single tab; `Close tabs to the right` disabled when the tab is the rightmost.

## Testing
<!-- How did you verify this works? "Ran tsc clean" is not enough on its own -
     describe the actual flows you exercised. -->

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS
- [ ] Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->


## Screenshots / GIFs
<!-- Required for any UI change. Before / after if applicable. -->

https://github.com/user-attachments/assets/6979061c-a3c9-4b60-9c03-fb708f7168a8

https://github.com/user-attachments/assets/bae815b2-019f-48bc-b4fd-2f4a30d4bc4d


https://github.com/user-attachments/assets/459ffa3e-8196-48ad-8c96-a2f8e760f7ee


<kbd>Confirmation Dialog when multiple tabs have unsaved changes
<img width="1512" height="858" alt="Confirmation Dialog when multiple tabs have unsaved chages" src="https://github.com/user-attachments/assets/1c987a1c-d7d7-4f6d-9a61-eb0849328737" /></kdb>

<kbd>Close options disabled when there are no tabs to close<img width="1512" height="858" alt="Close options disabled when there are no tabs to close" src="https://github.com/user-attachments/assets/c3285289-9111-4ea0-a56c-ec81881403ae" /></kbd>

<kbd>Close to right option disable when there are no tabs to the right<img width="1512" height="858" alt="Close to right option disable when there are no tabs to the right" src="https://github.com/user-attachments/assets/2432c52c-ae85-47b4-8e9e-7e0c25f0e172" /></kbd>


## Notes for reviewer
<!-- Anything risky, anything you want a second opinion on, follow-ups for later. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added context-menu actions to close all tabs to the right or close all other tabs.
  - Added confirmation dialogs for bulk closures involving unsaved changes, running processes, or multiple tabs.
  - Automatically handles affected editor and terminal sessions while preserving an appropriate active tab.

- **Bug Fixes**
  - Improved bulk tab-closing behavior across tab spaces, including edge cases and unknown selections.

- **Tests**
  - Added coverage for bulk-close planning, hazard detection, session disposal, and active-tab fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->