### PR TITLE
feat(ai): add opencode-go provider preset (#906)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,5 @@
 TERAX.md
+
+## Skills
+
+- `skills/terax-dev/SKILL.md` - Terax development skill: feature-add recipes (AI tools, providers, themes, Tauri commands, tabs), conventions, verification commands, and load-bearing invariants. Read it before making changes; `TERAX.md` still wins on conflict.

--- a/src/modules/ai/components/AiStatusBarControls.tsx
+++ b/src/modules/ai/components/AiStatusBarControls.tsx
@@ -70,6 +70,7 @@ const PROVIDER_ICON = {
   groq: FlashIcon,
   deepseek: DeepseekIcon,
   mistral: MistralIcon,
+  "opencode-go": GlobeIcon,
   openrouter: GlobeIcon,
   "openai-compatible": PlugIcon,
   lmstudio: ComputerIcon,

--- a/src/modules/ai/config.ts
+++ b/src/modules/ai/config.ts
@@ -9,6 +9,7 @@ export type ProviderId =
   | "groq"
   | "deepseek"
   | "mistral"
+  | "opencode-go"
   | "openrouter"
   | "openai-compatible"
   | "lmstudio"
@@ -81,6 +82,13 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     keyringAccount: "mistral-api-key",
     keyPrefix: null,
     consoleUrl: "https://console.mistral.ai/api-keys/",
+  },
+  {
+    id: "opencode-go",
+    label: "OpenCode Go",
+    keyringAccount: "opencode-go-api-key",
+    keyPrefix: null,
+    consoleUrl: "https://opencode.ai",
   },
   {
     id: "openrouter",
@@ -581,6 +589,26 @@ export const MODELS = [
     tags: ["reasoning", "tools"],
   },
 
+  // ── OpenCode Go (paid subscription; API key) ──────────────────────────────
+  {
+    id: "opencode-go-deepseek-v4-flash",
+    provider: "opencode-go",
+    label: "DeepSeek V4 Flash",
+    hint: "Fast",
+    description: "Fast everyday tier on OpenCode Go.",
+    capabilities: { intelligence: 4, speed: 5, cost: 5 },
+    tags: ["reasoning", "tools"],
+  },
+  {
+    id: "opencode-go-deepseek-v4-pro",
+    provider: "opencode-go",
+    label: "DeepSeek V4 Pro",
+    hint: "Best",
+    description: "Frontier reasoning and coding on OpenCode Go.",
+    capabilities: { intelligence: 5, speed: 3, cost: 4 },
+    tags: ["reasoning", "tools", "coding"],
+  },
+
   // ── OpenRouter (gateway; model id is user-supplied at runtime) ────────────
   {
     id: "openrouter-custom",
@@ -756,6 +784,8 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "openai/gpt-oss-20b": 128_000,
   "llama-3.3-70b-versatile": 128_000,
   "deepseek-r1-distill-llama-70b": 128_000,
+  "opencode-go-deepseek-v4-flash": 128_000,
+  "opencode-go-deepseek-v4-pro": 128_000,
   "openrouter-custom": 256_000,
   "openai-compatible-custom": 128_000,
   "lmstudio-local": 32_000,

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -142,6 +142,16 @@ export async function buildLanguageModel(
       })(resolvedModelId);
       break;
     }
+    case "opencode-go": {
+      const { createOpenAICompatible } =
+        await import("@ai-sdk/openai-compatible");
+      built = createOpenAICompatible({
+        name: "opencode-go",
+        baseURL: "https://opencode.ai/zen/go/v1",
+        apiKey: key,
+      })(resolvedModelId);
+      break;
+    }
     case "groq": {
       const { createGroq } = await import("@ai-sdk/groq");
       built = createGroq({ apiKey: key })(resolvedModelId);

--- a/src/modules/ai/lib/keyring.ts
+++ b/src/modules/ai/lib/keyring.ts
@@ -20,6 +20,7 @@ export const EMPTY_PROVIDER_KEYS: ProviderKeys = {
   groq: null,
   deepseek: null,
   mistral: null,
+  "opencode-go": null,
   openrouter: null,
   "openai-compatible": null,
   lmstudio: null,

--- a/src/settings/components/ProviderIcon.tsx
+++ b/src/settings/components/ProviderIcon.tsx
@@ -25,6 +25,7 @@ const ICON_BY_PROVIDER = {
   groq: FlashIcon,
   deepseek: DeepseekIcon,
   mistral: MistralIcon,
+  "opencode-go": GlobeIcon,
   openrouter: GlobeIcon,
   "openai-compatible": PlugIcon,
   lmstudio: ComputerIcon,


### PR DESCRIPTION
Automated fix for contrib/T4-906-opencode-go - see branch for details. Fixes untriaged issue (0 comments, 0 reactions). Codegraph context + pi auto-provider. Verified pnpm check-types + tests + cargo check.