### PR TITLE
test(history): cover histfile resolution and windows executables

### DIFF
--- a/src-tauri/src/modules/history/mod.rs
+++ b/src-tauri/src/modules/history/mod.rs
@@ -184,3 +184,97 @@ pub fn history_record(state: tauri::State<'_, HistoryState>, command: String) {
         sort_recent(&mut idx.entries);
     }
 }
+
+#[cfg(test)]
+mod mod_tests {
+    use super::*;
+
+    #[test]
+    fn zsh_histfile_prefers_an_existing_env_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let custom = tmp.path().join("custom_zhistory");
+        std::fs::write(&custom, b"").unwrap();
+        std::env::set_var("HISTFILE", &custom);
+
+        let got = zsh_histfile(Some(&tmp.path().join("home")));
+
+        std::env::remove_var("HISTFILE");
+        assert_eq!(got, Some(custom));
+    }
+
+    #[test]
+    fn zsh_histfile_falls_back_to_home_when_the_override_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        std::env::set_var("HISTFILE", tmp.path().join("missing"));
+
+        let got = zsh_histfile(Some(&home));
+
+        std::env::remove_var("HISTFILE");
+        assert_eq!(got, Some(home.join(".zsh_history")));
+    }
+
+    #[test]
+    fn fish_histfile_prefers_xdg_then_falls_back_to_default_location() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg = tmp.path().join("xdg-data");
+        std::fs::create_dir_all(xdg.join("fish")).unwrap();
+        let fish_file = xdg.join("fish").join("fish_history");
+        std::fs::write(&fish_file, b"").unwrap();
+        let home = tmp.path().join("home");
+
+        std::env::set_var("XDG_DATA_HOME", &xdg);
+        assert_eq!(fish_histfile(Some(&home)), Some(fish_file));
+
+        std::env::set_var("XDG_DATA_HOME", tmp.path().join("empty-xdg"));
+        assert_eq!(
+            fish_histfile(Some(&home)),
+            Some(home.join(".local/share/fish/fish_history"))
+        );
+
+        std::env::remove_var("XDG_DATA_HOME");
+        assert_eq!(
+            fish_histfile(Some(&home)),
+            Some(home.join(".local/share/fish/fish_history"))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_executable_detection_matches_launcher_extensions_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        for name in [
+            "cargo.exe",
+            "RUN.CMD",
+            "tool.bat",
+            "legacy.com",
+            "script.ps1",
+            "readme.txt",
+            "noext",
+        ] {
+            std::fs::write(tmp.path().join(name), b"").unwrap();
+        }
+
+        let mut found: Vec<(String, bool)> = Vec::new();
+        for entry in std::fs::read_dir(tmp.path()).unwrap().flatten() {
+            found.push((entry.file_name().to_string_lossy().into_owned(), is_executable(&entry)));
+        }
+        found.sort();
+
+        let is_exec = |name: &str| {
+            found
+                .iter()
+                .find(|(n, _)| n.eq_ignore_ascii_case(name))
+                .map(|(_, e)| *e)
+                .unwrap()
+        };
+        assert!(is_exec("cargo.exe"));
+        assert!(is_exec("run.cmd"));
+        assert!(is_exec("tool.bat"));
+        assert!(is_exec("legacy.com"));
+        assert!(is_exec("script.ps1"));
+        assert!(!is_exec("readme.txt"));
+        assert!(!is_exec("noext"));
+    }
+}


### PR DESCRIPTION
﻿## What

Adds tests for the history module's input resolution: shell history file
discovery and the Windows PATH-executable matcher. Test-only: no production
behavior is touched.

## Why

`read_histories()` decides which of `~/.zsh_history`, `$HISTFILE`,
`.bash_history`, and fish's XDG or default location feed the completion index,
and `is_executable` decides what counts as a completable command on Windows
(`.exe/.cmd/.bat/.com/.ps1`). Both were untested; a path-resolution regression
would silently empty the terminal's history suggestions.

## How

Plain unit tests against the private helpers. The histfile tests use
tempdirs plus `HISTFILE` / `XDG_DATA_HOME` overrides to exercise the
exists-check fallback chain; the executable test writes real files with mixed
extensions into a tempdir and walks it through `read_dir`, since the helper
consumes a real `DirEntry`.

Locked behavior:

- an existing `$HISTFILE` wins over the default zsh location
- a missing `$HISTFILE` falls back to `~/.zsh_history`
- fish prefers an existing `$XDG_DATA_HOME/fish/fish_history`, then the
  default user location, whether or not the default exists yet
- Windows detection matches launcher extensions case-insensitively and
  refuses non-launcher files

## Testing

Ran cargo test locally on Windows 11.

- [ ] `pnpm lint` - N/A, no frontend changes
- [ ] `pnpm check-types` - N/A, no frontend changes
- [ ] `pnpm test` - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean (239 lib tests)
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings`
      fails on this machine only due to the pre-existing `unused variable window`
      warning at src/lib.rs:131 (tracked in #1179). Nothing new from this branch.
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions inside `history/mod.rs`.
- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason.
