### PR TITLE
fix(preview): hint for cookie-auth in sandboxed iframe (#1148)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -144,7 +144,7 @@ Categories that will not be built into Terax. Individual feature requests in the
 - **Heavyweight IDE infrastructure.** Integrated debugger and profiler suites, unbounded background indexing, and always-resident extension hosts are out of scope. Focused LSP, autocomplete, formatting, and editor workflows remain in scope when they are opt-in, lazy, and resource-bounded.
 - **Notebook and document workspaces.** Anything that turns Terax into a document host rather than a terminal.
 - **Package manager and toolchain UIs.** Use `npm`, `pip`, `cargo` and friends in the terminal directly.
-- **Full web browser features.** Preview pane stays scoped to local dev servers and lightweight doc viewing. No navigation history, no bookmarks, no dev tools.
+- **Full web browser features.** Preview pane stays scoped to local dev servers and lightweight doc viewing. No navigation history, no bookmarks, no dev tools. Sandbox and WebView cookie policies can prevent cookie-based sign-in, so preview offers an external browser fallback instead of relaxing its security boundary.
 - **Telemetry, analytics, accounts.** Terax stays BYOK and offline-respectful.
 - **Extension marketplaces at IDE scale.** Narrowly-scoped AI tool / skill bundles may happen eventually. Arbitrary UI or behavior extensions will not.
 - **Third-party subscription session bridges.** Forwarding cloud subscription auth (provider-managed login sessions) through Terax is not technically feasible for third-party clients.

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -1,5 +1,10 @@
-import { Alert02Icon, Globe02Icon } from "@hugeicons/core-free-icons";
+import {
+  Alert02Icon,
+  Globe02Icon,
+  LinkSquare02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   forwardRef,
   useEffect,
@@ -60,6 +65,7 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
     );
 
     const showXfoHint = url ? !isLocalUrl(url) : false;
+    const showCookieHint = url ? isLocalUrl(url) : false;
 
     return (
       <div
@@ -87,6 +93,28 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
               Many public sites refuse to embed (X-Frame-Options). If the page
               is blank, open it externally.
             </span>
+          </div>
+        ) : null}
+        {showCookieHint ? (
+          <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border/60 bg-sky-500/8 px-3 text-[11px] text-sky-700 dark:text-sky-300">
+            <HugeiconsIcon
+              icon={Alert02Icon}
+              size={12}
+              strokeWidth={1.75}
+              className="shrink-0"
+            />
+            <span className="truncate">
+              Cookie login may not persist in sandboxed preview. If login fails,
+              open externally.
+            </span>
+            <button
+              type="button"
+              onClick={() => void openUrl(url).catch(console.error)}
+              className="ml-auto flex shrink-0 items-center gap-1 rounded bg-sky-500/15 px-1.5 py-0.5 text-[10.5px] hover:bg-sky-500/20"
+            >
+              <HugeiconsIcon icon={LinkSquare02Icon} size={10} strokeWidth={1.75} />
+              Open
+            </button>
           </div>
         ) : null}
         <div

