### PR TITLE
fix(pty): stop StrictMode from crashing the PowerShell profile

### DIFF
--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -3,8 +3,12 @@
 # boundaries. C comes from a PSConsoleHostReadLine wrapper (PowerShell has no
 # preexec hook).
 
-if ($global:__TERAX_HOOKS_LOADED) { return }
+# StrictMode treats a missing $global: as an error (#930). Probe the
+# variable drive instead of reading an unset value.
+if (Test-Path Variable:global:__TERAX_HOOKS_LOADED) { return }
 $global:__TERAX_HOOKS_LOADED = $true
+$global:__terax_readline_done = $false
+$global:__terax_block_seen = $false
 
 if ($env:TERAX_CLI -and (Test-Path -LiteralPath $env:TERAX_CLI -PathType Leaf)) {
     function global:terax {
@@ -75,7 +79,7 @@ function global:__terax_install_readline {
 
 function global:prompt {
     __terax_install_readline
-    $lec = $LASTEXITCODE
+    $lec = if (Test-Path Variable:LASTEXITCODE) { $LASTEXITCODE } else { $null }
     if ($null -eq $lec) { $lec = if ($?) { 0 } else { 1 } }
     $esc = [char]27
 

--- a/src-tauri/src/modules/pty/scripts/profile.ps1
+++ b/src-tauri/src/modules/pty/scripts/profile.ps1
@@ -5,7 +5,8 @@
 
 # StrictMode treats a missing $global: as an error (#930). Probe the
 # variable drive instead of reading an unset value.
-if (Test-Path Variable:global:__TERAX_HOOKS_LOADED) { return }
+if ((Test-Path Variable:global:__TERAX_HOOKS_LOADED) -and
+    $global:__TERAX_HOOKS_LOADED) { return }
 $global:__TERAX_HOOKS_LOADED = $true
 $global:__terax_readline_done = $false
 $global:__terax_block_seen = $false
@@ -78,9 +79,10 @@ function global:__terax_install_readline {
 }
 
 function global:prompt {
+    $promptStatus = $?
     __terax_install_readline
     $lec = if (Test-Path Variable:LASTEXITCODE) { $LASTEXITCODE } else { $null }
-    if ($null -eq $lec) { $lec = if ($?) { 0 } else { 1 } }
+    if ($null -eq $lec) { $lec = if ($promptStatus) { 0 } else { 1 } }
     $esc = [char]27
 
     $oscD = "$esc]133;D;$lec$esc\"

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -1152,4 +1152,21 @@ mod tests {
             Some(std::path::PathBuf::from("/app/bin"))
         );
     }
+
+    #[test]
+    fn powershell_profile_guard_is_strictmode_safe() {
+        const PROFILE: &str = include_str!("scripts/profile.ps1");
+        assert!(
+            PROFILE.contains("Test-Path Variable:global:__TERAX_HOOKS_LOADED"),
+            "must probe the variable drive; reading an unset $global: throws under StrictMode (#930)"
+        );
+        assert!(
+            !PROFILE.contains("if ($global:__TERAX_HOOKS_LOADED)"),
+            "bare $global:__TERAX_HOOKS_LOADED boolean test is the #930 crash"
+        );
+        assert!(
+            PROFILE.contains("Test-Path Variable:LASTEXITCODE"),
+            "prompt must not read an unset $LASTEXITCODE under StrictMode"
+        );
+    }
 }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -1165,8 +1165,20 @@ mod tests {
             "bare $global:__TERAX_HOOKS_LOADED boolean test is the #930 crash"
         );
         assert!(
+            PROFILE.contains("$global:__TERAX_HOOKS_LOADED) { return }"),
+            "re-entry guard must still require a truthy marker value"
+        );
+        assert!(
             PROFILE.contains("Test-Path Variable:LASTEXITCODE"),
             "prompt must not read an unset $LASTEXITCODE under StrictMode"
+        );
+        assert!(
+            PROFILE.contains("$promptStatus = $?"),
+            "prompt must capture $? before probing LASTEXITCODE / installing readline"
+        );
+        assert!(
+            PROFILE.contains("if ($promptStatus) { 0 } else { 1 }"),
+            "fallback exit code must use the captured $? value"
         );
     }
 }


### PR DESCRIPTION
## What

Make the PowerShell shell-integration profile StrictMode-safe so startup no longer throws `VariableIsUndefined` on unset globals.

## Why

Users with `Set-StrictMode` (common in `$PROFILE` / enterprise baselines) hit this on every new Terax terminal:

```
VariableIsUndefined: $global:__TERAX_HOOKS_LOADED
  at profile.ps1:6
if ($global:__TERAX_HOOKS_LOADED) { return }
```

Reading an unset `$global:` is an error under StrictMode. Same class of crash then hits `$LASTEXITCODE` the first time `prompt` runs.

## How

- Probe `Variable:global:__TERAX_HOOKS_LOADED` instead of reading it.
- Initialize `__terax_readline_done` / `__terax_block_seen` so later boolean tests are defined.
- Read `$LASTEXITCODE` only after `Test-Path Variable:LASTEXITCODE`.
- Rust unit test locks the guards.

## Testing

- [x] `cargo test --locked powershell_profile_guard_is_strictmode_safe` — 1 passed
- [x] Live Windows PowerShell: `Set-StrictMode -Version Latest` then `. profile.ps1` + `prompt` — old bare `$global:` still throws `VariableIsUndefined`; patched profile loads and prompt returns without error

Fixes #930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell profile compatibility with StrictMode when optional shell variables are unset.
  * Preserved correct command exit statuses in the prompt, including when fallback handling is used.
  * Improved reliability when the PowerShell profile is loaded more than once.
* **Tests**
  * Added regression coverage for StrictMode compatibility, profile re-entry checks, and prompt exit-status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->