### PR TITLE
test(pty): cover the common shell environment

### DIFF
--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -1121,6 +1121,28 @@ mod tests {
     }
 
     #[test]
+    fn common_env_sets_terminal_basics_without_control_context() {
+        let mut command = CommandBuilder::new("shell");
+        apply_common(&mut command, None, false, None);
+
+        assert_eq!(command.get_env("TERM"), Some(OsStr::new("xterm-256color")));
+        assert_eq!(command.get_env("COLORTERM"), Some(OsStr::new("truecolor")));
+        assert_eq!(command.get_env("TERAX_TERMINAL"), Some(OsStr::new("1")));
+        assert_eq!(command.get_env("TERAX_BLOCKS"), None);
+        assert_eq!(command.get_env("TERAX_CONTROL_ADDR"), None);
+        assert_eq!(command.get_env("TERAX_CONTROL_TOKEN"), None);
+        assert_eq!(command.get_env("TERAX_PANE_ID"), None);
+    }
+
+    #[test]
+    fn blocks_mode_is_opt_in() {
+        let mut command = CommandBuilder::new("shell");
+        apply_common(&mut command, None, true, None);
+
+        assert_eq!(command.get_env("TERAX_BLOCKS"), Some(OsStr::new("1")));
+    }
+
+    #[test]
     fn common_env_includes_authenticated_caller_context() {
         let mut command = CommandBuilder::new("shell");
         let control = ShellControlEnv {


### PR DESCRIPTION
﻿## What

Adds two tests for `apply_common` in `pty/shell_init.rs`, covering the base
terminal environment injected into every spawned shell. Test-only: no
production files are touched.

## Why

`TERM`/`COLORTERM`/`TERAX_TERMINAL` are what shell integration scripts and
CLI agents key off to detect they run inside Terax, and `TERAX_BLOCKS` is a
deliberate opt-in. The authenticated control-env path was tested; the plain
path was not.

## How

Plain assertions against a `CommandBuilder` inside the existing test module.

Locked behavior:

- the basics (`xterm-256color`, truecolor, `TERAX_TERMINAL=1`) are always set
- no control address/token/pane id leak when no control env is passed
- block mode sets `TERAX_BLOCKS=1` only when requested

## Testing

Ran cargo test locally on Windows (11 shell_init tests green).

- [ ] `pnpm lint` / check-types / test - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean
- [ ] (If you touched `src-tauri/`) clippy: no new warnings from this branch (pre-existing lib.rs warning tracked in #1179)
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions. Branched just before the `.github/workflows`
  dependabot bump for the usual workflow-scope reason.
