### PR TITLE
test(theme): cover the custom theme store

### DIFF
--- a/src/modules/theme/customThemes.test.ts
+++ b/src/modules/theme/customThemes.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const pluginStore = vi.hoisted(() => {
+  const instances: {
+    data: Map<string, unknown>;
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+    onChange: ReturnType<typeof vi.fn>;
+  }[] = [];
+  class LazyStore {
+    data = new Map<string, unknown>();
+    get = vi.fn(async (key: string) => this.data.get(key));
+    set = vi.fn(async (key: string, value: unknown) => {
+      this.data.set(key, value);
+    });
+    save = vi.fn(async () => undefined);
+    onChange = vi.fn(async () => () => undefined);
+    constructor() {
+      instances.push(this);
+    }
+  }
+  return { instances, LazyStore };
+});
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  LazyStore: pluginStore.LazyStore,
+}));
+
+const events = vi.hoisted(() => ({
+  listen: vi.fn(async () => () => undefined),
+  emit: vi.fn(async () => undefined),
+}));
+
+vi.mock("@tauri-apps/api/event", () => events);
+
+import type { Theme } from "./types";
+
+function theme(id: string): Theme {
+  return {
+    id,
+    name: id,
+    author: "",
+    description: "",
+    variants: {},
+  };
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return await import("./customThemes");
+}
+
+describe("custom theme store", () => {
+  beforeEach(() => {
+    pluginStore.instances.length = 0;
+    events.emit.mockClear();
+    events.listen.mockClear();
+  });
+
+  it("treats a missing or malformed store value as an empty list", async () => {
+    const mod = await loadModule();
+
+    await expect(mod.listCustomThemes()).resolves.toEqual([]);
+
+    const store = pluginStore.instances[0];
+    store.data.set("themes", "not-an-array");
+    await expect(mod.listCustomThemes()).resolves.toEqual([]);
+  });
+
+  it("upserts by id: appends unknown ids and replaces known ones", async () => {
+    const mod = await loadModule();
+
+    await mod.saveCustomTheme(theme("a"));
+    await mod.saveCustomTheme(theme("b"));
+    await mod.saveCustomTheme(theme("a"));
+
+    const store = pluginStore.instances[0];
+    const stored = store.data.get("themes") as Theme[];
+    expect(stored.map((t) => t.id)).toEqual(["b", "a"]);
+    expect(store.save).toHaveBeenCalledTimes(3);
+    expect(events.emit).toHaveBeenCalledWith("terax://custom-themes-changed");
+  });
+
+  it("delete is a no-op when the id does not exist", async () => {
+    const mod = await loadModule();
+    await mod.saveCustomTheme(theme("a"));
+    events.emit.mockClear();
+    const store = pluginStore.instances[0];
+    store.set.mockClear();
+    store.save.mockClear();
+
+    await mod.deleteCustomTheme("missing");
+
+    expect(store.set).not.toHaveBeenCalled();
+    expect(store.save).not.toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalled();
+  });
+
+  it("delete removes only the target theme and persists", async () => {
+    const mod = await loadModule();
+    await mod.saveCustomTheme(theme("a"));
+    await mod.saveCustomTheme(theme("b"));
+
+    await mod.deleteCustomTheme("a");
+
+    const store = pluginStore.instances[0];
+    const stored = store.data.get("themes") as Theme[];
+    expect(stored.map((t) => t.id)).toEqual(["b"]);
+    expect(events.emit).toHaveBeenCalledWith("terax://custom-themes-changed");
+  });
+
+  it("subscribes to store-key changes and cross-window events once", async () => {
+    const mod = await loadModule();
+    const cb = vi.fn();
+
+    const unlisten = await mod.onCustomThemesChange(cb);
+
+    const store = pluginStore.instances[0];
+    const keyHandler = store.onChange.mock.calls[0][0] as (k: string) => void;
+    keyHandler("themes");
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    keyHandler("other");
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    unlisten();
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the custom theme store in `theme/customThemes`. Test-only:
no production files are touched.

## Why

Custom themes persist through this store and sync across windows via a change
event. The upsert-by-id semantics, the delete no-op contract (no write, no
save, no broadcast when nothing matched), and the dual store-key/event
subscription were untested.

## How

Mocks `@tauri-apps/plugin-store` with an in-memory `LazyStore` recording
calls, plus the event API; module reloaded per test because the store is a
module singleton.

Locked behavior:

- missing or non-array stored values read as an empty list
- save appends unknown ids, replaces known ones in place, persists through
  set + save, and emits the change event
- deleting an absent id performs no write/save/emit at all
- deleting an existing id removes only it and broadcasts
- `onCustomThemesChange` reacts to the themes key specifically (not other
  keys) and to cross-window events, with a combined unsubscriber

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.
