### PR TITLE
test(net): harden the SSRF classification matrix

### DIFF
--- a/src-tauri/src/modules/net.rs
+++ b/src-tauri/src/modules/net.rs
@@ -545,4 +545,77 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn special_ipv4_ranges_do_not_classify_as_public() {
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+            IpKind::Loopback
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::BROADCAST)),
+            IpKind::Loopback
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1))),
+            IpKind::Loopback
+        );
+    }
+
+    #[test]
+    fn private_range_boundaries_hold_on_ipv4() {
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(172, 31, 255, 255))),
+            IpKind::Private
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(172, 32, 0, 1))),
+            IpKind::Public
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(100, 127, 255, 255))),
+            IpKind::Private
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(100, 128, 0, 1))),
+            IpKind::Public
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(198, 18, 0, 1))),
+            IpKind::Private
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(198, 19, 255, 255))),
+            IpKind::Private
+        );
+        assert_eq!(
+            ip_kind(IpAddr::V4(Ipv4Addr::new(198, 20, 0, 1))),
+            IpKind::Public
+        );
+    }
+
+    #[test]
+    fn ipv6_unique_local_and_multicast_are_not_public() {
+        assert_eq!(ip_kind("fd12:3456::1".parse().unwrap()), IpKind::Private);
+        assert_eq!(ip_kind("fc00::1".parse().unwrap()), IpKind::Private);
+        assert_eq!(ip_kind("ff02::1".parse().unwrap()), IpKind::Loopback);
+        assert_eq!(ip_kind("::".parse().unwrap()), IpKind::Loopback);
+        assert_eq!(
+            ip_kind("2606:4700::1111".parse().unwrap()),
+            IpKind::Public
+        );
+    }
+
+    #[test]
+    fn blocked_host_name_match_is_case_insensitive_and_exact() {
+        assert!(is_blocked_host_name("METADATA.google.internal"));
+        assert!(!is_blocked_host_name("metadata.evil.internal"));
+        assert!(!is_blocked_host_name("my-metadata"));
+    }
+
+    #[test]
+    fn validate_url_requires_a_host() {
+        // A URL that parses but carries no host must not slip through.
+        assert!(validate_url("http://", true).is_err());
+    }
 }


### PR DESCRIPTION
﻿## What

Extends the `net.rs` SSRF test module with the classification boundaries and
host-name matching cases not yet asserted. Test-only: no production files are
touched.

## Why

`ip_kind` is what stands between a user-configured endpoint URL and cloud
metadata services. The existing matrix covered the headline ranges; the
boundaries between them (172.16/12 edges, CGNAT edges, benchmarking range,
IPv6 unique-local vs metadata, multicast/unspecified buckets) were unlocked,
and those are exactly where an off-by-one would silently reclassify.

## How

Plain assertions against `ip_kind`, `is_blocked_host_name`, and
`validate_url` inside the existing test module.

Locked behavior:

- unspecified, broadcast, and multicast IPv4 land in the loopback bucket,
  never Public
- RFC1918 / CGNAT / benchmarking boundaries hold in both directions
  (172.31 vs 172.32, 100.127 vs 100.128, 198.19 vs 198.20)
- IPv6 unique-local addresses are Private, multicast and `::` are Loopback,
  a real public v6 address stays Public
- metadata host-name blocking is case-insensitive and exact-host only
  (`metadata.evil.internal`, `my-metadata` pass)
- a scheme-valid URL with no host is refused

## Testing

Ran cargo test locally on Windows (13 net tests green).

- [ ] `pnpm lint` / check-types / test - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean
- [ ] (If you touched `src-tauri/`) clippy: no new warnings from this branch (pre-existing lib.rs warning tracked in #1179)
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions. Branched just before the `.github/workflows`
  dependabot bump for the usual workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for IPv4 and IPv6 address classification.
  * Added validation for private-range boundaries and blocked-host matching.
  * Added tests to ensure URLs without hosts are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->