### PR TITLE
test(agents): cover the managed agents store

### DIFF
--- a/src/modules/agents/store/managedAgentsStore.test.ts
+++ b/src/modules/agents/store/managedAgentsStore.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_MAX_ROUNDS, useManagedAgentsStore } from "./managedAgentsStore";
+
+function reset() {
+  useManagedAgentsStore.setState({ agents: {} });
+}
+
+describe("managed agents store", () => {
+  beforeEach(reset);
+
+  it("registers an agent with defaults and explicit max rounds", () => {
+    useManagedAgentsStore.getState().register({
+      leafId: 7,
+      tabId: 3,
+      sessionId: "s1",
+      task: "fix flake",
+      cwd: "/repo",
+    });
+    useManagedAgentsStore.getState().register({
+      leafId: 8,
+      tabId: 4,
+      sessionId: "s2",
+      task: "other",
+      cwd: null,
+      maxRounds: 5,
+    });
+
+    const a = useManagedAgentsStore.getState().get(7);
+    expect(a).toMatchObject({
+      leafId: 7,
+      tabId: 3,
+      sessionId: "s1",
+      rounds: 0,
+      maxRounds: DEFAULT_MAX_ROUNDS,
+      phase: "spawning",
+      reviewedAtRound: -1,
+      pendingReview: false,
+    });
+    expect(useManagedAgentsStore.getState().get(8)?.maxRounds).toBe(5);
+  });
+
+  it("setPhase ignores unknown leaves and identical phases", () => {
+    expect(
+      useManagedAgentsStore.getState().setPhase(42, "working"),
+    ).toBeUndefined();
+
+    useManagedAgentsStore
+      .getState()
+      .register({ leafId: 7, tabId: 1, sessionId: "s", task: "t", cwd: null });
+    const before = useManagedAgentsStore.getState().get(7);
+
+    useManagedAgentsStore.getState().setPhase(7, "spawning");
+
+    expect(useManagedAgentsStore.getState().get(7)).toBe(before);
+  });
+
+  it("markReviewed stamps the current round and clears pendingReview", () => {
+    const store = useManagedAgentsStore.getState();
+    store.register({
+      leafId: 7,
+      tabId: 1,
+      sessionId: "s",
+      task: "t",
+      cwd: null,
+    });
+    store.bumpRound(7);
+    store.setPendingReview(7, true);
+    store.markReviewed(7);
+
+    const a = useManagedAgentsStore.getState().get(7);
+    expect(a).toBeDefined();
+    expect(a!.reviewedAtRound).toBe(1);
+    expect(a!.pendingReview).toBe(false);
+  });
+
+  it("bumpRound increments rounds and returns the agent to working", () => {
+    const store = useManagedAgentsStore.getState();
+    store.register({
+      leafId: 7,
+      tabId: 1,
+      sessionId: "s",
+      task: "t",
+      cwd: null,
+    });
+    store.setPhase(7, "reviewing");
+    store.bumpRound(7);
+
+    const a = useManagedAgentsStore.getState().get(7);
+    expect(a).toBeDefined();
+    expect(a!.rounds).toBe(1);
+    expect(a!.phase).toBe("working");
+  });
+
+  it("remove drops the agent entirely", () => {
+    const store = useManagedAgentsStore.getState();
+    store.register({
+      leafId: 7,
+      tabId: 1,
+      sessionId: "s",
+      task: "t",
+      cwd: null,
+    });
+    store.remove(7);
+
+    expect(useManagedAgentsStore.getState().get(7)).toBeUndefined();
+  });
+
+  it("getBySessionId finds the agent bound to a chat session", () => {
+    const store = useManagedAgentsStore.getState();
+    store.register({
+      leafId: 7,
+      tabId: 1,
+      sessionId: "session-a",
+      task: "t",
+      cwd: null,
+    });
+    store.register({
+      leafId: 9,
+      tabId: 2,
+      sessionId: "session-b",
+      task: "u",
+      cwd: null,
+    });
+
+    expect(useManagedAgentsStore.getState().getBySessionId("session-b")?.leafId).toBe(
+      9,
+    );
+    expect(
+      useManagedAgentsStore.getState().getBySessionId("missing"),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
﻿## What

Adds unit tests for the managed agents store in
`agents/store/managedAgentsStore`. Test-only: no production files are
touched.

## Why

This store tracks supervised terminal-agent rounds: registration defaults,
phase transitions, review stamping, round bumps, and session lookup. The
review-gating tests (#1175) mock it away, so its own contracts had no direct
coverage.

## How

Runs against the real zustand store with `setState` resets per test.

Locked behavior:

- register applies defaults (max rounds, spawning phase, reviewedAtRound -1)
  and honors an explicit maxRounds
- setPhase ignores unknown leaves and identical phases (same-state returns
  the same object)
- markReviewed stamps `reviewedAtRound` with the current round count and
  clears pendingReview
- bumpRound increments rounds and flips the phase back to working
- remove drops the agent entirely
- getBySessionId resolves agents by chat session id

## Testing

Ran the full suite plus type-check and lint locally on Windows.

- [x] `pnpm lint` clean (pre-existing warnings only, none introduced)
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [ ] Manual smoke-test of the affected feature - N/A, test-only, no runtime change
- [ ] (If you touched `src-tauri/`) cargo clippy - N/A, no Rust changes
- [ ] (If you touched `src-tauri/`) cargo nextest - N/A, no Rust changes
- [ ] (If you changed a `#[tauri::command]` signature) - N/A
- [ ] (If UI) tested in `pnpm tauri dev` - N/A, no UI change
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

## Screenshots / GIFs

N/A - no UI change.

## Notes for reviewer

- Test-only. Branched just before the `.github/workflows` dependabot bump for
  the usual workflow-scope reason. Single new file, merges cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for managed agent registration, defaults, phase handling, review tracking, round progression, removal, and session-based lookup.
  * Added test isolation through store reset setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->