### PR TITLE
test(editor): cover git diff content cache

### DIFF
--- a/src/modules/editor/lib/diffCache.test.ts
+++ b/src/modules/editor/lib/diffCache.test.ts
@@ -1,0 +1,165 @@
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const nativeMock = vi.hoisted(() => ({
+  gitDiffContent: vi.fn(),
+  gitCommitFileDiff: vi.fn(),
+}));
+
+vi.mock("@/modules/ai/lib/native", () => ({ native: nativeMock }));
+
+const workspaceMock = vi.hoisted(() => ({
+  currentWorkspaceScopeKey: vi.fn(() => "scope"),
+}));
+
+vi.mock("@/modules/workspace", () => workspaceMock);
+
+import type { GitDiffContentResult } from "@/modules/ai/lib/native";
+
+function result(modifiedContent: string): GitDiffContentResult {
+  return {
+    originalContent: "",
+    modifiedContent,
+    isBinary: false,
+    fallbackPatch: "",
+    truncated: false,
+  };
+}
+
+async function loadModule() {
+  return await import("./diffCache");
+}
+
+describe("git diff content cache", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    nativeMock.gitDiffContent.mockReset();
+    nativeMock.gitCommitFileDiff.mockReset();
+    workspaceMock.currentWorkspaceScopeKey.mockClear();
+    workspaceMock.currentWorkspaceScopeKey.mockReturnValue("scope");
+  });
+
+  it("scopes diff keys by workspace, repo, and kind", async () => {
+    const { workingDiffKey, commitDiffKey } = await loadModule();
+
+    expect(workingDiffKey("/repo", "src/a.ts", "-")).toBe(
+      "scope|/repo|w|-|src/a.ts",
+    );
+    expect(commitDiffKey("/repo", "abc123", "src/a.ts")).toBe(
+      "scope|/repo|c|abc123|src/a.ts",
+    );
+  });
+
+  it("serves repeated reads of the same file from cache", async () => {
+    const { fetchWorkingDiff } = await loadModule();
+    nativeMock.gitDiffContent.mockResolvedValue(result("- line"));
+
+    await fetchWorkingDiff("/repo", "a.ts", "-", null);
+    const second = await fetchWorkingDiff("/repo", "a.ts", "-", null);
+
+    expect(second.modifiedContent).toBe("- line");
+    expect(nativeMock.gitDiffContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent reads of the same diff into one backend call", async () => {
+    const { fetchWorkingDiff } = await loadModule();
+    let release: ((v: GitDiffContentResult) => void) | undefined;
+    nativeMock.gitDiffContent.mockReturnValue(
+      new Promise<GitDiffContentResult>((r) => {
+        release = r;
+      }),
+    );
+
+    const first = fetchWorkingDiff("/repo", "a.ts", "-", null);
+    const second = fetchWorkingDiff("/repo", "a.ts", "-", null);
+    release?.(result("shared"));
+
+    expect(await first).toBe(await second);
+    expect(nativeMock.gitDiffContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the least recently used entry past six", async () => {
+    const mod = await loadModule();
+    nativeMock.gitDiffContent.mockImplementation((_root, path: string) =>
+      Promise.resolve(result(`body ${path}`)),
+    );
+
+    for (let i = 0; i < 6; i++) {
+      await mod.fetchWorkingDiff("/repo", `f${i}.ts`, "-", null);
+    }
+    await mod.fetchWorkingDiff("/repo", "new.ts", "-", null);
+
+    expect(mod.getCachedDiff(mod.workingDiffKey("/repo", "f0.ts", "-"))).toBeUndefined();
+    expect(mod.getCachedDiff(mod.workingDiffKey("/repo", "f1.ts", "-"))).toBeDefined();
+  });
+
+  it("keeps an entry that was just read when the limit overflows", async () => {
+    const { fetchWorkingDiff, getCachedDiff, workingDiffKey } =
+      await loadModule();
+    nativeMock.gitDiffContent.mockImplementation((_root, path: string) =>
+      Promise.resolve(result(`body ${path}`)),
+    );
+
+    for (let i = 0; i < 6; i++) {
+      await fetchWorkingDiff("/repo", `f${i}.ts`, "-", null);
+    }
+    getCachedDiff(workingDiffKey("/repo", "f0.ts", "-"));
+    await fetchWorkingDiff("/repo", "new.ts", "-", null);
+
+    expect(getCachedDiff(workingDiffKey("/repo", "f0.ts", "-"))).toBeDefined();
+    expect(getCachedDiff(workingDiffKey("/repo", "f1.ts", "-"))).toBeUndefined();
+  });
+
+  it("does not retry or cache a failed backend call", async () => {
+    const { fetchWorkingDiff } = await loadModule();
+    nativeMock.gitDiffContent
+      .mockRejectedValueOnce(new Error("git failed"))
+      .mockResolvedValueOnce(result("recovered"));
+
+    await expect(fetchWorkingDiff("/repo", "a.ts", "-", null)).rejects.toThrow(
+      "git failed",
+    );
+    await expect(fetchWorkingDiff("/repo", "a.ts", "-", null)).resolves.toEqual(
+      result("recovered"),
+    );
+    expect(nativeMock.gitDiffContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates only the current workspace scope for a repo root", async () => {
+    const mod = await loadModule();
+    const { fetchWorkingDiff, getCachedDiff, workingDiffKey } = mod;
+    nativeMock.gitDiffContent.mockImplementation((_root, path: string) =>
+      Promise.resolve(result(`body ${path}`)),
+    );
+
+    await fetchWorkingDiff("/repo-a", "x.ts", "-", null);
+
+    workspaceMock.currentWorkspaceScopeKey.mockReturnValue("other");
+    await fetchWorkingDiff("/repo-a", "x.ts", "-", null);
+    workspaceMock.currentWorkspaceScopeKey.mockReturnValue("scope");
+
+    const { invalidateRepoDiffs } = mod;
+    invalidateRepoDiffs("/repo-a");
+
+    expect(getCachedDiff(workingDiffKey("/repo-a", "x.ts", "-"))).toBeUndefined();
+
+    workspaceMock.currentWorkspaceScopeKey.mockReturnValue("other");
+    expect(getCachedDiff(workingDiffKey("/repo-a", "x.ts", "-"))).toBeDefined();
+  });
+
+  it("keeps working-tree and commit diffs under separate namespaces", async () => {
+    const { fetchWorkingDiff, fetchCommitDiff } = await loadModule();
+    nativeMock.gitDiffContent.mockResolvedValue(result("work"));
+    nativeMock.gitCommitFileDiff.mockResolvedValue(result("commit"));
+
+    await fetchWorkingDiff("/repo", "a.ts", "+", null);
+    await fetchCommitDiff("/repo", "sha1", "a.ts", null);
+
+    expect(nativeMock.gitDiffContent).toHaveBeenCalledTimes(1);
+    expect(nativeMock.gitCommitFileDiff).toHaveBeenCalledWith(
+      "/repo",
+      "sha1",
+      "a.ts",
+      null,
+    );
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the git diff content cache in `editor/lib/diffCache`.
Test-only: no production files are touched.

## Why

The cache sits between the diff panes and the git backend: it dedupes
in-flight reads, caps memory with an LRU of six, and namespaces every key by
workspace scope. None of that was locked, and a regression would show up as
stale or cross-workspace diffs.

## How

Mocks `native` and `currentWorkspaceScopeKey`, reloading the module per test
with `vi.resetModules()` because both the LRU and the inflight map live at
module scope.

Locked behavior:

- keys embed workspace scope, repo root, kind (`w`/`c`), and path
- repeated reads hit the cache; concurrent reads share one backend promise
- the seventh entry evicts the least recently used one
- a read refreshes recency, so a freshly touched entry survives eviction
- a rejected backend call is not cached and the next read retries
- `invalidateRepoDiffs` clears only the current scope's entries for that repo
  and keeps other scopes
- working-tree and commit diffs use separate key namespaces

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the same
  workflow-scope reason as my earlier PRs. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for diff caching behavior.
  - Verified workspace and repository isolation, repeated-read caching, concurrent request coalescing, and LRU eviction.
  - Confirmed correct handling of failed reads, scoped invalidation, and separate working-tree and commit diff caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->