### PR TITLE
test(lsp): harden frame codec edges

### DIFF
--- a/src-tauri/src/modules/lsp/framing.rs
+++ b/src-tauri/src/modules/lsp/framing.rs
@@ -240,4 +240,48 @@ mod tests {
             vec![r#"{"first":1}"#.to_string(), r#"{"second":2}"#.to_string()]
         );
     }
+
+    #[test]
+    fn encode_frame_emits_exact_wire_bytes() {
+        let payload = r#"{"jsonrpc":"2.0"}"#;
+        assert_eq!(
+            encode_frame(payload),
+            format!("Content-Length: {}\r\n\r\n{}", payload.len(), payload).into_bytes()
+        );
+    }
+
+    #[test]
+    fn lf_only_headers_do_not_terminate_a_frame() {
+        let mut d = FrameDecoder::default();
+        let raw = b"Content-Length: 2\n\n{\"a\":1}".to_vec();
+        assert!(d.push(&raw).unwrap().is_empty());
+    }
+
+    #[test]
+    fn short_body_waits_silently_for_the_announced_length() {
+        let mut d = FrameDecoder::default();
+        let full = frame(r#"{"abc":1}"#);
+        let cut = full.len() - 3;
+        assert!(d.push(&full[..cut]).unwrap().is_empty());
+        assert_eq!(
+            d.push(&full[cut..]).unwrap(),
+            vec![r#"{"abc":1}"#.to_string()]
+        );
+    }
+
+    #[test]
+    fn decoder_stays_erroring_after_a_malformed_header_block() {
+        let mut d = FrameDecoder::default();
+        let bad = b"Content-Length: notanumber\r\n\r\n{}".to_vec();
+        assert_eq!(
+            d.push(&bad),
+            Err(FramingError::InvalidContentLength("notanumber".into()))
+        );
+        // The same bytes fed again (e.g. after a reconnect reusing the struct)
+        // must fail the same way rather than panic or half-parse.
+        assert_eq!(
+            d.push(&bad),
+            Err(FramingError::InvalidContentLength("notanumber".into()))
+        );
+    }
 }


### PR DESCRIPTION
﻿## What

Adds four edge tests to the LSP Content-Length frame codec. Test-only: no
production files are touched.

## Why

The decoder is the only thing between a language server's raw stdout and the
webview protocol layer. Round-trips, splits, and error variants were covered;
the strictness choices (CRLF-only terminator, silent wait for short bodies,
repeat-error behavior) were not, and each is a decision worth locking.

## How

Plain assertions against `FrameDecoder` / `encode_frame` inside the existing
test module.

Locked behavior:

- `encode_frame` emits exactly `Content-Length: N\r\n\r\n` + payload bytes
- LF-only header blocks do not terminate or error; the decoder keeps waiting
  for the CRLF CRLF terminator
- an announced body shorter than the buffer waits silently and completes
  when the remaining bytes arrive
- after a malformed Content-Length the decoder errors again on re-feed of
  the same bytes instead of panicking or half-parsing

## Testing

Ran cargo test locally on Windows (16 framing tests green).

- [ ] `pnpm lint` / check-types / test - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean
- [ ] (If you touched `src-tauri/`) clippy: no new warnings from this branch (pre-existing lib.rs warning tracked in #1179)
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions. Branched just before the `.github/workflows`
  dependabot bump for the usual workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for exact message framing and strict header termination.
  * Added tests for buffering incomplete message bodies.
  * Added tests confirming malformed headers consistently return errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->