### PR TITLE
test(ai): cover the streaming HTTP proxy fetch

### DIFF
--- a/src/modules/ai/lib/proxyFetch.test.ts
+++ b/src/modules/ai/lib/proxyFetch.test.ts
@@ -1,0 +1,186 @@
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const core = vi.hoisted(() => {
+  const channels: {
+    onmessage: ((event: unknown) => void) | null;
+  }[] = [];
+  const invoke = vi.fn(() => Promise.resolve());
+  class Channel {
+    onmessage: ((event: unknown) => void) | null = null;
+    constructor() {
+      channels.push(this);
+    }
+  }
+  return { channels, invoke, Channel };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: core.Channel,
+  invoke: core.invoke,
+}));
+
+import { createProxyFetch, proxyFetch } from "./proxyFetch";
+
+type FakeChannel = { onmessage: ((event: unknown) => void) | null };
+
+async function startFetch(
+  fn: typeof fetch,
+  input: string,
+  init?: RequestInit,
+): Promise<{ pending: Promise<Response>; channel: FakeChannel }> {
+  const pending = fn(input, init);
+  await Promise.resolve();
+  return {
+    pending,
+    channel: core.channels[core.channels.length - 1],
+  };
+}
+
+function invokeArgs(): Record<string, unknown> {
+  const calls = core.invoke.mock.calls as unknown as [string, Record<string, unknown>][];
+  return calls[calls.length - 1][1];
+}
+
+describe("AI HTTP stream proxy", () => {
+  beforeEach(() => {
+    core.channels.length = 0;
+    core.invoke.mockClear();
+  });
+
+  it("forwards url, method, headers, body bytes, and the private flag", async () => {
+    const fetchImpl = createProxyFetch({ allowPrivateNetwork: true });
+    const { channel } = await startFetch(
+      fetchImpl,
+      "http://127.0.0.1:1234/v1",
+      {
+        method: "post",
+        headers: { "content-type": "application/json" },
+        body: '{"a":1}',
+        signal: new AbortController().signal,
+      },
+    );
+    channel.onmessage?.({ kind: "headers", status: 200, headers: {} });
+
+    expect(invokeArgs()).toMatchObject({
+      url: "http://127.0.0.1:1234/v1",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: [123, 34, 97, 34, 58, 49, 125],
+      allowPrivateNetwork: true,
+    });
+  });
+
+  it("defaults to GET without body and refuses private networks by default", async () => {
+    const { channel, pending } = await startFetch(
+      proxyFetch,
+      "https://api.example.com/v1/models",
+    );
+    channel.onmessage?.({ kind: "headers", status: 200, headers: {} });
+    await pending;
+
+    expect(invokeArgs()).toMatchObject({
+      method: "GET",
+      body: undefined,
+      allowPrivateNetwork: false,
+    });
+  });
+
+  it("normalizes Headers and entry-array header inits", async () => {
+    const first = await startFetch(proxyFetch, "https://api.example.com", {
+      headers: new Headers({ authorization: "Bearer t" }),
+    });
+    first.channel.onmessage?.({ kind: "headers", status: 200, headers: {} });
+    await first.pending;
+    expect(invokeArgs().headers).toEqual({ authorization: "Bearer t" });
+
+    const second = await startFetch(proxyFetch, "https://api.example.com", {
+      headers: [["x-a", "1"]],
+    });
+    second.channel.onmessage?.({ kind: "headers", status: 200, headers: {} });
+    await second.pending;
+    expect(invokeArgs().headers).toEqual({ "x-a": "1" });
+  });
+
+  it("resolves a streaming response assembled from chunk events", async () => {
+    const { channel, pending } = await startFetch(
+      proxyFetch,
+      "https://api.example.com/stream",
+    );
+    channel.onmessage?.({
+      kind: "headers",
+      status: 200,
+      headers: { "x-test": "1" },
+    });
+
+    const response = await pending;
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-test")).toBe("1");
+
+    channel.onmessage?.({ kind: "chunk", bytes: [104, 105] });
+    channel.onmessage?.({ kind: "chunk", bytes: [33] });
+    channel.onmessage?.({ kind: "end" });
+
+    await expect(response.text()).resolves.toBe("hi!");
+  });
+
+  it("rejects with the backend message when an error precedes headers", async () => {
+    const { channel, pending } = await startFetch(
+      proxyFetch,
+      "https://api.example.com",
+    );
+
+    channel.onmessage?.({ kind: "error", message: "SSRF refused" });
+
+    await expect(pending).rejects.toThrow("SSRF refused");
+  });
+
+  it("errors the open stream when an error follows headers", async () => {
+    const { channel, pending } = await startFetch(
+      proxyFetch,
+      "https://api.example.com",
+    );
+    channel.onmessage?.({ kind: "headers", status: 200, headers: {} });
+    const response = await pending;
+
+    channel.onmessage?.({ kind: "error", message: "mid-stream boom" });
+
+    await expect(response.text()).rejects.toThrow("mid-stream boom");
+  });
+
+  it("propagates an invoke rejection while nothing resolved yet", async () => {
+    core.invoke.mockImplementationOnce(() =>
+      Promise.reject(new Error("ipc down")),
+    );
+
+    const { pending } = await startFetch(proxyFetch, "https://api.example.com");
+
+    await expect(pending).rejects.toThrow("ipc down");
+  });
+
+  it("throws immediately for an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      proxyFetch("https://api.example.com", { signal: controller.signal }),
+    ).rejects.toThrow(/abort/i);
+
+    expect(core.invoke).not.toHaveBeenCalled();
+  });
+
+  it("aborts mid-stream so further events are ignored", async () => {
+    const controller = new AbortController();
+    const { channel, pending } = await startFetch(
+      proxyFetch,
+      "https://api.example.com",
+      { signal: controller.signal },
+    );
+    channel.onmessage?.({ kind: "headers", status: 200, headers: {} });
+    const response = await pending;
+
+    controller.abort();
+    channel.onmessage?.({ kind: "chunk", bytes: [120] });
+
+    await expect(response.text()).rejects.toThrow(/abort/i);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for `ai/lib/proxyFetch`, the fetch implementation that tunnels
provider traffic through the Rust `ai_http_stream` command. Test-only: no
production files are touched.

## Why

Every AI SDK request to local or remote providers goes through this proxy, and
its SSRF posture depends on the `allowPrivateNetwork` flag staying false by
default. The stream assembly (headers -> chunks -> end/error) had no test.

## How

Mocks `@tauri-apps/api/core` with a fake `Channel` whose `onmessage` the tests
drive directly; the resulting `ReadableStream` is consumed with the real
`Response` API.

Locked behavior:

- invoke receives url, uppercased method, normalized headers (object, Headers,
  entry array), body as byte array, and the private-network flag
- the default export refuses private networks; `createProxyFetch({ true })`
  opts in
- a headers event resolves a streaming Response carrying status and headers;
  chunk events enqueue bytes and end closes the stream
- an error event before headers rejects the fetch promise; after headers it
  errors the open stream instead
- an invoke rejection surfaces while nothing resolved yet
- an already-aborted signal throws before any backend call; aborting mid-stream
  errors the stream and ignores later events

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for AI streaming requests and responses.
  - Verified request formatting, header handling, private-network options, streamed data assembly, backend errors, connection failures, and cancellation behavior.
  - Improved confidence that AI interactions handle successful and interrupted requests consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->