### PR TITLE
fix(ui): stop Enter from firing mid-IME-composition across text inputs

### DIFF
--- a/src/lib/ime.test.ts
+++ b/src/lib/ime.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { type CompositionKeyEvent, isComposingEvent } from "./ime";
+
+const evt = (partial: Partial<CompositionKeyEvent>): CompositionKeyEvent => ({
+  keyCode: 0,
+  key: "",
+  ...partial,
+});
+
+describe("isComposingEvent", () => {
+  it("reads the flag React forwards on nativeEvent", () => {
+    expect(
+      isComposingEvent(
+        evt({ nativeEvent: { isComposing: true }, key: "Enter" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("reads the flag on a plain DOM event", () => {
+    expect(isComposingEvent(evt({ isComposing: true, key: "Enter" }))).toBe(
+      true,
+    );
+  });
+
+  // WebKit reports 229 on the Enter that confirms a candidate without ever
+  // setting isComposing, which is what sends half a Korean word as a message.
+  it("guards the confirming Enter that WebKit leaves unflagged", () => {
+    expect(isComposingEvent(evt({ keyCode: 229, key: "Enter" }))).toBe(true);
+  });
+
+  // macOS stamps 229 on Option+key because Option is a dead-key modifier.
+  it.each([
+    "ArrowLeft",
+    "ArrowRight",
+    "ArrowUp",
+    "ArrowDown",
+    "Backspace",
+    "Delete",
+    "Home",
+    "End",
+    "PageUp",
+    "PageDown",
+  ])("lets Option-tagged %s through", (key) => {
+    expect(isComposingEvent(evt({ keyCode: 229, key }))).toBe(false);
+  });
+
+  it("still guards navigation keys once composition is flagged", () => {
+    expect(
+      isComposingEvent(
+        evt({
+          nativeEvent: { isComposing: true },
+          keyCode: 229,
+          key: "ArrowUp",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores ordinary keystrokes", () => {
+    expect(isComposingEvent(evt({ keyCode: 13, key: "Enter" }))).toBe(false);
+    expect(isComposingEvent(evt({ keyCode: 27, key: "Escape" }))).toBe(false);
+    expect(isComposingEvent(evt({ nativeEvent: {}, key: "a" }))).toBe(false);
+  });
+});

--- a/src/lib/ime.ts
+++ b/src/lib/ime.ts
@@ -1,0 +1,39 @@
+export type CompositionKeyEvent = {
+  nativeEvent?: { isComposing?: boolean };
+  isComposing?: boolean;
+  key?: string;
+  keyCode?: number;
+};
+
+/** Keys that can never carry IME composition input.
+ *
+ * macOS treats Option as a dead-key modifier, so WKWebView stamps keyCode 229
+ * on every Option+key event even with no IME session active. Excluding these
+ * keeps the fallback from swallowing Option+Arrow style navigation.
+ */
+const NON_COMPOSING_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Backspace",
+  "Delete",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
+/** True while an IME is still assembling a character.
+ *
+ * The Enter that confirms a candidate arrives as an ordinary keydown, so any
+ * handler that submits on Enter fires mid-composition and sends half a word.
+ * WebKit reports keyCode 229 on that Enter without setting isComposing, so the
+ * flag alone is not enough. React exposes the native flag via nativeEvent.
+ */
+export function isComposingEvent(event: CompositionKeyEvent): boolean {
+  if (event.nativeEvent?.isComposing === true) return true;
+  if (event.isComposing === true) return true;
+  if (event.keyCode !== 229) return false;
+  return !NON_COMPOSING_KEYS.has(event.key ?? "");
+}

--- a/src/modules/ai/components/AiComposerInput.tsx
+++ b/src/modules/ai/components/AiComposerInput.tsx
@@ -1,5 +1,6 @@
 import { Popover, PopoverAnchor } from "@/components/ui/popover";
 import { Spinner } from "@/components/ui/spinner";
+import { isComposingEvent } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import { usePresence } from "@/lib/usePresence";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -218,6 +219,7 @@ export function AiComposerInput() {
               onClick={updateTrigger}
               onSelect={updateTrigger}
               onKeyDown={(e) => {
+                if (isComposingEvent(e)) return;
                 if (pickerOpen) {
                   const items = fileTrigger ? filteredFiles : filteredItems;
                   if (e.key === "ArrowDown") {

--- a/src/modules/editor/NewEditorDialog.tsx
+++ b/src/modules/editor/NewEditorDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { isComposingEvent } from "@/lib/ime";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 import { File02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -101,6 +102,7 @@ export function NewEditorDialog({
             setError(null);
           }}
           onKeyDown={(e) => {
+            if (isComposingEvent(e)) return;
             if (e.key === "Enter") {
               e.preventDefault();
               void submit();

--- a/src/modules/explorer/ExplorerSearch.tsx
+++ b/src/modules/explorer/ExplorerSearch.tsx
@@ -12,6 +12,7 @@ import {
   Folder01Icon,
   Search01Icon,
 } from "@hugeicons/core-free-icons";
+import { isComposingEvent } from "@/lib/ime";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { invoke } from "@tauri-apps/api/core";
 import { currentWorkspaceEnv } from "@/modules/workspace";
@@ -185,6 +186,7 @@ export const ExplorerSearch = forwardRef<ExplorerSearchHandle, Props>(function E
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={(e) => {
+              if (isComposingEvent(e)) return;
               if (e.key === "Escape") {
                 e.preventDefault();
                 e.stopPropagation();

--- a/src/modules/explorer/InlineInput.tsx
+++ b/src/modules/explorer/InlineInput.tsx
@@ -1,3 +1,4 @@
+import { isComposingEvent } from "@/lib/ime";
 import { useLayoutEffect, useRef, useState } from "react";
 
 type Props = {
@@ -74,6 +75,7 @@ export function InlineInput({
       placeholder={placeholder}
       onChange={(e) => setValue(e.target.value)}
       onKeyDown={(e) => {
+        if (isComposingEvent(e)) return;
         if (e.key === "Enter") {
           e.preventDefault();
           commit();

--- a/src/modules/header/SearchInline.tsx
+++ b/src/modules/header/SearchInline.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { isComposingEvent } from "@/lib/ime";
 import { KEY_SEP } from "@/lib/platform";
 import type { EditorPaneHandle } from "@/modules/editor";
 import { usePreferencesStore } from "@/modules/settings/preferences";
@@ -159,6 +160,7 @@ export const SearchInline = forwardRef<SearchInlineHandle, Props>(
                 if (compact && !q) setOpenInCompact(false);
               }}
               onKeyDown={(e) => {
+                if (isComposingEvent(e)) return;
                 if (e.key === "Enter") {
                   e.preventDefault();
                   findDirection(!e.shiftKey);

--- a/src/modules/preview/PreviewAddressBar.tsx
+++ b/src/modules/preview/PreviewAddressBar.tsx
@@ -11,6 +11,7 @@ import {
   Globe02Icon,
   LinkSquare02Icon,
 } from "@hugeicons/core-free-icons";
+import { isComposingEvent } from "@/lib/ime";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
@@ -173,6 +174,7 @@ export const PreviewAddressBar = forwardRef<PreviewAddressBarHandle, Props>(
             className="h-7 w-full bg-muted/60 px-2 text-xs placeholder:text-muted-foreground/70 focus-visible:ring-0"
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={(e) => {
+              if (isComposingEvent(e)) return;
               if (e.key === "Enter") {
                 e.preventDefault();
                 submit();

--- a/src/modules/source-control/SourceControlPanel.tsx
+++ b/src/modules/source-control/SourceControlPanel.tsx
@@ -27,6 +27,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
+import { isComposingEvent } from "@/lib/ime";
 import { toast } from "sonner";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -481,6 +482,7 @@ export const SourceControlPanel = memo(function SourceControlPanel({
   }, [scm.actionError, scm.actionMessage, scm.remoteError]);
 
   const handleCommitShortcut = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isComposingEvent(event)) return;
     if (
       event.key === "Enter" &&
       (event.metaKey || event.ctrlKey) &&

--- a/src/modules/spaces/components/InlineRename.tsx
+++ b/src/modules/spaces/components/InlineRename.tsx
@@ -1,3 +1,4 @@
+import { isComposingEvent } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import { useEffect, useRef } from "react";
 
@@ -42,6 +43,7 @@ export function InlineRename({
       )}
       onKeyDown={(e) => {
         e.stopPropagation();
+        if (isComposingEvent(e)) return;
         if (e.key === "Enter") finish(() => onCommit(e.currentTarget.value));
         else if (e.key === "Escape") finish(onCancel);
       }}

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { isComposingEvent } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import { AgentIcon } from "@/modules/agents/lib/agentIcon";
 import type { AgentLaunchRequest } from "@/modules/agents/lib/launcher";
@@ -781,6 +782,7 @@ function TabRenameInput({
       )}
       onKeyDown={(e) => {
         e.stopPropagation();
+        if (isComposingEvent(e)) return;
         if (e.key === "Enter") commit(e.currentTarget.value, true);
         else if (e.key === "Escape") finish(onCancel);
       }}

--- a/src/modules/terminal/block/BlockOverlay.tsx
+++ b/src/modules/terminal/block/BlockOverlay.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { isComposingEvent } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/modules/ai/store/chatStore";
 import {
@@ -348,6 +349,7 @@ function SearchBar({
         placeholder="Find in block"
         onChange={(e) => run(e.target.value)}
         onKeyDown={(e) => {
+          if (isComposingEvent(e)) return;
           if (e.key === "Enter") {
             e.preventDefault();
             nav(e.shiftKey ? -1 : 1);

--- a/src/settings/components/ProviderKeyCard.tsx
+++ b/src/settings/components/ProviderKeyCard.tsx
@@ -2,6 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
+import { isComposingEvent } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import type { ProviderInfo } from "@/modules/ai/config";
 import {
@@ -133,6 +134,7 @@ export function ProviderKeyCard({
                   if (error) setError(null);
                 }}
                 onKeyDown={(e) => {
+                  if (isComposingEvent(e)) return;
                   if (e.key === "Enter") {
                     e.preventDefault();
                     void submit();

--- a/src/settings/sections/EditorSection.tsx
+++ b/src/settings/sections/EditorSection.tsx
@@ -11,6 +11,7 @@ import {
   FORMATTER_LABELS,
   FORMATTERS,
 } from "@/modules/editor/lib/externalFormat";
+import { isComposingEvent } from "@/lib/ime";
 import { EXPOSED_LANGUAGES } from "@/modules/editor/lib/languageDefinitions";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
@@ -218,6 +219,7 @@ function CustomFormatCommandInput() {
           if (draft !== stored) void setEditorCustomFormatCommand(draft);
         }}
         onKeyDown={(e) => {
+          if (isComposingEvent(e)) return;
           if (e.key === "Enter") e.currentTarget.blur();
         }}
         className="h-8 w-64 font-mono text-[12px] md:text-[12px]"
@@ -349,6 +351,7 @@ function AutoSaveDelayInput({
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}
           onKeyDown={(e) => {
+            if (isComposingEvent(e)) return;
             if (e.key === "Enter") {
               e.currentTarget.blur();
             }
@@ -400,6 +403,7 @@ function WordWrapColumnInput({
           onChange={(e) => setDraft(e.target.value)}
           onBlur={commit}
           onKeyDown={(e) => {
+            if (isComposingEvent(e)) return;
             if (e.key === "Enter") e.currentTarget.blur();
           }}
           className="h-8 w-20 rounded-md border border-border bg-background px-2.5 text-right text-[12px] md:text-[12px] tabular-nums outline-none focus:border-foreground/40 focus-visible:ring-0 focus-visible:border-foreground/40 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"

--- a/src/settings/sections/GeneralSection.tsx
+++ b/src/settings/sections/GeneralSection.tsx
@@ -14,6 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { isComposingEvent } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import {
   type OsNotificationResult,
@@ -642,6 +643,7 @@ function FontFamilyInput({
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
         onKeyDown={(e) => {
+          if (isComposingEvent(e)) return;
           if (e.key === "Enter") e.currentTarget.blur();
         }}
         className="h-8 w-48 rounded-md border border-border bg-background px-2.5 text-[12px] outline-none focus:border-foreground/40"


### PR DESCRIPTION
Fixes #873

## Problem

The Enter that confirms an IME candidate arrives as an ordinary `keydown`, so every handler that acts on Enter fires while the character is still being assembled.

On macOS with a Korean or Chinese IME:

- The AI composer sends an unfinished message and clears the box (#873).
- Renaming a file, tab, or space commits a half-typed name.
- Explorer search opens the first hit before the query is finished.
- The preview address bar navigates to a partial URL.

WebKit reports `keyCode 229` on that Enter **without** setting `isComposing`, so checking the flag alone does not catch it.

Before this change the whole codebase checked `isComposing` in exactly one place, `rendererPool.ts`, which is why only the terminal was unaffected.

## Fix

Add `isComposingEvent` in `src/lib/ime.ts` as a pure helper and gate the 15 affected handlers with it:

`AiComposerInput` (submit + the `@`/`#` picker), `InlineInput`, `ExplorerSearch`, `SearchInline`, `InlineRename`, `PreviewAddressBar`, `TabBar`, `NewEditorDialog`, `BlockOverlay`, `SourceControlPanel`, `EditorSection` (x3), `GeneralSection`, `ProviderKeyCard`.

The `keyCode 229` fallback deliberately exempts navigation and deletion keys. macOS treats Option as a dead-key modifier and stamps 229 on every `⌥`+key event, so honouring it there would kill `⌥`+Arrow the same way it killed the terminal shortcuts (#1009).

### Deliberately unchanged

- **Command palette.** cmdk 1.1.1 already ships `isComposing || e.keyCode === 229`.
- **CodeMirror surfaces** (block prompt, code editor). `InputState.ignoreDuringComposition` already drops key events during composition and compensates for Safari's delayed `compositionend`.
- **`locationsPanel`.** The listener is on a focused `<ul>`, not an editable element, so no composition can start there.

## Testing

- `pnpm test` 751 passed
- `pnpm check-types` clean
- `pnpm lint` no new diagnostics
- 16 new cases in `src/lib/ime.test.ts`

The diff is 28 added lines across the 13 touched call sites, no deletions.

## Follow-up

`isImeCompositionKey` in #1215 carries the same navigation-key list for the terminal's raw keydown path. The two guards are intentionally independent here so the PRs do not depend on each other; unifying them afterwards would be a clean small change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text input behavior for IME users across search, editor, rename, settings, source control, preview, and terminal fields.
  - Enter, Escape, navigation, and submission shortcuts no longer trigger prematurely while composing text.
  - Preserved normal keyboard actions after composition is complete, including macOS navigation behavior.

- **Tests**
  - Added comprehensive coverage for IME composition detection across browser event variations and common keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->