### PR TITLE
fix(macos): fix the window control strip in the header

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
         "minWidth": 420,
         "minHeight": 280,
         "titleBarStyle": "Overlay",
+        "trafficLightPosition": { "x": 14, "y": 22 },
         "hiddenTitle": true,
         "visible": false,
         "transparent": true,

--- a/src/lib/useFullscreen.test.ts
+++ b/src/lib/useFullscreen.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { registerFullscreenSync } from "./useFullscreen";
+
+describe("registerFullscreenSync", () => {
+  it("registers resize tracking before the initial fullscreen read", async () => {
+    const calls: string[] = [];
+    const values: boolean[] = [];
+    const window = {
+      async onResized(_handler: () => void) {
+        calls.push("listen");
+        return () => {};
+      },
+      async isFullscreen() {
+        calls.push("read");
+        return true;
+      },
+    };
+
+    await registerFullscreenSync(window, (value) => values.push(value));
+
+    expect(calls).toEqual(["listen", "read"]);
+    expect(values).toEqual([true]);
+  });
+
+  it("does not let an older fullscreen read overwrite a newer resize read", async () => {
+    let resize: (() => void) | undefined;
+    const resolvers: Array<(value: boolean) => void> = [];
+    const values: boolean[] = [];
+    const window = {
+      async onResized(handler: () => void) {
+        resize = handler;
+        return () => {};
+      },
+      isFullscreen() {
+        return new Promise<boolean>((resolve) => resolvers.push(resolve));
+      },
+    };
+
+    const registration = registerFullscreenSync(window, (value) =>
+      values.push(value),
+    );
+    await Promise.resolve();
+    expect(resize).toBeDefined();
+    expect(resolvers).toHaveLength(1);
+
+    resize?.();
+    expect(resolvers).toHaveLength(2);
+
+    resolvers[1]?.(true);
+    await Promise.resolve();
+    resolvers[0]?.(false);
+    await registration;
+
+    expect(values).toEqual([true]);
+  });
+});

--- a/src/lib/useFullscreen.ts
+++ b/src/lib/useFullscreen.ts
@@ -1,0 +1,65 @@
+import { IS_MAC } from "@/lib/platform";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useState } from "react";
+
+type FullscreenWindowLike = {
+  onResized(handler: () => void): Promise<() => void>;
+  isFullscreen(): Promise<boolean>;
+};
+
+/**
+ * Register resize tracking before reading the initial fullscreen state.
+ *
+ * The revision guard prevents a slower, older read from overwriting a newer
+ * resize-triggered read. This closes the startup race where fullscreen could
+ * change between the first read and listener registration.
+ */
+export async function registerFullscreenSync(
+  window: FullscreenWindowLike,
+  onChange: (fullscreen: boolean) => void,
+): Promise<() => void> {
+  let revision = 0;
+
+  const sync = async () => {
+    const currentRevision = ++revision;
+    const fullscreen = await window.isFullscreen();
+    if (currentRevision === revision) onChange(fullscreen);
+  };
+
+  const unlisten = await window.onResized(() => {
+    void sync();
+  });
+  await sync();
+  return unlisten;
+}
+
+/** Whether the main window is in macOS fullscreen.
+ *
+ * Always false off macOS: other platforms render their own window controls and
+ * do not reserve header space for native traffic lights.
+ */
+export function useFullscreen(): boolean {
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (!IS_MAC) return;
+
+    let alive = true;
+    let unlisten: (() => void) | undefined;
+    const window = getCurrentWindow();
+
+    void registerFullscreenSync(window, (value) => {
+      if (alive) setFullscreen(value);
+    }).then((un) => {
+      if (alive) unlisten = un;
+      else un();
+    });
+
+    return () => {
+      alive = false;
+      unlisten?.();
+    };
+  }, []);
+
+  return fullscreen;
+}

--- a/src/modules/header/Header.tsx
+++ b/src/modules/header/Header.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { WindowControls } from "@/components/WindowControls";
 import { IS_MAC, USE_CUSTOM_WINDOW_CONTROLS } from "@/lib/platform";
+import { useFullscreen } from "@/lib/useFullscreen";
+import { cn } from "@/lib/utils";
 import { NotificationBell } from "@/modules/agents";
 import type { AgentLaunchRequest } from "@/modules/agents/lib/launcher";
 import type { Tab } from "@/modules/tabs";
@@ -100,6 +102,8 @@ export function Header({
     return () => ro.disconnect();
   }, []);
 
+  const fullscreen = useFullscreen();
+
   const settingsButton = (
     <Button
       variant="ghost"
@@ -116,9 +120,10 @@ export function Header({
     <div
       ref={rootRef}
       data-tauri-drag-region
-      className={`flex h-10 shrink-0 items-center gap-2 select-none ${
-        IS_MAC ? "pr-2 pl-20" : "pr-0 pl-2"
-      }`}
+      className={cn(
+        "flex h-10 shrink-0 items-center gap-2 select-none",
+        IS_MAC ? (fullscreen ? "pr-2 pl-2" : "pr-2 pl-20") : "pr-0 pl-2",
+      )}
     >
       <div className="flex shrink-0 items-center gap-0.5">
         <Button


### PR DESCRIPTION
Refs #886, #667

What

This keeps the PR focused on the main macOS window:

- align the native traffic lights with the "h-10" app header via "trafficLightPosition: { x: 14, y: 22 }"
- remove the otherwise-empty "pl-20" traffic-light inset while macOS is fullscreen
- preserve the current upstream header behavior and non-macOS window controls

Implementation

The earlier revision used a Rust fullscreen tracker and emitted a custom event. Since then "main" has moved substantially, and the app already uses "Window.onResized()" + a state read in "WindowControls".

The rebased version follows that existing pattern instead:

1. register "onResized()" first
2. read "isFullscreen()" only after the listener is installed
3. re-read fullscreen state on resize
4. use a revision guard so a slower stale read cannot overwrite a newer resize-triggered state

This removes the stale Rust conflicts in "lib.rs"/"modules", keeps the change frontend-local, and addresses the startup race called out in the previous review.

Regression coverage

"src/lib/useFullscreen.test.ts" covers:

- listener registration happening before the initial fullscreen read
- an older asynchronous read being ignored when a newer resize read has already won

Platform isolation

- "useFullscreen()" is inert off macOS
- Windows/Linux keep the existing "pr-0 pl-2" branch and custom window controls
- the only Tauri config change is the macOS-native traffic-light position used by the main window

Testing status

- Added focused Vitest regression coverage for fullscreen state synchronization.
- The original traffic-light coordinates were manually measured/verified on macOS in the previous revision.
- This rebased revision has not been manually smoke-tested in this session; the fork CI run is awaiting upstream approval before jobs execute.

Scope change from the previous revision

The dynamic Settings-window traffic-light adjustment and Rust fullscreen event bridge were intentionally removed during the rebase. Issues #886 and #667 concern the main window, and keeping this PR to that surface avoids carrying unrelated conflicts from the newer upstream window lifecycle code.