### PR TITLE
test(ai): cover the context-aware transport

### DIFF
--- a/src/modules/ai/lib/transport.test.ts
+++ b/src/modules/ai/lib/transport.test.ts
@@ -1,0 +1,208 @@
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentMock = vi.hoisted(() => ({
+  runAgentStream: vi.fn(),
+}));
+
+vi.mock("./agent", () => agentMock);
+
+const nativeMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("./native", () => ({ native: nativeMock }));
+
+import { createContextAwareTransport, stripContextBlock } from "./transport";
+import type { UIMessage } from "@ai-sdk/react";
+
+agentMock.runAgentStream.mockImplementation(() => ({
+  toUIMessageStream: () => "stream-ok",
+}));
+
+function userMessage(text: string): UIMessage {
+  return { id: "u1", role: "user", parts: [{ type: "text", text }] };
+}
+
+function makeDeps(live: Record<string, unknown>) {
+  return {
+    getKeys: () => ({}) as never,
+    toolContext: {} as never,
+    getModelId: () => "gpt-test",
+    getCustomInstructions: () => "",
+    getAgentPersona: () => null,
+    getLive: () => live as never,
+  };
+}
+
+async function send(messages: UIMessage[], live: Record<string, unknown>) {
+  const transport = createContextAwareTransport(makeDeps(live));
+  await transport.sendMessages({ messages });
+  const call =
+    agentMock.runAgentStream.mock.calls[
+      agentMock.runAgentStream.mock.calls.length - 1
+    ][0];
+  return call.uiMessages as UIMessage[];
+}
+
+function lastUserText(messages: UIMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      const part = messages[i].parts[0] as { type: string; text?: string };
+      if (part.type === "text") return part.text ?? "";
+    }
+  }
+  throw new Error("no user text part");
+}
+
+describe("context-aware AI transport", () => {
+  beforeEach(() => {
+    agentMock.runAgentStream.mockClear();
+    nativeMock.readFile.mockReset();
+    nativeMock.readFile.mockRejectedValue(new Error("missing"));
+  });
+
+  it("strips a leading terminal-context block only", () => {
+    expect(
+      stripContextBlock(
+        '<terminal-context cwd="/repo">\noutput\n</terminal-context>\nquestion',
+      ),
+    ).toBe("question");
+    expect(stripContextBlock("keep <terminal-context>x</terminal-context>")).toBe(
+      "keep <terminal-context>x</terminal-context>",
+    );
+  });
+
+  it("injects an env block into the last user message without mutating input", async () => {
+    const original = [userMessage("first"), userMessage("do the thing")];
+    const snapshot = {
+      workspaceRoot: "/repo",
+      cwd: "/repo/sub",
+      activeFile: "/repo/a.ts",
+      terminalPrivate: true,
+    };
+
+    const out = await send(original, snapshot);
+
+    expect(out).not.toBe(original);
+    expect(lastUserText(out)).toBe(
+      '<env>\nworkspace_root: /repo\nactive_terminal_cwd: /repo/sub\nactive_file: /repo/a.ts\nactive_terminal_mode: private\n</env>\n\ndo the thing',
+    );
+    expect(lastUserText(original)).toBe("do the thing");
+    expect(out[0]).toBe(original[0]);
+  });
+
+  it("prepends a new text part when the user message has none", async () => {
+    const messages = [
+      {
+        id: "u2",
+        role: "user" as const,
+        parts: [{ type: "file" as const, url: "file:///a.ts" }],
+      },
+    ];
+
+    const out = await send(messages as UIMessage[], {
+      workspaceRoot: "/repo-prepend",
+      cwd: null,
+      activeFile: null,
+      terminalPrivate: false,
+    });
+
+    const parts = out[0].parts as { type: string; text?: string }[];
+    expect(parts[0].type).toBe("text");
+    expect(parts[0].text).toBe(
+      "<env>\nworkspace_root: /repo-prepend\n</env>",
+    );
+  });
+
+  it("passes messages untouched when no live context exists", async () => {
+    const original = [userMessage("hello")];
+
+    const out = await send(original, {
+      workspaceRoot: null,
+      cwd: null,
+      activeFile: null,
+      terminalPrivate: false,
+    });
+
+    expect(out).toBe(original);
+  });
+
+  it("reads TERAX.md from the workspace root as project memory", async () => {
+    nativeMock.readFile.mockResolvedValue({
+      kind: "text",
+      content: "# Project rules",
+    });
+
+    await send([userMessage("hi")], {
+      workspaceRoot: "/repo-read",
+      cwd: null,
+      activeFile: null,
+      terminalPrivate: false,
+    });
+
+    expect(nativeMock.readFile).toHaveBeenCalledWith("/repo-read/TERAX.md");
+    const call =
+      agentMock.runAgentStream.mock.calls[
+        agentMock.runAgentStream.mock.calls.length - 1
+      ][0];
+    expect(call.projectMemory).toBe("# Project rules");
+  });
+
+  it("caches project memory per workspace across sends", async () => {
+    nativeMock.readFile.mockResolvedValue({
+      kind: "text",
+      content: "# Rules",
+    });
+    const live = {
+      workspaceRoot: "/repo-cache",
+      cwd: null,
+      activeFile: null,
+      terminalPrivate: false,
+    };
+
+    await send([userMessage("a")], live);
+    await send([userMessage("b")], live);
+
+    expect(nativeMock.readFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a failed read as no memory instead of retrying", async () => {
+    nativeMock.readFile.mockRejectedValue(new Error("gone"));
+    const live = {
+      workspaceRoot: "/repo-fail",
+      cwd: null,
+      activeFile: null,
+      terminalPrivate: false,
+    };
+
+    await send([userMessage("a")], live);
+    await send([userMessage("b")], live);
+
+    expect(nativeMock.readFile).toHaveBeenCalledTimes(1);
+    const call =
+      agentMock.runAgentStream.mock.calls[
+        agentMock.runAgentStream.mock.calls.length - 1
+      ][0];
+    expect(call.projectMemory).toBeNull();
+  });
+
+  it("truncates oversized TERAX.md content to 32 KiB", async () => {
+    nativeMock.readFile.mockResolvedValue({
+      kind: "text",
+      content: "x".repeat(40 * 1024),
+    });
+
+    await send([userMessage("hi")], {
+      workspaceRoot: "/big",
+      cwd: null,
+      activeFile: null,
+      terminalPrivate: false,
+    });
+
+    const call =
+      agentMock.runAgentStream.mock.calls[
+        agentMock.runAgentStream.mock.calls.length - 1
+      ][0];
+    expect((call.projectMemory as string).length).toBe(32 * 1024);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for `ai/lib/transport`: env-block composition, injection into
the last user message, and the TERAX.md project-memory cache. Test-only: no
production files are touched.

## Why

This transport is the seam between the app and every model call: it decides
what workspace context the model sees (`<env>` block) and what project memory
(TERAX.md, capped and cached) rides along. The injection rules and cache TTL
behavior were untested.

## How

Mocks `./agent` (captures the `runAgentStream` payload) and `./native`
(readFile). Each test uses a distinct workspace root because the memory cache
is module-scoped with a 30s TTL - which is itself part of what gets locked.

Locked behavior:

- `stripContextBlock` removes only a leading `<terminal-context>` block
- the env block lists workspace root, terminal cwd, active file, and private
  mode, each only when present
- injection targets the last user message: prepended to its first text part,
  as a new part when none exists; earlier messages and the input array stay
  untouched
- with no live context at all the original array passes through unchanged
- TERAX.md is read from `<root>/TERAX.md`, truncated to 32 KiB, cached per
  workspace across sends within the TTL, and a failed read caches "no memory"
  instead of retrying

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. No public API, behavior, dependency, or config change.
- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for context-aware AI transport behavior.
  - Verified terminal context handling, environment injection, message immutability, empty messages, and no-context scenarios.
  - Added coverage for project-memory loading, successful and failed read caching, and 32 KiB content truncation.
  - Strengthened confidence in consistent AI responses across supported context and memory conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->