### PR TITLE
test: cover more pure helpers

### DIFF
--- a/src/lib/external-link.test.ts
+++ b/src/lib/external-link.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const opener = vi.hoisted(() => ({
+  openUrl: vi.fn(async () => undefined),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => opener);
+
+import { isExternalUrl, openExternalUrl } from "./external-link";
+
+describe("isExternalUrl", () => {
+  it("accepts web, mail, and phone schemes", () => {
+    expect(isExternalUrl("https://example.com")).toBe(true);
+    expect(isExternalUrl("HTTP://EXAMPLE.COM")).toBe(true);
+    expect(isExternalUrl("mailto:a@b.c")).toBe(true);
+    expect(isExternalUrl("tel:+1234")).toBe(true);
+  });
+
+  it("refuses app-relative and executable schemes", () => {
+    expect(isExternalUrl("/settings/general")).toBe(false);
+    expect(isExternalUrl("#anchor")).toBe(false);
+    expect(isExternalUrl("javascript:void(0)")).toBe(false);
+    expect(isExternalUrl("data:text/html,hi")).toBe(false);
+    expect(isExternalUrl("file:///etc/passwd")).toBe(false);
+  });
+});
+
+describe("openExternalUrl", () => {
+  beforeEach(() => {
+    opener.openUrl.mockClear();
+  });
+
+  it("opens external URLs through the opener plugin", async () => {
+    const settled = vi.fn();
+
+    await openExternalUrl("https://example.com", settled);
+
+    expect(opener.openUrl).toHaveBeenCalledWith("https://example.com");
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips non-external URLs without touching the plugin", async () => {
+    const settled = vi.fn();
+
+    await openExternalUrl("javascript:void(0)", settled);
+
+    expect(opener.openUrl).not.toHaveBeenCalled();
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it("still settles when the opener fails", async () => {
+    opener.openUrl.mockRejectedValueOnce(new Error("no handler"));
+    const settled = vi.fn();
+
+    await expect(
+      openExternalUrl("https://example.com", settled),
+    ).resolves.toBeUndefined();
+
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/editor/lib/diagnosticsStore.test.ts
+++ b/src/modules/editor/lib/diagnosticsStore.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDiagnosticsStore } from "./diagnosticsStore";
+
+function report(path: string, errors: number | null, warnings = 0) {
+  useDiagnosticsStore
+    .getState()
+    .report(path, errors === null ? null : { errors, warnings });
+}
+
+describe("diagnostics count store", () => {
+  beforeEach(() => {
+    useDiagnosticsStore.setState({ byPath: {} });
+  });
+
+  it("keeps counts per path", () => {
+    report("/a.ts", 1, 2);
+    report("/b.ts", 3);
+
+    expect(useDiagnosticsStore.getState().byPath).toEqual({
+      "/a.ts": { errors: 1, warnings: 2 },
+      "/b.ts": { errors: 3, warnings: 0 },
+    });
+  });
+
+  it("skips identical reports so subscribers stay quiet", () => {
+    report("/a.ts", 1, 2);
+    const before = useDiagnosticsStore.getState().byPath;
+
+    report("/a.ts", 1, 2);
+
+    expect(useDiagnosticsStore.getState().byPath).toBe(before);
+  });
+
+  it("replaces counts when they change", () => {
+    report("/a.ts", 1);
+    report("/a.ts", 0, 4);
+
+    expect(useDiagnosticsStore.getState().byPath["/a.ts"]).toEqual({
+      errors: 0,
+      warnings: 4,
+    });
+  });
+
+  it("drops the entry on a null report", () => {
+    report("/a.ts", 1);
+    report("/a.ts", null);
+
+    expect(useDiagnosticsStore.getState().byPath["/a.ts"]).toBeUndefined();
+  });
+
+  it("ignores null reports for paths with no entry", () => {
+    const before = useDiagnosticsStore.getState().byPath;
+
+    report("/missing.ts", null);
+
+    expect(useDiagnosticsStore.getState().byPath).toBe(before);
+  });
+});

--- a/src/modules/explorer/lib/gitStatusColor.test.ts
+++ b/src/modules/explorer/lib/gitStatusColor.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { explorerGitTextClass } from "./gitStatusColor";
+
+describe("explorer git status colors", () => {
+  it("maps each status code to its tint", () => {
+    expect(explorerGitTextClass("M")).toBe("text-amber-200/85");
+    expect(explorerGitTextClass("A")).toBe("text-[#73C991]/90");
+    expect(explorerGitTextClass("U")).toBe("text-[#73C991]/90");
+    expect(explorerGitTextClass("R")).toBe("text-sky-300/85");
+    expect(explorerGitTextClass("D")).toBe("text-rose-200/80");
+  });
+
+  it("treats adds and untracked identically", () => {
+    expect(explorerGitTextClass("A")).toBe(explorerGitTextClass("U"));
+  });
+});

--- a/src/modules/lsp/lib/protocolShim.test.ts
+++ b/src/modules/lsp/lib/protocolShim.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  CompletionItemKind,
+  CompletionTriggerKind,
+  DiagnosticSeverity,
+  DocumentHighlightKind,
+} from "./protocolShim";
+
+describe("LSP protocol shim enum values", () => {
+  it("keeps DiagnosticSeverity on the wire values", () => {
+    expect(DiagnosticSeverity.Error).toBe(1);
+    expect(DiagnosticSeverity.Warning).toBe(2);
+    expect(DiagnosticSeverity.Information).toBe(3);
+    expect(DiagnosticSeverity.Hint).toBe(4);
+  });
+
+  it("keeps CompletionTriggerKind on the wire values", () => {
+    expect(CompletionTriggerKind.Invoked).toBe(1);
+    expect(CompletionTriggerKind.TriggerCharacter).toBe(2);
+    expect(CompletionTriggerKind.TriggerForIncompleteCompletions).toBe(3);
+  });
+
+  it("keeps DocumentHighlightKind on the wire values", () => {
+    expect(DocumentHighlightKind.Text).toBe(1);
+    expect(DocumentHighlightKind.Read).toBe(2);
+    expect(DocumentHighlightKind.Write).toBe(3);
+  });
+
+  it("keeps representative CompletionItemKind entries on the wire values", () => {
+    expect(CompletionItemKind.Text).toBe(1);
+    expect(CompletionItemKind.Method).toBe(2);
+    expect(CompletionItemKind.Function).toBe(3);
+    expect(CompletionItemKind.Constructor).toBe(4);
+    expect(CompletionItemKind.Field).toBe(5);
+    expect(CompletionItemKind.Variable).toBe(6);
+    expect(CompletionItemKind.Class).toBe(7);
+    expect(CompletionItemKind.Interface).toBe(8);
+    expect(CompletionItemKind.Module).toBe(9);
+    expect(CompletionItemKind.Property).toBe(10);
+    expect(CompletionItemKind.Unit).toBe(11);
+    expect(CompletionItemKind.Value).toBe(12);
+    expect(CompletionItemKind.Enum).toBe(13);
+    expect(CompletionItemKind.Keyword).toBe(14);
+    expect(CompletionItemKind.Snippet).toBe(15);
+    expect(CompletionItemKind.Color).toBe(16);
+    expect(CompletionItemKind.File).toBe(17);
+    expect(CompletionItemKind.Reference).toBe(18);
+    expect(CompletionItemKind.Folder).toBe(19);
+    expect(CompletionItemKind.EnumMember).toBe(20);
+    expect(CompletionItemKind.Constant).toBe(21);
+    expect(CompletionItemKind.Struct).toBe(22);
+    expect(CompletionItemKind.Event).toBe(23);
+    expect(CompletionItemKind.Operator).toBe(24);
+    expect(CompletionItemKind.TypeParameter).toBe(25);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for four small pure-logic modules that had no coverage. One
commit per module. Test-only: no production files are touched.

- `explorer/lib/gitStatusColor` - status code to text-tint mapping
- `lib/external-link` - URL gate in front of the opener plugin
- `editor/lib/diagnosticsStore` - per-path diagnostics counts with dedupe
- `lsp/lib/protocolShim` - LSP enum wire values aliased into the client lib

## Why

Each is load-bearing in its own niche: git status tints color every explorer
row, `isExternalUrl` is the only thing standing between rendered markdown and
`javascript:` URLs, the diagnostics store drives the status-bar badge, and the
protocol shim substitutes for `vscode-languageserver-protocol` at build time,
so a wrong enum number silently corrupts server communication.

## How

Plain characterization tests; `external-link` mocks the opener plugin, the
diagnostics store tests run against the real zustand store with a reset state.
The shim test pins all four enums against the LSP specification numbers.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the same
  workflow-scope reason as my earlier PRs. Four new files only, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for validating and opening external web, mail, and phone links while rejecting unsafe or unsupported URLs.
  * Added tests for diagnostics count tracking, updates, removals, and avoiding unnecessary state changes.
  * Added coverage for Git status color indicators.
  * Added validation for language-server protocol enum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->