### PR TITLE
test(git): lock DTO serde wire shape

### DIFF
--- a/src-tauri/src/modules/git/types.rs
+++ b/src-tauri/src/modules/git/types.rs
@@ -153,3 +153,214 @@ impl TextSource {
         }
     }
 }
+
+#[cfg(test)]
+mod serde_shape_tests {
+    use super::*;
+
+    #[test]
+    fn repo_info_serializes_camel_case() {
+        let info = GitRepoInfo {
+            repo_root: "/repo".into(),
+            branch: "main".into(),
+            upstream: Some("origin/main".into()),
+            is_detached: false,
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "repoRoot": "/repo",
+                "branch": "main",
+                "upstream": "origin/main",
+                "isDetached": false,
+            })
+        );
+    }
+
+    #[test]
+    fn changed_file_serializes_all_fields_camel_case() {
+        let file = GitChangedFile {
+            path: "src/a.ts".into(),
+            original_path: Some("src/old.ts".into()),
+            index_status: "R".into(),
+            worktree_status: " ".into(),
+            staged: true,
+            unstaged: false,
+            untracked: false,
+            status_label: "renamed".into(),
+        };
+        let json = serde_json::to_value(&file).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "path": "src/a.ts",
+                "originalPath": "src/old.ts",
+                "indexStatus": "R",
+                "worktreeStatus": " ",
+                "staged": true,
+                "unstaged": false,
+                "untracked": false,
+                "statusLabel": "renamed",
+            })
+        );
+    }
+
+    #[test]
+    fn status_snapshot_nests_changed_files() {
+        let snapshot = GitStatusSnapshot {
+            repo_root: "/repo".into(),
+            branch: "main".into(),
+            upstream: None,
+            ahead: 2,
+            behind: 1,
+            is_detached: true,
+            truncated: false,
+            changed_files: vec![],
+        };
+        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "repoRoot": "/repo",
+                "branch": "main",
+                "upstream": null,
+                "ahead": 2,
+                "behind": 1,
+                "isDetached": true,
+                "truncated": false,
+                "changedFiles": [],
+            })
+        );
+    }
+
+    #[test]
+    fn panel_snapshot_allows_null_repo_and_status() {
+        let panel = GitPanelSnapshot {
+            repo: None,
+            status: None,
+        };
+        let json = serde_json::to_value(&panel).unwrap();
+        assert_eq!(json, serde_json::json!({ "repo": null, "status": null }));
+    }
+
+    #[test]
+    fn diff_content_result_keys_stay_camel_case() {
+        let diff = GitDiffContentResult {
+            original_content: "a".into(),
+            modified_content: "b".into(),
+            is_binary: false,
+            fallback_patch: "".into(),
+            truncated: true,
+        };
+        let json = serde_json::to_value(&diff).unwrap();
+        for key in [
+            "originalContent",
+            "modifiedContent",
+            "isBinary",
+            "fallbackPatch",
+            "truncated",
+        ] {
+            assert!(json.get(key).is_some(), "missing key {key}");
+        }
+    }
+
+    #[test]
+    fn commit_result_and_file_change_keep_their_contract() {
+        let commit = GitCommitResult {
+            commit_sha: "abc123".into(),
+            summary: "msg".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(&commit).unwrap(),
+            serde_json::json!({ "commitSha": "abc123", "summary": "msg" })
+        );
+
+        let change = GitCommitFileChange {
+            path: "f.rs".into(),
+            original_path: None,
+            status: "M".into(),
+            status_label: "modified".into(),
+            added: 3,
+            removed: 4,
+            is_binary: false,
+        };
+        let json = serde_json::to_value(&change).unwrap();
+        assert_eq!(json["originalPath"], serde_json::Value::Null);
+        for key in ["path", "status", "statusLabel", "added", "removed", "isBinary"] {
+            assert!(json.get(key).is_some(), "missing key {key}");
+        }
+    }
+
+    #[test]
+    fn log_entry_stats_use_camel_case_names() {
+        let entry = GitLogEntry {
+            sha: "deadbeef".into(),
+            short_sha: "deadbee".into(),
+            author: "A".into(),
+            author_email: "a@example.com".into(),
+            timestamp_secs: 1_700_000_000,
+            parents: vec!["p0".into()],
+            subject: "s".into(),
+            files_changed: 2,
+            insertions: 10,
+            deletions: 5,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        for key in [
+            "shortSha",
+            "authorEmail",
+            "timestampSecs",
+            "filesChanged",
+            "insertions",
+            "deletions",
+        ] {
+            assert!(json.get(key).is_some(), "missing key {key}");
+        }
+        assert_eq!(json["parents"], serde_json::json!(["p0"]));
+    }
+
+    #[test]
+    fn push_and_branch_results_serialize_as_named() {
+        let push = GitPushResult {
+            remote: Some("origin".into()),
+            branch: None,
+            pushed: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&push).unwrap(),
+            serde_json::json!({ "remote": "origin", "branch": null, "pushed": true })
+        );
+
+        let branch = GitBranchEntry {
+            name: "feature".into(),
+            kind: "local".into(),
+            worktree_path: None,
+            is_head: false,
+            is_detached: false,
+        };
+        let list = GitBranchListResult {
+            branches: vec![branch],
+        };
+        assert_eq!(
+            serde_json::to_value(&list).unwrap(),
+            serde_json::json!({
+                "branches": [{
+                    "name": "feature",
+                    "kind": "local",
+                    "worktreePath": null,
+                    "isHead": false,
+                    "isDetached": false,
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn discard_entry_deserializes_from_camel_case_json() {
+        let entry: DiscardEntry =
+            serde_json::from_str(r#"{ "path": "x.txt", "untracked": true }"#).unwrap();
+        assert_eq!(entry.path, "x.txt");
+        assert!(entry.untracked);
+    }
+}


### PR DESCRIPTION
﻿## What

Adds a test module to `git/types.rs` that locks the serde wire shape of every
DTO crossing the IPC boundary. Test-only: no production behavior is touched.

## Why

The frontend consumes these structs by exact field name through `invoke()`.
Every type relies on `#[serde(rename_all = "camelCase")]`, and nothing
prevented a refactor from silently dropping it: Rust would still compile, the
command would still return 200-style `Ok`, and every consumer would read
`undefined` fields. The testing guide lists the IPC command surface as
load-bearing.

## How

Serialize representative instances with `serde_json` and compare against
literal JSON for the small types (repo info, changed file, status snapshot,
panel snapshot, commit result, push result, branch list), and assert key
presence plus nesting for the larger aggregates. `DiscardEntry` is exercised
from the deserialize side since it is an inbound argument.

Locked behavior:

- camelCase names for every renamed field (`repoRoot`, `originalPath`,
  `indexStatus`, `statusLabel`, `changedFiles`, `isDetached`,
  `originalContent`, `commitSha`, `timestampSecs`, `filesChanged`,
  `worktreePath`, ...)
- optional fields serialize as explicit `null`, not absent keys
- nested collections (`changedFiles`, `branches`, `parents`) keep their shape

## Testing

Ran cargo test locally on Windows; clippy has one pre-existing warning.

- [ ] `pnpm lint` - N/A, no frontend changes
- [ ] `pnpm check-types` - N/A, no frontend changes
- [ ] `pnpm test` - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean (244 lib tests pass)
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings`
      fails on this machine due to one PRE-EXISTING warning on Windows builds:
      `unused variable window` at src/lib.rs:131 (the binding is only read under
      `#[cfg(target_os = "macos")]`). Verified present on a pristine checkout of
      this base commit; not introduced here.
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions inside `types.rs`. No command signatures touched.
- Branched just before the `.github/workflows` dependabot bump for the same
  workflow-scope reason as my earlier PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage to verify consistent data formatting across repository, file, status, panel, diff, commit, log, push, branch, and discard workflows.
  * Confirmed reliable conversion between application data and externally exchanged formats, improving confidence in related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->