### PR TITLE
test(ai): cover session persistence storage

### DIFF
--- a/src/modules/ai/lib/sessions.persistence.test.ts
+++ b/src/modules/ai/lib/sessions.persistence.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UIMessage } from "@ai-sdk/react";
+
+const pluginStore = vi.hoisted(() => {
+  const instances: {
+    data: Map<string, unknown>;
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    entries: ReturnType<typeof vi.fn>;
+  }[] = [];
+  class LazyStore {
+    data = new Map<string, unknown>();
+    get = vi.fn(async (key: string) => this.data.get(key));
+    set = vi.fn(async (key: string, value: unknown) => {
+      this.data.set(key, value);
+    });
+    delete = vi.fn(async (key: string) => {
+      this.data.delete(key);
+    });
+    entries = vi.fn(async () => [...this.data.entries()]);
+    constructor() {
+      instances.push(this);
+    }
+  }
+  return { instances, LazyStore };
+});
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  LazyStore: pluginStore.LazyStore,
+}));
+
+function store() {
+  return pluginStore.instances[pluginStore.instances.length - 1];
+}
+
+async function reload() {
+  vi.resetModules();
+  return await import("./sessions");
+}
+
+describe("session persistence", () => {
+  beforeEach(() => {
+    pluginStore.instances.length = 0;
+  });
+
+  it("reads sessions and active id, tolerating an empty store", async () => {
+    const mod = await reload();
+    await expect(mod.loadAll()).resolves.toEqual({
+      sessions: [],
+      activeId: null,
+    });
+
+    store().data.set("sessions", [
+      { id: "s-1", title: "T", createdAt: 1, updatedAt: 2 },
+    ]);
+    store().data.set("activeId", "s-1");
+
+    await expect(mod.loadAll()).resolves.toEqual({
+      sessions: [{ id: "s-1", title: "T", createdAt: 1, updatedAt: 2 }],
+      activeId: "s-1",
+    });
+  });
+
+  it("writes the session list and the active id under fixed keys", async () => {
+    const mod = await reload();
+    const metas = [{ id: "s-9", title: "X", createdAt: 0, updatedAt: 0 }];
+
+    await mod.saveSessionsList(metas);
+    expect(store().data.get("sessions")).toEqual(metas);
+
+    await mod.saveActiveId("s-9");
+    expect(store().data.get("activeId")).toBe("s-9");
+  });
+
+  it("namespaces per-session messages and returns null when missing", async () => {
+    const mod = await reload();
+    const messages = [{ id: "m1", role: "user", parts: [] }] as UIMessage[];
+
+    await expect(mod.loadMessages("s-1")).resolves.toBeNull();
+
+    await mod.saveMessages("s-1", messages);
+    expect(store().data.get("messages:s-1")).toEqual(messages);
+    await expect(mod.loadMessages("s-1")).resolves.toEqual(messages);
+  });
+
+  it("deletes only the targeted session's messages", async () => {
+    const mod = await reload();
+    await mod.saveMessages("s-1", [{ id: "a", role: "user", parts: [] }]);
+    await mod.saveMessages("s-2", [{ id: "b", role: "user", parts: [] }]);
+
+    await mod.deleteSessionData("s-1");
+
+    expect(store().data.has("messages:s-1")).toBe(false);
+    expect(store().data.has("messages:s-2")).toBe(true);
+  });
+
+  it("generates prefixed unique ids", async () => {
+    const mod = await reload();
+    const a = mod.newSessionId();
+    const b = mod.newSessionId();
+    expect(a.startsWith("s-")).toBe(true);
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the chat session persistence layer in `ai/lib/sessions`
(store reads/writes, message namespacing, id generation). Test-only: no
production files are touched.

## Why

Sessions survive relaunches through this layer; a key-name or namespacing
regression would silently lose every conversation. The deriveTitle selection
logic is covered separately (#1118); the storage half had nothing.

## How

Mocks `@tauri-apps/plugin-store` with an in-memory LazyStore recording calls.
File is named `sessions.persistence.test.ts` so it merges cleanly alongside
the deriveTitle suite from #1118 without colliding on the same filename.

Locked behavior:

- an empty store reads back as no sessions and no active id
- `sessions` / `activeId` round-trip under their fixed keys
- per-session messages live under `messages:<id>` and read back as null when
  absent
- `deleteSessionData` removes only the targeted session's messages
- generated ids are prefixed and unique

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage for AI session persistence.
  - Verified session loading and saving, active-session tracking, message storage, targeted deletion, empty-store handling, and unique session ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->