### PR TITLE
Fix OpenRouter model selection

### DIFF
--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -58,8 +58,13 @@ import {
 } from "../config";
 import { ACCEPTED_FILES, useComposer } from "../lib/composer";
 import { toggleFavoriteModel } from "../lib/modelPrefs";
+import {
+  isOpenRouterModelInfo,
+  useOpenRouterCatalog,
+} from "../lib/openrouterModels";
 import { useChatStore } from "../store/chatStore";
 import { usePreferencesStore } from "@/modules/settings/preferences";
+import { setOpenrouterModelId } from "@/modules/settings/store";
 
 const PROVIDER_ICON = {
   openai: ChatGptIcon,
@@ -141,7 +146,7 @@ export function AiStatusBarControls() {
           disabled={c.isBusy || c.voice.transcribing || !c.voice.hasKey}
           className={cn(
             c.voice.recording &&
-            "bg-destructive/10 text-destructive hover:bg-destructive/15",
+              "bg-destructive/10 text-destructive hover:bg-destructive/15",
           )}
         >
           {c.voice.recording ? (
@@ -214,9 +219,16 @@ function ModelDropdown() {
   const favoriteIds = usePreferencesStore((s) => s.favoriteModelIds);
   const recentIds = usePreferencesStore((s) => s.recentModelIds);
   const customEndpoints = usePreferencesStore((s) => s.customEndpoints);
-  const current = isCompatModelId(selected)
-    ? getCompatModelInfo(selected, customEndpoints)
-    : getModel(selected as ModelId);
+  const openrouterModelId = usePreferencesStore((s) => s.openrouterModelId);
+  const openrouterCatalog = useOpenRouterCatalog(apiKeys.openrouter);
+  const current =
+    selected === "openrouter-custom"
+      ? (openrouterCatalog.models.find(
+          (model) => model.openrouterModelId === openrouterModelId,
+        ) ?? getModel(selected as ModelId))
+      : isCompatModelId(selected)
+        ? getCompatModelInfo(selected, customEndpoints)
+        : getModel(selected as ModelId);
   const [search, setSearch] = useState("");
   const [activeProvider, setActiveProvider] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("all");
@@ -241,15 +253,23 @@ function ModelDropdown() {
     const unconfigured: (typeof PROVIDERS)[number][] = [];
     for (const p of PROVIDERS) {
       if (p.id === "openai-compatible") continue;
-      (hasKeyFor(p.id) ? configured : unconfigured).push(p);
+      const configuredForDropdown = providerNeedsKey(p.id)
+        ? !!apiKeys[p.id]
+        : true;
+      (configuredForDropdown ? configured : unconfigured).push(p);
     }
     return { configured, unconfigured };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiKeys]);
 
   const allModels = useMemo(
-    () => [...MODELS, ...epModelInfos],
-    [epModelInfos],
+    () => [
+      ...(openrouterCatalog.models.length > 0
+        ? MODELS.filter((model) => model.provider !== "openrouter")
+        : MODELS),
+      ...openrouterCatalog.models,
+      ...epModelInfos,
+    ],
+    [epModelInfos, openrouterCatalog.models],
   );
 
   const COMPAT_PROVIDER_ID = "__compat__";
@@ -278,6 +298,8 @@ function ModelDropdown() {
           m.hint.toLowerCase().includes(q) ||
           m.description.toLowerCase().includes(q) ||
           m.provider.includes(q) ||
+          (isOpenRouterModelInfo(m) &&
+            m.openrouterModelId.toLowerCase().includes(q)) ||
           (m.tags?.some((t) => t.includes(q)) ?? false),
       );
     }
@@ -371,22 +393,21 @@ function ModelDropdown() {
               active={activeProvider === null}
               onClick={() => setActiveProvider(null)}
             />
-            {[...sortedProviders.configured, ...sortedProviders.unconfigured].map(
-              (p) => (
-                <ProviderPill
-                  key={p.id}
-                  icon={PROVIDER_ICON[p.id]}
-                  title={
-                    hasKeyFor(p.id)
-                      ? p.label
-                      : `${p.label} — not configured`
-                  }
-                  active={activeProvider === p.id}
-                  muted={!hasKeyFor(p.id)}
-                  onClick={() => setActiveProvider(p.id)}
-                />
-              ),
-            )}
+            {[
+              ...sortedProviders.configured,
+              ...sortedProviders.unconfigured,
+            ].map((p) => (
+              <ProviderPill
+                key={p.id}
+                icon={PROVIDER_ICON[p.id]}
+                title={
+                  hasKeyFor(p.id) ? p.label : `${p.label} — not configured`
+                }
+                active={activeProvider === p.id}
+                muted={!hasKeyFor(p.id)}
+                onClick={() => setActiveProvider(p.id)}
+              />
+            ))}
             {customEndpoints.length > 0 && (
               <ProviderPill
                 icon={PlugIcon}
@@ -427,11 +448,13 @@ function ModelDropdown() {
                 <ModelRow
                   key={m.id}
                   model={m}
-                  selected={m.id === selected}
-                  hasKey={
-                    isCompatModelId(m.id) ||
-                    hasKeyFor(m.provider)
+                  selected={
+                    isOpenRouterModelInfo(m)
+                      ? selected === "openrouter-custom" &&
+                        openrouterModelId === m.openrouterModelId
+                      : m.id === selected
                   }
+                  hasKey={isCompatModelId(m.id) || hasKeyFor(m.provider)}
                   favorite={favoriteIds.includes(m.id)}
                   showProviderIcon={activeProvider === null}
                   onPick={() => {
@@ -439,7 +462,12 @@ function ModelDropdown() {
                       void openSettingsWindow("models");
                       return;
                     }
-                    setSelected(m.id);
+                    if (isOpenRouterModelInfo(m)) {
+                      void setOpenrouterModelId(m.openrouterModelId);
+                      setSelected("openrouter-custom", m.openrouterModelId);
+                    } else {
+                      setSelected(m.id);
+                    }
                   }}
                   onToggleFavorite={() => void toggleFavoriteModel(m.id)}
                 />
@@ -524,11 +552,7 @@ function ProviderHeader({ providerId }: { providerId: ProviderId }) {
   if (!p) return null;
   return (
     <div className="flex items-center gap-1.5 px-3 pt-1 pb-1.5 text-[11px] font-medium tracking-tight text-muted-foreground/90">
-      <HugeiconsIcon
-        icon={PROVIDER_ICON[p.id]}
-        size={13}
-        strokeWidth={1.75}
-      />
+      <HugeiconsIcon icon={PROVIDER_ICON[p.id]} size={13} strokeWidth={1.75} />
       <span>{p.label}</span>
     </div>
   );
@@ -616,11 +640,18 @@ function ModelRow({
       ) : null}
 
       <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
-        <span className="shrink-0 text-[12px] font-medium leading-none">
-          {model.label}
+        <span className="flex min-w-0 shrink-0 items-center gap-1.5 text-[12px] font-medium leading-none">
+          <span className="truncate">{model.label}</span>
+          {isOpenRouterModelInfo(model) && model.batchOnly ? (
+            <span className="shrink-0 text-[9px] text-amber-600 dark:text-amber-400">
+              Batch only
+            </span>
+          ) : null}
         </span>
         <span className="truncate text-[10.5px] leading-none text-muted-foreground">
-          {model.description}
+          {isOpenRouterModelInfo(model)
+            ? model.openrouterModelId
+            : model.description}
         </span>
       </div>
 
@@ -643,11 +674,7 @@ function CapabilityBars({ caps }: { caps: ModelCapabilities }) {
     <div className="ml-auto flex items-center gap-1.5">
       <CapBar icon={BrainIcon} value={caps.intelligence} label="Intelligence" />
       <CapBar icon={FlashIcon} value={caps.speed} label="Speed" />
-      <CapBar
-        icon={CoinsDollarIcon}
-        value={caps.cost}
-        label="Affordability"
-      />
+      <CapBar icon={CoinsDollarIcon} value={caps.cost} label="Affordability" />
     </div>
   );
 }
@@ -662,10 +689,7 @@ function CapBar({
   label: string;
 }) {
   return (
-    <span
-      className="flex items-center gap-0.5"
-      title={`${label}: ${value}/5`}
-    >
+    <span className="flex items-center gap-0.5" title={`${label}: ${value}/5`}>
       <HugeiconsIcon
         icon={icon}
         size={10}

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -109,7 +109,8 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     label: "MLX",
     keyringAccount: "",
     keyPrefix: null,
-    consoleUrl: "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md",
+    consoleUrl:
+      "https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md",
   },
   {
     id: "ollama",
@@ -772,7 +773,11 @@ export function getModelContextLimit(
 ): number {
   if (!modelId) return 128_000;
   if (isCompatModelId(modelId)) return compatOverride ?? 128_000;
-  if (modelId === "openai-compatible-custom" && compatOverride)
+  if (
+    (modelId === "openai-compatible-custom" ||
+      modelId === "openrouter-custom") &&
+    compatOverride
+  )
     return compatOverride;
   return MODEL_CONTEXT_LIMITS[modelId] ?? 128_000;
 }

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -27,6 +27,7 @@ import { compactModelMessagesDetailed } from "./compact";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
 import { prepareAgentPrompt } from "./prompt";
 import { createProxyFetch } from "./proxyFetch";
+import { getOpenRouterModelContextLimit } from "./openrouterModels";
 
 const localProxyFetch = createProxyFetch({ allowPrivateNetwork: true });
 
@@ -123,8 +124,9 @@ export async function buildLanguageModel(
       break;
     }
     case "deepseek": {
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "deepseek",
         baseURL: "https://api.deepseek.com",
@@ -133,8 +135,9 @@ export async function buildLanguageModel(
       break;
     }
     case "mistral": {
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "mistral",
         baseURL: "https://api.mistral.ai/v1",
@@ -148,8 +151,9 @@ export async function buildLanguageModel(
       break;
     }
     case "openrouter": {
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "openrouter",
         baseURL: "https://openrouter.ai/api/v1",
@@ -167,8 +171,9 @@ export async function buildLanguageModel(
           "OpenAI-compatible provider has no base URL. Set it in Settings → Models.",
         );
       }
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "openai-compatible",
         baseURL: compatURL,
@@ -178,8 +183,9 @@ export async function buildLanguageModel(
       break;
     }
     case "lmstudio": {
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "lmstudio",
         baseURL: lmstudioURL,
@@ -188,8 +194,9 @@ export async function buildLanguageModel(
       break;
     }
     case "mlx": {
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "mlx",
         baseURL: mlxURL,
@@ -198,8 +205,9 @@ export async function buildLanguageModel(
       break;
     }
     case "ollama": {
-      const { createOpenAICompatible } =
-        await import("@ai-sdk/openai-compatible");
+      const { createOpenAICompatible } = await import(
+        "@ai-sdk/openai-compatible"
+      );
       built = createOpenAICompatible({
         name: "ollama",
         baseURL: ollamaURL,
@@ -240,9 +248,7 @@ export function buildConfiguredLanguageModel(
     const ep = local.customEndpoints?.find((e) => e.id === eid);
     if (!ep) throw new Error(`Custom endpoint not found: ${eid}`);
     if (!ep.modelId.trim()) {
-      throw new Error(
-        `${ep.name}: no model id set. Open Settings → Models.`,
-      );
+      throw new Error(`${ep.name}: no model id set. Open Settings → Models.`);
     }
     return buildLanguageModel(
       "openai-compatible",
@@ -402,7 +408,9 @@ export async function runAgentStream(opts: RunAgentOptions) {
   const compatCtxOverride = isCompatModelId(modelId)
     ? endpoints.find((e) => e.id === endpointIdFromCompatModel(modelId))
         ?.contextLimit
-    : opts.openaiCompatibleContextLimit;
+    : modelId === "openrouter-custom"
+      ? getOpenRouterModelContextLimit(opts.openrouterModelId)
+      : opts.openaiCompatibleContextLimit;
   const compact = compactModelMessagesDetailed(
     prunedHistory,
     getModelContextLimit(modelId, compatCtxOverride),

--- a/src/modules/ai/lib/errors.test.ts
+++ b/src/modules/ai/lib/errors.test.ts
@@ -41,6 +41,18 @@ describe("formatAiError", () => {
     );
   });
 
+  it("labels models that only support the Batch API", () => {
+    expect(
+      formatAiError(
+        new Error(
+          "This model is only available through the Batch API. Use the /api/beta/batches endpoint instead.",
+        ),
+      ),
+    ).toBe(
+      "Batch-only model: This model is only available through the Batch API. Use the /api/beta/batches endpoint instead.",
+    );
+  });
+
   it("redacts credential-like values", () => {
     expect(
       formatAiError(

--- a/src/modules/ai/lib/errors.ts
+++ b/src/modules/ai/lib/errors.ts
@@ -70,6 +70,11 @@ function sanitizeErrorMessage(message: string): string {
 }
 
 function errorPrefix(code: string | null, message: string): string | null {
+  if (
+    /only available through the batch api|batch api.*instead/i.test(message)
+  ) {
+    return "Batch-only model";
+  }
   switch (code?.toLowerCase()) {
     case "model_not_found":
     case "not_found_error":

--- a/src/modules/ai/lib/openrouterModels.test.ts
+++ b/src/modules/ai/lib/openrouterModels.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseOpenRouterModels,
+  toOpenRouterModelInfo,
+} from "./openrouterModels";
+
+describe("OpenRouter model catalog", () => {
+  it("maps catalog metadata into selectable model info", () => {
+    const [model] = parseOpenRouterModels(
+      JSON.stringify({
+        data: [
+          {
+            id: "anthropic/claude-sonnet-4.5",
+            name: "Claude Sonnet 4.5",
+            description: "A capable model.",
+            context_length: 200_000,
+            architecture: { input_modalities: ["text", "image"] },
+            pricing: { prompt: "0.000003", completion: "0.000015" },
+            supported_parameters: ["tools", "temperature", "reasoning"],
+          },
+        ],
+      }),
+    );
+
+    expect(model).toMatchObject({
+      id: "anthropic/claude-sonnet-4.5",
+      provider: "openrouter",
+      label: "Claude Sonnet 4.5",
+      openrouterModelId: "anthropic/claude-sonnet-4.5",
+      contextLength: 200_000,
+      inputPricePerMillion: 3,
+      outputPricePerMillion: 15,
+      supportsTools: true,
+      batchOnly: false,
+    });
+    expect(model.tags).toEqual(["vision", "reasoning", "tools"]);
+  });
+
+  it("keeps batch-only models visible and marks them", () => {
+    const model = toOpenRouterModelInfo({
+      id: "openai/batch-model",
+      name: "Batch Model",
+      supported_parameters: ["batch"],
+    });
+
+    expect(model).toMatchObject({
+      openrouterModelId: "openai/batch-model",
+      batchOnly: true,
+      hint: "Batch only",
+    });
+  });
+
+  it("rejects malformed catalog responses", () => {
+    expect(() => parseOpenRouterModels(JSON.stringify({ data: {} }))).toThrow(
+      "invalid model catalog",
+    );
+  });
+});

--- a/src/modules/ai/lib/openrouterModels.ts
+++ b/src/modules/ai/lib/openrouterModels.ts
@@ -1,0 +1,290 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useSyncExternalStore } from "react";
+import type { ModelCapabilities, ModelInfo } from "../config";
+
+const OPENROUTER_MODELS_URL =
+  "https://openrouter.ai/api/v1/models?output_modalities=text";
+const CATALOG_TTL_MS = 5 * 60_000;
+
+type HttpResponse = {
+  status: number;
+  headers: Record<string, string>;
+  body: number[];
+};
+
+export type OpenRouterModel = {
+  id: string;
+  canonical_slug?: string | null;
+  name?: string | null;
+  description?: string | null;
+  context_length?: number | null;
+  architecture?: {
+    input_modalities?: string[] | null;
+    output_modalities?: string[] | null;
+    modality?: string | null;
+  } | null;
+  pricing?: {
+    prompt?: string | null;
+    completion?: string | null;
+  } | null;
+  supported_parameters?: string[] | null;
+  expiration_date?: string | null;
+  top_provider?: {
+    context_length?: number | null;
+    max_completion_tokens?: number | null;
+  } | null;
+};
+
+export type OpenRouterModelInfo = ModelInfo & {
+  openrouterModelId: string;
+  contextLength: number;
+  inputPricePerMillion: number | null;
+  outputPricePerMillion: number | null;
+  supportsTools: boolean;
+  batchOnly: boolean;
+};
+
+export type OpenRouterCatalogStatus = "idle" | "loading" | "ready" | "error";
+
+export type OpenRouterCatalogSnapshot = {
+  models: readonly OpenRouterModelInfo[];
+  status: OpenRouterCatalogStatus;
+  error: string | null;
+  loadedAt: number | null;
+};
+
+export function isOpenRouterModelInfo(
+  model: ModelInfo,
+): model is OpenRouterModelInfo {
+  return model.provider === "openrouter" && "openrouterModelId" in model;
+}
+
+const EMPTY_SNAPSHOT: OpenRouterCatalogSnapshot = {
+  models: [],
+  status: "idle",
+  error: null,
+  loadedAt: null,
+};
+
+let snapshot = EMPTY_SNAPSHOT;
+let request: Promise<void> | null = null;
+const knownBatchOnlyIds = new Set<string>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function setSnapshot(next: OpenRouterCatalogSnapshot): void {
+  snapshot = next;
+  notify();
+}
+
+function decodeBody(body: number[]): string {
+  return new TextDecoder().decode(Uint8Array.from(body));
+}
+
+function responseError(status: number, body: string): Error {
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string } };
+    const message = parsed.error?.message;
+    if (message) return new Error(message);
+  } catch {
+    // Fall through to the status-based message.
+  }
+  return new Error(`OpenRouter model catalog request failed (${status}).`);
+}
+
+function pricePerMillion(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed * 1_000_000 : null;
+}
+
+function capabilitiesForModel(model: OpenRouterModel): ModelCapabilities {
+  const parameters = new Set(model.supported_parameters ?? []);
+  const promptPrice = pricePerMillion(model.pricing?.prompt);
+  const completionPrice = pricePerMillion(model.pricing?.completion);
+  const averagePrice =
+    promptPrice != null && completionPrice != null
+      ? (promptPrice + completionPrice) / 2
+      : null;
+  const cost: ModelCapabilities["cost"] =
+    averagePrice == null
+      ? 3
+      : averagePrice <= 0.5
+        ? 5
+        : averagePrice <= 2
+          ? 4
+          : averagePrice <= 8
+            ? 3
+            : averagePrice <= 25
+              ? 2
+              : 1;
+
+  return {
+    intelligence: parameters.has("reasoning") ? 4 : 3,
+    speed: 3,
+    cost,
+  };
+}
+
+function isBatchOnlyModel(model: OpenRouterModel): boolean {
+  const parameters = model.supported_parameters ?? [];
+  return parameters.some((parameter) => parameter.toLowerCase() === "batch");
+}
+
+export function toOpenRouterModelInfo(
+  model: OpenRouterModel,
+): OpenRouterModelInfo | null {
+  const id = model.id.trim();
+  if (!id) return null;
+  const parameters = new Set(model.supported_parameters ?? []);
+  const batchOnly =
+    isBatchOnlyModel(model) || knownBatchOnlyIds.has(model.id.trim());
+  const inputs = model.architecture?.input_modalities ?? [];
+  const tags = [
+    ...(inputs.includes("image") ? (["vision"] as const) : []),
+    ...(parameters.has("reasoning") ? (["reasoning"] as const) : []),
+    ...(parameters.has("tools") ? (["tools"] as const) : []),
+  ];
+
+  return {
+    id,
+    provider: "openrouter",
+    label: model.name?.trim() || id,
+    hint: batchOnly
+      ? "Batch only"
+      : parameters.has("tools")
+        ? "Tools"
+        : "OpenRouter",
+    description: model.description?.trim() || id,
+    capabilities: capabilitiesForModel(model),
+    tags,
+    supportsTemperature: parameters.has("temperature"),
+    openrouterModelId: id,
+    contextLength: model.context_length ?? 128_000,
+    inputPricePerMillion: pricePerMillion(model.pricing?.prompt),
+    outputPricePerMillion: pricePerMillion(model.pricing?.completion),
+    supportsTools: parameters.has("tools"),
+    batchOnly,
+  };
+}
+
+export function parseOpenRouterModels(body: string): OpenRouterModelInfo[] {
+  const parsed = JSON.parse(body) as { data?: unknown };
+  if (!Array.isArray(parsed.data)) {
+    throw new Error("OpenRouter returned an invalid model catalog.");
+  }
+  return parsed.data
+    .filter((model): model is OpenRouterModel => {
+      if (!model || typeof model !== "object") return false;
+      const id = (model as { id?: unknown }).id;
+      return typeof id === "string";
+    })
+    .map(toOpenRouterModelInfo)
+    .filter((model): model is OpenRouterModelInfo => model !== null);
+}
+
+export async function fetchOpenRouterModels(
+  apiKey: string,
+): Promise<OpenRouterModelInfo[]> {
+  const response = await invoke<HttpResponse>("ai_http_request", {
+    url: OPENROUTER_MODELS_URL,
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "HTTP-Referer": "https://terax.ai",
+      "X-OpenRouter-Title": "Terax",
+    },
+  });
+  const body = decodeBody(response.body);
+  if (response.status < 200 || response.status >= 300) {
+    throw responseError(response.status, body);
+  }
+  return parseOpenRouterModels(body);
+}
+
+export function useOpenRouterCatalog(
+  apiKey: string | null | undefined,
+): OpenRouterCatalogSnapshot {
+  const current = useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => snapshot,
+    () => snapshot,
+  );
+
+  useEffect(() => {
+    if (!apiKey) {
+      if (snapshot.status !== "idle" || snapshot.models.length > 0) {
+        setSnapshot(EMPTY_SNAPSHOT);
+      }
+      return;
+    }
+    void loadOpenRouterCatalog(apiKey);
+  }, [apiKey]);
+
+  return current;
+}
+
+export async function loadOpenRouterCatalog(
+  apiKey: string,
+  force = false,
+): Promise<void> {
+  if (!apiKey.trim()) return;
+  if (
+    !force &&
+    snapshot.status === "ready" &&
+    snapshot.loadedAt != null &&
+    Date.now() - snapshot.loadedAt < CATALOG_TTL_MS
+  ) {
+    return;
+  }
+  if (request) return request;
+
+  setSnapshot({ ...snapshot, status: "loading", error: null });
+  request = fetchOpenRouterModels(apiKey)
+    .then((models) => {
+      setSnapshot({
+        models,
+        status: "ready",
+        error: null,
+        loadedAt: Date.now(),
+      });
+    })
+    .catch((error) => {
+      setSnapshot({
+        ...snapshot,
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    })
+    .finally(() => {
+      request = null;
+    });
+  return request;
+}
+
+export function markOpenRouterModelBatchOnly(modelId: string): void {
+  if (!modelId.trim()) return;
+  knownBatchOnlyIds.add(modelId);
+  const models = snapshot.models.map((model) =>
+    model.openrouterModelId === modelId
+      ? { ...model, batchOnly: true, hint: "Batch only" }
+      : model,
+  );
+  if (models.some((model, index) => model !== snapshot.models[index])) {
+    setSnapshot({ ...snapshot, models });
+  }
+}
+
+export function getOpenRouterModelContextLimit(
+  modelId: string | undefined,
+): number | undefined {
+  if (!modelId) return undefined;
+  return snapshot.models.find((model) => model.openrouterModelId === modelId)
+    ?.contextLength;
+}

--- a/src/modules/ai/lib/transport.ts
+++ b/src/modules/ai/lib/transport.ts
@@ -3,6 +3,7 @@ import type { CustomEndpoint } from "../config";
 import { runAgentStream, type AgentUsageDelta } from "./agent";
 import type { ProviderKeys, CustomEndpointKeys } from "./keyring";
 import { formatAiError } from "./errors";
+import { markOpenRouterModelBatchOnly } from "./openrouterModels";
 import { native } from "./native";
 import type { ToolContext } from "../tools/tools";
 
@@ -10,7 +11,9 @@ const TERAX_MD_MAX_BYTES = 32 * 1024;
 type MemoryCacheEntry = { content: string | null; mtime: number };
 const projectMemoryCache = new Map<string, MemoryCacheEntry>();
 
-async function readTeraxMd(workspaceRoot: string | null): Promise<string | null> {
+async function readTeraxMd(
+  workspaceRoot: string | null,
+): Promise<string | null> {
   if (!workspaceRoot) return null;
   const path = `${workspaceRoot.replace(/\/$/, "")}/TERAX.md`;
   const cached = projectMemoryCache.get(workspaceRoot);
@@ -18,7 +21,10 @@ async function readTeraxMd(workspaceRoot: string | null): Promise<string | null>
   try {
     const r = await native.readFile(path);
     if (r.kind !== "text") {
-      projectMemoryCache.set(workspaceRoot, { content: null, mtime: Date.now() });
+      projectMemoryCache.set(workspaceRoot, {
+        content: null,
+        mtime: Date.now(),
+      });
       return null;
     }
     const content =
@@ -109,7 +115,16 @@ export function createContextAwareTransport(deps: Deps) {
     });
     return result.toUIMessageStream({
       originalMessages: options.messages,
-      onError: formatAiError,
+      onError: (error) => {
+        const message = formatAiError(error);
+        if (
+          /batch-only model|only available through the batch api/i.test(message)
+        ) {
+          const modelId = deps.getOpenrouterModelId?.();
+          if (modelId) markOpenRouterModelBatchOnly(modelId);
+        }
+        return message;
+      },
     });
   };
 

--- a/src/modules/ai/store/chatStore.ts
+++ b/src/modules/ai/store/chatStore.ts
@@ -11,7 +11,11 @@ import {
 } from "../config";
 import { useTodosStore } from "./todoStore";
 import type { AgentUsage } from "../lib/agent";
-import { EMPTY_PROVIDER_KEYS, type ProviderKeys, type CustomEndpointKeys } from "../lib/keyring";
+import {
+  EMPTY_PROVIDER_KEYS,
+  type ProviderKeys,
+  type CustomEndpointKeys,
+} from "../lib/keyring";
 import {
   deleteSessionData,
   deriveTitle,
@@ -87,10 +91,7 @@ export type PendingSelection = {
   source: "terminal" | "editor";
 };
 
-export type ApprovalResponder = (
-  approvalId: string,
-  approved: boolean,
-) => void;
+export type ApprovalResponder = (approvalId: string, approved: boolean) => void;
 
 type StoreState = {
   live: Live;
@@ -113,7 +114,7 @@ type StoreState = {
   setCustomEndpointKeys: (keys: CustomEndpointKeys) => void;
 
   selectedModelId: string;
-  setSelectedModelId: (id: string) => void;
+  setSelectedModelId: (id: string, recentId?: string) => void;
 
   mini: MiniState;
   openMini: () => void;
@@ -229,9 +230,9 @@ export const useChatStore = create<StoreState>((set, get) => ({
   setCustomEndpointKeys: (keys) => set({ customEndpointKeys: keys }),
 
   selectedModelId: DEFAULT_MODEL_ID,
-  setSelectedModelId: (id) => {
+  setSelectedModelId: (id, recentId = id) => {
     set({ selectedModelId: id });
-    void pushRecentModel(id);
+    void pushRecentModel(recentId);
   },
 
   mini: { open: false },
@@ -266,7 +267,10 @@ export const useChatStore = create<StoreState>((set, get) => ({
     set((s) => ({
       panelOpen: true,
       focusSignal: s.focusSignal + 1,
-      pendingSelections: [...s.pendingSelections, { id, text: trimmed, source }],
+      pendingSelections: [
+        ...s.pendingSelections,
+        { id, text: trimmed, source },
+      ],
     }));
   },
   consumeSelections: () => {
@@ -428,7 +432,8 @@ export function getAgentMeta(): AgentMeta {
 }
 
 export function getActiveProviderKey(): string | null {
-  const { selectedModelId, apiKeys, customEndpointKeys } = useChatStore.getState();
+  const { selectedModelId, apiKeys, customEndpointKeys } =
+    useChatStore.getState();
   if (isCompatModelId(selectedModelId)) {
     const eid = endpointIdFromCompatModel(selectedModelId);
     return customEndpointKeys[eid] ?? null;

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_AUTOCOMPLETE_MODEL,
   DEFAULT_MODEL_ID,
   DEFAULT_STT_PROVIDER,
+  isCompatModelId,
   isKnownModelId,
   LMSTUDIO_DEFAULT_BASE_URL,
   MLX_DEFAULT_BASE_URL,
@@ -368,6 +369,10 @@ async function writePref<T>(key: string, value: T): Promise<void> {
   await emit(PREFS_CHANGED_EVENT, { key, value });
 }
 
+function isPersistedModelId(value: string): boolean {
+  return isKnownModelId(value) || isCompatModelId(value) || value.includes("/");
+}
+
 export async function loadPreferences(): Promise<Preferences> {
   // Single IPC roundtrip — fetching keys individually fans out to one
   // `plugin:store|get` per setting and is the dominant boot cost.
@@ -463,10 +468,10 @@ export async function loadPreferences(): Promise<Preferences> {
       DEFAULT_PREFERENCES.whispercppBaseURL,
     favoriteModelIds: (
       get<string[]>(KEY_FAVORITE_MODELS) ?? DEFAULT_PREFERENCES.favoriteModelIds
-    ).filter(isKnownModelId),
+    ).filter(isPersistedModelId),
     recentModelIds: (
       get<string[]>(KEY_RECENT_MODELS) ?? DEFAULT_PREFERENCES.recentModelIds
-    ).filter(isKnownModelId),
+    ).filter(isPersistedModelId),
     vimMode: get<boolean>(KEY_VIM_MODE) ?? DEFAULT_PREFERENCES.vimMode,
     editorWordWrap:
       get<boolean>(KEY_EDITOR_WORD_WRAP) ?? DEFAULT_PREFERENCES.editorWordWrap,

--- a/src/settings/sections/ModelsSection.tsx
+++ b/src/settings/sections/ModelsSection.tsx
@@ -17,10 +17,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import {
-  getBindingTokens,
-  SHORTCUTS,
-} from "@/modules/shortcuts/shortcuts";
+import { getBindingTokens, SHORTCUTS } from "@/modules/shortcuts/shortcuts";
 import {
   type CustomEndpoint,
   compatModelIdForEndpoint,
@@ -50,6 +47,11 @@ import {
   setKey,
 } from "@/modules/ai/lib/keyring";
 import { useChatStore } from "@/modules/ai/store/chatStore";
+import {
+  loadOpenRouterCatalog,
+  type OpenRouterModelInfo,
+  useOpenRouterCatalog,
+} from "@/modules/ai/lib/openrouterModels";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   type AutocompleteTrigger,
@@ -320,6 +322,7 @@ export function ModelsSection() {
     PROVIDERS.filter((p) => isConfigured(p.id)).map((p) => p.id),
   );
   const visibleIds = new Set<ProviderId>(configuredIds);
+  if (keys.openrouter) visibleIds.add("openrouter");
   for (const id of adding) visibleIds.add(id);
   const visibleProviders = PROVIDERS.filter(
     (p) => p.id !== "openai-compatible" && visibleIds.has(p.id),
@@ -545,6 +548,7 @@ function DefaultsBlock({
           <DefaultModelPicker
             defaultModel={defaultModel}
             configuredIds={configuredIds}
+            openrouterApiKey={keys.openrouter}
           />
         </FieldRow>
         <AutocompleteRow
@@ -560,12 +564,21 @@ function DefaultsBlock({
 function DefaultModelPicker({
   defaultModel,
   configuredIds,
+  openrouterApiKey,
 }: {
   defaultModel: ModelId;
   configuredIds: Set<ProviderId>;
+  openrouterApiKey: string | null;
 }) {
-  const m = getModel(defaultModel);
   const hasAny = configuredIds.size > 0;
+  const openrouterCatalog = useOpenRouterCatalog(openrouterApiKey);
+  const openrouterModelId = usePreferencesStore((s) => s.openrouterModelId);
+  const m =
+    defaultModel === "openrouter-custom"
+      ? (openrouterCatalog.models.find(
+          (model) => model.openrouterModelId === openrouterModelId,
+        ) ?? getModel(defaultModel))
+      : getModel(defaultModel);
 
   return (
     <DropdownMenu>
@@ -597,7 +610,10 @@ function DefaultModelPicker({
       >
         <div className="max-h-72 overflow-y-auto overscroll-contain pr-1">
           {PROVIDERS.filter((p) => configuredIds.has(p.id)).map((p) => {
-            const models = MODELS.filter((x) => x.provider === p.id);
+            const models =
+              p.id === "openrouter"
+                ? openrouterCatalog.models
+                : MODELS.filter((x) => x.provider === p.id);
             if (models.length === 0) return null;
             return (
               <div key={p.id} className="px-1 pt-1.5 first:pt-1">
@@ -608,14 +624,37 @@ function DefaultModelPicker({
                 {models.map((mod) => (
                   <DropdownMenuItem
                     key={mod.id}
-                    onSelect={() => void setDefaultModel(mod.id as ModelId)}
+                    onSelect={() => {
+                      if (p.id === "openrouter") {
+                        const openrouterModel = mod as OpenRouterModelInfo;
+                        void setOpenrouterModelId(
+                          openrouterModel.openrouterModelId,
+                        );
+                        void setDefaultModel("openrouter-custom");
+                      } else {
+                        void setDefaultModel(mod.id as ModelId);
+                      }
+                    }}
                     className={cn(
                       "flex items-start gap-2 text-[12px]",
-                      mod.id === defaultModel && "bg-accent/50",
+                      ((p.id === "openrouter" &&
+                        (mod as OpenRouterModelInfo).openrouterModelId ===
+                          openrouterModelId &&
+                        defaultModel === "openrouter-custom") ||
+                        (p.id !== "openrouter" && mod.id === defaultModel)) &&
+                        "bg-accent/50",
                     )}
                   >
                     <span className="flex flex-1 flex-col">
-                      <span>{mod.label}</span>
+                      <span className="flex items-center gap-1.5">
+                        <span>{mod.label}</span>
+                        {p.id === "openrouter" &&
+                        (mod as OpenRouterModelInfo).batchOnly ? (
+                          <span className="text-[9px] text-amber-600 dark:text-amber-400">
+                            Batch only
+                          </span>
+                        ) : null}
+                      </span>
                       <span className="text-[10px] text-muted-foreground">
                         {mod.description}
                       </span>
@@ -944,17 +983,27 @@ function LocalProviderCard({
         )}
 
         <FieldRow label="Model ID">
-          <Input
-            value={modelDraft}
-            onChange={(e) => setModelDraft(e.target.value)}
-            onBlur={() => {
-              const v = modelDraft.trim();
-              if (v !== modelId) void setModelId(v);
-            }}
-            placeholder={meta.modelPlaceholder}
-            spellCheck={false}
-            className="h-8 font-mono text-[11.5px]"
-          />
+          {provider.id === "openrouter" ? (
+            <OpenRouterModelField
+              apiKey={compatKey ?? null}
+              value={modelDraft}
+              placeholder={meta.modelPlaceholder}
+              onChange={setModelDraft}
+              onCommit={(value) => void setModelId(value)}
+            />
+          ) : (
+            <Input
+              value={modelDraft}
+              onChange={(e) => setModelDraft(e.target.value)}
+              onBlur={() => {
+                const v = modelDraft.trim();
+                if (v !== modelId) void setModelId(v);
+              }}
+              placeholder={meta.modelPlaceholder}
+              spellCheck={false}
+              className="h-8 font-mono text-[11.5px]"
+            />
+          )}
         </FieldRow>
 
         {setContextLimit ? (
@@ -1036,6 +1085,112 @@ function LocalProviderCard({
           </p>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function OpenRouterModelField({
+  apiKey,
+  value,
+  placeholder,
+  onChange,
+  onCommit,
+}: {
+  apiKey: string | null;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onCommit: (value: string) => void;
+}) {
+  const catalog = useOpenRouterCatalog(apiKey);
+  const selected = catalog.models.find(
+    (model) => model.openrouterModelId === value.trim(),
+  );
+
+  return (
+    <div className="flex flex-1 flex-col gap-1.5">
+      <div className="flex gap-1.5">
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={() => onCommit(value.trim())}
+          placeholder={placeholder}
+          spellCheck={false}
+          className="h-8 flex-1 font-mono text-[11.5px]"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 shrink-0 px-2.5 text-[11px]"
+              disabled={
+                catalog.status === "loading" && catalog.models.length === 0
+              }
+            >
+              {catalog.status === "loading" && catalog.models.length === 0
+                ? "Loading"
+                : "Browse"}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            collisionPadding={12}
+            className="max-h-80 min-w-80 overflow-y-auto"
+          >
+            {catalog.models.map((model) => (
+              <DropdownMenuItem
+                key={model.openrouterModelId}
+                onSelect={() => {
+                  onChange(model.openrouterModelId);
+                  onCommit(model.openrouterModelId);
+                }}
+                className="flex items-start gap-2 text-[11.5px]"
+              >
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="flex items-center gap-1.5">
+                    <span className="truncate">{model.label}</span>
+                    {model.batchOnly ? (
+                      <span className="shrink-0 text-[9px] text-amber-600 dark:text-amber-400">
+                        Batch only
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="truncate font-mono text-[10px] text-muted-foreground">
+                    {model.openrouterModelId}
+                  </span>
+                </span>
+              </DropdownMenuItem>
+            ))}
+            {catalog.status === "error" ? (
+              <div className="flex items-center gap-2 px-2 py-2 text-[10.5px] text-destructive">
+                <span className="min-w-0 flex-1">{catalog.error}</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 shrink-0 px-1.5 text-[10px]"
+                  onClick={() => {
+                    void loadOpenRouterCatalog(apiKey ?? "", true);
+                  }}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : null}
+            {catalog.status === "ready" && catalog.models.length === 0 ? (
+              <div className="px-2 py-2 text-[10.5px] text-muted-foreground">
+                No models returned.
+              </div>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {selected?.batchOnly ? (
+        <p className="text-[10.5px] leading-relaxed text-amber-600 dark:text-amber-400">
+          This model is marked batch-only by OpenRouter and may reject normal
+          chat requests.
+        </p>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fetch authenticated OpenRouter model metadata for model selection.
- Persist selected OpenRouter model IDs and dynamic context limits.
- Keep batch-only models visible and mark them in the UI.
- Detect batch-only runtime errors and mark the selected model.
- Preserve manual OpenRouter model ID entry as a fallback.

## Verification
- pnpm check-types
- pnpm test
- pnpm build
- pnpm lint, existing warnings only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter catalog browsing and search in model settings.
  * OpenRouter models now display capabilities, pricing, context limits, and batch-only availability.
  * Added loading, retry, empty-state, and batch-only indicators for catalog models.
  * OpenRouter model selections and favorites persist correctly.

* **Bug Fixes**
  * Improved context-limit handling for custom OpenRouter models.
  * Added clearer error messages when a selected model is batch-only.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->