### PR TITLE
fix(terminal): deliver IME punctuation commits exactly once on WKWebView

### DIFF
--- a/src/modules/shortcuts/lib/useGlobalShortcuts.ts
+++ b/src/modules/shortcuts/lib/useGlobalShortcuts.ts
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from "react";
 import { usePreferencesStore } from "@/modules/settings/preferences";
-import {
-  SHORTCUTS,
-  matchBinding,
-  type ShortcutId,
-} from "../shortcuts";
+import { SHORTCUTS, matchBinding, type ShortcutId } from "../shortcuts";
 
 export type ShortcutHandler = (e: KeyboardEvent) => void;
 export type ShortcutHandlers = Partial<Record<ShortcutId, ShortcutHandler>>;
@@ -25,6 +21,9 @@ export function useGlobalShortcuts(
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // Never fire global shortcuts from keys an IME is still processing
+      // (keyCode 229 = "Process"); they belong to the composition.
+      if (e.isComposing || e.keyCode === 229) return;
       const { handlers, options } = latest.current;
       for (const s of SHORTCUTS) {
         if (e.repeat && !s.allowRepeat) continue;

--- a/src/modules/terminal/lib/imeBridge.test.ts
+++ b/src/modules/terminal/lib/imeBridge.test.ts
@@ -180,6 +180,56 @@ describe("imeBridgeInput", () => {
     ).toBe("주");
   });
 
+  it("forwards a non-composed non-ASCII commit xterm's gate drops (Shift+; first press)", () => {
+    // WKWebView delivers the Chinese-IME full-width punctuation commit as
+    // insertText with composed=false while the previous key's
+    // keyPressHandled is still set: xterm's _inputEvent drops it, so the
+    // bridge must compensate.
+    expect(
+      imeBridgeInput(
+        createImeBridgeState(),
+        1,
+        { inputType: "insertText", data: "：", composed: false },
+        { keyDownSeen: false, keyPressHandled: true },
+      ),
+    ).toBe("：");
+  });
+
+  it("forwards a composed non-ASCII commit while keyDownSeen is stale (#1112)", () => {
+    expect(
+      imeBridgeInput(
+        createImeBridgeState(),
+        1,
+        { inputType: "insertText", data: "가", composed: true },
+        KEY_HELD,
+      ),
+    ).toBe("가");
+  });
+
+  it("never forwards when xterm's gate will deliver (no double write)", () => {
+    // composed=false + both flags clear: xterm's _inputEvent delivers this
+    // insertText itself, so the bridge must stand down.
+    expect(
+      imeBridgeInput(
+        createImeBridgeState(),
+        1,
+        { inputType: "insertText", data: "：", composed: false },
+        IDLE,
+      ),
+    ).toBeNull();
+  });
+
+  it("never forwards a composed commit xterm will deliver (kds=false, kph=false)", () => {
+    expect(
+      imeBridgeInput(
+        createImeBridgeState(),
+        1,
+        { inputType: "insertText", data: "あ", composed: true },
+        { keyDownSeen: false, keyPressHandled: false },
+      ),
+    ).toBeNull();
+  });
+
   it("delivers the first syllable typed fast after a space once", () => {
     expect(
       replay([
@@ -235,21 +285,72 @@ describe("imeBridgeInput", () => {
     ).toBe("å");
   });
 
-  it("does not duplicate ASCII key data", () => {
+  it("forwards an ASCII IME commit dropped by the held-key gate (Shift+3 → '#')", () => {
+    // Chinese-IME Shift+digit commits ASCII (@ # % & * +) as insertText with
+    // isComposing=false while the still-held Shift keydown keeps xterm's
+    // _keyDownSeen high — xterm's _inputEvent drops it, nothing else
+    // delivers it (keydown was 229-swallowed), so the bridge must compensate.
+    expect(
+      imeBridgeInput(
+        createImeBridgeState(),
+        1,
+        {
+          inputType: "insertText",
+          data: "#",
+          composed: true,
+          isComposing: false,
+        },
+        KEY_HELD,
+      ),
+    ).toBe("#");
+  });
+
+  it("never forwards keypress-delivered ASCII (kph=true, no double write)", () => {
     const state = createImeBridgeState();
     expect(
       imeBridgeInput(
         state,
         1,
-        { inputType: "insertText", data: " ", composed: true },
+        {
+          inputType: "insertText",
+          data: " ",
+          composed: true,
+          isComposing: false,
+        },
         AFTER_KEYPRESS,
       ),
     ).toBeNull();
+    // The A-Z/dead-key keypress path: xterm _keyPress delivered the char and
+    // set _keyPressHandled; the following input event must not re-send it.
     expect(
       imeBridgeInput(
         state,
         1,
-        { inputType: "insertText", data: "a", composed: true },
+        {
+          inputType: "insertText",
+          data: "A",
+          composed: true,
+          isComposing: false,
+        },
+        AFTER_KEYPRESS,
+      ),
+    ).toBeNull();
+  });
+
+  it("never forwards in-progress ASCII composition text (composition-bypassing builds)", () => {
+    // On WKWebView builds that skip composition events (#1112 path),
+    // in-progress pinyin can surface as plain ASCII insertText; isComposing
+    // stays true for those edits, so the bridge must leave them alone.
+    expect(
+      imeBridgeInput(
+        createImeBridgeState(),
+        1,
+        {
+          inputType: "insertText",
+          data: "i",
+          composed: true,
+          isComposing: true,
+        },
         KEY_HELD,
       ),
     ).toBeNull();
@@ -271,7 +372,7 @@ describe("imeBridgeInput", () => {
     );
   });
 
-  it("stands down permanently after native composition starts", () => {
+  it("stands down during a native composition session, then re-arms at compositionend", () => {
     const state = createImeBridgeState();
     noteNativeComposition(state);
     expect(
@@ -290,6 +391,66 @@ describe("imeBridgeInput", () => {
         KEY_HELD,
       ),
     ).toBeNull();
+
+    // compositionend (or blur) resets the latch: the bridge must compensate
+    // again afterwards.
+    resetImeBridge(state);
+    expect(
+      imeBridgeInput(
+        state,
+        1,
+        { inputType: "insertText", data: "주", composed: true },
+        KEY_HELD,
+      ),
+    ).toBe("주");
+  });
+
+  it("re-arms after compositionend and compensates the dropped Shift+punct commit (WKWebView trace scene 1)", () => {
+    // Measured trace: a Chinese-IME pinyin session latches nativeComposition;
+    // after compositionend the user presses Shift+; — the insertText arrives
+    // with composed=true while the still-held Shift keydown keeps xterm's
+    // _keyDownSeen high, so xterm's gate drops it. With the session-scoped
+    // latch the bridge must forward it (exactly once).
+    const state = createImeBridgeState();
+    noteNativeComposition(state);
+    resetImeBridge(state); // compositionend
+    expect(
+      imeBridgeInput(
+        state,
+        1,
+        { inputType: "insertText", data: "：", composed: true },
+        KEY_HELD,
+      ),
+    ).toBe("：");
+  });
+
+  it("stands down for an insertText swept by xterm's pending composition finalize", () => {
+    // Measured trace: the commit is delivered by CompositionHelper's 0ms
+    // finalize diff (set at compositionend), never by a post-compositionend
+    // insertText. Any insertText landing while that finalize send is pending
+    // (sendingComposition=true) is swept into its textarea diff — the bridge
+    // must not forward it even when the key flags say xterm's _inputEvent
+    // gate drops it, or the commit/punct would be written twice.
+    const state = createImeBridgeState();
+    noteNativeComposition(state);
+    resetImeBridge(state); // compositionend; finalize timer still pending
+    expect(
+      imeBridgeInput(
+        state,
+        1,
+        { inputType: "insertText", data: "：", composed: true },
+        { ...KEY_HELD, sendingComposition: true },
+      ),
+    ).toBeNull();
+    // Once the finalize send has completed, compensation resumes.
+    expect(
+      imeBridgeInput(
+        state,
+        1,
+        { inputType: "insertText", data: "：", composed: true },
+        { ...KEY_HELD, sendingComposition: false },
+      ),
+    ).toBe("：");
   });
 
   it("keeps native composition ownership across slot transitions", () => {

--- a/src/modules/terminal/lib/imeBridge.ts
+++ b/src/modules/terminal/lib/imeBridge.ts
@@ -9,11 +9,19 @@ export type ImeInputEvent = {
   inputType: string;
   data: string | null;
   composed: boolean;
+  /** InputEvent.isComposing — false on IME commits, true on in-progress text. */
+  isComposing?: boolean;
 };
 
 export type XtermKeyFlags = {
   keyDownSeen: boolean;
   keyPressHandled: boolean;
+  /**
+   * xterm CompositionHelper._isSendingComposition: true between
+   * compositionend and its 0ms finalize timer, whose textarea diff delivers
+   * anything that just landed — the bridge must stand down in that window.
+   */
+  sendingComposition?: boolean;
 };
 
 export function createImeBridgeState(): ImeBridgeState {
@@ -32,6 +40,12 @@ function clearTransientState(state: ImeBridgeState): void {
 
 export function resetImeBridge(state: ImeBridgeState): void {
   clearTransientState(state);
+  // Session-scoped latch: compositionstart sets it, compositionend/blur
+  // clears it here. A permanent latch disables the bridge after the first
+  // IME session, while xterm's input gate drops every Shift+punct commit
+  // whose insertText arrives with _keyDownSeen held high by the still-held
+  // Shift keydown — the "press twice" bug (#983, WKWebView trace-verified).
+  state.nativeComposition = false;
 }
 
 export function transitionImeBridgeOwner(
@@ -87,16 +101,32 @@ export function imeBridgeInput(
 
   if (e.inputType === "insertText") {
     state.pendingRegion = e.data ?? "";
-    // Fast IME input can inherit xterm's key flags from the previous key.
-    // Correlated key data means xterm already sent this exact character.
-    if (
-      e.data &&
-      e.composed &&
-      NON_ASCII_RE.test(e.data) &&
-      (flags.keyDownSeen || flags.keyPressHandled) &&
-      !sentByXtermKey
-    ) {
-      return e.data;
+    // Mirror xterm CoreBrowserTerminal._inputEvent's delivery gate:
+    //   xterm delivers ⟺ data && inputType==='insertText'
+    //     && (!composed || !keyDownSeen) && !keyPressHandled
+    //   (Terax never enables screenReaderMode, which would also gate it.)
+    // Plus one composition-lifecycle clause: while the finalize send is
+    // pending (sendingComposition), the 0ms textarea diff delivers anything
+    // that just landed — including this event's text — so xterm effectively
+    // owns it.
+    // xterm's own listener runs first on this same event and does not
+    // mutate the flags, so the mirror is exact and order-independent:
+    // whatever xterm drops, the bridge forwards — exactly once.
+    const xtermWillDeliver =
+      ((!e.composed || !flags.keyDownSeen) && !flags.keyPressHandled) ||
+      flags.sendingComposition === true;
+    if (e.data && !xtermWillDeliver && !sentByXtermKey) {
+      if (NON_ASCII_RE.test(e.data)) return e.data;
+      // ASCII: forward only a provable IME commit — never key-delivered
+      // text (double-write) or in-progress composition (raw pinyin leak):
+      //  - !isComposing guards composition-bypassing WKWebView builds
+      //    (#1112), where in-progress pinyin can surface as plain insertText.
+      //  - !keyPressHandled guards keypress-delivered ASCII (xterm's A-Z /
+      //    dead-key path): that input event was dropped because the keypress
+      //    already sent it.
+      // What remains is an IME commit with no keypress, e.g. Chinese-IME
+      // Shift+3 → "#" dropped by the held-Shift keydown's _keyDownSeen.
+      if (!e.isComposing && !flags.keyPressHandled) return e.data;
     }
     return null;
   }

--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isIme229PassthroughKey,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
   terminalReadlineSequence,
@@ -15,6 +16,51 @@ const evt = (partial: Partial<TerminalKeyEvent>): TerminalKeyEvent => ({
   key: "",
   code: "",
   ...partial,
+});
+
+describe("isIme229PassthroughKey", () => {
+  it.each([
+    ["Option+Left", evt({ altKey: true, key: "ArrowLeft" })],
+    ["Option+Right", evt({ altKey: true, key: "ArrowRight" })],
+    ["Option+Up", evt({ altKey: true, key: "ArrowUp" })],
+    ["Option+Down", evt({ altKey: true, key: "ArrowDown" })],
+    ["Option+Backspace", evt({ altKey: true, key: "Backspace" })],
+  ])(
+    "passes %s through the 229 swallow (Option dead-key mistag, #956)",
+    (_name, event) => {
+      expect(isIme229PassthroughKey(event)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["bare Left", evt({ key: "ArrowLeft" })],
+    ["bare Right", evt({ key: "ArrowRight" })],
+    ["bare Up", evt({ key: "ArrowUp" })],
+    ["bare Down", evt({ key: "ArrowDown" })],
+    ["bare Backspace", evt({ key: "Backspace" })],
+  ])(
+    "swallows %s (IME candidate-window navigation must not reach the shell)",
+    (_name, event) => {
+      expect(isIme229PassthroughKey(event)).toBe(false);
+    },
+  );
+
+  it.each([
+    ["Ctrl+Left", evt({ ctrlKey: true, key: "ArrowLeft" })],
+    ["Cmd+Left", evt({ metaKey: true, key: "ArrowLeft" })],
+    [
+      "Ctrl+Option+Left",
+      evt({ ctrlKey: true, altKey: true, key: "ArrowLeft" }),
+    ],
+    [
+      "Cmd+Option+Backspace",
+      evt({ metaKey: true, altKey: true, key: "Backspace" }),
+    ],
+    ["Option+A", evt({ altKey: true, key: "a" })],
+    ["Option+Enter", evt({ altKey: true, key: "Enter" })],
+  ])("swallows %s (not an Option dead-key mistag)", (_name, event) => {
+    expect(isIme229PassthroughKey(event)).toBe(false);
+  });
 });
 
 describe("terminalWordNavigationSequence", () => {
@@ -74,7 +120,12 @@ describe("terminalLineNavigationSequence", () => {
   it("does not remap Cmd+Option+Arrow (selection-style combos pass through)", () => {
     expect(
       terminalLineNavigationSequence(
-        evt({ metaKey: true, altKey: true, key: "ArrowLeft", code: "ArrowLeft" }),
+        evt({
+          metaKey: true,
+          altKey: true,
+          key: "ArrowLeft",
+          code: "ArrowLeft",
+        }),
         { isMac: true },
       ),
     ).toBeNull();
@@ -129,10 +180,9 @@ describe("terminalDeleteSequence", () => {
 
   it("does not remap plain Backspace", () => {
     expect(
-      terminalDeleteSequence(
-        evt({ key: "Backspace", code: "Backspace" }),
-        { isMac: true },
-      ),
+      terminalDeleteSequence(evt({ key: "Backspace", code: "Backspace" }), {
+        isMac: true,
+      }),
     ).toBeNull();
   });
 });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -5,7 +5,26 @@ export type TerminalKeyEvent = Pick<
 
 export type PlatformOpts = { isMac: boolean };
 
-export function terminalWordNavigationSequence(event: TerminalKeyEvent): string | null {
+/** WKWebView also mistags Option-modified dead keys (Option+←/→,
+ * Option+Backspace) with keyCode 229 ("Process") outside any IME session;
+ * the mistag carries altKey (#956). Only those events may pass through the
+ * 229 swallow so they still reach the readline remaps. Bare arrows/Backspace
+ * from IME candidate-window navigation report 229 WITHOUT alt and must stay
+ * swallowed so they never leak to the shell. */
+export function isIme229PassthroughKey(event: TerminalKeyEvent): boolean {
+  if (!event.altKey || event.ctrlKey || event.metaKey) return false;
+  return (
+    event.key === "ArrowLeft" ||
+    event.key === "ArrowRight" ||
+    event.key === "ArrowUp" ||
+    event.key === "ArrowDown" ||
+    event.key === "Backspace"
+  );
+}
+
+export function terminalWordNavigationSequence(
+  event: TerminalKeyEvent,
+): string | null {
   if (!event.altKey || event.ctrlKey || event.metaKey) return null;
   if (event.key === "ArrowLeft" || event.code === "ArrowLeft") return "\x1bb";
   if (event.key === "ArrowRight" || event.code === "ArrowRight") return "\x1bf";

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -20,7 +20,7 @@ import {
   resetImeBridge,
   transitionImeBridgeOwner,
 } from "./imeBridge";
-import { terminalReadlineSequence } from "./keymap";
+import { isIme229PassthroughKey, terminalReadlineSequence } from "./keymap";
 import {
   readTerminalClipboard,
   writeTerminalClipboard,
@@ -281,23 +281,41 @@ function createSlot(): Slot {
       ta.addEventListener("input", (ev) => {
         const e = ev as InputEvent;
         if (slot.currentLeafId === null) return;
+        // SAFETY: xterm's public Terminal hides CoreBrowserTerminal behind
+        // `any`; _core._keyDownSeen/_keyPressHandled are the delivery-gate
+        // flags the bridge mirrors, and
+        // _core._compositionHelper._isSendingComposition marks the pending
+        // finalize send (verified against @xterm/xterm sources).
         const core = (
           slot.term as unknown as {
-            _core?: { _keyDownSeen?: boolean; _keyPressHandled?: boolean };
+            _core?: {
+              _keyDownSeen?: boolean;
+              _keyPressHandled?: boolean;
+              _compositionHelper?: { _isSendingComposition?: boolean };
+            };
           }
         )._core;
         const out = imeBridgeInput(
           imeState,
           slot.currentLeafId,
-          { inputType: e.inputType, data: e.data, composed: e.composed },
+          {
+            inputType: e.inputType,
+            data: e.data,
+            composed: e.composed,
+            isComposing: e.isComposing,
+          },
           {
             keyDownSeen: core?._keyDownSeen ?? false,
             keyPressHandled: core?._keyPressHandled ?? false,
+            sendingComposition:
+              core?._compositionHelper?._isSendingComposition ?? false,
           },
         );
         if (out) adapter?.resolveLeaf(slot.currentLeafId)?.writeToPty(out);
       });
-      // Native composition means xterm owns this slot's IME delivery.
+      // Native composition means xterm owns this slot's IME delivery for
+      // the duration of that composition session; resetImeBridge
+      // (compositionend/blur) re-arms the bridge afterwards.
       ta.addEventListener("compositionstart", () =>
         noteNativeComposition(imeState),
       );
@@ -310,11 +328,25 @@ function createSlot(): Slot {
     // During IME composition the browser is assembling a multi-keystroke
     // character (Chinese pinyin → hanzi, Korean jamo → syllable, etc.).
     // Raw keydown events — including the Enter that commits a candidate —
-    // must NOT be forwarded to the PTY; xterm will receive the final
-    // composed string through its own compositionend handler instead.
-    // keyCode 229 ("Process") is what Chromium reports for every key
-    // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // must NOT be forwarded to the PTY. Composed text reaches the PTY via
+    // the textarea input event (xterm's _inputEvent, with the imeBridge
+    // compensating exactly the events xterm's gate drops).
+    // keyCode 229 ("Process") is what WebKit reports for keys consumed by
+    // an active IME session — including candidate-window digit/arrow keys —
+    // and for non-composing IME mode-switch keystrokes (Chinese-IME
+    // Shift+punctuation). Swallowing them at the keydown layer is safe
+    // because delivery is reconstructed from the input event, never from
+    // keydown. Do NOT preventDefault: the browser default (IME text into
+    // the textarea → input event) must survive.
+    // The only exemption is Option-modified dead keys mistagged as 229
+    // (Option+←/→, Option+Backspace, #956), which fall through to the
+    // readline remaps below.
+    if (
+      event.isComposing ||
+      (event.keyCode === 229 && !isIme229PassthroughKey(event))
+    ) {
+      return false;
+    }
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;
@@ -477,7 +509,9 @@ function discardRetention(slot: Slot): void {
   for (const d of slot.oscDisposers) {
     try {
       d();
-    } catch {}
+    } catch {
+      // Best-effort cleanup: a failing OSC disposer must not block the rest.
+    }
   }
   slot.oscDisposers = [];
 }
@@ -538,12 +572,16 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
     }
     try {
       slot.term.write("\x1b[?25h");
-    } catch {}
+    } catch {
+      // Best-effort cursor restore; the slot may already be detached.
+    }
 
     for (const d of slot.oscDisposers) {
       try {
         d();
-      } catch {}
+      } catch {
+        // Best-effort cleanup: a failing OSC disposer must not block reattach.
+      }
     }
     slot.oscDisposers = p.registerOsc(slot.term);
   } else {
@@ -564,7 +602,9 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
   if (!fast && p.searchQuery) {
     try {
       slot.searchAddon.findNext(p.searchQuery);
-    } catch {}
+    } catch {
+      // Stale queries can throw on a freshly recycled buffer; skip.
+    }
   }
 
   applyCursorBlinkOnSlot(slot, adapter?.isLeafFocused(p.leafId) ?? false);
@@ -578,7 +618,9 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
       if (!slot.webglAddon) attachWebgl(slot);
       try {
         slot.term.refresh(0, slot.term.rows - 1);
-      } catch {}
+      } catch {
+        // Refresh is cosmetic; a mid-dispose renderer may throw.
+      }
     }
     if (adapter?.isLeafFocused(p.leafId)) slot.term.focus();
   } else {
@@ -597,7 +639,9 @@ function scheduleUnhide(slot: Slot, stale: boolean): void {
         if (!slot.webglAddon) attachWebgl(slot);
         try {
           slot.term.refresh(0, slot.term.rows - 1);
-        } catch {}
+        } catch {
+          // Refresh is cosmetic; a mid-dispose renderer may throw.
+        }
       }
       const leafId = slot.currentLeafId;
       if (leafId !== null && adapter?.isLeafFocused(leafId)) {
@@ -804,7 +848,9 @@ function disposeSlot(slot: Slot): void {
   for (const d of slot.oscDisposers) {
     try {
       d();
-    } catch {}
+    } catch {
+      // Best-effort cleanup: a failing OSC disposer must not block parking.
+    }
   }
   slot.oscDisposers = [];
   disposeSlotWebgl(slot);
@@ -843,7 +889,9 @@ function attachWebgl(slot: Slot): void {
       }
       try {
         webgl.dispose();
-      } catch {}
+      } catch {
+        // The context may already be lost; disposal failure is harmless here.
+      }
       // Recovery: WebKit may transiently lose contexts on sleep/wake or GPU
       // reset; without re-attach the slot would silently fall back to DOM
       // forever. Defer past WebKit's reset window before retrying.
@@ -855,7 +903,9 @@ function attachWebgl(slot: Slot): void {
         if (slot.webglAddon) {
           try {
             slot.term.refresh(0, slot.term.rows - 1);
-          } catch {}
+          } catch {
+            // Refresh is cosmetic; a mid-dispose renderer may throw.
+          }
         }
       }, WEBGL_RECOVERY_DELAY_MS);
     });
@@ -881,6 +931,9 @@ function disposeSlotWebgl(slot: Slot): void {
     console.warn("[terax-webgl] dispose failed:", e);
   }
   try {
+    // SAFETY: the WebGL addon's renderer/render-service fields are private
+    // xterm internals; nulling them forces re-creation on next attach. The
+    // shape is probed defensively and any mismatch is caught below.
     const r = (
       addon as unknown as { _renderer?: Record<string, unknown> | null }
     )._renderer;
@@ -890,13 +943,17 @@ function disposeSlotWebgl(slot: Slot): void {
       r._charAtlas = null;
       r._atlas = null;
     }
-    (
-      addon as unknown as { _renderer?: unknown; _renderService?: unknown }
-    )._renderer = null;
-    (
-      addon as unknown as { _renderer?: unknown; _renderService?: unknown }
-    )._renderService = null;
-  } catch {}
+    // SAFETY: same private-internals probe as above; nulling forces
+    // re-creation on next attach and any shape mismatch is caught below.
+    const internals = addon as unknown as {
+      _renderer?: unknown;
+      _renderService?: unknown;
+    };
+    internals._renderer = null;
+    internals._renderService = null;
+  } catch {
+    // Internal shape changed across xterm versions; disposal already ran.
+  }
   slot.webglAddon = null;
 }
 
@@ -904,22 +961,30 @@ function releaseCanvasContext(canvas: HTMLCanvasElement): void {
   let gl: WebGL2RenderingContext | WebGLRenderingContext | null = null;
   try {
     gl = canvas.getContext("webgl2") as WebGL2RenderingContext | null;
-  } catch {}
+  } catch {
+    // WebGL2 unsupported or context creation failed; fall back to webgl.
+  }
   if (!gl) {
     try {
       gl = canvas.getContext("webgl") as WebGLRenderingContext | null;
-    } catch {}
+    } catch {
+      // No WebGL support at all; nothing to release.
+    }
   }
   if (gl) {
     try {
       const ext = gl.getExtension("WEBGL_lose_context");
       if (ext && !gl.isContextLost()) ext.loseContext();
-    } catch {}
+    } catch {
+      // Context may already be lost; nothing more to do.
+    }
   }
   try {
     canvas.width = 0;
     canvas.height = 0;
-  } catch {}
+  } catch {
+    // Releasing the backing store is best-effort during teardown.
+  }
 }
 
 export function applyWebglPreference(enabled: boolean): void {
@@ -930,7 +995,9 @@ export function applyWebglPreference(enabled: boolean): void {
         if (slot.webglAddon) {
           try {
             slot.term.refresh(0, slot.term.rows - 1);
-          } catch {}
+          } catch {
+            // Refresh is cosmetic; a mid-dispose renderer may throw.
+          }
         }
       }
     } else if (slot.webglAddon) {
@@ -1078,7 +1145,9 @@ export function refreshLeafSlot(leafId: number): void {
   }
   try {
     slot.term.refresh(0, slot.term.rows - 1);
-  } catch {}
+  } catch {
+    // Refresh is cosmetic; a mid-dispose renderer may throw.
+  }
 }
 
 export function disposeLeafSlot(leafId: number): void {


### PR DESCRIPTION
## What changed

Fixes IME input in the terminal on macOS WKWebView: Chinese-IME Shift+punct commits (full-width and ASCII alike) were dropped on first press (the "press twice" bug), and fast-typed IME text could be lost or doubled.

- Swallow keyCode-229 keydowns (IME-consumed keys) without preventDefault; delivery is reconstructed from input events, never from keydown. Option+arrow / Option+Backspace dead-key mistags still pass through (#956).
- The imeBridge mirrors xterm's `_inputEvent` delivery gate exactly — forwarding only what xterm provably drops — plus CompositionHelper's finalize-send flag, so delivery stays exactly-once.
- The `nativeComposition` latch is scoped to the composition session (reset at compositionend/blur) instead of sticking forever after the first IME session.
- ASCII commits (Shift+2/3/5/7/8/= producing @ # % & * +) are forwarded only when `isComposing=false` and `keyPressHandled=false` — never in-progress pinyin, never keypress-delivered text.
- Global shortcuts stay inert during composition and for 229 keys.

## Why

Root causes, verified with a capture-phase event trace on the helper textarea (keydown/keyup/beforeinput/input/composition* plus xterm's internal gate flags):

- xterm's `_inputEvent` gate drops a commit whose insertText arrives while `_keyDownSeen` is held high by the still-held Shift keydown.
- The bridge's `nativeComposition` latch was never reset, so after the first composition session nothing compensated the gate's drops.
- ASCII commits were excluded from compensation entirely.

## How tested

- `pnpm lint`, `pnpm check-types`, `pnpm test` (702 passed, incl. new imeBridge/keymap cases locking the gate mirror, latch reset, finalize stand-down, and ASCII commit path) on this branch standalone against main's xterm 6.0.0; `cargo clippy --all-targets --locked -- -D warnings` and `cargo nextest run --locked` (310 passed).
- Manual on a built Terax.app (macOS, system Pinyin): after typing hanzi, one press of Shift+; / Shift+1/4/6 produces ：！¥…… immediately; Shift+2/3/5/7/8/= produce @ # % & * + on first press; rapid repeats neither drop nor double; pinyin + digit candidate selection never leaks digits; Enter-to-commit does not reach the shell; Option+Left/Right word jumps and Option+Backspace word delete still work.
