### PR TITLE
fix(workspace): recover from deleted workspace directories

### DIFF
--- a/src/modules/spaces/lib/cwdRecovery.test.ts
+++ b/src/modules/spaces/lib/cwdRecovery.test.ts
@@ -1,0 +1,106 @@
+import type { Tab } from "@/modules/tabs";
+import type { PaneNode } from "@/modules/terminal/lib/panes";
+import { describe, expect, it } from "vitest";
+import {
+  fixBrokenCwds,
+  fixBrokenSpaceRoots,
+  uniqueCwds,
+} from "./cwdRecovery";
+import type { SpaceMeta } from "./store";
+
+function leaf(id: number, cwd?: string): PaneNode {
+  return { kind: "leaf", id, cwd };
+}
+
+function terminalTab(
+  id: number,
+  cwd: string | undefined,
+  paneTree: PaneNode,
+): Tab {
+  return {
+    id,
+    kind: "terminal",
+    title: "t",
+    spaceId: "s1",
+    cwd,
+    paneTree,
+    activeLeafId: id,
+  } as Tab;
+}
+
+function space(over: Partial<SpaceMeta>): SpaceMeta {
+  return {
+    id: "s1",
+    name: "Space",
+    root: null,
+    env: { kind: "local" },
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+describe("uniqueCwds", () => {
+  it("includes tab.cwd and leaf cwds", () => {
+    const tabs = [
+      terminalTab(1, "/tab-cwd", leaf(10, "/leaf-cwd")),
+      terminalTab(2, "/tab-cwd", leaf(11, "/other")),
+    ];
+    expect(uniqueCwds(tabs).sort()).toEqual(
+      ["/leaf-cwd", "/other", "/tab-cwd"].sort(),
+    );
+  });
+
+  it("ignores non-terminal tabs", () => {
+    const editor = {
+      id: 9,
+      kind: "editor",
+      title: "e",
+      spaceId: "s1",
+      path: "/x.ts",
+      dirty: false,
+      preview: false,
+    } as Tab;
+    expect(uniqueCwds([editor])).toEqual([]);
+  });
+});
+
+describe("fixBrokenCwds", () => {
+  it("rewrites broken tab and leaf cwds to the fallback", () => {
+    const tabs = [
+      terminalTab(1, "/gone", leaf(10, "/gone")),
+      terminalTab(2, "/ok", leaf(11, "/ok")),
+    ];
+    fixBrokenCwds(tabs, new Set(["/gone"]), "/home");
+    expect(tabs[0].cwd).toBe("/home");
+    expect((tabs[0].paneTree as { cwd?: string }).cwd).toBe("/home");
+    expect(tabs[1].cwd).toBe("/ok");
+  });
+
+  it("clears broken cwds when fallback is null", () => {
+    const tabs = [terminalTab(1, "/gone", leaf(10, "/gone"))];
+    fixBrokenCwds(tabs, new Set(["/gone"]), null);
+    expect(tabs[0].cwd).toBeUndefined();
+    expect((tabs[0].paneTree as { cwd?: string }).cwd).toBeUndefined();
+  });
+});
+
+describe("fixBrokenSpaceRoots", () => {
+  it("replaces broken roots and leaves healthy ones alone", () => {
+    const spaces = [
+      space({ id: "a", root: "/gone" }),
+      space({ id: "b", root: "/ok" }),
+    ];
+    const next = fixBrokenSpaceRoots(spaces, new Set(["/gone"]), "/home");
+    expect(next).not.toBe(spaces);
+    expect(next[0].root).toBe("/home");
+    expect(next[1].root).toBe("/ok");
+  });
+
+  it("returns the same array when nothing is broken", () => {
+    const spaces = [space({ root: "/ok" })];
+    expect(fixBrokenSpaceRoots(spaces, new Set(["/gone"]), "/home")).toBe(
+      spaces,
+    );
+  });
+});

--- a/src/modules/spaces/lib/cwdRecovery.test.ts
+++ b/src/modules/spaces/lib/cwdRecovery.test.ts
@@ -1,4 +1,4 @@
-import type { Tab } from "@/modules/tabs";
+import type { Tab, TerminalTab } from "@/modules/tabs";
 import type { PaneNode } from "@/modules/terminal/lib/panes";
 import { describe, expect, it } from "vitest";
 import {
@@ -16,7 +16,7 @@ function terminalTab(
   id: number,
   cwd: string | undefined,
   paneTree: PaneNode,
-): Tab {
+): TerminalTab {
   return {
     id,
     kind: "terminal",
@@ -25,7 +25,7 @@ function terminalTab(
     cwd,
     paneTree,
     activeLeafId: id,
-  } as Tab;
+  };
 }
 
 function space(over: Partial<SpaceMeta>): SpaceMeta {
@@ -67,7 +67,7 @@ describe("uniqueCwds", () => {
 
 describe("fixBrokenCwds", () => {
   it("rewrites broken tab and leaf cwds to the fallback", () => {
-    const tabs = [
+    const tabs: TerminalTab[] = [
       terminalTab(1, "/gone", leaf(10, "/gone")),
       terminalTab(2, "/ok", leaf(11, "/ok")),
     ];
@@ -78,7 +78,7 @@ describe("fixBrokenCwds", () => {
   });
 
   it("clears broken cwds when fallback is null", () => {
-    const tabs = [terminalTab(1, "/gone", leaf(10, "/gone"))];
+    const tabs: TerminalTab[] = [terminalTab(1, "/gone", leaf(10, "/gone"))];
     fixBrokenCwds(tabs, new Set(["/gone"]), null);
     expect(tabs[0].cwd).toBeUndefined();
     expect((tabs[0].paneTree as { cwd?: string }).cwd).toBeUndefined();

--- a/src/modules/spaces/lib/cwdRecovery.ts
+++ b/src/modules/spaces/lib/cwdRecovery.ts
@@ -1,0 +1,60 @@
+import type { Tab } from "@/modules/tabs";
+import { isLeaf, type PaneNode } from "@/modules/terminal/lib/panes";
+import type { SpaceMeta } from "./store";
+
+/** Collect every terminal cwd that might be authorized / spawned on boot. */
+export function uniqueCwds(tabs: Tab[]): string[] {
+  const set = new Set<string>();
+  const walk = (n: PaneNode) => {
+    if (isLeaf(n)) {
+      if (n.cwd) set.add(n.cwd);
+      return;
+    }
+    for (const c of n.children) walk(c);
+  };
+  for (const t of tabs) {
+    if (t.kind !== "terminal") continue;
+    if (t.cwd) set.add(t.cwd);
+    walk(t.paneTree);
+  }
+  return [...set];
+}
+
+/** Rewrite broken terminal cwds in place so hydration does not re-stick them. */
+export function fixBrokenCwds(
+  tabs: Tab[],
+  broken: Set<string>,
+  fallback: string | null,
+): void {
+  const fix = (node: PaneNode) => {
+    if (isLeaf(node)) {
+      if (node.cwd && broken.has(node.cwd)) node.cwd = fallback ?? undefined;
+      return;
+    }
+    for (const child of node.children) fix(child);
+  };
+
+  for (const tab of tabs) {
+    if (tab.kind !== "terminal") continue;
+    fix(tab.paneTree);
+    if (tab.cwd && broken.has(tab.cwd)) tab.cwd = fallback ?? undefined;
+  }
+}
+
+/**
+ * Replace space roots that failed authorization with the boot fallback.
+ * Returns a new array when any root changed; otherwise the input array.
+ */
+export function fixBrokenSpaceRoots(
+  spaces: SpaceMeta[],
+  broken: Set<string>,
+  fallback: string | null,
+): SpaceMeta[] {
+  let changed = false;
+  const next = spaces.map((space) => {
+    if (!space.root || !broken.has(space.root)) return space;
+    changed = true;
+    return { ...space, root: fallback, updatedAt: Date.now() };
+  });
+  return changed ? next : spaces;
+}

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -110,13 +110,22 @@ export function useSpacesBoot({
         });
         let spacesForHydrate = spaces;
         if (failed.size > 0) {
-          fixBrokenCwds(restored, failed, fallback);
-          spacesForHydrate = fixBrokenSpaceRoots(spaces, failed, fallback);
+          // Prefer a fallback that actually authorizes; never persist a dead launch cwd.
+          let safeFallback: string | null = null;
+          for (const candidate of [launchCwd, restoredHome, home]) {
+            if (!candidate || failed.has(candidate)) continue;
+            try {
+              await native.workspaceAuthorize(candidate);
+              safeFallback = candidate;
+              break;
+            } catch {
+              failed.add(candidate);
+            }
+          }
+          fixBrokenCwds(restored, failed, safeFallback);
+          spacesForHydrate = fixBrokenSpaceRoots(spaces, failed, safeFallback);
           if (spacesForHydrate !== spaces) {
             await saveSpacesList(spacesForHydrate);
-          }
-          if (fallback) {
-            await native.workspaceAuthorize(fallback).catch(() => undefined);
           }
         }
 

--- a/src/modules/spaces/lib/useSpacesBoot.ts
+++ b/src/modules/spaces/lib/useSpacesBoot.ts
@@ -2,10 +2,14 @@ import { native } from "@/modules/ai/lib/native";
 import { usePreferencesStore } from "@/modules/settings/preferences";
 import type { Tab } from "@/modules/tabs";
 import { DEFAULT_SPACE_ID } from "@/modules/tabs/lib/useTabs";
-import { isLeaf, type PaneNode } from "@/modules/terminal/lib/panes";
 import { parseWorkspaceScopeKey, type WorkspaceEnv } from "@/modules/workspace";
 import { useEffect, useRef } from "react";
 import { activeSpaceEnv, freshTabCwd } from "./activeSpace";
+import {
+  fixBrokenCwds,
+  fixBrokenSpaceRoots,
+  uniqueCwds,
+} from "./cwdRecovery";
 import { freshTerminalTab, hydrateTabs } from "./serialize";
 import { loadAll, type SpaceMeta, saveActiveId, saveSpacesList } from "./store";
 import { useSpaces } from "./useSpaces";
@@ -20,19 +24,6 @@ type Params = {
   setActiveSpaceForNewTabs: (id: string) => void;
   adoptWorkspaceEnv: (env: WorkspaceEnv) => Promise<string | null>;
 };
-
-function uniqueCwds(tabs: Tab[]): string[] {
-  const set = new Set<string>();
-  const walk = (n: PaneNode) => {
-    if (isLeaf(n)) {
-      if (n.cwd) set.add(n.cwd);
-      return;
-    }
-    for (const c of n.children) walk(c);
-  };
-  for (const t of tabs) if (t.kind === "terminal") walk(t.paneTree);
-  return [...set];
-}
 
 export function useSpacesBoot({
   ready,
@@ -53,9 +44,10 @@ export function useSpacesBoot({
     void (async () => {
       try {
         const { spaces, activeId, states } = await loadAll();
+        const fallback = launchCwd ?? home ?? null;
 
         if (spaces.length === 0) {
-          const root = launchCwd ?? home ?? null;
+          const root = fallback;
           // Hydrate prefs before reading the saved workspace env.
           await usePreferencesStore
             .getState()
@@ -102,14 +94,38 @@ export function useSpacesBoot({
           restored.push(freshTerminalTab(active, cwd, allocId));
         }
 
-        await Promise.allSettled(
-          uniqueCwds(restored).map((cwd) => native.workspaceAuthorize(cwd)),
+        // Authorize terminal cwds and space roots. Deleted folders used to
+        // stick in persisted state (#816); sanitize before hydrate.
+        const rootPaths = spaces
+          .map((s) => s.root)
+          .filter((r): r is string => !!r);
+        const cwds = uniqueCwds(restored);
+        const toAuthorize = [...new Set([...cwds, ...rootPaths])];
+        const authResults = await Promise.allSettled(
+          toAuthorize.map((cwd) => native.workspaceAuthorize(cwd)),
         );
+        const failed = new Set<string>();
+        authResults.forEach((result, index) => {
+          if (result.status === "rejected") failed.add(toAuthorize[index]);
+        });
+        let spacesForHydrate = spaces;
+        if (failed.size > 0) {
+          fixBrokenCwds(restored, failed, fallback);
+          spacesForHydrate = fixBrokenSpaceRoots(spaces, failed, fallback);
+          if (spacesForHydrate !== spaces) {
+            await saveSpacesList(spacesForHydrate);
+          }
+          if (fallback) {
+            await native.workspaceAuthorize(fallback).catch(() => undefined);
+          }
+        }
 
         const initialActiveIndex: Record<string, number> = {};
         for (const [id, st] of states)
           initialActiveIndex[id] = st.activeTabIndex;
-        useSpaces.getState().hydrate(spaces, active, initialActiveIndex);
+        useSpaces
+          .getState()
+          .hydrate(spacesForHydrate, active, initialActiveIndex);
 
         const inActive = restored.filter((t) => t.spaceId === active);
         const idx = states.get(active)?.activeTabIndex ?? 0;


### PR DESCRIPTION
## Summary
Opening Terax from a folder and then deleting that folder could leave persisted space roots / terminal cwds pointing at a path that no longer exists. Restarts kept reusing that stale state (#816). Closed unmerged #817 attempted this earlier; #799 later added backend spawn fallback (`user_spawn_cwd_or_home`), but boot still did not sanitize persisted FE state.

This revive:
- Collects `tab.cwd` as well as leaf cwds before authorize
- Authorizes space roots together with terminal cwds
- Rewrites failed paths to launch cwd / home before hydrate
- Persists cleaned space roots when they change

Helpers live in `cwdRecovery.ts` with unit coverage.

Fixes #816

## Test plan
- [ ] Open Terax on a folder, delete that folder, restart → terminals / explorer land on launch cwd or home instead of staying stuck
- [ ] Healthy workspaces still boot unchanged
- [ ] `pnpm test` covers `cwdRecovery.test.ts`
- [ ] CI frontend / rust / coverage green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace startup recovery when saved terminal directories or space roots are unavailable.
  - Replaces invalid paths with a working fallback location, or clears them when none is available.
  - Prevents inaccessible directories from being restored while preserving valid terminal sessions and space locations.
  - Default spaces now use the launch location or home directory when available.
  - Workspace restoration repairs only affected paths and continues loading with valid workspace data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->