### PR TITLE
feat(git): show branch and tag refs in graph (#984)

### DIFF
--- a/src-tauri/src/modules/git/operations.rs
+++ b/src-tauri/src/modules/git/operations.rs
@@ -470,7 +470,7 @@ pub fn push(
     })
 }
 
-const LOG_FORMAT: &str = "%H%x1f%an%x1f%ae%x1f%at%x1f%P%x1f%s";
+const LOG_FORMAT: &str = "%H%x1f%an%x1f%ae%x1f%at%x1f%P%x1f%D%x1f%s";
 const MAX_LOG_LIMIT: u32 = 200;
 
 pub fn log(
@@ -497,6 +497,7 @@ pub fn log(
     let mut args: Vec<&OsStr> = vec![
         OsStr::new("log"),
         OsStr::new("--no-color"),
+        OsStr::new("--decorate=full"),
         OsStr::new("--shortstat"),
         OsStr::new(&count_arg),
         OsStr::new(&format_arg),
@@ -527,7 +528,7 @@ pub fn log(
     let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");
     let mut entries: Vec<GitLogEntry> = Vec::with_capacity(bounded as usize);
     // Lines we get back interleave:
-    //   <sha>\x1f<author>\x1f<email>\x1f<ts>\x1f<parents>\x1f<subject>
+    //   <sha>\x1f<author>\x1f<email>\x1f<ts>\x1f<parents>\x1f<refs>\x1f<subject>
     //   <blank>
     //    5 files changed, 12 insertions(+), 3 deletions(-)
     // Commits without diffstats (root commits, merges with no changes) just
@@ -539,7 +540,7 @@ pub fn log(
             continue;
         }
         if line.contains('\x1f') {
-            let mut fields = line.splitn(6, '\x1f');
+            let mut fields = line.splitn(7, '\x1f');
             let sha = fields.next().unwrap_or("").to_string();
             if !sha_is_safe(&sha) {
                 continue;
@@ -552,6 +553,12 @@ pub fn log(
                 .split_ascii_whitespace()
                 .map(|s| s.to_string())
                 .collect();
+            let refs_raw = fields.next().unwrap_or("");
+            let refs: Vec<String> = refs_raw
+                .split(", ")
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
             let subject = fields.next().unwrap_or("").to_string();
             let short_sha = sha.chars().take(7).collect::<String>();
             entries.push(GitLogEntry {
@@ -561,6 +568,7 @@ pub fn log(
                 author_email,
                 timestamp_secs: timestamp,
                 parents,
+                refs,
                 subject,
                 files_changed: 0,
                 insertions: 0,

--- a/src-tauri/src/modules/git/types.rs
+++ b/src-tauri/src/modules/git/types.rs
@@ -101,6 +101,7 @@ pub struct GitLogEntry {
     pub author_email: String,
     pub timestamp_secs: i64,
     pub parents: Vec<String>,
+    pub refs: Vec<String>,
     pub subject: String,
     pub files_changed: u32,
     pub insertions: u32,
@@ -301,6 +302,7 @@ mod serde_shape_tests {
             author_email: "a@example.com".into(),
             timestamp_secs: 1_700_000_000,
             parents: vec!["p0".into()],
+            refs: vec!["refs/heads/main".into(), "tag: v1.0".into()],
             subject: "s".into(),
             files_changed: 2,
             insertions: 10,
@@ -314,10 +316,15 @@ mod serde_shape_tests {
             "filesChanged",
             "insertions",
             "deletions",
+            "refs",
         ] {
             assert!(json.get(key).is_some(), "missing key {key}");
         }
         assert_eq!(json["parents"], serde_json::json!(["p0"]));
+        assert_eq!(
+            json["refs"],
+            serde_json::json!(["refs/heads/main", "tag: v1.0"])
+        );
     }
 
     #[test]

--- a/src/modules/ai/lib/native.ts
+++ b/src/modules/ai/lib/native.ts
@@ -98,6 +98,7 @@ export type GitLogEntry = {
   authorEmail: string;
   timestampSecs: number;
   parents: string[];
+  refs: string[];
   subject: string;
   filesChanged: number;
   insertions: number;

--- a/src/modules/git-history/GitHistoryPane.tsx
+++ b/src/modules/git-history/GitHistoryPane.tsx
@@ -743,6 +743,35 @@ const CommitRow = memo(function CommitRow({
           <span className="text-muted-foreground">(no subject)</span>
         )}
       </span>
+      {commit.refs && commit.refs.length > 0 ? (
+        <span className="inline-flex flex-wrap gap-1">
+          {commit.refs.map((r) => {
+            const label = r
+              .replace(/^HEAD -> /, "")
+              .replace(/^refs\/heads\//, "")
+              .replace(/^refs\/remotes\//, "")
+              .replace(/^refs\/tags\//, "")
+              .replace(/^tag: /, "");
+            const isTag = r.includes("tag:") || r.startsWith("refs/tags/");
+            const isRemote = r.includes("origin/") || r.startsWith("refs/remotes/");
+            return (
+              <span
+                key={r}
+                className={cn(
+                  "inline-flex items-center rounded px-1 py-0.5 text-[10px] font-medium",
+                  isTag
+                    ? "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+                    : isRemote
+                      ? "bg-sky-500/15 text-sky-700 dark:text-sky-300"
+                      : "bg-primary/10 text-primary",
+                )}
+              >
+                {label}
+              </span>
+            );
+          })}
+        </span>
+      ) : null}
       <span aria-hidden />
       <span
         className="ml-2 inline-flex h-[18px] max-w-full min-w-0 items-center gap-1.5 justify-self-start self-center overflow-hidden rounded-md bg-foreground/6 pl-1 pr-1.5 text-[10.5px] font-medium text-foreground/85"
@@ -848,6 +877,35 @@ function CommitDetail({
             )}
           </div>
         </div>
+        {commit.refs && commit.refs.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {commit.refs.map((r) => {
+              const label = r
+                .replace(/^HEAD -> /, "")
+                .replace(/^refs\/heads\//, "")
+                .replace(/^refs\/remotes\//, "")
+                .replace(/^refs\/tags\//, "")
+                .replace(/^tag: /, "");
+              const isTag = r.includes("tag:") || r.startsWith("refs/tags/");
+              const isRemote = r.includes("origin/") || r.startsWith("refs/remotes/");
+              return (
+                <span
+                  key={r}
+                  className={cn(
+                    "inline-flex items-center rounded px-1.5 py-0.5 text-[10.5px] font-medium",
+                    isTag
+                      ? "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+                      : isRemote
+                        ? "bg-sky-500/15 text-sky-700 dark:text-sky-300"
+                        : "bg-primary/10 text-primary",
+                  )}
+                >
+                  {label}
+                </span>
+              );
+            })}
+          </div>
+        ) : null}
         <div className="mt-2 flex min-w-0 items-center gap-1.5 text-[10.5px] text-muted-foreground">
           <span className="truncate">{commit.author || "Unknown"}</span>
           {commit.authorEmail ? (


### PR DESCRIPTION
Automated fix for contrib/T3-984-git-graph-refs - see branch for details. Fixes untriaged issue (0 comments, 0 reactions). Codegraph context + pi auto-provider. Verified pnpm check-types + tests + cargo check.