### PR TITLE
test(terminal): cover pane tree transforms

### DIFF
--- a/src/modules/terminal/lib/paneTree.test.ts
+++ b/src/modules/terminal/lib/paneTree.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  findLeafCwd,
+  firstLeafSlotId,
+  leafIds,
+  nextLeafId,
+  removeLeaf,
+  setLeafCwd,
+  siblingLeafOf,
+  splitLeaf,
+  type PaneNode,
+} from "./panes";
+
+function row(...children: PaneNode[]): PaneNode {
+  return { kind: "split", id: 100 + children.length, dir: "row", children };
+}
+
+const leafA: PaneNode = { kind: "leaf", id: 1, slotId: 11, cwd: "/a" };
+const leafB: PaneNode = { kind: "leaf", id: 2, cwd: "/b" };
+
+describe("splitLeaf", () => {
+  it("appends as a sibling when the enclosing split already runs that way", () => {
+    const tree = row(leafA, leafB);
+    const out = splitLeaf(tree, 1, 50, 3, "row");
+
+    expect(leafIds(out)).toEqual([1, 3, 2]);
+    expect(out).toMatchObject({ kind: "split" });
+  });
+
+  it("creates a nested perpendicular split otherwise", () => {
+    const tree = row(leafA, leafB);
+    const out = splitLeaf(tree, 1, 50, 3, "col");
+    expect(out.kind).toBe("split");
+
+    const first = (out as Extract<PaneNode, { kind: "split" }>).children[0];
+    expect(first).toEqual({
+      kind: "split",
+      id: 50,
+      dir: "col",
+      children: [leafA, { kind: "leaf", id: 3 }],
+    });
+  });
+
+  it("carries the new leaf's cwd and leaves other branches untouched", () => {
+    const tree: PaneNode = {
+      kind: "split",
+      id: 9,
+      dir: "col",
+      children: [leafA, row(leafB, { kind: "leaf", id: 4 })],
+    };
+    const out = splitLeaf(tree, 2, 50, 5, "row", "/new");
+
+    expect(findLeafCwd(out, 5)).toBe("/new");
+    expect(findLeafCwd(out, 1)).toBe("/a");
+  });
+});
+
+describe("removeLeaf", () => {
+  it("collapses single-child splits left behind", () => {
+    const tree: PaneNode = {
+      kind: "split",
+      id: 9,
+      dir: "col",
+      children: [leafA, row(leafB)],
+    };
+
+    const out = removeLeaf(tree, 2);
+
+    expect(out).toBe(leafA);
+  });
+
+  it("returns null when the last leaf is removed", () => {
+    expect(removeLeaf(leafA, 1)).toBeNull();
+    expect(removeLeaf(row(leafA, leafB), 1)).toEqual(leafB);
+  });
+});
+
+describe("nextLeafId", () => {
+  it("wraps at both ends of the tree", () => {
+    const tree = row(leafA, leafB);
+    expect(nextLeafId(tree, 1, 1)).toBe(2);
+    expect(nextLeafId(tree, 2, 1)).toBe(1);
+    expect(nextLeafId(tree, 1, -1)).toBe(2);
+  });
+
+  it("falls back to the first leaf for unknown or empty trees", () => {
+    expect(nextLeafId(row(leafA, leafB), 99, 1)).toBe(1);
+    expect(nextLeafId(leafA, 1, 1)).toBe(1);
+  });
+});
+
+describe("siblingLeafOf", () => {
+  it("prefers the next sibling then the previous one", () => {
+    const tree = row(leafA, leafB, { kind: "leaf", id: 3 });
+    expect(siblingLeafOf(tree, 1)).toBe(2);
+    expect(siblingLeafOf(tree, 3)).toBe(2);
+  });
+
+  it("descends into nested splits for the closest neighbor", () => {
+    const tree: PaneNode = {
+      kind: "split",
+      id: 9,
+      dir: "col",
+      children: [leafA, row(leafB, { kind: "leaf", id: 4 })],
+    };
+    expect(siblingLeafOf(tree, 2)).toBe(4);
+    expect(siblingLeafOf(tree, 1)).toBe(2);
+  });
+});
+
+describe("cwd helpers", () => {
+  it("finds a leaf cwd anywhere in the tree", () => {
+    const tree: PaneNode = {
+      kind: "split",
+      id: 9,
+      dir: "row",
+      children: [leafA, leafB],
+    };
+    expect(findLeafCwd(tree, 2)).toBe("/b");
+    expect(findLeafCwd(tree, 42)).toBeUndefined();
+  });
+
+  it("updates the matching leaf only and preserves identity elsewhere", () => {
+    const tree = row(leafA, leafB);
+    const out = setLeafCwd(tree, 1, "/changed");
+
+    expect(findLeafCwd(out, 1)).toBe("/changed");
+    expect((out as Extract<PaneNode, { kind: "split" }>).children[1]).toBe(leafB);
+  });
+
+  it("returns the same node when nothing changes", () => {
+    expect(setLeafCwd(leafA, 1, "/a")).toBe(leafA);
+    expect(setLeafCwd(leafA, 99, "/x")).toBe(leafA);
+  });
+});
+
+describe("firstLeafSlotId", () => {
+  it("prefers an explicit slotId over the leaf id", () => {
+    expect(firstLeafSlotId(row({ kind: "leaf", id: 7 }, leafA))).toBe(7);
+    expect(firstLeafSlotId(row(leafA, leafB))).toBe(11);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the terminal pane-tree transforms in
`terminal/lib/panes`: splitting, removal with collapse, focus walking, and
cwd helpers. Test-only: no production files are touched.

## Why

The existing suite covers `swapLeafInDirection` thoroughly, but the tree
rewriting underneath it (`splitLeaf`, `removeLeaf`, `siblingLeafOf`) decides
where new terminals land and where focus goes when one closes - regressions
there reshape user layouts.

## How

Plain characterization tests over small hand-built trees.

Locked behavior:

- `splitLeaf` appends as a sibling inside an already-aligned split (keeping
  the tree shallow), and creates a nested perpendicular split otherwise,
  carrying the new leaf's cwd
- `removeLeaf` collapses single-child splits left behind and returns null
  when the last leaf goes
- `nextLeafId` wraps at both ends and falls back to the first leaf for
  unknown ids or empty trees
- `siblingLeafOf` prefers the next sibling then the previous, descending into
  nested splits and returning that subtree's first leaf
- `setLeafCwd` updates only the matching leaf, returns the same node when
  nothing changes, and preserves sibling identity
- `firstLeafSlotId` prefers an explicit slotId

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.
