### PR TITLE
test: cover platform detection and launch context

### DIFF
--- a/src/lib/launchDir.test.ts
+++ b/src/lib/launchDir.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const core = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => core);
+
+import { consumeLaunchFiles, getLaunchDir, initLaunchDir } from "./launchDir";
+
+describe("launch context", () => {
+  beforeEach(() => {
+    core.invoke.mockReset();
+  });
+
+  it("prefers the CLI launch dir and normalizes separators", async () => {
+    core.invoke.mockResolvedValueOnce("C:\\repo\\sub");
+
+    await initLaunchDir();
+
+    expect(getLaunchDir()).toBe("C:/repo/sub");
+    expect(core.invoke).toHaveBeenNthCalledWith(1, "get_launch_dir");
+    expect(core.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the workspace cwd when no CLI dir was passed", async () => {
+    core.invoke
+      .mockRejectedValueOnce(new Error("none"))
+      .mockResolvedValueOnce("/home/me/repo");
+
+    await initLaunchDir();
+
+    expect(getLaunchDir()).toBe("/home/me/repo");
+  });
+
+  it("caches an undefined dir when both probes fail", async () => {
+    core.invoke.mockRejectedValue(new Error("down"));
+
+    await initLaunchDir();
+
+    expect(getLaunchDir()).toBeUndefined();
+  });
+
+  it("normalizes opened file paths to forward slashes", async () => {
+    core.invoke.mockResolvedValueOnce([
+      "C:\\repo\\a.ts",
+      "/home/me/b.ts",
+      "already/clean.ts",
+    ]);
+
+    await expect(consumeLaunchFiles()).resolves.toEqual([
+      "C:/repo/a.ts",
+      "/home/me/b.ts",
+      "already/clean.ts",
+    ]);
+  });
+
+  it("returns an empty list when the backend probe fails", async () => {
+    core.invoke.mockRejectedValueOnce(new Error("no files"));
+
+    await expect(consumeLaunchFiles()).resolves.toEqual([]);
+  });
+});

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const osPlugin = vi.hoisted(() => ({
+  platform: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-os", () => ({ platform: osPlugin.platform }));
+
+async function loadWith(platformValue: string) {
+  vi.resetModules();
+  osPlugin.platform.mockReturnValue(platformValue as never);
+  return await import("./platform");
+}
+
+describe("platform detection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("flags macOS and keeps native window controls there", async () => {
+    const mod = await loadWith("macos");
+    expect(mod.IS_MAC).toBe(true);
+    expect(mod.IS_WINDOWS).toBe(false);
+    expect(mod.IS_LINUX).toBe(false);
+    expect(mod.USE_CUSTOM_WINDOW_CONTROLS).toBe(false);
+  });
+
+  it("renders custom window controls on windows and linux", async () => {
+    const win = await loadWith("windows");
+    expect(win.IS_WINDOWS).toBe(true);
+    expect(win.USE_CUSTOM_WINDOW_CONTROLS).toBe(true);
+
+    const linux = await loadWith("linux");
+    expect(linux.IS_LINUX).toBe(true);
+    expect(linux.USE_CUSTOM_WINDOW_CONTROLS).toBe(true);
+  });
+
+  it("treats an unknown platform as non-mac but without custom controls", async () => {
+    const mod = await loadWith("");
+    expect(mod.IS_MAC).toBe(false);
+    expect(mod.USE_CUSTOM_WINDOW_CONTROLS).toBe(false);
+  });
+
+  it("uses meta for the primary modifier on mac and ctrl elsewhere", async () => {
+    expect((await loadWith("macos")).MOD_PROP).toBe("meta");
+    expect((await loadWith("windows")).MOD_PROP).toBe("ctrl");
+  });
+
+  it("joins shortcut parts without a separator on mac", async () => {
+    const mac = await loadWith("macos");
+    expect(mac.KEY_SEP).toBe("");
+    expect(mac.fmtShortcut("Mod", "K")).toBe("ModK");
+
+    const win = await loadWith("windows");
+    expect(win.KEY_SEP).toBe("+");
+    expect(win.fmtShortcut("Ctrl", "K")).toBe("Ctrl+K");
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for two small lib helpers: `lib/platform` (platform flags,
modifier keys, shortcut formatting) and `lib/launchDir` (CLI launch dir +
OS-opened files). Two commits, one per module. Test-only: no production files
are touched.

## Why

Nearly every module imports `IS_WINDOWS` / `MOD_PROP` from platform, and the
launch helpers decide where new tabs start and which files open at boot. The
platform matrix (mac vs windows vs linux vs unknown) and the separator
normalization were unlocked.

## How

Mocks `@tauri-apps/plugin-os.platform()` and reloads the module per case
since every export is computed at import time; mocks `invoke` for the launch
helpers.

Locked behavior:

- macOS keeps native traffic lights; windows and linux render custom
  controls; an unknown platform is non-mac but also opts out of custom
  controls
- primary modifier is meta on mac, ctrl elsewhere; shortcut parts join with
  no separator on mac and `+` elsewhere
- `initLaunchDir` prefers `get_launch_dir`, falls back to
  `workspace_current_dir`, normalizes separators, and caches undefined when
  both probes fail
- `consumeLaunchFiles` normalizes each path and maps backend failure to an
  empty list

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.
