### PR TITLE
docs: align Node prerequisite with the engines field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ pnpm install
 pnpm tauri dev
 ```
 
-Prereqs: Rust (stable), Node 20+, pnpm, plus your platform's [Tauri prerequisites](https://tauri.app/start/prerequisites/).
+Prereqs: Rust (stable), Node 22+, pnpm, plus your platform's [Tauri prerequisites](https://tauri.app/start/prerequisites/).
 
 For the architecture and how to contribute safely, see [TERAX.md](TERAX.md) and the [docs/ index](docs/README.md).
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Latest installers are on the [Releases](https://github.com/crynta/terax-ai/relea
 
 **Prerequisites**
 - Rust (stable), https://rustup.rs
-- Node 20+ and [pnpm](https://pnpm.io)
+- Node 22+ and [pnpm](https://pnpm.io)
 - Tauri prerequisites for your platform, https://tauri.app/start/prerequisites/
 
 **Run**

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -138,7 +138,7 @@ Die neuesten Installationspakete stehen auf der Seite [Releases](https://github.
 **Voraussetzungen**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ und [pnpm](https://pnpm.io)
+- Node 22+ und [pnpm](https://pnpm.io)
 - Tauri-Voraussetzungen für deine Plattform, https://tauri.app/start/prerequisites/
 
 **Ausführen**

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -138,7 +138,7 @@ Los instaladores más recientes están en la página de [Releases](https://githu
 **Requisitos previos**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ y [pnpm](https://pnpm.io)
+- Node 22+ y [pnpm](https://pnpm.io)
 - Requisitos previos de Tauri para tu plataforma, https://tauri.app/start/prerequisites/
 
 **Ejecutar**

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -114,7 +114,7 @@ Les installateurs récents sont disponibles sur la page [Releases](https://githu
 **Prérequis**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ et [pnpm](https://pnpm.io)
+- Node 22+ et [pnpm](https://pnpm.io)
 - Prérequis Tauri pour votre plateforme, https://tauri.app/start/prerequisites/
 
 **Exécution**

--- a/docs/readme/README.hi.md
+++ b/docs/readme/README.hi.md
@@ -114,7 +114,7 @@ Terax एक हल्का, ओपन-सोर्स, टर्मिनल-�
 **आवश्यकताएँ**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ और [pnpm](https://pnpm.io)
+- Node 22+ और [pnpm](https://pnpm.io)
 - आपके प्लेटफ़ॉर्म के लिए Tauri आवश्यकताएँ, https://tauri.app/start/prerequisites/
 
 **चलाएँ**

--- a/docs/readme/README.id.md
+++ b/docs/readme/README.id.md
@@ -114,7 +114,7 @@ Penginstal terbaru tersedia di halaman [Releases](https://github.com/crynta/tera
 **Prasyarat**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ dan [pnpm](https://pnpm.io)
+- Node 22+ dan [pnpm](https://pnpm.io)
 - Prasyarat Tauri untuk platform Anda, https://tauri.app/start/prerequisites/
 
 **Jalankan**

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -114,7 +114,7 @@ Terax は、Tauri 2 + Rust と React 19 で構築された、軽量かつオー�
 **前提条件**
 
 - Rust（stable）、https://rustup.rs
-- Node 20+ と [pnpm](https://pnpm.io)
+- Node 22+ と [pnpm](https://pnpm.io)
 - プラットフォームごとの Tauri 前提条件、https://tauri.app/start/prerequisites/
 
 **実行**

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -114,7 +114,7 @@ Terax는 Tauri 2 + Rust와 React 19로 만든 가볍고 오픈 소스이며 터�
 **필수 항목**
 
 - Rust(stable), https://rustup.rs
-- Node 20+와 [pnpm](https://pnpm.io)
+- Node 22+와 [pnpm](https://pnpm.io)
 - 플랫폼별 Tauri 필수 항목, https://tauri.app/start/prerequisites/
 
 **실행**

--- a/docs/readme/README.pl.md
+++ b/docs/readme/README.pl.md
@@ -114,7 +114,7 @@ Najnowsze instalatory znajdują się na stronie [Releases](https://github.com/cr
 **Wymagania**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ i [pnpm](https://pnpm.io)
+- Node 22+ i [pnpm](https://pnpm.io)
 - Wymagania Tauri dla platformy, https://tauri.app/start/prerequisites/
 
 **Uruchamianie**

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -114,7 +114,7 @@ Os instaladores mais recentes estão na página de [Releases](https://github.com
 **Pré-requisitos**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ e [pnpm](https://pnpm.io)
+- Node 22+ e [pnpm](https://pnpm.io)
 - Pré-requisitos do Tauri para sua plataforma, https://tauri.app/start/prerequisites/
 
 **Executar**

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -114,7 +114,7 @@ Terax представляет собой легковесную среду ра
 **Требования**
 
 - Rust (stable), https://rustup.rs
-- Node 20+ и [pnpm](https://pnpm.io)
+- Node 22+ и [pnpm](https://pnpm.io)
 - Требования Tauri для вашей платформы, https://tauri.app/start/prerequisites/
 
 **Запуск**

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -140,7 +140,7 @@ Terax 是一个轻量、开源、终端优先的 AI 原生开发环境（ADE）�
 **前置要求**
 
 - Rust（stable），https://rustup.rs
-- Node 20+ 和 [pnpm](https://pnpm.io)
+- Node 22+ 和 [pnpm](https://pnpm.io)
 - 适用于你平台的 Tauri 前置要求，https://tauri.app/start/prerequisites/
 
 **运行**


### PR DESCRIPTION
﻿## What

Updates the "Build from source" prerequisite in the root README and all eleven
translations from Node 20+ to Node 22+, matching the `engines` requirement
that `package.json` has enforced all along (`"node": ">=22"`).

## Why

Following the documented prerequisite on a fresh machine installs Node 20,
and `pnpm install` then refuses to run with an engine-mismatch error. One
line per language file, nothing else touched.

## How

Byte-level text replacement of the `Node 20+` token only; line endings and
encodings of each file are untouched.

## Testing

- [x] Verified `"node": ">=22"` in `package.json` against every updated line
- [ ] `pnpm lint` / check-types / test - N/A, docs only
- [ ] Manual smoke-test - N/A, docs only
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [ ] Platforms tested: N/A, docs only
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Docs-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build prerequisites to require Node.js 22 or newer instead of Node.js 20 or newer.
  * Synchronized this requirement across the contributing guide and localized documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->