### PR TITLE
fix(ai): deny pending tool approvals before follow-up sends

### DIFF
--- a/src/modules/ai/components/AgentRunBridge.tsx
+++ b/src/modules/ai/components/AgentRunBridge.tsx
@@ -17,7 +17,7 @@ import { getOrCreateChat } from "../store/chatRuntime";
  *
  * Side effects:
  *  - Patches `agentMeta` on every status / approvals change.
- *  - Auto-opens the mini-window when an approval is pending — the user has
+ *  - Auto-opens the mini-window when an approval is pending ??? the user has
  *    to act on it; hiding it would be hostile.
  *  - For pending `write_file` calls, opens an AI diff tab in the editor area
  *    so the user can review the proposed change before approving.
@@ -192,7 +192,8 @@ function Bridge({
         } else if (
           state === "approval-responded" ||
           state === "output-available" ||
-          state === "output-error"
+          state === "output-error" ||
+          state === "output-denied"
         ) {
           if (openedRef.current.has(approvalId)) toClose.add(approvalId);
         }
@@ -359,7 +360,7 @@ async function readOriginal(
   try {
     const r = await native.readFile(abs);
     if (r.kind === "text") return { content: r.content, isNewFile: false };
-    // Binary or oversized — we can't render the original sensibly. Show the
+    // Binary or oversized ??? we can't render the original sensibly. Show the
     // proposed content as a "new" view; the user can still cancel.
     return { content: "", isNewFile: false };
   } catch (e) {

--- a/src/modules/ai/components/AgentRunBridge.tsx
+++ b/src/modules/ai/components/AgentRunBridge.tsx
@@ -17,7 +17,7 @@ import { getOrCreateChat } from "../store/chatRuntime";
  *
  * Side effects:
  *  - Patches `agentMeta` on every status / approvals change.
- *  - Auto-opens the mini-window when an approval is pending ??? the user has
+ *  - Auto-opens the mini-window when an approval is pending — the user has
  *    to act on it; hiding it would be hostile.
  *  - For pending `write_file` calls, opens an AI diff tab in the editor area
  *    so the user can review the proposed change before approving.
@@ -360,7 +360,7 @@ async function readOriginal(
   try {
     const r = await native.readFile(abs);
     if (r.kind === "text") return { content: r.content, isNewFile: false };
-    // Binary or oversized ??? we can't render the original sensibly. Show the
+    // Binary or oversized — we can't render the original sensibly. Show the
     // proposed content as a "new" view; the user can still cancel.
     return { content: "", isNewFile: false };
   } catch (e) {

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -315,9 +315,7 @@ export function AiComposerProvider({ children }: ProviderProps) {
       // MissingToolResultsError (Fixes #514). Prefer mutating to
       // output-denied over addToolApprovalResponse to avoid racing
       // sendAutomaticallyWhen.
-      denyPendingToolApprovals(
-        chat.messages as Parameters<typeof denyPendingToolApprovals>[0],
-      );
+      denyPendingToolApprovals(chat.messages);
       void chat.sendMessage({ role: "user", parts } as Parameters<
         typeof chat.sendMessage
       >[0]);

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -10,6 +10,7 @@ import { useWhisperRecording } from "../hooks/useWhisperRecording";
 import { expandSnippetTokens, type Snippet } from "../lib/snippets";
 import { tryRunSlashCommand, type SlashCommandMeta } from "./slashCommands";
 import { getChat, useChatStore } from "../store/chatStore";
+import { denyPendingToolApprovals } from "./denyPendingApprovals";
 import { useSnippetsStore } from "../store/snippetsStore";
 import { currentWorkspaceEnv } from "@/modules/workspace";
 
@@ -41,7 +42,7 @@ type ComposerCtx = {
   setValue: React.Dispatch<React.SetStateAction<string>>;
   files: FileAttachment[];
   addFiles: (list: FileList | null) => Promise<void>;
-  /** Attach a file by absolute path — used by the file explorer's "Attach to Agent". */
+  /** Attach a file by absolute path ??? used by the file explorer's "Attach to Agent". */
   attachFileByPath: (path: string) => Promise<void>;
   removeFile: (id: string) => void;
   pickedSnippets: Snippet[];
@@ -310,6 +311,13 @@ export function AiComposerProvider({ children }: ProviderProps) {
     void (async () => {
       const { getOrCreateChat } = await import("../store/chatRuntime");
       const chat = getOrCreateChat(sessionId);
+      // Deny pending tool approvals so a follow-up cannot trip
+      // MissingToolResultsError (Fixes #514). Prefer mutating to
+      // output-denied over addToolApprovalResponse to avoid racing
+      // sendAutomaticallyWhen.
+      denyPendingToolApprovals(
+        chat.messages as Parameters<typeof denyPendingToolApprovals>[0],
+      );
       void chat.sendMessage({ role: "user", parts } as Parameters<
         typeof chat.sendMessage
       >[0]);

--- a/src/modules/ai/lib/composer.tsx
+++ b/src/modules/ai/lib/composer.tsx
@@ -42,7 +42,7 @@ type ComposerCtx = {
   setValue: React.Dispatch<React.SetStateAction<string>>;
   files: FileAttachment[];
   addFiles: (list: FileList | null) => Promise<void>;
-  /** Attach a file by absolute path ??? used by the file explorer's "Attach to Agent". */
+  /** Attach a file by absolute path — used by the file explorer's "Attach to Agent". */
   attachFileByPath: (path: string) => Promise<void>;
   removeFile: (id: string) => void;
   pickedSnippets: Snippet[];

--- a/src/modules/ai/lib/denyPendingApprovals.test.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.test.ts
@@ -107,7 +107,7 @@ describe("denyPendingToolApprovals", () => {
           toolCallId: "c-x",
           state: "approval-requested",
           input: {},
-        } as UIMessage["parts"][number],
+        } as unknown as UIMessage["parts"][number],
       ]),
     ];
     expect(denyPendingToolApprovals(messages)).toBe(0);

--- a/src/modules/ai/lib/denyPendingApprovals.test.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  denyPendingToolApprovals,
+  FOLLOW_UP_DENY_REASON,
+  listPendingApprovalIds,
+  type MessageLike,
+} from "./denyPendingApprovals";
+
+function assistantWith(
+  parts: MessageLike["parts"],
+): MessageLike {
+  return { role: "assistant", parts };
+}
+
+describe("denyPendingToolApprovals", () => {
+  it("returns 0 and leaves messages alone when nothing is pending", () => {
+    const messages: MessageLike[] = [
+      { role: "user", parts: [{ type: "text", text: "hi" }] },
+      assistantWith([
+        { type: "text", text: "done" },
+        {
+          type: "tool-bash_run",
+          state: "output-available",
+          approval: { id: "a1", approved: true },
+        },
+      ]),
+    ];
+    expect(denyPendingToolApprovals(messages)).toBe(0);
+    expect(messages[1].parts[1].state).toBe("output-available");
+  });
+
+  it("rewrites approval-requested parts to output-denied", () => {
+    const messages: MessageLike[] = [
+      assistantWith([
+        {
+          type: "tool-bash_run",
+          toolCallId: "c1",
+          state: "approval-requested",
+          approval: { id: "appr-1" },
+          input: { command: "rm -rf /" },
+        },
+        { type: "text", text: "may I?" },
+      ]),
+    ];
+    expect(denyPendingToolApprovals(messages)).toBe(1);
+    const part = messages[0].parts[0];
+    expect(part.state).toBe("output-denied");
+    expect(part.approval).toEqual({
+      id: "appr-1",
+      approved: false,
+      reason: FOLLOW_UP_DENY_REASON,
+    });
+    expect(part.input).toEqual({ command: "rm -rf /" });
+    expect(messages[0].parts[1].state).toBeUndefined();
+  });
+
+  it("denies every pending approval across assistant messages", () => {
+    const messages: MessageLike[] = [
+      assistantWith([
+        {
+          type: "tool-write_file",
+          state: "approval-requested",
+          approval: { id: "w1" },
+        },
+      ]),
+      { role: "user", parts: [{ type: "text", text: "earlier" }] },
+      assistantWith([
+        {
+          type: "tool-bash_run",
+          state: "approval-requested",
+          approval: { id: "b1" },
+        },
+        {
+          type: "tool-edit",
+          state: "approval-requested",
+          approval: { id: "e1" },
+        },
+      ]),
+    ];
+    expect(denyPendingToolApprovals(messages)).toBe(3);
+    expect(listPendingApprovalIds(messages)).toEqual([]);
+    expect(messages[0].parts[0].state).toBe("output-denied");
+    expect(messages[2].parts.map((p) => p.state)).toEqual([
+      "output-denied",
+      "output-denied",
+    ]);
+  });
+
+  it("uses a fallback id when approval.id is missing", () => {
+    const messages: MessageLike[] = [
+      assistantWith([{ type: "tool-x", state: "approval-requested" }]),
+    ];
+    denyPendingToolApprovals(messages);
+    expect(messages[0].parts[0].approval?.id).toBe("unknown");
+  });
+});
+
+describe("listPendingApprovalIds", () => {
+  it("collects only approval-requested ids", () => {
+    const messages: MessageLike[] = [
+      assistantWith([
+        { state: "approval-requested", approval: { id: "a" } },
+        { state: "output-denied", approval: { id: "b" } },
+        { state: "approval-requested", approval: { id: "c" } },
+      ]),
+    ];
+    expect(listPendingApprovalIds(messages)).toEqual(["a", "c"]);
+  });
+});

--- a/src/modules/ai/lib/denyPendingApprovals.test.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.test.ts
@@ -1,36 +1,40 @@
 import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
 import {
   denyPendingToolApprovals,
   FOLLOW_UP_DENY_REASON,
   listPendingApprovalIds,
-  type MessageLike,
 } from "./denyPendingApprovals";
 
 function assistantWith(
-  parts: MessageLike["parts"],
-): MessageLike {
-  return { role: "assistant", parts };
+  parts: UIMessage["parts"],
+): UIMessage {
+  return { id: "a1", role: "assistant", parts };
 }
 
 describe("denyPendingToolApprovals", () => {
   it("returns 0 and leaves messages alone when nothing is pending", () => {
-    const messages: MessageLike[] = [
-      { role: "user", parts: [{ type: "text", text: "hi" }] },
+    const messages: UIMessage[] = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
       assistantWith([
         { type: "text", text: "done" },
         {
           type: "tool-bash_run",
+          toolCallId: "c0",
           state: "output-available",
+          input: { command: "echo hi" },
+          output: "hi",
           approval: { id: "a1", approved: true },
         },
       ]),
     ];
     expect(denyPendingToolApprovals(messages)).toBe(0);
-    expect(messages[1].parts[1].state).toBe("output-available");
+    const tool = messages[1].parts[1];
+    expect(tool).toMatchObject({ state: "output-available" });
   });
 
   it("rewrites approval-requested parts to output-denied", () => {
-    const messages: MessageLike[] = [
+    const messages: UIMessage[] = [
       assistantWith([
         {
           type: "tool-bash_run",
@@ -44,64 +48,105 @@ describe("denyPendingToolApprovals", () => {
     ];
     expect(denyPendingToolApprovals(messages)).toBe(1);
     const part = messages[0].parts[0];
-    expect(part.state).toBe("output-denied");
-    expect(part.approval).toEqual({
-      id: "appr-1",
-      approved: false,
-      reason: FOLLOW_UP_DENY_REASON,
+    expect(part).toMatchObject({
+      state: "output-denied",
+      toolCallId: "c1",
+      input: { command: "rm -rf /" },
+      approval: {
+        id: "appr-1",
+        approved: false,
+        reason: FOLLOW_UP_DENY_REASON,
+      },
     });
-    expect(part.input).toEqual({ command: "rm -rf /" });
-    expect(messages[0].parts[1].state).toBeUndefined();
+    expect(messages[0].parts[1]).toMatchObject({ type: "text" });
   });
 
   it("denies every pending approval across assistant messages", () => {
-    const messages: MessageLike[] = [
+    const messages: UIMessage[] = [
       assistantWith([
         {
           type: "tool-write_file",
+          toolCallId: "c-w",
           state: "approval-requested",
           approval: { id: "w1" },
+          input: { path: "a.txt", content: "x" },
         },
       ]),
-      { role: "user", parts: [{ type: "text", text: "earlier" }] },
+      { id: "u2", role: "user", parts: [{ type: "text", text: "earlier" }] },
       assistantWith([
         {
           type: "tool-bash_run",
+          toolCallId: "c-b",
           state: "approval-requested",
           approval: { id: "b1" },
+          input: { command: "ls" },
         },
         {
           type: "tool-edit",
+          toolCallId: "c-e",
           state: "approval-requested",
           approval: { id: "e1" },
+          input: { path: "b.ts", old: "a", new: "b" },
         },
       ]),
     ];
     expect(denyPendingToolApprovals(messages)).toBe(3);
     expect(listPendingApprovalIds(messages)).toEqual([]);
-    expect(messages[0].parts[0].state).toBe("output-denied");
-    expect(messages[2].parts.map((p) => p.state)).toEqual([
+    expect(messages[0].parts[0]).toMatchObject({ state: "output-denied" });
+    expect(messages[2].parts.map((p) => ("state" in p ? p.state : undefined))).toEqual([
       "output-denied",
       "output-denied",
     ]);
   });
 
-  it("uses a fallback id when approval.id is missing", () => {
-    const messages: MessageLike[] = [
-      assistantWith([{ type: "tool-x", state: "approval-requested" }]),
+  it("skips incomplete approval-requested parts (no invented approval id)", () => {
+    const messages: UIMessage[] = [
+      assistantWith([
+        {
+          type: "tool-x",
+          toolCallId: "c-x",
+          state: "approval-requested",
+          input: {},
+        } as UIMessage["parts"][number],
+      ]),
     ];
-    denyPendingToolApprovals(messages);
-    expect(messages[0].parts[0].approval?.id).toBe("unknown");
+    expect(denyPendingToolApprovals(messages)).toBe(0);
+    expect(messages[0].parts[0]).toMatchObject({
+      state: "approval-requested",
+    });
+    expect(
+      "approval" in messages[0].parts[0]
+        ? (messages[0].parts[0] as { approval?: { id?: string } }).approval?.id
+        : undefined,
+    ).toBeUndefined();
   });
 });
 
 describe("listPendingApprovalIds", () => {
   it("collects only approval-requested ids", () => {
-    const messages: MessageLike[] = [
+    const messages: UIMessage[] = [
       assistantWith([
-        { state: "approval-requested", approval: { id: "a" } },
-        { state: "output-denied", approval: { id: "b" } },
-        { state: "approval-requested", approval: { id: "c" } },
+        {
+          type: "tool-bash_run",
+          toolCallId: "c1",
+          state: "approval-requested",
+          approval: { id: "a" },
+          input: { command: "a" },
+        },
+        {
+          type: "tool-bash_run",
+          toolCallId: "c2",
+          state: "output-denied",
+          approval: { id: "b", approved: false, reason: "no" },
+          input: { command: "b" },
+        },
+        {
+          type: "tool-bash_run",
+          toolCallId: "c3",
+          state: "approval-requested",
+          approval: { id: "c" },
+          input: { command: "c" },
+        },
       ]),
     ];
     expect(listPendingApprovalIds(messages)).toEqual(["a", "c"]);

--- a/src/modules/ai/lib/denyPendingApprovals.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.ts
@@ -1,0 +1,64 @@
+/**
+ * When the user sends a follow-up while tool approvals are still pending,
+ * the AI SDK throws MissingToolResultsError because approval-requested parts
+ * have no matching tool-result. Mutating those parts to output-denied (the
+ * state convertToModelMessages already understands) lets the follow-up send
+ * cleanly without racing sendAutomaticallyWhen via addToolApprovalResponse.
+ *
+ * See: https://github.com/crynta/terax-ai/issues/514
+ */
+
+export type ApprovalPart = {
+  state?: string;
+  approval?: { id?: string; approved?: boolean; reason?: string };
+  [key: string]: unknown;
+};
+
+export type MessageLike = {
+  role: string;
+  parts: ApprovalPart[];
+};
+
+export const FOLLOW_UP_DENY_REASON = "Superseded by follow-up prompt";
+
+/**
+ * In-place: rewrite every approval-requested tool part to output-denied.
+ * Returns the number of parts denied (0 if none pending).
+ */
+export function denyPendingToolApprovals(
+  messages: MessageLike[],
+  reason: string = FOLLOW_UP_DENY_REASON,
+): number {
+  let denied = 0;
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    m.parts = m.parts.map((part) => {
+      if (part.state !== "approval-requested") return part;
+      denied += 1;
+      return {
+        ...part,
+        state: "output-denied",
+        approval: {
+          id: part.approval?.id ?? "unknown",
+          approved: false,
+          reason,
+        },
+      };
+    });
+  }
+  return denied;
+}
+
+/** Collect approval ids currently waiting on the user. */
+export function listPendingApprovalIds(messages: MessageLike[]): string[] {
+  const ids: string[] = [];
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    for (const part of m.parts) {
+      if (part.state !== "approval-requested") continue;
+      const id = part.approval?.id;
+      if (typeof id === "string" && id.length > 0) ids.push(id);
+    }
+  }
+  return ids;
+}

--- a/src/modules/ai/lib/denyPendingApprovals.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.ts
@@ -28,7 +28,7 @@ function hasApprovalId(
   );
 }
 
-/** Local stand-in for isToolUIPart — avoids a runtime `ai` import. */
+/** Local stand-in for isToolUIPart - avoids a runtime `ai` import. */
 function isToolPart(
   part: MessagePart,
 ): part is MessagePart & {

--- a/src/modules/ai/lib/denyPendingApprovals.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.ts
@@ -51,7 +51,7 @@ function isToolPart(
 /**
  * In-place: rewrite every valid approval-requested tool part to output-denied.
  * Only mutates AI SDK tool parts that already carry toolCallId, input, and
- * approval.id — incomplete parts are left alone so we never emit invalid
+ * approval.id - incomplete parts are left alone so we never emit invalid
  * output-denied shapes. Returns the number of parts denied (0 if none pending).
  */
 export function denyPendingToolApprovals(

--- a/src/modules/ai/lib/denyPendingApprovals.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.ts
@@ -8,39 +8,49 @@
  * See: https://github.com/crynta/terax-ai/issues/514
  */
 
-export type ApprovalPart = {
-  state?: string;
-  approval?: { id?: string; approved?: boolean; reason?: string };
-  [key: string]: unknown;
-};
-
-export type MessageLike = {
-  role: string;
-  parts: ApprovalPart[];
-};
+import { isToolUIPart, type UIMessage } from "ai";
 
 export const FOLLOW_UP_DENY_REASON = "Superseded by follow-up prompt";
 
+function hasApprovalId(
+  approval: unknown,
+): approval is { id: string; approved?: boolean; reason?: string } {
+  return (
+    typeof approval === "object" &&
+    approval !== null &&
+    typeof (approval as { id?: unknown }).id === "string" &&
+    (approval as { id: string }).id.length > 0
+  );
+}
+
 /**
- * In-place: rewrite every approval-requested tool part to output-denied.
- * Returns the number of parts denied (0 if none pending).
+ * In-place: rewrite every valid approval-requested tool part to output-denied.
+ * Only mutates AI SDK tool parts that already carry toolCallId, input, and
+ * approval.id — incomplete parts are left alone so we never emit invalid
+ * output-denied shapes. Returns the number of parts denied (0 if none pending).
  */
 export function denyPendingToolApprovals(
-  messages: MessageLike[],
+  messages: UIMessage[],
   reason: string = FOLLOW_UP_DENY_REASON,
 ): number {
   let denied = 0;
   for (const m of messages) {
     if (m.role !== "assistant") continue;
     m.parts = m.parts.map((part) => {
+      if (!isToolUIPart(part)) return part;
       if (part.state !== "approval-requested") return part;
+      if (!hasApprovalId(part.approval)) return part;
+      if (typeof part.toolCallId !== "string" || part.toolCallId.length === 0) {
+        return part;
+      }
+      if (!("input" in part) || part.input === undefined) return part;
       denied += 1;
       return {
         ...part,
-        state: "output-denied",
+        state: "output-denied" as const,
         approval: {
-          id: part.approval?.id ?? "unknown",
-          approved: false,
+          id: part.approval.id,
+          approved: false as const,
           reason,
         },
       };
@@ -50,14 +60,15 @@ export function denyPendingToolApprovals(
 }
 
 /** Collect approval ids currently waiting on the user. */
-export function listPendingApprovalIds(messages: MessageLike[]): string[] {
+export function listPendingApprovalIds(messages: UIMessage[]): string[] {
   const ids: string[] = [];
   for (const m of messages) {
     if (m.role !== "assistant") continue;
     for (const part of m.parts) {
+      if (!isToolUIPart(part)) continue;
       if (part.state !== "approval-requested") continue;
-      const id = part.approval?.id;
-      if (typeof id === "string" && id.length > 0) ids.push(id);
+      if (!hasApprovalId(part.approval)) continue;
+      ids.push(part.approval.id);
     }
   }
   return ids;

--- a/src/modules/ai/lib/denyPendingApprovals.ts
+++ b/src/modules/ai/lib/denyPendingApprovals.ts
@@ -6,11 +6,16 @@
  * cleanly without racing sendAutomaticallyWhen via addToolApprovalResponse.
  *
  * See: https://github.com/crynta/terax-ai/issues/514
+ *
+ * Uses `import type` only from `ai` so this helper stays out of the eager
+ * startup graph (see src/app/eager-budget.test.ts).
  */
 
-import { isToolUIPart, type UIMessage } from "ai";
+import type { UIMessage } from "ai";
 
 export const FOLLOW_UP_DENY_REASON = "Superseded by follow-up prompt";
+
+type MessagePart = UIMessage["parts"][number];
 
 function hasApprovalId(
   approval: unknown,
@@ -20,6 +25,26 @@ function hasApprovalId(
     approval !== null &&
     typeof (approval as { id?: unknown }).id === "string" &&
     (approval as { id: string }).id.length > 0
+  );
+}
+
+/** Local stand-in for isToolUIPart — avoids a runtime `ai` import. */
+function isToolPart(
+  part: MessagePart,
+): part is MessagePart & {
+  type: string;
+  state?: string;
+  toolCallId?: string;
+  input?: unknown;
+  approval?: unknown;
+} {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    "type" in part &&
+    typeof (part as { type: unknown }).type === "string" &&
+    ((part as { type: string }).type.startsWith("tool-") ||
+      (part as { type: string }).type === "dynamic-tool")
   );
 }
 
@@ -37,7 +62,7 @@ export function denyPendingToolApprovals(
   for (const m of messages) {
     if (m.role !== "assistant") continue;
     m.parts = m.parts.map((part) => {
-      if (!isToolUIPart(part)) return part;
+      if (!isToolPart(part)) return part;
       if (part.state !== "approval-requested") return part;
       if (!hasApprovalId(part.approval)) return part;
       if (typeof part.toolCallId !== "string" || part.toolCallId.length === 0) {
@@ -65,7 +90,7 @@ export function listPendingApprovalIds(messages: UIMessage[]): string[] {
   for (const m of messages) {
     if (m.role !== "assistant") continue;
     for (const part of m.parts) {
-      if (!isToolUIPart(part)) continue;
+      if (!isToolPart(part)) continue;
       if (part.state !== "approval-requested") continue;
       if (!hasApprovalId(part.approval)) continue;
       ids.push(part.approval.id);


### PR DESCRIPTION
## Summary
- When the user sends a follow-up while tool approvals are still pending, rewrite `approval-requested` parts to `output-denied` before `chat.sendMessage`, so the AI SDK does not throw `MissingToolResultsError` and lock the session (Fixes #514).
- Prefer mutating to `output-denied` (the state `convertToModelMessages` already handles) over `addToolApprovalResponse`, which would race `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses`.
- Close AI diff tabs when a part becomes `output-denied` as well.
- Unit coverage for the pure helper.

## Context
#520 attempted a similar fix and was closed in favor of an official SDK path that never landed; the bug is still reproducible on current `main` (`composer.tsx` submits with no pending-approval handling).

## Test plan
- [x] `denyPendingApprovals.test.ts` covers idle / single / multi / missing-id cases
- [ ] Manual: start a chat → prompt a `bash_run` / write that needs approval → send a follow-up before Approve/Deny → no MissingToolResultsError; chat continues; approval UI / diff tab clears
- [ ] Manual: Approve/Deny still work when the user clicks them (no follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up messages now automatically deny pending AI tool approvals and explain when approvals are superseded.
  * Incomplete or invalid approval requests are safely left unchanged.

* **Bug Fixes**
  * AI diff tabs now close when file-mutation approvals are denied or encounter an error.
  * Resolved issues that could prevent follow-up messages from being sent successfully.
  * Approval handling now remains reliable when multiple pending approvals are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->