### PR TITLE
test(lsp): cover binary detection single-flight

### DIFF
--- a/src/modules/lsp/lib/detect.test.ts
+++ b/src/modules/lsp/lib/detect.test.ts
@@ -94,12 +94,21 @@ describe("LSP binary detection", () => {
     expect(core.invoke).toHaveBeenCalledTimes(2);
   });
 
-  it("redetect re-probes immediately even while the previous probe is stuck", async () => {
-    core.invoke.mockResolvedValue(null);
-    await detectBinary("rust-analyzer");
-    core.invoke.mockResolvedValue("/late/path");
+  it("redetect re-probes while the previous probe is still pending", async () => {
+    let releaseFirst: ((v: string | null) => void) | undefined;
+    core.invoke.mockReturnValueOnce(
+      new Promise<string | null>((r) => {
+        releaseFirst = r;
+      }),
+    );
+
+    const stuck = detectBinary("rust-analyzer");
+    core.invoke.mockResolvedValueOnce("/late/path");
 
     await expect(redetectBinary("rust-analyzer")).resolves.toBe("/late/path");
     expect(core.invoke).toHaveBeenCalledTimes(2);
+
+    releaseFirst?.(null);
+    await expect(stuck).resolves.toBeNull();
   });
 });

--- a/src/modules/lsp/lib/detect.test.ts
+++ b/src/modules/lsp/lib/detect.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const core = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => core);
+
+const runtime = vi.hoisted(() => {
+  const state = {
+    detected: {} as Record<string, string | null>,
+    setDetected: vi.fn((command: string, path: string | null) => {
+      state.detected[command] = path;
+    }),
+    clearDetected: vi.fn((command: string) => {
+      delete state.detected[command];
+    }),
+  };
+  return { state, useLspRuntimeStore: { getState: () => state } };
+});
+
+vi.mock("./runtimeStore", () => ({ useLspRuntimeStore: runtime.useLspRuntimeStore }));
+
+import { detectBinary, redetectBinary } from "./detect";
+
+describe("LSP binary detection", () => {
+  beforeEach(() => {
+    core.invoke.mockReset();
+    runtime.state.detected = {};
+    runtime.state.setDetected.mockClear();
+    runtime.state.clearDetected.mockClear();
+  });
+
+  it("coalesces concurrent detections of the same command into one probe", async () => {
+    let release: ((v: string | null) => void) | undefined;
+    core.invoke.mockReturnValue(
+      new Promise<string | null>((r) => {
+        release = r;
+      }),
+    );
+
+    const first = detectBinary("rust-analyzer");
+    const second = detectBinary("rust-analyzer");
+    release?.("/usr/bin/rust-analyzer");
+
+    expect(await first).toBe("/usr/bin/rust-analyzer");
+    expect(await second).toBe("/usr/bin/rust-analyzer");
+    expect(core.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves later calls from the runtime store without probing again", async () => {
+    core.invoke.mockResolvedValue("/usr/local/bin/typescript-language-server");
+
+    await detectBinary("typescript-language-server");
+    await detectBinary("typescript-language-server");
+
+    expect(core.invoke).toHaveBeenCalledTimes(1);
+    expect(runtime.state.setDetected).toHaveBeenCalledWith(
+      "typescript-language-server",
+      "/usr/local/bin/typescript-language-server",
+    );
+  });
+
+  it("caches a failed probe as null instead of retrying forever", async () => {
+    core.invoke.mockRejectedValue(new Error("spawn failed"));
+
+    await expect(detectBinary("gopls")).resolves.toBeNull();
+    await expect(detectBinary("gopls")).resolves.toBeNull();
+
+    expect(core.invoke).toHaveBeenCalledTimes(1);
+    expect(runtime.state.detected.gopls).toBeNull();
+  });
+
+  it("probes distinct commands independently", async () => {
+    core.invoke.mockImplementation((_cmd: string, args: { command: string }) =>
+      Promise.resolve(args.command === "pyright" ? "/bin/pyright" : null),
+    );
+
+    await expect(detectBinary("pyright")).resolves.toBe("/bin/pyright");
+    await expect(detectBinary("ruff")).resolves.toBeNull();
+
+    expect(core.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("redetect drops the cached answer and probes again", async () => {
+    core.invoke
+      .mockResolvedValueOnce("/old/path")
+      .mockResolvedValueOnce("/new/path");
+
+    await detectBinary("rust-analyzer");
+    await expect(redetectBinary("rust-analyzer")).resolves.toBe("/new/path");
+
+    expect(runtime.state.clearDetected).toHaveBeenCalledWith("rust-analyzer");
+    expect(core.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("redetect re-probes immediately even while the previous probe is stuck", async () => {
+    core.invoke.mockResolvedValue(null);
+    await detectBinary("rust-analyzer");
+    core.invoke.mockResolvedValue("/late/path");
+
+    await expect(redetectBinary("rust-analyzer")).resolves.toBe("/late/path");
+    expect(core.invoke).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the LSP binary detection helpers in `lsp/lib/detect`.
Test-only: no production files are touched.

## Why

`detectBinary` gates the whole opt-in LSP feature: it single-flights probes so
several editor panes opening at once cannot spam `lsp_detect`, and it caches
the answer (including failures) in the runtime store. Nothing locked that.

## How

Mocks `invoke` and the runtime store, keeping a real map behind
`setDetected`/`clearDetected` so cache hits behave like production.

Locked behavior:

- concurrent detections of one command share a single backend probe and
  resolve with the same path
- later calls read the runtime-store cache instead of probing again
- a failed probe is cached as null, matching the "binary absent" state rather
  than retrying on every keystroke
- distinct commands probe independently
- `redetectBinary` clears the cached answer and re-probes, including when an
  earlier probe already settled

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the same
  workflow-scope reason as my earlier PRs. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for language server binary detection.
  * Verified concurrent detection requests are combined efficiently.
  * Verified successful and failed results are cached appropriately.
  * Verified separate commands are detected independently.
  * Verified forced re-detection clears cached results and probes again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->