### PR TITLE
fix(terminal): narrow the IME guard so it cannot swallow navigation keys

### DIFF
--- a/src/modules/terminal/lib/keymap.test.ts
+++ b/src/modules/terminal/lib/keymap.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  type ImeGuardEvent,
+  isImeCompositionKey,
   terminalDeleteSequence,
   terminalLineNavigationSequence,
   terminalReadlineSequence,
@@ -175,5 +177,62 @@ describe("terminalReadlineSequence", () => {
         isAlternateScreen: true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("isImeCompositionKey", () => {
+  const ime = (partial: Partial<ImeGuardEvent>): ImeGuardEvent => ({
+    isComposing: false,
+    keyCode: 0,
+    key: "",
+    ...partial,
+  });
+
+  it("guards an active composition regardless of key", () => {
+    expect(
+      isImeCompositionKey(ime({ isComposing: true, key: "ArrowLeft" })),
+    ).toBe(true);
+    expect(isImeCompositionKey(ime({ isComposing: true, key: "Enter" }))).toBe(
+      true,
+    );
+  });
+
+  it("guards the first keystroke of a session, before isComposing is set", () => {
+    expect(isImeCompositionKey(ime({ keyCode: 229, key: "Process" }))).toBe(
+      true,
+    );
+    expect(isImeCompositionKey(ime({ keyCode: 229, key: "a" }))).toBe(true);
+  });
+
+  // macOS stamps 229 on every Option+key event because Option is a dead-key
+  // modifier. Bailing on that killed the word-navigation shortcuts outright.
+  it.each([
+    "ArrowLeft",
+    "ArrowRight",
+    "ArrowUp",
+    "ArrowDown",
+    "Backspace",
+    "Delete",
+    "Home",
+    "End",
+    "PageUp",
+    "PageDown",
+  ])("lets Option-tagged %s through", (key) => {
+    expect(isImeCompositionKey(ime({ keyCode: 229, key }))).toBe(false);
+  });
+
+  it("still guards navigation keys once composition is actually active", () => {
+    expect(
+      isImeCompositionKey(
+        ime({ isComposing: true, keyCode: 229, key: "ArrowLeft" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores ordinary keys", () => {
+    expect(isImeCompositionKey(ime({ keyCode: 13, key: "Enter" }))).toBe(false);
+    expect(isImeCompositionKey(ime({ keyCode: 37, key: "ArrowLeft" }))).toBe(
+      false,
+    );
   });
 });

--- a/src/modules/terminal/lib/keymap.ts
+++ b/src/modules/terminal/lib/keymap.ts
@@ -55,3 +55,38 @@ export function terminalReadlineSequence(
     terminalDeleteSequence(event, opts)
   );
 }
+
+export type ImeGuardEvent = Pick<
+  KeyboardEvent,
+  "isComposing" | "keyCode" | "key"
+>;
+
+/** Keys that can never carry IME composition input.
+ *
+ * macOS treats Option as a dead-key modifier, so WKWebView stamps keyCode 229
+ * on every Option+key event even with no IME session active. On these keys 229
+ * is therefore always that artifact and never a composition signal; bailing on
+ * it outright is what killed Option+Arrow and Option+Backspace. A composition
+ * is only ever started or refined by a character key.
+ */
+const NON_COMPOSING_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Backspace",
+  "Delete",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
+/** True when the event belongs to an IME session and must not reach the PTY.
+ * `isComposing` is authoritative; the keyCode 229 fallback covers the first
+ * keystroke of a session, before the browser sets `isComposing`. */
+export function isImeCompositionKey(event: ImeGuardEvent): boolean {
+  if (event.isComposing) return true;
+  if (event.keyCode !== 229) return false;
+  return !NON_COMPOSING_KEYS.has(event.key);
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -20,7 +20,7 @@ import {
   resetImeBridge,
   transitionImeBridgeOwner,
 } from "./imeBridge";
-import { terminalReadlineSequence } from "./keymap";
+import { isImeCompositionKey, terminalReadlineSequence } from "./keymap";
 import {
   readTerminalClipboard,
   writeTerminalClipboard,
@@ -309,12 +309,10 @@ function createSlot(): Slot {
   term.attachCustomKeyEventHandler((event) => {
     // During IME composition the browser is assembling a multi-keystroke
     // character (Chinese pinyin → hanzi, Korean jamo → syllable, etc.).
-    // Raw keydown events — including the Enter that commits a candidate —
-    // must NOT be forwarded to the PTY; xterm will receive the final
-    // composed string through its own compositionend handler instead.
-    // keyCode 229 ("Process") is what Chromium reports for every key
-    // pressed inside an active IME session when isComposing is not yet set.
-    if (event.isComposing || event.keyCode === 229) return false;
+    // Raw keydown events, including the Enter that commits a candidate, must
+    // NOT be forwarded to the PTY; xterm will receive the final composed
+    // string through its own compositionend handler instead.
+    if (isImeCompositionKey(event)) return false;
 
     const leafId = slot.currentLeafId;
     if (leafId === null) return false;


### PR DESCRIPTION
Refs #1009

## What the guard does today

`rendererPool.ts` opens its custom key handler with:

```ts
if (event.isComposing || event.keyCode === 229) return false;
```

The `keyCode 229` half is load-bearing and has to stay. In WKWebView it is the **only** signal a composition gives. Captured in this app while typing 테스트:

```
ㅌ  alt:false composing:false keyCode:229
ㅔ  alt:false composing:false keyCode:229
ㅅ  alt:false composing:false keyCode:229
ㅡ  alt:false composing:false keyCode:229
```

`isComposing` never becomes true for Korean, which is the same finding that motivated #1112.

## The problem

That fallback is applied to every key, including ones no input method uses to start or refine a composition. #1009 reports this costing `⌥`+`←`/`→` and `⌥`+`Backspace` entirely on macOS, on the grounds that Option is a dead-key modifier and WKWebView stamps 229 on every `⌥`+key event.

## Fix

Route the guard through a pure `isImeCompositionKey`:

- `isComposing` stays authoritative and unconditional.
- The 229 fallback now skips navigation and deletion keys (arrows, Backspace, Delete, Home, End, PageUp, PageDown).

## Honest caveat: I could not reproduce #1009

On this machine `⌥`+arrow reports the real keyCode, so the old guard never fired for it:

```
ArrowLeft   alt:true composing:false keyCode:37
ArrowRight  alt:true composing:false keyCode:39
```

`⌥`+`←`/`→` work correctly on unmodified `main` here. The reporter captured 229 on the same keys with a capture script, so the tagging appears conditional on something environmental (macOS version, keyboard layout, or active input source) that I have not isolated.

I am opening this anyway because the change is defensible on its own terms: it is a **no-op** where 229 is not stamped on those keys, and it restores the shortcuts where it is. Maintainers may prefer to hold it until #1009 is reproduced on a second machine, which is a reasonable call.

## Testing

- `pnpm test` 750 passed
- `pnpm check-types` clean
- `pnpm lint` no new diagnostics
- 14 new cases in `keymap.test.ts`: the Option artifact, the pre-`isComposing` keystroke, navigation keys during a genuine composition, and ordinary keys

Korean input in the terminal still works with this applied, verified against a `main` dev build.