### PR TITLE
fix(settings): stop Settings floating above all apps

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,10 +81,6 @@ fn parse_launch_target() -> LaunchTarget {
     resolve_launch_target(entries)
 }
 
-const fn settings_always_on_top(is_macos: bool) -> bool {
-    !is_macos
-}
-
 #[tauri::command]
 async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Result<(), String> {
     let url_path = match tab.as_deref() {
@@ -93,8 +89,6 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
     };
 
     if let Some(window) = app.get_webview_window("settings") {
-        #[cfg(not(target_os = "macos"))]
-        let _ = window.set_always_on_top(true);
         let _ = window.show();
         let _ = window.set_focus();
         if let Some(t) = tab.as_deref().filter(|s| !s.is_empty()) {
@@ -110,12 +104,10 @@ async fn open_settings_window(app: tauri::AppHandle, tab: Option<String>) -> Res
         .inner_size(900.0, 700.0)
         .min_inner_size(820.0, 620.0)
         .resizable(true)
-        .visible(false)
-        .always_on_top(settings_always_on_top(cfg!(target_os = "macos")));
+        .visible(false);
 
-    // A normal-level child stays above Terax but recedes with the app on macOS.
-    // Never combine the macOS parent with always_on_top; that breaks WebView
-    // compositing and can hide Settings behind the main window (#33, #957).
+    // Parent/owner keeps Settings above Terax's main window without a
+    // system-wide always-on-top flag that floats above every other app (#33, #957).
     let builder = if let Some(main) = app.get_webview_window("main") {
         builder.parent(&main).map_err(|e| e.to_string())?
     } else {
@@ -388,7 +380,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod launch_target_tests {
-    use super::{resolve_launch_target, settings_always_on_top, LaunchEntry, LaunchTarget};
+    use super::{resolve_launch_target, LaunchEntry, LaunchTarget};
     use std::path::PathBuf;
 
     #[test]
@@ -433,11 +425,5 @@ mod launch_target_tests {
         ]);
         assert_eq!(out.dir.as_deref(), Some("/workspace"));
         assert_eq!(out.files, vec!["/other/x.rs".to_string()]);
-    }
-
-    #[test]
-    fn settings_float_only_outside_macos() {
-        assert!(!settings_always_on_top(true));
-        assert!(settings_always_on_top(false));
     }
 }


### PR DESCRIPTION
## Summary
Settings was still using system-wide `always_on_top` on non-macOS (builder + reopen path). That maps to a global floating window level, so Settings stays above every app — not just Terax.

## Fix
Remove `always_on_top` entirely from `open_settings_window`. The existing `.parent(&main)` owner relationship already keeps Settings above Terax’s main window without floating over unrelated apps.

Also drop the now-unused `settings_always_on_top` helper and its unit test.

## Notes
#1227 already disabled always-on-top on macOS, but left it enabled elsewhere and did not close #957. This finishes the fix cross-platform.

Fixes #957

## Test plan
- [ ] Open Settings, then switch to another app (Alt/Cmd-Tab) — Settings should recede behind that app
- [ ] Click back into Terax main window — Settings should still stay above the main Terax window
- [ ] Re-open Settings while already open (tab switch / gear) — still focuses correctly without re-asserting always-on-top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings windows now remain above the main Terax window without staying above unrelated applications.
  * Improved settings window behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->