### PR TITLE
fix(ai): stop multiline paste from submitting the composer

### DIFF
--- a/src/modules/ai/components/AiComposerInput.tsx
+++ b/src/modules/ai/components/AiComposerInput.tsx
@@ -3,6 +3,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { usePresence } from "@/lib/usePresence";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { shouldSubmitComposerEnter } from "../lib/composerEnter";
 import { useWorkspaceFiles } from "../hooks/useWorkspaceFiles";
 import { useComposer } from "../lib/composer";
 import { SLASH_COMMANDS } from "../lib/slashCommands";
@@ -196,6 +197,28 @@ export function AiComposerInput() {
     if (it) onPickItem(it);
   };
 
+  const pastingRef = useRef(false);
+  const pasteClearTimerRef = useRef<number | null>(null);
+  const markPasting = () => {
+    pastingRef.current = true;
+    if (pasteClearTimerRef.current != null) {
+      window.clearTimeout(pasteClearTimerRef.current);
+    }
+    // Cover sync + microtask Enter synth from Windows multiline paste.
+    pasteClearTimerRef.current = window.setTimeout(() => {
+      pastingRef.current = false;
+      pasteClearTimerRef.current = null;
+    }, 50);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (pasteClearTimerRef.current != null) {
+        window.clearTimeout(pasteClearTimerRef.current);
+      }
+    };
+  }, []);
+
   const voiceLabel = c.voice.recording
     ? "Listening…"
     : c.voice.transcribing
