### PR TITLE
fix(linux): prevent launch crash on NVIDIA Wayland explicit sync

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,5 +14,8 @@ fn main() {
         }
     }
 
+    #[cfg(target_os = "linux")]
+    terax_lib::modules::workspace::disable_nv_explicit_sync_if_needed();
+
     terax_lib::run()
 }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -155,12 +155,12 @@ fn apply_common(
     if blocks {
         cmd.env("TERAX_BLOCKS", "1");
     }
-    let appimage_overrides = workspace::appimage_env_overrides();
-    let clean_path = match appimage_overrides.iter().find(|(key, _)| *key == "PATH") {
+    let env_overrides = workspace::child_env_overrides();
+    let clean_path = match env_overrides.iter().find(|(key, _)| *key == "PATH") {
         Some((_, value)) => value.clone(),
         None => std::env::var_os("PATH"),
     };
-    for (key, value) in appimage_overrides {
+    for (key, value) in env_overrides {
         match value {
             Some(v) => {
                 cmd.env(key, v);

--- a/src-tauri/src/modules/shell/mod.rs
+++ b/src-tauri/src/modules/shell/mod.rs
@@ -301,7 +301,7 @@ pub(crate) fn build_oneshot_command(
     {
         let mut cmd = Command::new("/bin/sh");
         cmd.arg("-c").arg(command);
-        for (key, value) in crate::modules::workspace::appimage_env_overrides() {
+        for (key, value) in crate::modules::workspace::child_env_overrides() {
             match value {
                 Some(v) => {
                     cmd.env(key, v);

--- a/src-tauri/src/modules/workspace.rs
+++ b/src-tauri/src/modules/workspace.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -306,6 +308,67 @@ fn compute_appimage_env_overrides(
     }
 
     out
+}
+
+#[cfg(target_os = "linux")]
+const NV_DISABLE_EXPLICIT_SYNC: &str = "__NV_DISABLE_EXPLICIT_SYNC";
+
+#[cfg(target_os = "linux")]
+static NV_EXPLICIT_SYNC_DISABLED: AtomicBool = AtomicBool::new(false);
+
+// WebKitGTK commits DMABUF buffers without an explicit-sync acquire point, so an
+// explicit-sync compositor answers with a wp_linux_drm_syncobj_surface_v1
+// protocol error and GDK aborts before the window maps. Falling back to implicit
+// sync keeps the DMABUF renderer, unlike WEBKIT_DISABLE_DMABUF_RENDERER, which
+// costs terminal latency. Must run before GTK init and before any thread spawns.
+#[cfg(target_os = "linux")]
+pub fn disable_nv_explicit_sync_if_needed() {
+    let has_nvidia_driver = Path::new("/sys/module/nvidia").exists();
+    if should_disable_nv_explicit_sync(|k| std::env::var_os(k), has_nvidia_driver) {
+        std::env::set_var(NV_DISABLE_EXPLICIT_SYNC, "1");
+        NV_EXPLICIT_SYNC_DISABLED.store(true, Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_disable_nv_explicit_sync(
+    read: impl Fn(&str) -> Option<OsString>,
+    has_nvidia_driver: bool,
+) -> bool {
+    if read(NV_DISABLE_EXPLICIT_SYNC).is_some() {
+        return false;
+    }
+    let is_wayland = read("WAYLAND_DISPLAY").is_some()
+        || read("XDG_SESSION_TYPE").is_some_and(|v| v.eq_ignore_ascii_case("wayland"));
+    is_wayland && has_nvidia_driver
+}
+
+/// Env fixups applied to every child process Terax spawns.
+pub fn child_env_overrides() -> Vec<(&'static str, Option<OsString>)> {
+    #[cfg(target_os = "linux")]
+    {
+        compute_child_env_overrides(
+            appimage_env_overrides(),
+            NV_EXPLICIT_SYNC_DISABLED.load(Ordering::Relaxed),
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        appimage_env_overrides()
+    }
+}
+
+// The workaround exists for the Terax webview only. A child that inherited it
+// would lose explicit sync for no reason.
+#[cfg(target_os = "linux")]
+fn compute_child_env_overrides(
+    mut appimage: Vec<(&'static str, Option<OsString>)>,
+    nv_explicit_sync_disabled: bool,
+) -> Vec<(&'static str, Option<OsString>)> {
+    if nv_explicit_sync_disabled {
+        appimage.push((NV_DISABLE_EXPLICIT_SYNC, None));
+    }
+    appimage
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -997,5 +1060,79 @@ mod appimage_tests {
 
         let outside = reader(&[("FONTCONFIG_FILE", "/etc/fonts/fonts.conf")]);
         assert!(find(&compute_appimage_env_overrides(appdir, outside), "FONTCONFIG_FILE").is_none());
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod nv_explicit_sync_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn reader(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<OsString> {
+        let map: HashMap<String, OsString> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), OsString::from(v)))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn disables_on_wayland_with_nvidia() {
+        assert!(should_disable_nv_explicit_sync(
+            reader(&[("WAYLAND_DISPLAY", "wayland-0")]),
+            true
+        ));
+        // Session type alone is enough, and its value is not case sensitive.
+        assert!(should_disable_nv_explicit_sync(
+            reader(&[("XDG_SESSION_TYPE", "Wayland")]),
+            true
+        ));
+    }
+
+    #[test]
+    fn skips_x11_sessions_and_non_nvidia_systems() {
+        assert!(!should_disable_nv_explicit_sync(
+            reader(&[("XDG_SESSION_TYPE", "x11"), ("DISPLAY", ":0")]),
+            true
+        ));
+        assert!(!should_disable_nv_explicit_sync(
+            reader(&[("WAYLAND_DISPLAY", "wayland-0")]),
+            false
+        ));
+    }
+
+    #[test]
+    fn never_overrides_an_explicit_user_value() {
+        let env = reader(&[
+            ("WAYLAND_DISPLAY", "wayland-0"),
+            ("__NV_DISABLE_EXPLICIT_SYNC", "0"),
+        ]);
+        assert!(!should_disable_nv_explicit_sync(env, true));
+    }
+
+    #[test]
+    fn children_do_not_inherit_the_workaround() {
+        let out = compute_child_env_overrides(Vec::new(), true);
+        let entry = out.iter().find(|(k, _)| *k == NV_DISABLE_EXPLICIT_SYNC);
+        assert_eq!(entry.map(|(_, value)| value), Some(&None));
+    }
+
+    #[test]
+    fn child_env_is_untouched_when_the_workaround_is_off() {
+        assert!(compute_child_env_overrides(Vec::new(), false).is_empty());
+    }
+
+    #[test]
+    fn appimage_overrides_survive_alongside_the_workaround() {
+        let appimage = vec![("PATH", Some(OsString::from("/usr/bin")))];
+        let out = compute_child_env_overrides(appimage, true);
+
+        assert_eq!(
+            out.iter()
+                .find(|(k, _)| *k == "PATH")
+                .map(|(_, value)| value),
+            Some(&Some(OsString::from("/usr/bin")))
+        );
+        assert!(out.iter().any(|(k, _)| *k == NV_DISABLE_EXPLICIT_SYNC));
     }
 }


### PR DESCRIPTION
## What

Terax exits before its window maps on Wayland with the NVIDIA driver. This sets `__NV_DISABLE_EXPLICIT_SYNC` before GTK init, gated to exactly that configuration, so the window can map.

## Why

Closes #424.

WebKitGTK commits its DMABUF buffers without an explicit-sync acquire point. An explicit-sync compositor rejects the commit, GDK treats the resulting protocol error as fatal, and the process exits before the window maps:

```
wp_linux_drm_syncobj_surface_v1#44: error 4: explicit sync is used, but no acquire point is set
Gdk-Message: Error 71 (Protocol error) dispatching to Wayland display.
```

There is no window and no dialog, so from the user side nothing happens at all, which is how #424 describes it.

Reproduced on Arch with KWin 6.7.4, NVIDIA 610.57.04, webkit2gtk 2.52.6, GTK 3.24.52, RTX 4070 Max-Q. #424 reports the same on CachyOS with an RTX 2060 SUPER on Plasma 6.6, so the common factor is NVIDIA plus Wayland plus an explicit-sync compositor rather than any one distro.

## How

`__NV_DISABLE_EXPLICIT_SYNC=1` makes the NVIDIA EGL Wayland platform fall back to implicit sync, the path everything used before explicit sync existed. Synchronization still happens, so this is a fallback rather than a loss of correctness.

Picked over `WEBKIT_DISABLE_DMABUF_RENDERER=1`, which the README already suggests manually: that one disables DMABUF zero-copy entirely and costs terminal latency, while this keeps the DMABUF renderer and only gives up explicit sync. Both were confirmed to fix the crash here.

The override is deliberately narrow:

- Linux only, Wayland session only, and only when `/sys/module/nvidia` is present.
- Never replaces a value the user already set, so the variable stays an escape hatch.
- Routed through the existing `workspace` child-env override list, so PTY shells and one-shot AI commands strip it again. A GUI app launched from a Terax terminal keeps explicit sync.

The decision is a pure function taking an env reader, mirroring `compute_appimage_env_overrides` next to it, so the gate is testable without mutating real process env.

This is a WebKitGTK and driver bug rather than a Terax bug, so it is meant to be deletable once fixed upstream. Keeping it gated and honoring an explicit user value is what makes removing it safe later.

Prior art: #583 proposed the same variable, and also the idea of stripping it from spawned children, which is the part most people would miss. That PR is conflicting and predates the current `apply_common` signature (two arguments then, four now), so it no longer applies. I asked there before opening this. Credit to @devils-eye for the approach. What differs here: the child strip reuses the existing override list instead of duplicating a helper into each spawn site, and there are tests, which CONTRIBUTING requires for changes to shell spawn env.

## Testing

Platform: Linux (Arch, KWin 6.7.4 Wayland, NVIDIA 610.57.04 via nvidia-open-dkms, webkit2gtk 2.52.6, RTX 4070 Max-Q).

- Reproduced on 0.8.6 first: window never maps, the GDK protocol error above, process gone in under a second.
- Confirmed the shipping driver actually reads the variable rather than assuming it: `__NV_DISABLE_EXPLICIT_SYNC` is present in `libnvidia-egl-wayland.so.1.1.21` and `libnvidia-glcore.so.610.57.04`.
- Built this branch with `pnpm tauri build --no-bundle` and ran the release binary with the variable unset. Window maps, the terminal UI renders, and the process stayed up over 13 minutes with zero protocol errors logged.
- New unit tests cover Wayland via `WAYLAND_DISPLAY`, Wayland via a mixed-case `XDG_SESSION_TYPE`, X11 sessions, non-NVIDIA systems, an explicit user value, and that the variable reaches the child-strip list without disturbing AppImage overrides.

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test` clean (811 tests)
- [x] Manual smoke-test of the affected feature
- [x] (If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean
- [x] (If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`) - used `cargo test --locked`, 270 tests
- [ ] (If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep
- [ ] (If UI) tested in `pnpm tauri dev`
- [x] Platforms tested: Linux
- [x] Shells tested (if relevant): zsh

Not exercised on macOS or Windows. The new code is `#[cfg(target_os = "linux")]`, and `child_env_overrides` returns the existing AppImage list unchanged off Linux.

## Screenshots / GIFs

Not a UI change.

## Notes for reviewer

- The main thing worth a second opinion: `__NV_` variables are NVIDIA-internal and undocumented. This one is honored by the current driver, but it could change, which is another argument for keeping the gate narrow and the removal easy.
- I did not benchmark frame pacing. Explicit sync exists partly to improve it, so there may be a small regression under heavy GPU load. For a text terminal that should be negligible, and the alternative today is not launching at all.
- Only the PTY and one-shot shell paths strip the variable. git, LSP and `pgrep` spawns still inherit it. None of them touch Wayland, so chasing those looked like noise, but I am happy to extend it for uniformity.
- `appimage_env_overrides` is now reached only through `child_env_overrides`. I left it `pub` and otherwise untouched to keep the diff focused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display reliability on Linux systems using Wayland with NVIDIA graphics.
  * Prevented graphics compatibility settings used by the app from affecting launched terminal processes.
  * Improved environment handling for terminal sessions and one-shot commands on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->