### PR TITLE
chore(tauri): keep clippy -D warnings green on windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,9 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     let builder = builder.decorations(false).transparent(true);
 
+    // Linux re-asserts decorations below; macOS centers below. Windows does
+    // neither, where the binding would otherwise trip `-D warnings`.
+    #[cfg_attr(target_os = "windows", allow(unused_variables))]
     let window = builder.build().map_err(|e| e.to_string())?;
 
     // Some Linux compositors (GNOME/Mutter with CSD-by-default) ignore the


### PR DESCRIPTION
﻿## What

One-line lint fix: the `window` binding in `open_settings_window` is now
exempted from the unused-variables lint on Windows, where it has no consumer.

## Why

`cargo clippy --all-targets --locked -- -D warnings` (the canonical check from
the README and CI) currently fails on Windows checkouts of `main`:

    warning: unused variable: `window`
      --> src/lib.rs:131:9

The binding is only read under `#[cfg(target_os = "linux")]` (decoration
re-assert) and `#[cfg(target_os = "macos")]` (centering). The Windows arm
consumes neither, so contributors on Windows cannot get a clean clippy run
without locally patching this. Verified present on a pristine checkout before
this change.

## How

`#[cfg_attr(target_os = "windows", allow(unused_variables))]` on the binding,
plus a comment naming which platform consumes what. No behavior change on any
platform; the build call itself is untouched.

## Testing

Ran the full Rust suite plus clippy locally on Windows 11 (build 26200).

- [ ] `pnpm lint` - N/A, no frontend changes
- [ ] `pnpm check-types` - N/A, no frontend changes
- [ ] `pnpm test` - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, no behavior change (settings window opens exactly as before)
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean (235 lib + integration suites pass)
- [x] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean on Windows for the first time since the settings-window rework
- [ ] (If you changed a `#[tauri::command]` signature) - N/A, signature untouched
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no runtime change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- If you would rather restructure the cfg arms so the warning disappears
  structurally (e.g. per-platform build calls), happy to do that instead.
- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason.