--- a/src/modules/preview/PreviewPane.tsx
+++ b/src/modules/preview/PreviewPane.tsx
@@ -1,6 +1,8 @@
 import {
   Alert02Icon,
+  Cancel01Icon,
   Globe02Icon,
+  InformationCircleIcon,
   LinkSquare02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -16,6 +18,7 @@ import {
   PreviewAddressBar,
   type PreviewAddressBarHandle,
 } from "./PreviewAddressBar";
+import { loopbackPreviewOrigin } from "./lib/previewUrl";
 
 export type PreviewPaneHandle = {
   reload: () => void;
@@ -40,6 +43,9 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
     // contentWindow.location.reload() throws on cross-origin frames).
     const [nonce, setNonce] = useState(0);
     const [loaded, setLoaded] = useState(visible);
+    const [dismissedCookieOrigin, setDismissedCookieOrigin] = useState<
+      string | null
+    >(null);
     const addressRef = useRef<PreviewAddressBarHandle>(null);
 
     useEffect(() => {
@@ -64,8 +70,10 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
       [url],
     );
 
-    const showXfoHint = url ? !isLocalUrl(url) : false;
-    const showCookieHint = url ? isLocalUrl(url) : false;
+    const cookieOrigin = loopbackPreviewOrigin(url);
+    const showXfoHint = url ? cookieOrigin === null : false;
+    const showCookieHint =
+      cookieOrigin !== null && cookieOrigin !== dismissedCookieOrigin;
 
     return (
       <div
@@ -96,24 +104,42 @@ export const PreviewPane = forwardRef<PreviewPaneHandle, Props>(
           </div>
         ) : null}
         {showCookieHint ? (
-          <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border/60 bg-sky-500/8 px-3 text-[11px] text-sky-700 dark:text-sky-300">
+          <div
+            role="note"
+            className="flex h-7 shrink-0 items-center gap-1.5 border-b border-border/60 bg-sky-500/8 px-3 text-[11px] text-sky-700 dark:text-sky-300"
+          >
             <HugeiconsIcon
-              icon={Alert02Icon}
+              icon={InformationCircleIcon}
               size={12}
               strokeWidth={1.75}
               className="shrink-0"
             />
-            <span className="truncate">
-              Cookie login may not persist in sandboxed preview. If login fails,
-              open externally.
+            <span
+              className="min-w-0 flex-1 truncate"
+              title="Cookie-based sign-in may not work in the sandboxed preview."
+            >
+              Cookie-based sign-in may not work in preview.
             </span>
             <button
               type="button"
               onClick={() => void openUrl(url).catch(console.error)}
-              className="ml-auto flex shrink-0 items-center gap-1 rounded bg-sky-500/15 px-1.5 py-0.5 text-[10.5px] hover:bg-sky-500/20"
+              className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-medium hover:bg-sky-500/15"
             >
-              <HugeiconsIcon icon={LinkSquare02Icon} size={10} strokeWidth={1.75} />
-              Open
+              <HugeiconsIcon
+                icon={LinkSquare02Icon}
+                size={10}
+                strokeWidth={1.75}
+              />
+              Open in browser
+            </button>
+            <button
+              type="button"
+              aria-label="Dismiss cookie sign-in notice"
+              title="Dismiss"
+              onClick={() => setDismissedCookieOrigin(cookieOrigin)}
+              className="flex size-5 shrink-0 items-center justify-center rounded text-sky-700/70 hover:bg-sky-500/15 hover:text-sky-800 dark:text-sky-300/70 dark:hover:text-sky-200"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} size={10} strokeWidth={2} />
             </button>
           </div>
         ) : null}
@@ -199,26 +225,10 @@ function EmptyState() {
             Ports
           </span>{" "}
           dropdown to jump straight to your running dev server. Public sites
-          often block embedding — open them in your browser via the link icon
-          if you see a blank page.
+          often block embedding. Open them in your browser via the link icon if
+          you see a blank page.
         </p>
       </div>
     </div>
   );
-}
-
-function isLocalUrl(url: string): boolean {
-  try {
-    const u = new URL(url);
-    const h = u.hostname;
-    return (
-      h === "localhost" ||
-      h === "127.0.0.1" ||
-      h === "0.0.0.0" ||
-      h === "[::1]" ||
-      h.endsWith(".localhost")
-    );
-  } catch {
-    return false;
-  }
 }

--- a/src/modules/preview/lib/previewUrl.test.ts
+++ b/src/modules/preview/lib/previewUrl.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { loopbackPreviewOrigin } from "./previewUrl";
+
+describe("loopbackPreviewOrigin", () => {
+  it.each([
+    ["http://localhost:5173/login", "http://localhost:5173"],
+    ["https://app.localhost/auth", "https://app.localhost"],
+    ["http://localhost.:3000", "http://localhost.:3000"],
+    ["http://127.0.0.1:8080", "http://127.0.0.1:8080"],
+    ["http://127.0.0.42:8080", "http://127.0.0.42:8080"],
+    ["http://127.1:8080", "http://127.0.0.1:8080"],
+    ["http://0.0.0.0:4173", "http://0.0.0.0:4173"],
+    ["http://[::1]:3000", "http://[::1]:3000"],
+  ])("returns the origin for %s", (url, origin) => {
+    expect(loopbackPreviewOrigin(url)).toBe(origin);
+  });
+
+  it.each([
+    "https://example.com",
+    "http://192.168.1.10:3000",
+    "ftp://localhost/file",
+    "javascript:alert(1)",
+    "not a url",
+    "",
+  ])("rejects non-loopback or unusable URL %s", (url) => {
+    expect(loopbackPreviewOrigin(url)).toBeNull();
+  });
+});

--- a/src/modules/preview/lib/previewUrl.ts
+++ b/src/modules/preview/lib/previewUrl.ts
@@ -1,0 +1,22 @@
+const IPV4_LOOPBACK = /^127(?:\.\d{1,3}){3}$/;
+
+export function loopbackPreviewOrigin(rawUrl: string): string | null {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+    const hostname = url.hostname.toLowerCase().replace(/\.$/, "");
+    if (
+      hostname !== "localhost" &&
+      !hostname.endsWith(".localhost") &&
+      hostname !== "0.0.0.0" &&
+      hostname !== "[::1]" &&
+      !IPV4_LOOPBACK.test(hostname)
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Automated fix for contrib/T5-1148-preview-cookies - see branch for details. Fixes untriaged issue (0 comments, 0 reactions). Codegraph context + pi auto-provider. Verified pnpm check-types + tests + cargo check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismissible notice when cookie-based sign-in may be blocked in the preview.
  * Added an “Open in browser” option to continue sign-in externally.
  * Improved preview guidance for embedded content and local development URLs.

* **Bug Fixes**
  * Improved detection of trusted loopback preview addresses, including IPv4, IPv6, and localhost variants.

* **Documentation**
  * Documented cookie sign-in limitations and the external-browser fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->