### PR TITLE
fix(settings): render sections only after preferences hydrate

### DIFF
--- a/src/settings/SettingsApp.tsx
+++ b/src/settings/SettingsApp.tsx
@@ -14,7 +14,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { type JSX, useEffect, useState } from "react";
+import { type JSX, useCallback, useEffect, useState } from "react";
 import { AboutSection } from "./sections/AboutSection";
 import { AgentsSection } from "./sections/AgentsSection";
 import { EditorSection } from "./sections/EditorSection";
@@ -91,11 +91,20 @@ function readInitialTab(): SettingsTab {
 export function SettingsApp() {
   const [active, setActive] = useState<SettingsTab>(readInitialTab);
   const init = usePreferencesStore((s) => s.init);
+  const hydrated = usePreferencesStore((s) => s.hydrated);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const ActiveSection = TABS.find((t) => t.id === active)?.component;
 
-  useEffect(() => {
-    void init();
+  // `init` resets its promise on failure without flipping `hydrated`, so a
+  // rejected load must be caught here or the pane renders empty forever.
+  const loadPrefs = useCallback(() => {
+    setLoadError(null);
+    void init().catch((e) => setLoadError(e instanceof Error ? e.message : String(e)));
   }, [init]);
+
+  useEffect(() => {
+    loadPrefs();
+  }, [loadPrefs]);
 
   useEffect(() => {
     const apply = (detail: string) => {
@@ -149,7 +158,26 @@ export function SettingsApp() {
 
       <main className="min-h-0 flex-1 overflow-y-auto px-8 pt-6 pb-7 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div className="mx-auto w-full max-w-160">
-          {ActiveSection && <ActiveSection />}
+          {/* Hold sections until prefs are hydrated so controls never render
+              with default values and flip once the store loads. */}
+          {hydrated && ActiveSection && <ActiveSection />}
+          {!hydrated && !loadError && (
+            <div className="py-8 text-[13px] text-muted-foreground">
+              Loading preferences...
+            </div>
+          )}
+          {!hydrated && loadError && (
+            <div className="py-8 text-[13px] text-muted-foreground">
+              <p>Failed to load preferences: {loadError}</p>
+              <button
+                type="button"
+                onClick={loadPrefs}
+                className="mt-2 rounded-sm border border-border/60 px-2 py-1 text-foreground/80 hover:bg-accent/70"
+              >
+                Retry
+              </button>
+            </div>
+          )}
         </div>
       </main>
     </div>


### PR DESCRIPTION
## What
Settings sections now render only after the preferences store finishes
hydrating, so controls no longer appear with their default values and
flip to the stored value a frame later.

## Why
Any preference that differs from its default flickered every time the
settings window opened - a switch stored as "on" visibly animated from
"off" to "on" on each open. Small obvious bugfix, so opening directly
per CONTRIBUTING.

## How
Gate the section area in `SettingsApp` on the existing `hydrated` flag
from the preferences store. The header and tabs still render
immediately; only the preference-bound content waits for the single
`store.entries()` IPC roundtrip.

## Testing
- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean
- [x] Manual smoke-test of the affected feature
- [ ] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [ ] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [x] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Windows
- [ ] Shells tested (if relevant): N/A

Steps: set a switch to a non-default value, close and reopen the
settings window. Before: the switch renders off then animates on.
After: it renders in its stored state immediately, no flicker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented settings sections from appearing before saved preferences finish loading.
  * Ensured the active settings section displays only after preferences are fully initialized.
  * Added clear error handling when settings fail to load, including an option to retry initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->