### PR TITLE
test: lock the eager import tracer parsing rules

### DIFF
--- a/scripts/eager-graph.test.ts
+++ b/scripts/eager-graph.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { traceEager } from "./eager-graph.mjs";
+
+let fixtureDir: string;
+
+beforeEach(() => {
+  fixtureDir = mkdtempSync(join(process.cwd(), ".eager-fixture-"));
+});
+
+afterEach(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string): void {
+  writeFileSync(join(fixtureDir, name), content);
+}
+
+function trace(entry: string) {
+  const rel = relative(process.cwd(), join(fixtureDir, `${entry}.ts`))
+    .split("\\")
+    .join("/");
+  return traceEager(rel, ["heavy-pkg"]);
+}
+
+describe("eager graph tracer rules", () => {
+  it("counts a static import of a watched package as a hit", () => {
+    write("entry.ts", 'import { x } from "heavy-pkg";\nexport const v = x;\n');
+    const { hits, moduleCount } = trace("entry");
+    expect([...hits.keys()]).toEqual(["heavy-pkg"]);
+    expect(hits.get("heavy-pkg")?.spec).toBe("heavy-pkg");
+    expect(moduleCount).toBe(1);
+  });
+
+  it("ignores type-only imports", () => {
+    write(
+      "entry.ts",
+      'import type { X } from "heavy-pkg";\nexport type T = X;\n',
+    );
+    const { hits } = trace("entry");
+    expect(hits.size).toBe(0);
+  });
+
+  it("treats dynamic imports and lazy wrappers as lazy boundaries", () => {
+    write(
+      "entry.ts",
+      [
+        'const m = await import("heavy-pkg");',
+        'const lazyLoad = () => import("heavy-pkg");',
+        "void m; void lazyLoad;",
+      ].join("\n"),
+    );
+    const { hits } = trace("entry");
+    expect(hits.size).toBe(0);
+  });
+
+  it("follows relative chains but only reports watched bare packages", () => {
+    write(
+      "entry.ts",
+      'import "./helper";\nimport "unrelated-pkg";\nexport {};',
+    );
+    write("helper.ts", 'import { x } from "heavy-pkg";\nexport const v = x;\n');
+    const { hits, moduleCount } = trace("entry");
+    expect(moduleCount).toBe(2);
+    expect(hits.get("heavy-pkg")?.file).toContain("helper.ts");
+  });
+
+  it("terminates on import cycles without duplicating hits", () => {
+    write("a.ts", 'import "./b";\nimport "heavy-pkg";\nexport {};\n');
+    write("b.ts", 'import "./a";\nexport {};\n');
+    const { hits, moduleCount } = trace("a");
+    expect(moduleCount).toBe(2);
+    expect(hits.size).toBe(1);
+  });
+
+  it("keeps the first pulling file for repeated packages", () => {
+    write("entry.ts", 'import "heavy-pkg";\nimport "./second";\nexport {};\n');
+    write("second.ts", 'import "heavy-pkg";\nexport {};\n');
+    const { hits } = trace("entry");
+    expect(hits.get("heavy-pkg")?.file).toContain("entry.ts");
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the eager import tracer in `scripts/eager-graph.mjs`,
covering its parsing rules directly with throwaway fixture files. Test-only:
no production files are touched.

## Why

`traceEager` is the engine behind `src/app/eager-budget.test.ts`, which locks
the startup-bundle invariant for both window entries. The existing budget test
asserts outcomes on the real tree, but the tracer's own rules - what counts as
eager, what counts as lazy - were only validated indirectly.

## How

Writes small TypeScript fixtures into a temp directory inside the repo and
traces them through the real tracer; cleanup in `afterEach`.

Locked behavior:

- a static import of a watched package produces one hit with the spec and the
  first-pulling file
- `import type` is erased and never hits
- dynamic `import()` and lazy wrappers are lazy boundaries
- relative chains are followed transitively; unwatched bare packages are
  ignored
- import cycles terminate without duplicating hits
- repeated packages keep the first pulling file in the report

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (including both eager-budget suites)
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for dependency tracing scenarios.
  - Verified static imports are detected correctly while type-only imports are excluded.
  - Added coverage for dynamic imports and lazy-loading boundaries.
  - Confirmed relative import chains, repeated dependencies, and circular references are handled reliably without duplicate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->