### PR TITLE
feat(terminal): configure pane limit

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -776,6 +776,7 @@ export default function App() {
   const explorerGitDecorations = usePreferencesStore(
     (s) => s.explorerGitDecorations,
   );
+  const terminalPaneLimit = usePreferencesStore((s) => s.terminalPaneLimit);
 
   const openPreviewTab = useCallback(
     (url: string) => {
@@ -1215,6 +1216,7 @@ export default function App() {
             searchTarget,
             explorerRoot,
             home,
+            terminalPaneLimit,
             openNewTab,
             openNewBlock: openNewBlockTab,
             openNewPrivate: openNewPrivateTab,
@@ -1246,6 +1248,7 @@ export default function App() {
       searchTarget,
       explorerRoot,
       home,
+      terminalPaneLimit,
       openNewTab,
       openNewBlockTab,
       openNewPrivateTab,

--- a/src/modules/command-palette/commands.test.ts
+++ b/src/modules/command-palette/commands.test.ts
@@ -5,13 +5,26 @@ import {
   createCommandItems,
 } from "./commands";
 
-function terminalTab(id: number): Tab {
+function terminalTab(id: number, paneCount = 1): Tab {
+  const leaves = Array.from({ length: paneCount }, (_, index) => ({
+    kind: "leaf" as const,
+    id: id * 10 + index,
+  }));
+  const paneTree =
+    leaves.length === 1
+      ? leaves[0]
+      : {
+          kind: "split" as const,
+          id: id * 100,
+          dir: "row" as const,
+          children: leaves,
+        };
   return {
     id,
     kind: "terminal",
     spaceId: "s",
     title: "shell",
-    paneTree: { kind: "leaf", id: id * 10 },
+    paneTree,
     activeLeafId: id * 10,
   } as unknown as Tab;
 }
@@ -60,8 +73,15 @@ function reasonById(over: Partial<CommandPaletteActionContext>, id: string) {
 
 describe("createCommandItems", () => {
   it("enables split on a terminal tab below the pane limit", () => {
-    expect(reasonById({}, "pane.splitRight")).toBeUndefined();
-    expect(reasonById({}, "pane.splitDown")).toBeUndefined();
+    const tabs = [terminalTab(1, 7)];
+    expect(reasonById({ tabs }, "pane.splitRight")).toBeUndefined();
+    expect(reasonById({ tabs }, "pane.splitDown")).toBeUndefined();
+  });
+
+  it("disables split at the eight-pane limit", () => {
+    const tabs = [terminalTab(1, 8)];
+    expect(reasonById({ tabs }, "pane.splitRight")).toBe("Pane limit");
+    expect(reasonById({ tabs }, "pane.splitDown")).toBe("Pane limit");
   });
 
   it("disables split when there is no terminal tab", () => {

--- a/src/modules/command-palette/commands.test.ts
+++ b/src/modules/command-palette/commands.test.ts
@@ -39,6 +39,7 @@ function baseContext(
     searchTarget: "content" as never,
     explorerRoot: "/workspace",
     home: "/home/me",
+    terminalPaneLimit: 8,
     spaces: [],
     activeSpaceId: null,
     openNewTab: noop,
@@ -78,10 +79,11 @@ describe("createCommandItems", () => {
     expect(reasonById({ tabs }, "pane.splitDown")).toBeUndefined();
   });
 
-  it("disables split at the eight-pane limit", () => {
-    const tabs = [terminalTab(1, 8)];
-    expect(reasonById({ tabs }, "pane.splitRight")).toBe("Pane limit");
-    expect(reasonById({ tabs }, "pane.splitDown")).toBe("Pane limit");
+  it("disables split at the configured pane limit", () => {
+    const tabs = [terminalTab(1, 4)];
+    const context = { tabs, terminalPaneLimit: 4 };
+    expect(reasonById(context, "pane.splitRight")).toBe("Pane limit");
+    expect(reasonById(context, "pane.splitDown")).toBe("Pane limit");
   });
 
   it("disables split when there is no terminal tab", () => {

--- a/src/modules/command-palette/commands.ts
+++ b/src/modules/command-palette/commands.ts
@@ -1,5 +1,5 @@
 import type { SearchTarget } from "@/modules/header";
-import { MAX_PANES_PER_TAB, type Tab } from "@/modules/tabs";
+import type { Tab } from "@/modules/tabs";
 import { leafIds } from "@/modules/terminal";
 import {
   Cancel01Icon,
@@ -38,6 +38,7 @@ export type CommandPaletteActionContext = {
   searchTarget: SearchTarget;
   explorerRoot: string | null;
   home: string | null;
+  terminalPaneLimit: number;
   openNewTab: () => void;
   openNewBlock: () => void;
   openNewPrivate: () => void;
@@ -76,7 +77,7 @@ export function createCommandItems(
   const noWorkspaceRoot = !ctx.explorerRoot && !ctx.home;
   const splitDisabled = !activeTerminalTab
     ? "No terminal tab"
-    : activePaneCount >= MAX_PANES_PER_TAB
+    : activePaneCount >= ctx.terminalPaneLimit
       ? "Pane limit"
       : undefined;
   const closeDisabled =

--- a/src/modules/settings/store.ts
+++ b/src/modules/settings/store.ts
@@ -165,6 +165,7 @@ export type Preferences = {
   terminalLetterSpacing: number;
   terminalFontSize: number;
   terminalScrollback: number;
+  terminalPaneLimit: number;
   confirmCloseRunningTerminal: boolean;
   lastWslDistro: string | null;
   zoomLevel: number;
@@ -258,6 +259,7 @@ const KEY_TERMINAL_SHELL = "terminalShell";
 const KEY_TERMINAL_LETTER_SPACING = "terminalLetterSpacing";
 const KEY_TERMINAL_FONT_SIZE = "terminalFontSize";
 const KEY_TERMINAL_SCROLLBACK = "terminalScrollback";
+const KEY_TERMINAL_PANE_LIMIT = "terminalPaneLimit";
 const KEY_CONFIRM_CLOSE_RUNNING_TERMINAL = "confirmCloseRunningTerminal";
 const KEY_LAST_WSL_DISTRO = "lastWslDistro";
 const KEY_ZOOM_LEVEL = "zoomLevel";
@@ -299,6 +301,10 @@ export const TERMINAL_SCROLLBACK_MAX = 50_000;
 export const TERMINAL_SCROLLBACK_PRESETS = [
   500, 1000, 2000, 5000, 10_000, 25_000,
 ] as const;
+export const TERMINAL_PANE_LIMIT_DEFAULT = 8;
+export const TERMINAL_PANE_LIMIT_MIN = 1;
+export const TERMINAL_PANE_LIMIT_MAX = 8;
+export const TERMINAL_PANE_LIMIT_PRESETS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 
 export const DEFAULT_PREFERENCES: Preferences = {
   theme: "system",
@@ -347,6 +353,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   terminalLetterSpacing: 0,
   terminalFontSize: TERMINAL_FONT_SIZE_DEFAULT,
   terminalScrollback: TERMINAL_SCROLLBACK_DEFAULT,
+  terminalPaneLimit: TERMINAL_PANE_LIMIT_DEFAULT,
   confirmCloseRunningTerminal: true,
   lastWslDistro: null,
   zoomLevel: 1.0,
@@ -518,6 +525,10 @@ export async function loadPreferences(): Promise<Preferences> {
     terminalScrollback: clampScrollback(
       get<number>(KEY_TERMINAL_SCROLLBACK) ??
         DEFAULT_PREFERENCES.terminalScrollback,
+    ),
+    terminalPaneLimit: clampTerminalPaneLimit(
+      get<number>(KEY_TERMINAL_PANE_LIMIT) ??
+        DEFAULT_PREFERENCES.terminalPaneLimit,
     ),
     confirmCloseRunningTerminal:
       get<boolean>(KEY_CONFIRM_CLOSE_RUNNING_TERMINAL) ??
@@ -832,6 +843,18 @@ export async function setTerminalFontSize(value: number): Promise<void> {
   await writePref(KEY_TERMINAL_FONT_SIZE, clamped);
 }
 
+export function clampTerminalPaneLimit(value: number): number {
+  if (!Number.isFinite(value)) return TERMINAL_PANE_LIMIT_DEFAULT;
+  return Math.min(
+    TERMINAL_PANE_LIMIT_MAX,
+    Math.max(TERMINAL_PANE_LIMIT_MIN, Math.round(value)),
+  );
+}
+
+export async function setTerminalPaneLimit(value: number): Promise<void> {
+  await writePref(KEY_TERMINAL_PANE_LIMIT, clampTerminalPaneLimit(value));
+}
+
 function clampScrollback(value: number): number {
   if (!Number.isFinite(value)) return TERMINAL_SCROLLBACK_DEFAULT;
   return Math.min(
@@ -979,6 +1002,7 @@ export async function onPreferencesChange(
     [KEY_TERMINAL_LETTER_SPACING]: "terminalLetterSpacing",
     [KEY_TERMINAL_FONT_SIZE]: "terminalFontSize",
     [KEY_TERMINAL_SCROLLBACK]: "terminalScrollback",
+    [KEY_TERMINAL_PANE_LIMIT]: "terminalPaneLimit",
     [KEY_CONFIRM_CLOSE_RUNNING_TERMINAL]: "confirmCloseRunningTerminal",
     [KEY_LAST_WSL_DISTRO]: "lastWslDistro",
     [KEY_ZOOM_LEVEL]: "zoomLevel",

--- a/src/modules/settings/terminalPaneLimit.test.ts
+++ b/src/modules/settings/terminalPaneLimit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { clampTerminalPaneLimit } from "./store";
+
+describe("clampTerminalPaneLimit", () => {
+  it("keeps supported pane limits", () => {
+    expect(clampTerminalPaneLimit(1)).toBe(1);
+    expect(clampTerminalPaneLimit(4)).toBe(4);
+    expect(clampTerminalPaneLimit(8)).toBe(8);
+  });
+
+  it("clamps persisted values to the supported range", () => {
+    expect(clampTerminalPaneLimit(0)).toBe(1);
+    expect(clampTerminalPaneLimit(9)).toBe(8);
+  });
+
+  it("normalizes fractional and non-finite values", () => {
+    expect(clampTerminalPaneLimit(4.6)).toBe(5);
+    expect(clampTerminalPaneLimit(Number.NaN)).toBe(8);
+  });
+});

--- a/src/modules/tabs/index.ts
+++ b/src/modules/tabs/index.ts
@@ -6,7 +6,6 @@ export {
 } from "./lib/useTabSwitcher";
 export { labelFor } from "./lib/tabLabel";
 export {
-  MAX_PANES_PER_TAB,
   DEFAULT_SPACE_ID,
   useTabs,
   nextActiveInSpace,

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -7,6 +7,7 @@ import {
   findLeafCwd,
   hasLeaf,
   leafIds,
+  MAX_PANES_PER_TAB,
   nextLeafId,
   type PaneBounds,
   type PaneDirection,
@@ -27,8 +28,7 @@ import {
   useState,
 } from "react";
 
-// Matches the renderer slot pool size — over this we'd evict an active leaf.
-export const MAX_PANES_PER_TAB = 4;
+export { MAX_PANES_PER_TAB };
 
 type TabBase = {
   spaceId: string;

--- a/src/modules/tabs/lib/useTabs.ts
+++ b/src/modules/tabs/lib/useTabs.ts
@@ -7,7 +7,6 @@ import {
   findLeafCwd,
   hasLeaf,
   leafIds,
-  MAX_PANES_PER_TAB,
   nextLeafId,
   type PaneBounds,
   type PaneDirection,
@@ -20,6 +19,7 @@ import {
   swapLeafInDirection,
 } from "@/modules/terminal/lib/panes";
 import { disposeSession } from "@/modules/terminal/lib/useTerminalSession";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   useCallback,
   useEffect,
@@ -27,8 +27,6 @@ import {
   useRef,
   useState,
 } from "react";
-
-export { MAX_PANES_PER_TAB };
 
 type TabBase = {
   spaceId: string;
@@ -571,6 +569,7 @@ export function planSpaceRemoval(
 }
 
 export function useTabs(initial?: Partial<TerminalTab>) {
+  const terminalPaneLimit = usePreferencesStore((s) => s.terminalPaneLimit);
   const [tabs, setTabs] = useState<Tab[]>(() => {
     const tabId = 1;
     const leafId = 2;
@@ -1292,7 +1291,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       setTabs((curr) =>
         curr.map((t) => {
           if (t.id !== tabId || t.kind !== "terminal" || t.blocks) return t;
-          if (leafIds(t.paneTree).length >= MAX_PANES_PER_TAB) return t;
+          if (leafIds(t.paneTree).length >= terminalPaneLimit) return t;
           const splitId = nextIdRef.current++;
           const leafId = nextIdRef.current++;
           newLeafId = leafId;
@@ -1309,7 +1308,7 @@ export function useTabs(initial?: Partial<TerminalTab>) {
       );
       return newLeafId;
     },
-    [],
+    [terminalPaneLimit],
   );
 
   const closePaneByLeaf = useCallback((leafId: number): void => {

--- a/src/modules/terminal/lib/panes.ts
+++ b/src/modules/terminal/lib/panes.ts
@@ -1,7 +1,5 @@
 export type PaneId = number;
 
-export const MAX_PANES_PER_TAB = 8;
-
 export type SplitDir = "row" | "col";
 export type PaneDirection = "left" | "right" | "up" | "down";
 export type PaneBounds = {

--- a/src/modules/terminal/lib/panes.ts
+++ b/src/modules/terminal/lib/panes.ts
@@ -1,5 +1,7 @@
 export type PaneId = number;
 
+export const MAX_PANES_PER_TAB = 8;
+
 export type SplitDir = "row" | "col";
 export type PaneDirection = "left" | "right" | "up" | "down";
 export type PaneBounds = {

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -27,8 +27,9 @@ import {
 } from "./terminalClipboard";
 import { createTerminalLinkHandler } from "./terminalLinks";
 import { pasteIntoTerminal } from "./terminalPaste";
+import { MAX_PANES_PER_TAB } from "./panes";
 
-export const POOL_MAX_SIZE = 5;
+export const POOL_MAX_SIZE = MAX_PANES_PER_TAB + 1;
 const FIT_DEBOUNCE_MS = 8;
 const PTY_RESIZE_DEBOUNCE_MS = 256;
 const SNAPSHOT_SCROLLBACK_CAP = 5_000;

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -1,7 +1,10 @@
 import { openExternalUrl } from "@/lib/external-link";
 import { resolveFontFamily } from "@/lib/fonts";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import type { TerminalCursorStyle } from "@/modules/settings/store";
+import {
+  TERMINAL_PANE_LIMIT_MAX,
+  type TerminalCursorStyle,
+} from "@/modules/settings/store";
 import { buildTerminalTheme } from "@/styles/terminalTheme";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
@@ -27,9 +30,8 @@ import {
 } from "./terminalClipboard";
 import { createTerminalLinkHandler } from "./terminalLinks";
 import { pasteIntoTerminal } from "./terminalPaste";
-import { MAX_PANES_PER_TAB } from "./panes";
 
-export const POOL_MAX_SIZE = MAX_PANES_PER_TAB + 1;
+export const POOL_MAX_SIZE = TERMINAL_PANE_LIMIT_MAX + 1;
 const FIT_DEBOUNCE_MS = 8;
 const PTY_RESIZE_DEBOUNCE_MS = 256;
 const SNAPSHOT_SCROLLBACK_CAP = 5_000;

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -35,11 +35,13 @@ import {
   setTerminalFontSize,
   setTerminalFontWeight,
   setTerminalLetterSpacing,
+  setTerminalPaneLimit,
   setTerminalScrollback,
   setTerminalShell,
   setTerminalWebglEnabled,
   setZoomLevel,
   TERMINAL_FONT_SIZES,
+  TERMINAL_PANE_LIMIT_PRESETS,
   TERMINAL_SCROLLBACK_PRESETS,
 } from "@/modules/settings/store";
 import { useTheme } from "@/modules/theme";
@@ -116,6 +118,7 @@ export function GeneralSection() {
   );
   const terminalFontSize = usePreferencesStore((s) => s.terminalFontSize);
   const terminalScrollback = usePreferencesStore((s) => s.terminalScrollback);
+  const terminalPaneLimit = usePreferencesStore((s) => s.terminalPaneLimit);
   const confirmCloseRunningTerminal = usePreferencesStore(
     (s) => s.confirmCloseRunningTerminal,
   );
@@ -483,6 +486,30 @@ export function GeneralSection() {
                   className="text-[12px]"
                 >
                   {lines.toLocaleString()} lines
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+        <SettingRow
+          title="Maximum panes per tab"
+          description="Maximum terminal panes in one tab. Existing panes remain open when this is lowered."
+        >
+          <Select
+            value={String(terminalPaneLimit)}
+            onValueChange={(v) => void setTerminalPaneLimit(Number(v))}
+          >
+            <SelectTrigger size="sm" className="h-8 w-28 text-[12px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TERMINAL_PANE_LIMIT_PRESETS.map((count) => (
+                <SelectItem
+                  key={count}
+                  value={String(count)}
+                  className="text-[12px]"
+                >
+                  {count}
                 </SelectItem>
               ))}
             </SelectContent>


### PR DESCRIPTION
## What

Add a General > Terminal setting for the maximum number of panes per tab. The selectable range is one through eight, with eight as the default.

## Why

Terminal workflows that monitor several processes or CLI agents need more than four panes, while users with smaller layouts can retain a lower limit.

Closes #1149

## How

Persist and clamp `terminalPaneLimit`, use it in both the split action and command-palette availability, and size the lazily allocated renderer pool from the supported maximum. Lowering the setting does not close existing panes; it only prevents additional splits until the count is below the selected limit.

## Testing

- [ ] `pnpm lint` clean (command passes with the repository's existing warnings; changed files add no diagnostics)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (102 files, 680 tests)
- [ ] Manual smoke-test of the affected feature
- [x] `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] `cargo test --locked` clean
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: macOS (automated checks)
- [ ] Shells tested (if relevant): not applicable

## Screenshots / GIFs

Not included yet. The setting appears under General > Terminal as `Maximum panes per tab`.

## Notes for reviewer

Opened as a draft for product-direction feedback per the contribution guide. The renderer pool remains lazily allocated and reserves one slot beyond the supported maximum.