### PR TITLE
test(ai): cover the per-session todos store

### DIFF
--- a/src/modules/ai/store/todoStore.test.ts
+++ b/src/modules/ai/store/todoStore.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Todo } from "../lib/todos";
+
+const todos = vi.hoisted(() => {
+  const state = { data: new Map<string, Todo[]>() };
+  return {
+    state,
+    loadTodos: vi.fn(async (sessionId: string) => state.data.get(sessionId) ?? []),
+    saveTodos: vi.fn(async (sessionId: string, list: Todo[]) => {
+      state.data.set(sessionId, list);
+    }),
+    deleteTodos: vi.fn(async (sessionId: string) => {
+      state.data.delete(sessionId);
+    }),
+  };
+});
+
+vi.mock("../lib/todos", () => ({
+  get loadTodos() {
+    return todos.loadTodos;
+  },
+  get saveTodos() {
+    return todos.saveTodos;
+  },
+  get deleteTodos() {
+    return todos.deleteTodos;
+  },
+}));
+
+import { getTodos, useTodosStore } from "./todoStore";
+
+function todo(id: string, status: Todo["status"] = "pending"): Todo {
+  return { id, title: `task ${id}`, status };
+}
+
+function resetState() {
+  useTodosStore.setState({ bySession: {}, hydrated: new Set() });
+}
+
+describe("todos store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    todos.state.data.clear();
+    resetState();
+  });
+
+  it("hydrates a session once and caches the result", async () => {
+    todos.state.data.set("s1", [todo("t1")]);
+
+    await useTodosStore.getState().hydrate("s1");
+    await useTodosStore.getState().hydrate("s1");
+
+    expect(getTodos("s1")).toEqual([todo("t1")]);
+    expect(todos.loadTodos).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates sessions independently", async () => {
+    todos.state.data.set("s1", [todo("t1")]);
+
+    await useTodosStore.getState().hydrate("s2");
+
+    expect(getTodos("s1")).toEqual([]);
+    expect(getTodos("s2")).toEqual([]);
+
+    await useTodosStore.getState().hydrate("s1");
+    expect(getTodos("s1")).toEqual([todo("t1")]);
+  });
+
+  it("setTodos writes the session list and persists", () => {
+    const list = [todo("t1", "in_progress"), todo("t2")];
+
+    useTodosStore.getState().setTodos("s1", list);
+
+    expect(getTodos("s1")).toEqual(list);
+    expect(todos.saveTodos).toHaveBeenCalledWith("s1", list);
+  });
+
+  it("clearSession drops the cache entry, hydration flag, and storage", async () => {
+    useTodosStore.getState().setTodos("s1", [todo("t1")]);
+    await useTodosStore.getState().hydrate("s1");
+
+    await useTodosStore.getState().clearSession("s1");
+
+    expect(getTodos("s1")).toEqual([]);
+    expect(useTodosStore.getState().hydrated.has("s1")).toBe(false);
+    expect(todos.deleteTodos).toHaveBeenCalledWith("s1");
+  });
+
+  it("getTodos returns an empty list without a session id", () => {
+    expect(getTodos(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the per-session todos store in `ai/store/todoStore`.
Test-only: no production files are touched.

## Why

The todo tool tests (#1068) mock this store away, so the store's own
contracts - hydrate-once per session, persistence on write, full teardown on
clearSession - had no coverage of their own.

## How

Mocks `../lib/todos` with a real Map backing so reloads observe writes;
store state reset per test via `setState`.

Locked behavior:

- hydration loads once per session and caches; repeat calls skip the backend
- sessions hydrate independently
- `setTodos` writes the session list and persists it
- `clearSession` drops the cache entry, clears the hydration flag, and
  deletes persisted storage
- `getTodos` returns an empty list without a session id

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for todo data persistence and session behavior.
  * Verified session-specific caching, isolated data, list updates, session clearing, and empty results without a session identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->