### PR TITLE
test(wsl): harden drvfs and distro-name guards

### DIFF
--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -733,6 +733,41 @@ mod tests {
     }
 
     #[test]
+    fn wsl_drvfs_rejects_multi_character_and_non_alpha_drives() {
+        assert_eq!(wsl_drvfs_to_windows("/mnt/ab/Users/x"), None);
+        assert_eq!(wsl_drvfs_to_windows("/mnt/1/Users/x"), None);
+        assert_eq!(wsl_drvfs_to_windows("/mnt//Users/x"), None);
+    }
+
+    #[test]
+    fn wsl_drvfs_normalizes_backslash_input_and_lowercased_drives() {
+        assert_eq!(
+            wsl_drvfs_to_windows("\\mnt\\c\\Users\\vinicios"),
+            Some(PathBuf::from(r"C:\Users\vinicios"))
+        );
+        assert_eq!(
+            wsl_drvfs_to_windows("/mnt/z/"),
+            Some(PathBuf::from(r"Z:\"))
+        );
+    }
+
+    #[test]
+    fn safe_distro_names_accept_common_shapes() {
+        assert!(is_safe_distro_name("Ubuntu"));
+        assert!(is_safe_distro_name("Ubuntu-22.04"));
+        assert!(is_safe_distro_name("Debian GNU"));
+        assert!(is_safe_distro_name("openSUSE_Leap"));
+    }
+
+    #[test]
+    fn safe_distro_names_reject_traversal_and_overlong_names() {
+        assert!(!is_safe_distro_name(".."));
+        assert!(!is_safe_distro_name("ub..untu"));
+        assert!(!is_safe_distro_name(&"a".repeat(256)));
+        assert!(is_safe_distro_name(&"a".repeat(255)));
+    }
+
+    #[test]
     fn normalize_wsl_value_uses_last_nonempty_line() {
         assert_eq!(
             normalize_wsl_value("banner\n  /bin/zsh \n".into(), "/bin/sh"),


### PR DESCRIPTION
﻿## What

Adds Windows-gated tests around the WSL path translation and distro-name
guards in `workspace.rs`. Test-only: no production files are touched.

## Why

`wsl_drvfs_to_windows` decides when a WSL-side path is really Windows storage
and rewrites it onto the native drive; a regression there would send the app
down the UNC share where drvfs paths can fail with access-denied. The distro
validator is the traversal guard for `\\wsl.localhost` construction. Existing
tests covered happy paths and one rejection shape each.

## How

Plain assertions against the existing private helpers inside the existing
Windows test module.

Locked behavior:

- multi-character mounts (`/mnt/ab/...`), non-alphabetic drives, and empty
  drive segments are refused
- backslash input normalizes to forward-slash handling and lowercased drives
  map to uppercase roots
- common real-world distro names (hyphens, dots, spaces, underscores) pass
- `..`, embedded `..`, and names over 255 chars are refused while exactly 255
  passes

## Testing

Ran cargo test locally on Windows 11 (38 workspace tests green).

- [ ] `pnpm lint` / check-types / test - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean
- [ ] (If you touched `src-tauri/`) clippy: no new warnings from this branch (pre-existing lib.rs warning tracked in #1179)
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows (tests are `#[cfg(windows)]`-gated)
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions. Branched just before the `.github/workflows`
  dependabot bump for the usual workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Windows coverage for validating drive mounts, including empty, malformed, and non-alphabetic inputs.
  * Added tests for path separator normalization and lowercase drive-letter conversion.
  * Added coverage for accepted and rejected WSL distribution names, including traversal and length-limit cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->