@@ -217,6 +240,10 @@ export function AiComposerInput() {
               onKeyUp={updateTrigger}
               onClick={updateTrigger}
               onSelect={updateTrigger}
+              onPaste={markPasting}
+              onBeforeInput={(e) => {
+                if (e.nativeEvent.inputType === "insertFromPaste") markPasting();
+              }}
               onKeyDown={(e) => {
                 if (pickerOpen) {
                   const items = fileTrigger ? filteredFiles : filteredItems;
@@ -232,12 +259,32 @@ export function AiComposerInput() {
                     setActiveIndex((i) => Math.max(0, i - 1));
                     return;
                   }
-                  if (e.key === "Tab" || e.key === "Enter") {
+                  if (e.key === "Tab") {
                     if (items.length > 0) {
                       e.preventDefault();
                       pickActive();
                       return;
                     }
+                  }
+                  if (e.key === "Enter") {
+                    if (
+                      items.length > 0 &&
+                      shouldSubmitComposerEnter({
+                        key: e.key,
+                        shiftKey: e.shiftKey,
+                        isComposing: e.nativeEvent.isComposing,
+                        keyCode: e.keyCode,
+                        isPasting: pastingRef.current,
+                        ctrlKey: e.ctrlKey,
+                        metaKey: e.metaKey,
+                        altKey: e.altKey,
+                      })
+                    ) {
+                      e.preventDefault();
+                      pickActive();
+                      return;
+                    }
+                    // Fall through: paste/IME Enter must not submit either.
                   }
                   if (e.key === "Escape") {
                     e.preventDefault();
@@ -252,7 +299,18 @@ export function AiComposerInput() {
                     return;
                   }
                 }
-                if (e.key === "Enter" && !e.shiftKey) {
+                if (
+                  shouldSubmitComposerEnter({
+                    key: e.key,
+                    shiftKey: e.shiftKey,
+                    isComposing: e.nativeEvent.isComposing,
+                    keyCode: e.keyCode,
+                    isPasting: pastingRef.current,
+                    ctrlKey: e.ctrlKey,
+                    metaKey: e.metaKey,
+                    altKey: e.altKey,
+                  })
+                ) {
                   e.preventDefault();
                   c.submit();
                 }

--- a/src/modules/ai/lib/composerEnter.test.ts
+++ b/src/modules/ai/lib/composerEnter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { shouldSubmitComposerEnter } from "./composerEnter";
+
+describe("shouldSubmitComposerEnter", () => {
+  it("submits plain Enter", () => {
+    expect(shouldSubmitComposerEnter({ key: "Enter", shiftKey: false })).toBe(
+      true,
+    );
+  });
+
+  it("keeps Shift+Enter as a newline", () => {
+    expect(shouldSubmitComposerEnter({ key: "Enter", shiftKey: true })).toBe(
+      false,
+    );
+  });
+
+  it("ignores Enter during IME composition", () => {
+    expect(
+      shouldSubmitComposerEnter({
+        key: "Enter",
+        shiftKey: false,
+        isComposing: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores Chromium Process Enter (keyCode 229)", () => {
+    expect(
+      shouldSubmitComposerEnter({
+        key: "Enter",
+        shiftKey: false,
+        keyCode: 229,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores Enter while a paste is settling (Windows multiline)", () => {
+    expect(
+      shouldSubmitComposerEnter({
+        key: "Enter",
+        shiftKey: false,
+        isPasting: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores Enter while Ctrl/Meta/Alt is held (Ctrl+V paste synth)", () => {
+    expect(
+      shouldSubmitComposerEnter({
+        key: "Enter",
+        shiftKey: false,
+        ctrlKey: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerEnter({
+        key: "Enter",
+        shiftKey: false,
+        metaKey: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores non-Enter keys", () => {
+    expect(shouldSubmitComposerEnter({ key: "a", shiftKey: false })).toBe(
+      false,
+    );
+  });
+});

--- a/src/modules/ai/lib/composerEnter.ts
+++ b/src/modules/ai/lib/composerEnter.ts
@@ -1,0 +1,31 @@
+/** Decide whether the AI composer should submit on this Enter keydown. */
+export type ComposerEnterEvent = {
+  key: string;
+  shiftKey: boolean;
+  /** True while IME composition is active (`KeyboardEvent.isComposing`). */
+  isComposing?: boolean;
+  /**
+   * Chromium "Process" keyCode. macOS reports 229 for the Enter that confirms
+   * an IME candidate before `isComposing` flips (see terminal IME guard).
+   */
+  keyCode?: number;
+  /**
+   * True for a short window after `paste` / `insertFromPaste`. On Windows
+   * WebView2, multiline clipboard paste can synthesize Enter keydowns for
+   * each newline; those must not submit the composer.
+   */
+  isPasting?: boolean;
+  /** Ctrl/Meta/Alt held — e.g. Ctrl still down during Ctrl+V paste synth. */
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+};
+
+export function shouldSubmitComposerEnter(e: ComposerEnterEvent): boolean {
+  if (e.key !== "Enter") return false;
+  if (e.shiftKey) return false;
+  if (e.isComposing || e.keyCode === 229) return false;
+  if (e.isPasting) return false;
+  if (e.ctrlKey || e.metaKey || e.altKey) return false;
+  return true;
+}

--- a/src/modules/ai/lib/composerEnter.ts
+++ b/src/modules/ai/lib/composerEnter.ts
@@ -15,7 +15,7 @@ export type ComposerEnterEvent = {
    * each newline; those must not submit the composer.
    */
   isPasting?: boolean;
-  /** Ctrl/Meta/Alt held — e.g. Ctrl still down during Ctrl+V paste synth. */
+  /** Ctrl/Meta/Alt held  -  e.g. Ctrl still down during Ctrl+V paste synth. */
   ctrlKey?: boolean;
   metaKey?: boolean;
   altKey?: boolean;


### PR DESCRIPTION
## What

Gate AI composer Enter-to-submit so multiline clipboard paste (and IME / modifier chords) cannot fire `submit()`.

## Why

On Windows, pasting text with line breaks into the composer was submitting a message per newline (#845). The textarea `onKeyDown` treated every non-Shift Enter as submit, and WebView2 can synthesize Enter keydowns while a paste is settling (or while Ctrl is still held from Ctrl+V).

## How

- Add pure `shouldSubmitComposerEnter` (`src/modules/ai/lib/composerEnter.ts`) that returns false for Shift+Enter, IME (`isComposing` / keyCode 229), an in-flight paste window, or Ctrl/Meta/Alt.
- `AiComposerInput` marks pasting on `onPaste` / `beforeinput insertFromPaste` for ~50ms and routes Enter through the helper (picker Enter included).
- Unit tests cover the gates.

Voice-to-text insertion from external tools (second half of #845) is unchanged — that needs a separate input path.

## Testing

- [x] `pnpm exec vitest run src/modules/ai/lib/composerEnter.test.ts` — 7 passed
- [ ] Manual (Windows): paste multiline text into the AI composer → stays in the box, no auto-send; plain Enter still sends; Shift+Enter still newlines

Fixes #845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI composer Enter-key handling across IME input, keyboard shortcuts, and multiline paste operations.
  - Prevented unintended submissions or picker selections triggered by paste-related synthetic key events.
  - Preserved Shift+Enter for new lines and Tab for selecting the active picker item.
  - Prevented submission when modifier keys are held or while text composition is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->