### PR TITLE
fix(ui): run hooks unconditionally before conditional returns

### DIFF
--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -341,6 +341,12 @@ const RenderedMessage = memo(function RenderedMessage({
       break;
     }
   }
+  // Hooks must run unconditionally (Rules of Hooks) even though user messages
+  // render without groups; grouping is cheap so this stays out of the way.
+  const groups = useMemo(() => buildPartGroups(message.parts as AnyPart[]), [
+    message.parts,
+  ]);
+
   if (message.role === "user") {
     const rawText = message.parts
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
@@ -368,10 +374,6 @@ const RenderedMessage = memo(function RenderedMessage({
       </Message>
     );
   }
-
-  const groups = useMemo(() => buildPartGroups(message.parts as AnyPart[]), [
-    message.parts,
-  ]);
 
   return (
     <Message from={message.role}>

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -18,16 +18,18 @@ type Props = {
   onSelect: (env: WorkspaceEnv) => void;
 };
 
+/** Hook-free wrapper so non-Windows never subscribes to the workspace env store. */
 export function WorkspaceEnvSelector({ onSelect }: Props) {
+  if (!IS_WINDOWS) return null;
+  return <WorkspaceEnvSelectorWindows onSelect={onSelect} />;
+}
+
+function WorkspaceEnvSelectorWindows({ onSelect }: Props) {
   const env = useWorkspaceEnvStore((s) => s.env);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);
   const error = useWorkspaceEnvStore((s) => s.error);
   const refreshDistros = useWorkspaceEnvStore((s) => s.refreshDistros);
-
-  // Hooks must run unconditionally (Rules of Hooks); the platform gate only
-  // controls whether anything is rendered.
-  if (!IS_WINDOWS) return null;
 
   const handleOpenChange = (open: boolean) => {
     if (open && distros.length === 0 && !loading) {

--- a/src/modules/statusbar/WorkspaceEnvSelector.tsx
+++ b/src/modules/statusbar/WorkspaceEnvSelector.tsx
@@ -19,13 +19,15 @@ type Props = {
 };
 
 export function WorkspaceEnvSelector({ onSelect }: Props) {
-  if (!IS_WINDOWS) return null;
-
   const env = useWorkspaceEnvStore((s) => s.env);
   const distros = useWorkspaceEnvStore((s) => s.distros);
   const loading = useWorkspaceEnvStore((s) => s.loading);
   const error = useWorkspaceEnvStore((s) => s.error);
   const refreshDistros = useWorkspaceEnvStore((s) => s.refreshDistros);
+
+  // Hooks must run unconditionally (Rules of Hooks); the platform gate only
+  // controls whether anything is rendered.
+  if (!IS_WINDOWS) return null;
 
   const handleOpenChange = (open: boolean) => {
     if (open && distros.length === 0 && !loading) {


### PR DESCRIPTION
﻿## What

Fixes two Rules of Hooks violations where hooks ran after conditional early
returns:

- `WorkspaceEnvSelector` subscribed to the workspace store (5 hooks) after
  `if (!IS_WINDOWS) return null`
- the AiChat message row called `useMemo` after the user-message early
  return, so a message instance changing shape between renders would alter
  hook order

Both components now compute hooks unconditionally first; the platform gate
and role check only control what gets rendered. Grouping a user message
unnecessarily is cheap (a single pass over its parts).

## Why

Latent crashes: any future refactor that makes platform dynamic, reuses
component slots without stable keys, or lets a message gain parts in place
would throw "Rendered more hooks than during the previous render". Biome
flags both sites (`useHookAtTopLevel`, 5 + 1 diagnostics).

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint`: useHookAtTopLevel count drops from 6 to 0 (99 -> 93 total warnings)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (109 files / 736 tests)
- [ ] Manual smoke-test - status bar on macOS/Linux renders without the WSL pill (logic unchanged); AI messages stream as before
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - see smoke-test note above
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - behavior unchanged on every current path.

## Notes for reviewer

- Branched just before the `.github/workflows` dependabot bump for the usual
  workflow-scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message rendering consistency and reliability.
  * Prevented unnecessary workspace environment processing on non-Windows platforms while preserving the selector’s existing Windows-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->