### PR TITLE
test(lsp): cover runtime session store

### DIFF
--- a/src/modules/lsp/lib/runtimeStore.test.ts
+++ b/src/modules/lsp/lib/runtimeStore.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useLspRuntimeStore } from "./runtimeStore";
+
+const session = {
+  key: "rust-analyzer\u0000/repo",
+  presetId: "rust-analyzer",
+  root: "/repo",
+  status: "starting" as const,
+};
+
+describe("LSP runtime store", () => {
+  beforeEach(() => {
+    useLspRuntimeStore.setState({
+      sessions: {},
+      detected: {},
+      generations: {},
+      failed: {},
+    });
+  });
+
+  it("upserts sessions by key and replaces on re-upsert", () => {
+    const store = useLspRuntimeStore.getState();
+    store.upsertSession(session);
+    store.upsertSession({ ...session, status: "running" });
+
+    expect(useLspRuntimeStore.getState().sessions[session.key].status).toBe(
+      "running",
+    );
+  });
+
+  it("removeSession bumps the preset generation for re-acquire", () => {
+    const store = useLspRuntimeStore.getState();
+    store.upsertSession(session);
+    store.removeSession(session.key, session.presetId);
+
+    expect(useLspRuntimeStore.getState().sessions[session.key]).toBeUndefined();
+    expect(useLspRuntimeStore.getState().generations["rust-analyzer"]).toBe(1);
+  });
+
+  it("removeSessionQuiet tears down without a generation bump", () => {
+    const store = useLspRuntimeStore.getState();
+    store.upsertSession(session);
+    store.removeSessionQuiet(session.key);
+
+    expect(useLspRuntimeStore.getState().sessions[session.key]).toBeUndefined();
+    expect(useLspRuntimeStore.getState().generations).toEqual({});
+  });
+
+  it("bumpGeneration accumulates per preset independently", () => {
+    const store = useLspRuntimeStore.getState();
+    store.bumpGeneration("rust-analyzer");
+    store.bumpGeneration("rust-analyzer");
+    store.bumpGeneration("pyright");
+
+    expect(useLspRuntimeStore.getState().generations).toEqual({
+      "rust-analyzer": 2,
+      pyright: 1,
+    });
+  });
+
+  it("setFailed records a reason and clearFailed removes only its own entry", () => {
+    const store = useLspRuntimeStore.getState();
+    store.setFailed("rust-analyzer", "kept crashing");
+    store.setFailed("pyright", "budget kill");
+
+    store.clearFailed("rust-analyzer");
+
+    expect(useLspRuntimeStore.getState().failed).toEqual({
+      pyright: "budget kill",
+    });
+  });
+
+  it("clearFailed is a no-op for an unknown preset", () => {
+    const before = useLspRuntimeStore.getState();
+
+    before.clearFailed("gopls");
+
+    expect(useLspRuntimeStore.getState()).toBe(before);
+  });
+
+  it("detected map stores paths and nulls, clearDetected forgets entirely", () => {
+    const store = useLspRuntimeStore.getState();
+    store.setDetected("rust-analyzer", "/bin/ra");
+    store.setDetected("gopls", null);
+
+    expect(useLspRuntimeStore.getState().detected).toEqual({
+      "rust-analyzer": "/bin/ra",
+      gopls: null,
+    });
+
+    store.clearDetected("rust-analyzer");
+    expect(useLspRuntimeStore.getState().detected).toEqual({ gopls: null });
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the LSP runtime store in `lsp/lib/runtimeStore`. Test-only:
no production files are touched.

## Why

The generation counter in this store is the re-acquire trigger after a server
teardown, and the quiet variant exists precisely so crash cleanup does not
trigger respawns. Nothing distinguished those two paths under test.

## How

Runs against the real zustand store with `setState` resets per test.

Locked behavior:

- sessions upsert by key and replace on re-upsert
- `removeSession` bumps the preset generation; `removeSessionQuiet` does not
- generations accumulate independently per preset
- failed reasons are recorded per preset and cleared selectively
- `clearFailed` returns the same state object for unknown presets
- detected commands store both paths and nulls; `clearDetected` forgets the
  key entirely rather than writing null

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for LSP runtime session management.
  * Verified session updates, removals, generation tracking, failure records, executable detection, preset isolation, clearing behavior, null values, and no-op handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->