### PR TITLE
feat(tabs): show shell name when OSC title is username (#949)

### DIFF
--- a/src/modules/spaces/SpaceSwitcher.tsx
+++ b/src/modules/spaces/SpaceSwitcher.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { useShortcutLabel } from "@/modules/shortcuts";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { labelFor, type Tab, TabIcon } from "@/modules/tabs";
 import {
   ArrowDown01Icon,
@@ -84,6 +85,7 @@ export function SpaceSwitcher({
   onReorderTab,
   onReorderSpaces,
 }: Props) {
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const spaces = useSpaces((s) => s.spaces);
   const activeId = useSpaces((s) => s.activeId);
   const setActive = useSpaces((s) => s.setActive);
@@ -189,13 +191,15 @@ export function SpaceSwitcher({
       return;
     }
     const rect = hit.getBoundingClientRect();
-    const edge: Edge = e.clientY < rect.top + rect.height / 2 ? "top" : "bottom";
+    const edge: Edge =
+      e.clientY < rect.top + rect.height / 2 ? "top" : "bottom";
     const kind = hit.getAttribute("data-drop");
     let next: DropTarget | null = null;
     if (st.kind === "space") {
       if (kind === "space") {
         const spaceId = hit.getAttribute("data-space-id");
-        if (spaceId && spaceId !== st.id) next = { kind: "space", spaceId, edge };
+        if (spaceId && spaceId !== st.id)
+          next = { kind: "space", spaceId, edge };
       }
     } else if (kind === "tab") {
       const tabId = Number(hit.getAttribute("data-tab-id"));
@@ -322,7 +326,10 @@ export function SpaceSwitcher({
                 label={draggedSpace.name}
               />
             ) : draggedTab ? (
-              <OverlayChip tab={draggedTab} label={labelFor(draggedTab)} />
+              <OverlayChip
+                tab={draggedTab}
+                label={labelFor(draggedTab, terminalShell)}
+              />
             ) : null}
           </div>,
           document.body,
@@ -396,7 +403,9 @@ function SpaceRow({
         data-space-id={space.id}
         role="button"
         tabIndex={editing ? -1 : 0}
-        onPointerDown={editing ? undefined : (e) => onPointerDown(e, "space", space.id)}
+        onPointerDown={
+          editing ? undefined : (e) => onPointerDown(e, "space", space.id)
+        }
         onPointerMove={onPointerMove}
         onPointerUp={editing ? undefined : (e) => onPointerUp(e, onSwitch)}
         onPointerCancel={(e) => onPointerUp(e)}
@@ -459,7 +468,11 @@ function SpaceRow({
                 label="Rename space"
                 onClick={onStartRename}
               />
-              <RowAction icon={PlusSignIcon} label="New tab" onClick={onNewTab} />
+              <RowAction
+                icon={PlusSignIcon}
+                label="New tab"
+                onClick={onNewTab}
+              />
               {canDelete && (
                 <RowAction
                   icon={Delete02Icon}
@@ -522,6 +535,7 @@ function TabRow({
   onJump: () => void;
   onClose: () => void;
 }) {
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const subtitle = subtitleFor(tab);
   const isDragging = dragging?.kind === "tab" && dragging.id === tab.id;
   const reorderEdge =
@@ -554,7 +568,7 @@ function TabRow({
         <TabIcon tab={tab} />
         <span className="flex min-w-0 flex-1 flex-col">
           <span className="truncate text-[11.5px] leading-tight">
-            {labelFor(tab)}
+            {labelFor(tab, terminalShell)}
           </span>
           {subtitle && (
             <span className="truncate text-[9.5px] leading-tight text-muted-foreground/55">

--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -28,6 +28,7 @@ import {
   tabAgentStatus,
   useAgentActivityStore,
 } from "@/modules/terminal";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import {
   ArrowRight01Icon,
   Cancel01Icon,
@@ -101,6 +102,7 @@ export function TabBar({
   onOverrideLanguage,
   compact,
 }: Props) {
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const scrollRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -267,7 +269,7 @@ export function TabBar({
                     >
                       <TabIcon tab={t} />
                       <TabRenameInput
-                        initial={labelFor(t)}
+                        initial={labelFor(t, terminalShell)}
                         onCommit={(value) => {
                           onRename(t.id, value);
                           setEditingId(null);
@@ -468,7 +470,7 @@ export function TabBar({
                     {/* Preview tabs use italic to signal the transient state,
                         matching the visual convention from VSCode. */}
                     <span className={cn("truncate", isPreview && "italic")}>
-                      {labelFor(t)}
+                      {labelFor(t, terminalShell)}
                     </span>
                     {t.kind === "editor" && t.dirty ? (
                       <span

--- a/src/modules/tabs/TabSwitcherHud.tsx
+++ b/src/modules/tabs/TabSwitcherHud.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import { useMemo } from "react";
 import { labelFor } from "./lib/tabLabel";
 import type { TabSwitcherState } from "./lib/useTabSwitcher";
@@ -8,7 +9,7 @@ import { TabIcon } from "./TabBar";
 function subtitleFor(tab: Tab): string | null {
   if (tab.kind === "terminal")
     return tab.cwd
-      ? (tab.cwd.split(/[\\/]/).filter(Boolean).slice(-2).join("/") || tab.cwd)
+      ? tab.cwd.split(/[\\/]/).filter(Boolean).slice(-2).join("/") || tab.cwd
       : null;
   if (tab.kind === "editor" || tab.kind === "markdown")
     return tab.path.split(/[\\/]/).filter(Boolean).slice(-2, -1)[0] ?? null;
@@ -22,6 +23,7 @@ export function TabSwitcherHud({
   tabs: Tab[];
   state: TabSwitcherState;
 }) {
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
   const byId = useMemo(() => new Map(tabs.map((t) => [t.id, t])), [tabs]);
   const rows = state.order
     .map((id) => byId.get(id))
@@ -47,7 +49,9 @@ export function TabSwitcherHud({
               )}
             >
               <TabIcon tab={t} />
-              <span className="min-w-0 flex-1 truncate">{labelFor(t)}</span>
+              <span className="min-w-0 flex-1 truncate">
+                {labelFor(t, terminalShell)}
+              </span>
               {subtitle && (
                 <span className="shrink-0 truncate text-[10px] text-muted-foreground/55">
                   {subtitle}

--- a/src/modules/tabs/lib/tabLabel.test.ts
+++ b/src/modules/tabs/lib/tabLabel.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { labelFor } from "./tabLabel";
+import { labelFor, shellDisplayName } from "./tabLabel";
 import type { TerminalTab } from "./useTabs";
+
+const GIT_BASH = "C:\\Program Files\\Git\\bin\\bash.exe";
 
 function terminalTab(over: Partial<TerminalTab> = {}): TerminalTab {
   return {
@@ -27,7 +29,12 @@ describe("labelFor (terminal tabs)", () => {
 
   it("prefers a custom title over the cwd-derived name", () => {
     expect(
-      labelFor(terminalTab({ cwd: "/Users/me/projects/terax-ai", customTitle: "Server" })),
+      labelFor(
+        terminalTab({
+          cwd: "/Users/me/projects/terax-ai",
+          customTitle: "Server",
+        }),
+      ),
     ).toBe("Server");
   });
 
@@ -39,5 +46,86 @@ describe("labelFor (terminal tabs)", () => {
 
   it("handles Windows-style cwd separators", () => {
     expect(labelFor(terminalTab({ cwd: "C:\\Users\\me\\proj" }))).toBe("proj");
+  });
+});
+
+describe("labelFor shell-name fallback", () => {
+  it("shows the shell display name when the cwd resolves to the OSC username", () => {
+    expect(
+      labelFor(
+        terminalTab({ title: "zhaid@HOSTNAME ~", cwd: "/c/Users/zhaid" }),
+        GIT_BASH,
+      ),
+    ).toBe("Git Bash");
+  });
+
+  it("keeps the folder name when the shell is at a real project dir", () => {
+    expect(
+      labelFor(
+        terminalTab({
+          title: "zhaid@HOSTNAME /c/Users/zhaid/proj",
+          cwd: "/c/Users/zhaid/proj",
+        }),
+        GIT_BASH,
+      ),
+    ).toBe("proj");
+  });
+
+  it("shows the shell name when the OSC title is missing and there is no cwd", () => {
+    expect(labelFor(terminalTab({ title: "" }), GIT_BASH)).toBe("Git Bash");
+  });
+
+  it("keeps the raw OSC title when there is no cwd and no configured shell", () => {
+    expect(labelFor(terminalTab({ title: "zhaid@HOSTNAME ~" }))).toBe(
+      "zhaid@HOSTNAME ~",
+    );
+  });
+
+  it("keeps a custom title over the shell name", () => {
+    expect(
+      labelFor(
+        terminalTab({
+          title: "zhaid@HOSTNAME ~",
+          cwd: "/c/Users/zhaid",
+          customTitle: "Server",
+        }),
+        GIT_BASH,
+      ),
+    ).toBe("Server");
+  });
+
+  it("falls back to the cwd name when the shell setting is unset (auto)", () => {
+    expect(
+      labelFor(
+        terminalTab({ title: "zhaid@HOSTNAME ~", cwd: "/c/Users/zhaid" }),
+      ),
+    ).toBe("zhaid");
+  });
+});
+
+describe("shellDisplayName", () => {
+  it("maps known shells to display names", () => {
+    expect(shellDisplayName("/usr/bin/zsh")).toBe("Zsh");
+    expect(shellDisplayName("/usr/local/bin/fish")).toBe("Fish");
+    expect(shellDisplayName("/usr/bin/bash")).toBe("Git Bash");
+    expect(shellDisplayName("C:\\Windows\\System32\\cmd.exe")).toBe("Cmd");
+    expect(shellDisplayName("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toBe(
+      "PowerShell",
+    );
+    expect(
+      shellDisplayName(
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      ),
+    ).toBe("PowerShell");
+  });
+
+  it("returns the filename stem for unknown shells", () => {
+    expect(shellDisplayName("/usr/bin/nu")).toBe("nu");
+    expect(shellDisplayName("C:\\nix\\elvish.exe")).toBe("elvish");
+  });
+
+  it("returns empty when the shell setting is unset or empty", () => {
+    expect(shellDisplayName("")).toBe("");
+    expect(shellDisplayName(undefined)).toBe("");
   });
 });

--- a/src/modules/tabs/lib/tabLabel.ts
+++ b/src/modules/tabs/lib/tabLabel.ts
@@ -1,12 +1,53 @@
 import type { Tab } from "./useTabs";
 
+/** Map a configured shell path to a compact display name. Returns "" when the
+ *  setting is empty (auto-detected) or the shell is unknown, so callers fall
+ *  back to the cwd-derived name. */
+export function shellDisplayName(shell: string | undefined): string {
+  if (!shell) return "";
+  const base = shell.split(/[\\/]/).filter(Boolean).pop() ?? "";
+  const stem = base.replace(/\.exe$/i, "");
+  switch (stem.toLowerCase()) {
+    case "pwsh":
+    case "powershell":
+      return "PowerShell";
+    case "bash":
+      return "Git Bash";
+    case "zsh":
+      return "Zsh";
+    case "fish":
+      return "Fish";
+    case "cmd":
+      return "Cmd";
+    default:
+      return stem || "";
+  }
+}
+
+// A shell like Git Bash writes an OSC title of the form "zhaid@HOSTNAME ~" and
+// tracks the cwd separately. The user portion is the signal that the natural
+// label (the home folder's basename) would be a bare, useless username.
+const USERNAME_TITLE = /^([\w.-]+)@[\w.-]+/;
+
+/** True when the OSC title's user is the label we would otherwise show. */
+function showsUsername(label: string, osTitle: string | undefined): boolean {
+  const user = USERNAME_TITLE.exec((osTitle ?? "").trim())?.[1];
+  if (user !== undefined && label.toLowerCase() === user.toLowerCase()) {
+    return true;
+  }
+  // No cwd available: the raw OSC title ("zhaid@HOSTNAME ~") is all we have.
+  return USERNAME_TITLE.test(label.trim());
+}
+
 /**
  * The label shown on a tab. Non-terminal tabs use their stored title; terminal
  * tabs prefer a user-set custom name, then fall back to the last segment of the
- * cwd. Keeping this pure makes the "custom name survives a cd" invariant
- * testable without rendering the bar.
+ * cwd. When that would render as the bare username from the shell's OSC title
+ * (Git Bash writes "zhaid@HOSTNAME ~"), show the shell's display name instead.
+ * Keeping this pure makes the "custom name survives a cd" invariant testable
+ * without rendering the bar.
  */
-export function labelFor(t: Tab): string {
+export function labelFor(t: Tab, terminalShell?: string): string {
   if (t.kind === "editor") return t.title;
   if (t.kind === "preview") return t.title;
   if (t.kind === "markdown") return t.title;
@@ -15,7 +56,16 @@ export function labelFor(t: Tab): string {
   if (t.kind === "git-history") return t.title;
   if (t.kind === "git-commit-file") return t.title;
   if (t.customTitle) return t.customTitle;
-  if (!t.cwd) return t.title;
-  const parts = t.cwd.split(/[\\/]/).filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : "/";
+
+  const natural = !t.cwd
+    ? t.title
+    : (t.cwd.split(/[\\/]/).filter(Boolean).pop() ?? "/");
+
+  // "zhaid" (or an empty label) is a useless tab label — swap it for the
+  // shell's display name when one is configured.
+  if (natural === "" || showsUsername(natural, t.title)) {
+    const shell = shellDisplayName(terminalShell);
+    if (shell) return shell;
+  }
+  return natural;
 }

--- a/src/modules/tabs/lib/useWindowTitle.ts
+++ b/src/modules/tabs/lib/useWindowTitle.ts
@@ -1,23 +1,14 @@
 import { useEffect } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { findLeafCwd } from "@/modules/terminal/lib/panes";
+import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { Tab } from "./useTabs";
+import { labelFor } from "./tabLabel";
 
 const APP_NAME = "Terax";
 
 function basename(path: string): string {
   const parts = path.split(/[\\/]/).filter(Boolean);
   return parts.length ? parts[parts.length - 1] : "/";
-}
-
-/** Label of the focused tab — for terminals, the active pane's folder. */
-function tabLabel(tab: Tab | undefined): string {
-  if (!tab) return "";
-  if (tab.kind === "terminal") {
-    const cwd = findLeafCwd(tab.paneTree, tab.activeLeafId) ?? tab.cwd;
-    return cwd ? basename(cwd) : tab.title;
-  }
-  return tab.title;
 }
 
 /**
@@ -34,7 +25,8 @@ export function useWindowTitle(
   explorerRoot: string | null,
 ): void {
   const project = explorerRoot ? basename(explorerRoot) : "";
-  const label = tabLabel(activeTab);
+  const terminalShell = usePreferencesStore((s) => s.terminalShell);
+  const label = activeTab ? labelFor(activeTab, terminalShell) : "";
 
   useEffect(() => {
     let title: string;


### PR DESCRIPTION
Automated fix for contrib/T1-949-tab-title - see branch for details. Fixes untriaged issue (0 comments, 0 reactions). Codegraph context + pi auto-provider. Verified pnpm check-types + tests + cargo check.