### PR TITLE
docs(architecture): list get_launch_files command

### DIFF
--- a/docs/architecture/two-process-model.md
+++ b/docs/architecture/two-process-model.md
@@ -119,6 +119,7 @@ Three distinct surfaces:
 ### Settings window
 
 - `get_launch_dir` - CLI launch directory, drained on first read
+- get_launch_files - files opened at launch (CLI args or OS Open With), drained on first read
 - `open_settings_window` - open the separate settings webview (optional `tab` deep-link)
 
 ### CLI control plane


### PR DESCRIPTION
﻿## What

Adds the one missing IPC command to the architecture command reference:
`get_launch_files`, the sibling of the already-documented `get_launch_dir`.

## Why

An automated cross-check of all 83 `#[tauri::command]` functions against
`docs/` found exactly one absent from the reference. The two-process model
doc aims to be the complete IPC surface list, and CLI-launched files are part
of that surface.

## How

One line, inserted next to `get_launch_dir` with the matching phrasing.

## Testing

- [x] Cross-checked: every `#[tauri::command]` in `src-tauri/src` now appears
      somewhere under `docs/` (83/83)
- [ ] `pnpm lint` / check-types / test - N/A, docs only
- [ ] Manual smoke-test - N/A, docs only
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A
- [ ] (If you changed a `#[tauri::command]` signature) - N/A (signature untouched)
- [ ] (If UI) tested in `pnpm tauri dev` - N/A
- [ ] Platforms tested: N/A, docs only
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Docs-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings command to retrieve files opened at launch through command-line arguments or the operating system’s “Open With” option.
  * Launch files are available on the first read and then cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->