### PR TITLE
test(editor): cover formatter execution and minimal diffing

### DIFF
--- a/src/modules/editor/lib/externalFormat.test.ts
+++ b/src/modules/editor/lib/externalFormat.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { resolveFormatter } from "./externalFormat";
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const core = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => core);
+
+vi.mock("@/modules/workspace", () => ({
+  currentWorkspaceEnv: () => "local",
+}));
+
+import {
+  applyFormattedContent,
+  readFileText,
+  resolveFormatter,
+  runExternalFormatter,
+} from "./externalFormat";
 
 const prefs = (
   global: Parameters<typeof resolveFormatter>[1]["editorFormatter"],
@@ -25,5 +41,170 @@ describe("resolveFormatter", () => {
 
   it("unknown language falls back to lsp for external globals", () => {
     expect(resolveFormatter(null, prefs("biome"))).toBe("lsp");
+  });
+});
+
+describe("runExternalFormatter", () => {
+  beforeEach(() => {
+    core.invoke.mockReset();
+  });
+
+  it("builds the tool command and runs it in the file's directory", async () => {
+    core.invoke.mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exit_code: 0,
+      timed_out: false,
+    });
+
+    await expect(runExternalFormatter("rustfmt", "/repo/src/a.rs")).resolves.toBeNull();
+
+    expect(core.invoke).toHaveBeenCalledWith(
+      "shell_run_command",
+      expect.objectContaining({
+        command: "rustfmt --edition 2021 '/repo/src/a.rs'",
+        cwd: "/repo/src",
+        timeoutSecs: 20,
+        workspace: "local",
+      }),
+    );
+  });
+
+  it("reports a timeout and a failing stderr tail", async () => {
+    core.invoke.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      exit_code: null,
+      timed_out: true,
+    });
+    await expect(runExternalFormatter("biome", "/a.ts")).resolves.toBe(
+      "biome timed out",
+    );
+
+    core.invoke.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "x".repeat(400),
+      exit_code: 1,
+      timed_out: false,
+    });
+    const err = await runExternalFormatter("biome", "/a.ts");
+    expect(err).toBe("x".repeat(300));
+  });
+
+  it("falls back to a generic failure when stderr is empty", async () => {
+    core.invoke.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "  ",
+      exit_code: 2,
+      timed_out: false,
+    });
+
+    await expect(runExternalFormatter("gofmt", "/a.go")).resolves.toBe(
+      "gofmt failed",
+    );
+  });
+
+  it("refuses custom formatting without a configured template", async () => {
+    await expect(runExternalFormatter("custom", "/a.ts", "   ")).resolves.toBe(
+      "No custom format command configured in Settings.",
+    );
+    expect(core.invoke).not.toHaveBeenCalled();
+  });
+
+  it("substitutes {file} in custom templates or appends the path", async () => {
+    core.invoke.mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exit_code: 0,
+      timed_out: false,
+    });
+
+    await runExternalFormatter("custom", "/dir/my file.ts", "prettier --write {file}");
+    expect(core.invoke).toHaveBeenLastCalledWith(
+      "shell_run_command",
+      expect.objectContaining({ command: "prettier --write '/dir/my file.ts'" }),
+    );
+
+    await runExternalFormatter("custom", "/dir/b.ts", "npx fmt");
+    expect(core.invoke).toHaveBeenLastCalledWith(
+      "shell_run_command",
+      expect.objectContaining({ command: "npx fmt '/dir/b.ts'" }),
+    );
+  });
+
+  it("stringifies backend failures", async () => {
+    core.invoke.mockRejectedValueOnce(new Error("spawn gone"));
+
+    await expect(runExternalFormatter("shfmt", "/a.sh")).resolves.toBe(
+      "Error: spawn gone",
+    );
+  });
+});
+
+describe("readFileText", () => {
+  beforeEach(() => {
+    core.invoke.mockReset();
+  });
+
+  it("returns text and mtime for text reads", async () => {
+    core.invoke.mockResolvedValueOnce({
+      kind: "text",
+      content: "body",
+      mtime: 123,
+    });
+
+    await expect(readFileText("/a.ts")).resolves.toEqual({
+      text: "body",
+      mtime: 123,
+    });
+  });
+
+  it("maps binary, missing-content, and failed reads to null", async () => {
+    core.invoke.mockResolvedValueOnce({ kind: "binary" });
+    await expect(readFileText("/a.png")).resolves.toBeNull();
+
+    core.invoke.mockResolvedValueOnce({ kind: "text", content: null });
+    await expect(readFileText("/a.ts")).resolves.toBeNull();
+
+    core.invoke.mockRejectedValueOnce(new Error("denied"));
+    await expect(readFileText("/etc/shadow")).resolves.toBeNull();
+  });
+});
+
+describe("applyFormattedContent", () => {
+  function fakeView(current: string) {
+    return {
+      state: { doc: { toString: () => current } },
+      dispatch: vi.fn(),
+    };
+  }
+
+  it("does nothing when content is unchanged", () => {
+    const view = fakeView("same");
+    applyFormattedContent(view as never, "same");
+    expect(view.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches only the changed middle span, keeping both ends intact", () => {
+    const view = fakeView("hello world");
+    applyFormattedContent(view as never, "hello brave world");
+
+    expect(view.dispatch).toHaveBeenCalledWith({
+      changes: { from: 6, to: 6, insert: "brave " },
+    });
+  });
+
+  it("handles pure appends and pure deletions", () => {
+    const appendView = fakeView("ab");
+    applyFormattedContent(appendView as never, "abc");
+    expect(appendView.dispatch).toHaveBeenCalledWith({
+      changes: { from: 2, to: 2, insert: "c" },
+    });
+
+    const deleteView = fakeView("abc");
+    applyFormattedContent(deleteView as never, "ac");
+    expect(deleteView.dispatch).toHaveBeenCalledWith({
+      changes: { from: 1, to: 2, insert: "" },
+    });
   });
 });


### PR DESCRIPTION
﻿## What

Extends `editor/lib/externalFormat` tests from resolver-only coverage to the
run paths: command construction, backend failure mapping, file reads, and the
minimal-change dispatcher. Test-only: no production files are touched.

## Why

Format-on-save pipes user files through `shell_run_command` with a built
command line and then splices the result back into the CodeMirror buffer.
Neither the command shapes (quoting, custom templates, cwd) nor the
prefix/suffix diffing that keeps the cursor stable had any test.

## How

Mocks `invoke` and the workspace env; `applyFormattedContent` runs against a
fake view recording dispatch calls.

Locked behavior:

- known formatters build `<command> '<path>'` with shell-safe quoting, run in
  the file's directory with a 20s budget
- timeouts, non-zero exits (stderr tail capped at 300 chars, generic
  fallback), and invoke rejections map to error strings
- custom formatting without a template is refused before any process runs;
  `{file}` placeholders substitute, absent ones append
- `readFileText` maps text reads to `{text, mtime}` (mtime defaults to 0) and
  binary/missing/failed reads to null
- `applyFormattedContent` no-ops on identical content and dispatches only the
  trimmed middle span for insertions, deletions, and middle edits

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.
