### PR TITLE
test(control-protocol): lock the wire shapes

### DIFF
--- a/src-tauri/crates/terax-control-protocol/src/lib.rs
+++ b/src-tauri/crates/terax-control-protocol/src/lib.rs
@@ -164,4 +164,121 @@ mod tests {
             serde_json::from_value(json!({ "path": "/tmp/a" })).expect("deserialize open params");
         assert!(params.focus);
     }
+
+    #[test]
+    fn protocol_version_is_locked_at_one() {
+        assert_eq!(PROTOCOL_VERSION, 1);
+        assert_eq!(MAX_MESSAGE_BYTES, 64 * 1024);
+    }
+
+    #[test]
+    fn methods_catalog_matches_the_documented_constants() {
+        assert_eq!(
+            METHODS,
+            &[
+                METHOD_PING,
+                METHOD_CAPABILITIES,
+                METHOD_IDENTIFY,
+                METHOD_OPEN
+            ]
+        );
+    }
+
+    #[test]
+    fn open_params_omit_absent_optionals_from_the_wire() {
+        let minimal = OpenParams {
+            path: "/tmp/a".into(),
+            line: None,
+            column: None,
+            focus: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&minimal).unwrap(),
+            json!({ "path": "/tmp/a", "focus": true })
+        );
+
+        let located = OpenParams {
+            path: "/tmp/a".into(),
+            line: Some(12),
+            column: Some(34),
+            focus: false,
+        };
+        assert_eq!(
+            serde_json::to_value(&located).unwrap(),
+            json!({
+                "path": "/tmp/a",
+                "line": 12,
+                "column": 34,
+                "focus": false,
+            })
+        );
+    }
+
+    #[test]
+    fn success_responses_omit_null_fields_and_failures_omit_results() {
+        let success = ControlResponse::success("7", json!({ "version": "0.8.6" }));
+        let value = serde_json::to_value(&success).unwrap();
+        assert!(value.get("result").is_some());
+        assert!(value.get("error").is_none());
+
+        let failure = ControlResponse::failure("8", "unauthorized", "bad token");
+        let value = serde_json::to_value(&failure).unwrap();
+        assert!(value.get("result").is_none());
+        assert!(value.get("error").is_some());
+    }
+
+    #[test]
+    fn caller_context_round_trips_with_and_without_a_pane() {
+        let with_pane = CallerContext {
+            pane_id: Some(3),
+        };
+        let value = serde_json::to_value(&with_pane).unwrap();
+        assert_eq!(value, json!({ "pane_id": 3 }));
+        let back: CallerContext = serde_json::from_value(value).unwrap();
+        assert_eq!(back, with_pane);
+
+        let value = serde_json::to_value(CallerContext::default()).unwrap();
+        assert_eq!(value, json!({}));
+    }
+
+    #[test]
+    fn frontend_exchange_shapes_survive_a_round_trip() {
+        let request = FrontendRequest {
+            id: "9".into(),
+            method: METHOD_OPEN.into(),
+            params: json!({ "path": "/tmp/a", "line": 1 }),
+            caller: CallerContext { pane_id: Some(5) },
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        let back: FrontendRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(back, request);
+
+        let response = FrontendResponse {
+            ok: true,
+            result: Some(json!({ "opened": true })),
+            error: None,
+        };
+        let value = serde_json::to_value(&response).unwrap();
+        assert!(value.get("error").is_none());
+        let back: FrontendResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(back, response);
+    }
+
+    #[test]
+    fn descriptor_carries_the_discovery_fields() {
+        let descriptor = ControlDescriptor {
+            protocol: PROTOCOL_VERSION,
+            address: "127.0.0.1:54321".into(),
+            token: "tok".into(),
+            pid: 4242,
+            app_version: "0.8.6".into(),
+        };
+        let back: ControlDescriptor =
+            serde_json::from_str(&serde_json::to_string(&descriptor).unwrap()).unwrap();
+        assert_eq!(back.protocol, 1);
+        assert_eq!(back.address, "127.0.0.1:54321");
+        assert_eq!(back.token, "tok");
+        assert_eq!(back.pid, 4242);
+        assert_eq!(back.app_version, "0.8.6");
+    }
 }

--- a/src-tauri/crates/terax-control-protocol/src/lib.rs
+++ b/src-tauri/crates/terax-control-protocol/src/lib.rs
@@ -172,16 +172,8 @@ mod tests {
     }
 
     #[test]
-    fn methods_catalog_matches_the_documented_constants() {
-        assert_eq!(
-            METHODS,
-            &[
-                METHOD_PING,
-                METHOD_CAPABILITIES,
-                METHOD_IDENTIFY,
-                METHOD_OPEN
-            ]
-        );
+    fn methods_catalog_matches_the_wire_literals() {
+        assert_eq!(METHODS, &["ping", "capabilities", "identify", "open"]);
     }
 
     #[test]


### PR DESCRIPTION
﻿## What

Extends the `terax-control-protocol` test module with wire-shape locks for
every type that crosses the CLI-to-app socket. Test-only: no production files
are touched.

## Why

The descriptor file, requests, and responses are a versioned contract between
independent binaries (the bundled `terax` CLI talks to any running Terax
instance). The existing tests covered request defaults and response helpers,
but not the serialization surface: which optional fields are omitted versus
emitted as null, and whether `METHODS` stays in sync with the method
constants.

## How

Plain serde round-trips plus exact `serde_json` value comparisons.

Locked behavior:

- protocol stays at 1 and the message cap stays at 64 KiB (bumping either is
  a compatibility event that must be deliberate)
- `METHODS` matches the four documented constants, so `capabilities` cannot
  drift
- `OpenParams` omits absent line/column from the wire and emits them when
  set; focus defaults to true on deserialize
- success responses carry `result` and omit `error`; failures invert that
- `CallerContext` omits itself down to `{}` when no pane is known
- frontend request/response pairs and the discovery descriptor survive a
  full serialize/deserialize cycle

## Testing

Ran cargo test locally on Windows.

- [ ] `pnpm lint` / check-types / test - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean (10 tests in the crate)
- [x] (If you touched `src-tauri/`) clippy `-D warnings` clean for this crate (the pre-existing lib.rs warning from #1179 does not affect this workspace member)
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions inside the crate's existing test module.
- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for protocol version and message-size limits.
  * Verified method catalog consistency and JSON serialization behavior.
  * Added round-trip tests for request, response, and caller context data.
  * Confirmed control descriptors expose the expected discovery fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->