### PR TITLE
test(theme): cover vibrancy application queue

### DIFF
--- a/src/modules/theme/vibrancy.test.ts
+++ b/src/modules/theme/vibrancy.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const core = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => core);
+
+type FakeRoot = {
+  attrs: Map<string, string>;
+  style: { backgroundColor: string };
+};
+
+function fakeDocument(): FakeRoot {
+  const attrs = new Map<string, string>();
+  const root = {
+    attrs,
+    style: { backgroundColor: "" },
+    setAttribute(k: string, v: string) {
+      attrs.set(k, v);
+    },
+    removeAttribute(k: string) {
+      attrs.delete(k);
+    },
+    hasAttribute(k: string) {
+      return attrs.has(k);
+    },
+  };
+  vi.stubGlobal("document", { documentElement: root });
+  return root as unknown as FakeRoot;
+}
+
+async function loadModule() {
+  return await import("./vibrancy");
+}
+
+describe("vibrancy application", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    core.invoke.mockReset();
+  });
+
+  it("caches the backdrop kind in a single backend probe", async () => {
+    fakeDocument();
+    core.invoke.mockResolvedValue("mica");
+    const vibrancy = await loadModule();
+
+    await vibrancy.getBackdropKind();
+    await vibrancy.getBackdropKind();
+
+    expect(core.invoke).toHaveBeenCalledTimes(1);
+    expect(core.invoke).toHaveBeenCalledWith("window_backdrop_kind");
+  });
+
+  it("falls back to none when the backend probe fails", async () => {
+    fakeDocument();
+    core.invoke.mockRejectedValue(new Error("unsupported"));
+    const vibrancy = await loadModule();
+
+    await expect(vibrancy.getBackdropKind()).resolves.toBe("none");
+  });
+
+  it("turns the effect on and repaints the transparent surface", async () => {
+    const root = fakeDocument();
+    root.style.backgroundColor = "#141414";
+    core.invoke.mockResolvedValue("vibrancy");
+    const vibrancy = await loadModule();
+
+    await vibrancy.applyVibrancy(true, true);
+
+    expect(root.attrs.get("data-vibrancy")).toBe("on");
+    expect(root.style.backgroundColor).toBe("");
+    expect(core.invoke).toHaveBeenCalledWith("window_set_backdrop", {
+      enabled: true,
+      dark: true,
+    });
+  });
+
+  it("skips the native call when the state was already applied", async () => {
+    fakeDocument();
+    core.invoke.mockResolvedValue("vibrancy");
+    const vibrancy = await loadModule();
+
+    await vibrancy.applyVibrancy(true, true);
+    await vibrancy.applyVibrancy(true, true);
+
+    expect(core.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds mica on a dark-mode flip", async () => {
+    fakeDocument();
+    core.invoke.mockResolvedValue("mica");
+    const vibrancy = await loadModule();
+
+    await vibrancy.applyVibrancy(true, true);
+    await vibrancy.applyVibrancy(true, false);
+
+    const backdrop = core.invoke.mock.calls.filter(
+      (c) => c[0] === "window_set_backdrop",
+    );
+    expect(backdrop).toHaveLength(2);
+    expect(backdrop[1][1]).toEqual({ enabled: true, dark: false });
+  });
+
+  it("keeps an existing NSVisualEffectView across a dark-mode flip", async () => {
+    fakeDocument();
+    core.invoke.mockResolvedValue("vibrancy");
+    const vibrancy = await loadModule();
+
+    await vibrancy.applyVibrancy(true, true);
+    await vibrancy.applyVibrancy(true, false);
+
+    const backdrop = core.invoke.mock.calls.filter(
+      (c) => c[0] === "window_set_backdrop",
+    );
+    expect(backdrop).toHaveLength(1);
+  });
+
+  it("paints opaque and disables natively when the platform reports none", async () => {
+    const root = fakeDocument();
+    root.style.backgroundColor = "";
+    core.invoke.mockResolvedValue("none");
+    const vibrancy = await loadModule();
+
+    await vibrancy.applyVibrancy(true, true);
+
+    expect(root.attrs.has("data-vibrancy")).toBe(false);
+    expect(root.style.backgroundColor).toBe("#141414");
+    const backdrop = core.invoke.mock.calls.filter(
+      (c) => c[0] === "window_set_backdrop",
+    );
+    expect(backdrop).toEqual([["window_set_backdrop", { enabled: false, dark: true }]]);
+  });
+
+  it("repaints opaque when the native side fails so the webview is never see-through", async () => {
+    const root = fakeDocument();
+    core.invoke.mockResolvedValue("vibrancy");
+    const vibrancy = await loadModule();
+
+    core.invoke.mockImplementation((cmd: string) =>
+      cmd === "window_backdrop_kind"
+        ? Promise.resolve("vibrancy")
+        : Promise.reject(new Error("boom")),
+    );
+    await vibrancy.applyVibrancy(true, true);
+
+    expect(root.attrs.has("data-vibrancy")).toBe(false);
+    expect(root.style.backgroundColor).toBe("#141414");
+
+    core.invoke.mockImplementation(() => Promise.resolve());
+    await vibrancy.applyVibrancy(true, true);
+
+    expect(root.attrs.get("data-vibrancy")).toBe("on");
+  });
+
+  it("repaints the light pre-paint color when disabling in light mode", async () => {
+    const root = fakeDocument();
+    core.invoke.mockResolvedValue("vibrancy");
+    const vibrancy = await loadModule();
+
+    await vibrancy.applyVibrancy(false, false);
+
+    expect(root.style.backgroundColor).toBe("#ffffff");
+    expect(core.invoke).toHaveBeenCalledWith("window_set_backdrop", {
+      enabled: false,
+      dark: false,
+    });
+  });
+
+  it("serializes concurrent toggles so they cannot land out of order", async () => {
+    fakeDocument();
+    const vibrancy = await loadModule();
+    let releaseFirst: (() => void) | undefined;
+    core.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "window_backdrop_kind") return Promise.resolve("vibrancy");
+      if (core.invoke.mock.calls.filter((c) => c[0] === "window_set_backdrop").length === 1) {
+        return new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+
+    const first = vibrancy.applyVibrancy(true, true);
+    const second = vibrancy.applyVibrancy(false, true);
+
+    const backdropCalls = () =>
+      core.invoke.mock.calls.filter((c) => c[0] === "window_set_backdrop").length;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(backdropCalls()).toBe(1);
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(backdropCalls()).toBe(2);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the window vibrancy bridge logic in `theme/vibrancy`.
Test-only: no production files are touched.

## Why

`applyVibrancy` decides whether the webview stays transparent. A regression
here is user-visible as a see-through or fully black window, and the module
carries non-obvious invariants (state dedupe, mica rebuild on dark flip,
opaque fallback on native failure) that nothing locked.

## How

Mocks `invoke` and a minimal `document.documentElement`, and reloads the
module per test with `vi.resetModules()` because the cache and queue live at
module scope.

Locked behavior:

- the backdrop-kind probe runs once per session and falls back to `none` on
  failure
- enabling sets `data-vibrancy=on` and clears the pre-paint background color
- an identical re-apply skips the native call; mica rebuilds on dark flip
  while NSVisualEffectView does not
- with kind `none` the surface paints opaque and the native side gets one
  disabling call instead of enabling into nothing
- a failed `window_set_backdrop` repaints opaque immediately, and a later
  retry works because the dedupe key was reset
- concurrent toggles serialize: the second waits for the first native call to
  settle before issuing its own

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the same
  workflow-scope reason as my earlier PRs. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for backdrop detection, including caching and fallback behavior.
  * Verified vibrancy enable/disable behavior across supported and unsupported platforms.
  * Tested dark-mode transitions, repainting, redundant-call avoidance, and concurrent toggle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->