### PR TITLE
test(cli): cover endpoint protocol and address guards

### DIFF
--- a/src-tauri/crates/terax-cli/src/main.rs
+++ b/src-tauri/crates/terax-cli/src/main.rs
@@ -667,6 +667,30 @@ mod tests {
     }
 
     #[test]
+    fn endpoint_validation_rejects_a_protocol_mismatch() {
+        let descriptor = ControlDescriptor {
+            protocol: PROTOCOL_VERSION + 1,
+            address: "127.0.0.1:4312".into(),
+            token: "a".repeat(64),
+            pid: 1,
+            app_version: "test".into(),
+        };
+        let Err(error) = validate_endpoint(descriptor, false) else {
+            panic!("accepted foreign protocol");
+        };
+        assert_eq!(error.code, "unsupported_protocol");
+    }
+
+    #[test]
+    fn loopback_parsing_rejects_hostnames_and_remote_hosts() {
+        let error =
+            parse_loopback_address("localhost:4312").expect_err("reject hostname");
+        assert_eq!(error.code, "invalid_endpoint");
+        let error = parse_loopback_address("127.0.0.1").expect_err("reject missing port");
+        assert_eq!(error.code, "invalid_endpoint");
+    }
+
+    #[test]
     fn protocol_framing_round_trips_one_bounded_json_message() {
         let request = ControlRequest {
             protocol: PROTOCOL_VERSION,


### PR DESCRIPTION
﻿## What

Adds three guard tests to the `terax-cli` endpoint validation. Test-only: no
production files are touched.

## Why

The CLI refuses to talk to anything that is not a live, loopback,
protocol-matching Terax instance. The stale-process and token-format guards
were tested; the protocol-mismatch branch, hostname-as-address refusal, and
the missing-port parse failure were not.

## How

Plain assertions inside the existing test module.

Locked behavior:

- a descriptor advertising a foreign protocol version is rejected with
  `unsupported_protocol` before any connection attempt
- a hostname (`localhost:4312`) is not accepted in place of a numeric socket
  address
- an address without a port fails parsing with `invalid_endpoint`

## Testing

Ran cargo test locally on Windows (15 CLI tests green).

- [ ] `pnpm lint` / check-types / test - N/A, no frontend changes
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [x] (If you touched `src-tauri/`) `cargo test --locked` clean
- [ ] (If you touched `src-tauri/`) clippy: no new warnings from this branch (pre-existing lib.rs warning tracked in #1179)
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only additions. Branched just before the `.github/workflows`
  dependabot bump for the usual workflow-scope reason.
