### PR TITLE
test(ai): lock model catalog tables and cost estimation

### DIFF
--- a/src/modules/ai/config.test.ts
+++ b/src/modules/ai/config.test.ts
@@ -1,13 +1,16 @@
-import { describe, expect, it } from "vitest";
+﻿import { describe, expect, it } from "vitest";
 import {
   compatModelIdForEndpoint,
   endpointIdFromCompatModel,
+  estimateCost,
   getModelContextLimit,
   isCompatModelId,
   migrateLegacyCompatEndpoint,
   modelKeepsReasoning,
   modelSupportsTemperature,
   modelUsesReasoningTokens,
+  MODELS,
+  MODEL_CONTEXT_LIMITS,
   MODEL_PRICING,
   resolveModel,
   type CustomEndpoint,
@@ -170,5 +173,56 @@ describe("migrateLegacyCompatEndpoint", () => {
   it("skips migration when base URL or model id is missing", () => {
     expect(migrateLegacyCompatEndpoint("", "m", 1, "x")).toEqual([]);
     expect(migrateLegacyCompatEndpoint("u", "  ", 1, "x")).toEqual([]);
+  });
+});
+
+describe("model catalog invariants", () => {
+  const allIds: string[] = MODELS.map((m) => m.id);
+
+  it("keeps the context-limit table free of stale catalog ids", () => {
+    const stale = Object.keys(MODEL_CONTEXT_LIMITS).filter(
+      (id) => !allIds.includes(id),
+    );
+    expect(stale).toEqual([]);
+  });
+
+  it("keeps the pricing table free of stale catalog ids", () => {
+    const stale = Object.keys(MODEL_PRICING).filter(
+      (id) => !allIds.includes(id),
+    );
+    expect(stale).toEqual([]);
+  });
+});
+
+describe("estimateCost", () => {
+  const usage = {
+    inputTokens: 2_000_000,
+    outputTokens: 1_000_000,
+    cachedInputTokens: 500_000,
+  };
+
+  it("returns null without a model id or a priced model", () => {
+    expect(estimateCost(undefined, usage)).toBeNull();
+    expect(
+      estimateCost("unknown-model", {
+        inputTokens: 1,
+        outputTokens: 1,
+        cachedInputTokens: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("charges fresh tokens at input price and cached tokens at cache price", () => {
+    expect(estimateCost("gpt-5.6", usage)).toBeCloseTo(37.75, 6);
+  });
+
+  it("falls back to the input price when a model has no cache-read rate", () => {
+    const grok = { inputTokens: 1_000_000, outputTokens: 0, cachedInputTokens: 400_000 };
+    expect(estimateCost("grok-4.20-reasoning", grok)).toBeCloseTo(3, 6);
+  });
+
+  it("never charges negative fresh tokens when cache exceeds input", () => {
+    const over = { inputTokens: 100, outputTokens: 0, cachedInputTokens: 900 };
+    expect(estimateCost("gpt-5.6", over)).toBeGreaterThanOrEqual(0);
   });
 });


### PR DESCRIPTION
﻿## What

Adds catalog-drift and cost-estimation tests to `ai/config`. Test-only: no
production files are touched.

## Why

`MODEL_CONTEXT_LIMITS`, `MODEL_PRICING`, and the `MODELS` catalog are three
hand-maintained tables that must stay in sync across model renames; the
existing tests sample individual ids but nothing caught a renamed model
leaving a stale pricing entry behind. `estimateCost` (the usage-to-dollars
math shown in the UI) was also unlocked, including its cached-token
discounting.

## How

Cross-table membership assertions plus arithmetic assertions against
`estimateCost`.

Locked behavior:

- no context-limit or pricing entry references a model id that has left the
  catalog
- unknown or missing ids price to null rather than guessing
- fresh tokens bill at input price, cached tokens at the cache-read rate,
  falling back to the input rate when a model defines none
- cache counts exceeding input never produce a negative cost

## Reviewer flag

While writing this I checked the inverse invariants too. Two static catalog
ids have no explicit context-limit entry (`gpt-4.1-mini`,
`deepseek-reasoner`) and fall through to the 128k default, and a handful of
Groq-hosted open models are intentionally unpriced. The context-limit gap
looks like drift worth a follow-up, but asserting it here would fail CI on
what may be intended defaults - flagged instead of locked.

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.
