### PR TITLE
test(spaces): cover the persistence store

### DIFF
--- a/src/modules/spaces/lib/store.test.ts
+++ b/src/modules/spaces/lib/store.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SerializedTab } from "./serialize";
+import type { SpaceMeta, SpaceState } from "./store";
+
+const pluginStore = vi.hoisted(() => {
+  const instances: {
+    data: Map<string, unknown>;
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    entries: ReturnType<typeof vi.fn>;
+  }[] = [];
+  class LazyStore {
+    data = new Map<string, unknown>();
+    get = vi.fn(async (key: string) => this.data.get(key));
+    set = vi.fn(async (key: string, value: unknown) => {
+      this.data.set(key, value);
+    });
+    delete = vi.fn(async (key: string) => {
+      this.data.delete(key);
+    });
+    entries = vi.fn(async () => [...this.data.entries()]);
+    constructor() {
+      instances.push(this);
+    }
+  }
+  return { instances, LazyStore };
+});
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  LazyStore: pluginStore.LazyStore,
+}));
+
+vi.mock("@/modules/workspace", () => ({}));
+
+function store() {
+  return pluginStore.instances[pluginStore.instances.length - 1];
+}
+
+async function reload() {
+  vi.resetModules();
+  return await import("./store");
+}
+
+function meta(id: string): SpaceMeta {
+  return {
+    id,
+    name: `Space ${id}`,
+    root: `/repo/${id}`,
+    env: { kind: "local" } as SpaceMeta["env"],
+    createdAt: 1,
+    updatedAt: 2,
+  };
+}
+
+function state(): SpaceState {
+  return {
+    tabs: [{ id: "tab-1", kind: "terminal" } as unknown as SerializedTab],
+    activeTabIndex: 0,
+  };
+}
+
+describe("space persistence", () => {
+  beforeEach(() => {
+    pluginStore.instances.length = 0;
+  });
+
+  it("loadAll tolerates an empty store", async () => {
+    const mod = await reload();
+
+    await expect(mod.loadAll()).resolves.toEqual({
+      spaces: [],
+      activeId: null,
+      states: new Map(),
+    });
+  });
+
+  it("round-trips spaces, the active id, and per-space tab states", async () => {
+    const mod = await reload();
+    const spaces = [meta("a"), meta("b")];
+
+    await mod.saveSpacesList(spaces);
+    await mod.saveActiveId("b");
+    await mod.saveState("a", state());
+
+    const loaded = await mod.loadAll();
+
+    expect(loaded.spaces).toEqual(spaces);
+    expect(loaded.activeId).toBe("b");
+    expect(loaded.states.get("a")).toEqual(state());
+    expect(loaded.states.has("b")).toBe(false);
+  });
+
+  it("ignores foreign keys while parsing stored entries", async () => {
+    const mod = await reload();
+    await mod.saveSpacesList([meta("a")]);
+    store().data.set("unrelated", "keep-me");
+
+    const loaded = await mod.loadAll();
+
+    expect(loaded.spaces.map((s) => s.id)).toEqual(["a"]);
+    expect(store().data.get("unrelated")).toBe("keep-me");
+  });
+
+  it("deleteSpaceData removes only that space's state key", async () => {
+    const mod = await reload();
+    await mod.saveState("a", state());
+    await mod.saveState("b", state());
+
+    await mod.deleteSpaceData("a");
+
+    expect(store().data.has("state:a")).toBe(false);
+    expect(store().data.has("state:b")).toBe(true);
+  });
+
+  it("newSpaceId is prefixed and unique", async () => {
+    const mod = await reload();
+    const a = mod.newSpaceId();
+    const b = mod.newSpaceId();
+    expect(a.startsWith("sp-")).toBe(true);
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the spaces persistence store in `spaces/lib/store`.
Test-only: no production files are touched.

## Why

Spaces are the top-level unit users trust with their layout: names, roots,
environments, and per-space tab states. `loadAll` is what stands between a
relaunch and every tab coming back exactly where it was; it had no test.

## How

Mocks `@tauri-apps/plugin-store` with an in-memory LazyStore recording calls,
reloading the module per test since the store is a module singleton.

Locked behavior:

- an empty store reads back as no spaces, no active id, and no states
- spaces list, active id, and per-space tab state round-trip under their
  fixed keys (`spaces`, `activeId`, `state:<id>`)
- foreign keys in the store are ignored during parsing but preserved
- `deleteSpaceData` removes only the targeted space's state key
- generated ids are prefixed (`sp-`) and unique

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for space persistence and state management.
  * Verified loading empty stores, saving and restoring spaces, ignoring unrelated data, selective state deletion, and unique space ID generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->