### PR TITLE
fix(window): settings not system-floating on macOS (#957)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     };
 
     if let Some(window) = app.get_webview_window("settings") {
+        #[cfg(not(target_os = "macos"))]
         let _ = window.set_always_on_top(true);
         let _ = window.show();
         let _ = window.set_focus();
@@ -106,7 +107,12 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         .visible(false)
         // Keep settings above the main app window so it doesn't get hidden
         // when the user clicks back into the editor or terminal (#33).
-        .always_on_top(true);
+        // On macOS always_on_top maps to NSWindow.level=.floating which is
+        // system-wide (above all apps). Avoid it there; show()+focus is enough
+        // to bring the window above the main window without floating over Safari etc. (#957).
+        .always_on_top(false);
+    #[cfg(not(target_os = "macos"))]
+    let builder = builder.always_on_top(true);
 
     // Tie lifecycle to the main window so settings minimizes/closes with it.
     // macOS: skip parent() — child + always_on_top leaves the settings webview

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,9 @@ use modules::{
 };
 use std::path::PathBuf;
 use std::sync::Mutex;
-use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 #[cfg(target_os = "macos")]
-use tauri::{PhysicalPosition, WindowEvent};
+use tauri::PhysicalPosition;
+use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_window_state::StateFlags;
 
 /// Drained on first read so HMR / re-mounts can't replay the launch dir.
@@ -79,6 +79,10 @@ fn parse_launch_target() -> LaunchTarget {
     resolve_launch_target(entries)
 }
 
+const fn settings_always_on_top(is_macos: bool) -> bool {
+    !is_macos
+}
+
 #[tauri::command]
 async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Result<(), String> {
     let url_path = match tab.as_deref() {
@@ -105,19 +109,11 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         .min_inner_size(820.0, 620.0)
         .resizable(true)
         .visible(false)
-        // Keep settings above the main app window so it doesn't get hidden
-        // when the user clicks back into the editor or terminal (#33).
-        // On macOS always_on_top maps to NSWindow.level=.floating which is
-        // system-wide (above all apps). Avoid it there; show()+focus is enough
-        // to bring the window above the main window without floating over Safari etc. (#957).
-        .always_on_top(false);
-    #[cfg(not(target_os = "macos"))]
-    let builder = builder.always_on_top(true);
+        .always_on_top(settings_always_on_top(cfg!(target_os = "macos")));
 
-    // Tie lifecycle to the main window so settings minimizes/closes with it.
-    // macOS: skip parent() — child + always_on_top leaves the settings webview
-    // behind the main window except while the parent is being dragged (#33).
-    #[cfg(not(target_os = "macos"))]
+    // A normal-level child stays above Terax but recedes with the app on macOS.
+    // Never combine the macOS parent with always_on_top; that breaks WebView
+    // compositing and can hide Settings behind the main window (#33, #957).
     let builder = if let Some(main) = app.get_webview_window("main") {
         builder.parent(&main).map_err(|e| e.to_string())?
     } else {
@@ -213,22 +209,6 @@ pub fn run() {
         .setup(move |_app| {
             if let Err(error) = control::start(_app.handle().clone(), control_for_setup.clone()) {
                 log::warn!("could not start Terax control server: {error}");
-            }
-            // macOS skips parent() for the settings window, so tie its lifecycle
-            // to the main window here instead. Other platforms keep parent().
-            #[cfg(target_os = "macos")]
-            if let Some(main) = _app.get_webview_window("main") {
-                let handle = _app.handle().clone();
-                main.on_window_event(move |event| {
-                    if matches!(
-                        event,
-                        WindowEvent::CloseRequested { .. } | WindowEvent::Destroyed
-                    ) {
-                        if let Some(settings) = handle.get_webview_window("settings") {
-                            let _ = settings.close();
-                        }
-                    }
-                });
             }
             Ok(())
         })
@@ -388,7 +368,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod launch_target_tests {
-    use super::{resolve_launch_target, LaunchEntry, LaunchTarget};
+    use super::{resolve_launch_target, settings_always_on_top, LaunchEntry, LaunchTarget};
     use std::path::PathBuf;
 
     #[test]
@@ -405,8 +385,9 @@ mod launch_target_tests {
 
     #[test]
     fn file_arg_opens_file_and_uses_parent_as_workspace() {
-        let out =
-            resolve_launch_target(vec![LaunchEntry::File(PathBuf::from("/home/u/proj/main.rs"))]);
+        let out = resolve_launch_target(vec![LaunchEntry::File(PathBuf::from(
+            "/home/u/proj/main.rs",
+        ))]);
         assert_eq!(out.dir.as_deref(), Some("/home/u/proj"));
         assert_eq!(out.files, vec!["/home/u/proj/main.rs".to_string()]);
     }
@@ -432,5 +413,11 @@ mod launch_target_tests {
         ]);
         assert_eq!(out.dir.as_deref(), Some("/workspace"));
         assert_eq!(out.files, vec!["/other/x.rs".to_string()]);
+    }
+
+    #[test]
+    fn settings_float_only_outside_macos() {
+        assert!(!settings_always_on_top(true));
+        assert!(settings_always_on_top(false));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,9 @@ use modules::{
 };
 use std::path::PathBuf;
 use std::sync::Mutex;
-#[cfg(target_os = "macos")]
-use tauri::PhysicalPosition;
 use tauri::{Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+#[cfg(target_os = "macos")]
+use tauri::{PhysicalPosition, WindowEvent};
 use tauri_plugin_window_state::StateFlags;
 
 /// Drained on first read so HMR / re-mounts can't replay the launch dir.
@@ -209,6 +209,18 @@ pub fn run() {
         .setup(move |_app| {
             if let Err(error) = control::start(_app.handle().clone(), control_for_setup.clone()) {
                 log::warn!("could not start Terax control server: {error}");
+            }
+            #[cfg(target_os = "macos")]
+            if let Some(main) = _app.get_webview_window("main") {
+                let handle = _app.handle().clone();
+                main.on_window_event(move |event| {
+                    // CloseRequested can be cancelled by the frontend guard.
+                    if matches!(event, WindowEvent::Destroyed) {
+                        if let Some(settings) = handle.get_webview_window("settings") {
+                            let _ = settings.destroy();
+                        }
+                    }
+                });
             }
             Ok(())
         })


### PR DESCRIPTION
Automated fix for contrib/T2-957-settings-float - see branch for details. Fixes untriaged issue (0 comments, 0 reactions). Codegraph context + pi auto-provider. Verified pnpm check-types + tests + cargo check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings window behavior across platforms.
  * Settings remains on top where supported without being forced on macOS.
  * Improved settings window lifecycle behavior when closing or destroying the window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->