### PR TITLE
fix(ai): resolve custom endpoints when callers omit them

### DIFF
--- a/.terax-agent/1137-NOTE.md
+++ b/.terax-agent/1137-NOTE.md
@@ -1,0 +1,3 @@
+# 1137
+
+Pass customEndpoints + customEndpointKeys into buildConfiguredLanguageModel for SCM commit-message generation.

--- a/.terax-agent/1137-NOTE.md
+++ b/.terax-agent/1137-NOTE.md
@@ -1,3 +1,0 @@
-# 1137
-
-Pass customEndpoints + customEndpointKeys into buildConfiguredLanguageModel for SCM commit-message generation.

--- a/src/modules/ai/lib/agent.ts
+++ b/src/modules/ai/lib/agent.ts
@@ -230,14 +230,27 @@ export type LocalProviderConfig = {
   customEndpointKeys?: CustomEndpointKeys;
 };
 
-export function buildConfiguredLanguageModel(
+export async function buildConfiguredLanguageModel(
   modelId: string,
   keys: ProviderKeys,
   local: LocalProviderConfig = {},
 ): Promise<LanguageModel> {
   if (isCompatModelId(modelId)) {
     const eid = endpointIdFromCompatModel(modelId);
-    const ep = local.customEndpoints?.find((e) => e.id === eid);
+    let endpoints = local.customEndpoints;
+    let endpointKeys = local.customEndpointKeys;
+    // Call sites like SCM commit-message historically omitted these; chat
+    // already passes them. Fall back to live prefs/keys so compat-* models
+    // resolve (Fixes #1137).
+    if (!endpoints?.find((e) => e.id === eid)) {
+      const { usePreferencesStore } = await import(
+        "@/modules/settings/preferences"
+      );
+      const { useChatStore } = await import("@/modules/ai/store/chatStore");
+      endpoints = usePreferencesStore.getState().customEndpoints;
+      endpointKeys = useChatStore.getState().customEndpointKeys;
+    }
+    const ep = endpoints?.find((e) => e.id === eid);
     if (!ep) throw new Error(`Custom endpoint not found: ${eid}`);
     if (!ep.modelId.trim()) {
       throw new Error(
@@ -249,7 +262,7 @@ export function buildConfiguredLanguageModel(
       keys,
       ep.modelId.trim(),
       { openaiCompatibleBaseURL: ep.baseURL },
-      local.customEndpointKeys?.[eid],
+      endpointKeys?.[eid],
     );
   }
   const m = resolveModel(modelId);


### PR DESCRIPTION
## What

`buildConfiguredLanguageModel` falls back to live preferences / chat keys when a caller omits `customEndpoints` for compat-* models.

## Why

Source Control "Generate commit message" threw `Custom endpoint not found: <id>` because it did not pass customEndpoints (chat already did).

## Testing

- [ ] Custom endpoint selected → Generate commit message works
- [ ] Chat custom endpoints still work
- [ ] CI

Fixes #1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility-model configuration when custom endpoint details are not provided directly.
  - The system now uses the matching endpoint from current preferences and chat settings when available.
  - Ensures requests are routed through the correctly resolved endpoint, improving reliability for configured AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->