### PR TITLE
fix(tabs): close tabs on middle-click mousedown, not auxclick

### DIFF
--- a/src/modules/tabs/TabBar.tsx
+++ b/src/modules/tabs/TabBar.tsx
@@ -51,6 +51,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { shouldCloseTabOnMiddleMouse } from "./lib/middleClickClose";
 import { labelFor } from "./lib/tabLabel";
 import type { EditorTab, Tab } from "./lib/useTabs";
 import { NewTabMenu } from "./NewTabMenu";
@@ -322,18 +323,18 @@ export function TabBar({
                   }}
                   onPointerCancel={(e) => endDrag(e.currentTarget)}
                   onDoubleClick={() => isPreview && onPin(t.id)}
-                  onAuxClick={(e) => {
-                    if (e.button === 1 && tabs.length > 1) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onClose(t.id);
-                    }
-                  }}
+                  // Middle-click close must run on mousedown: preventDefault
+                  // here (autoscroll suppress) cancels auxclick per the DOM
+                  // spec, so an onAuxClick handler never fires (#609 / #400).
                   // Suppress Radix's switch-on-mousedown so a tab grabbed to
                   // drag (or a plain click) only activates on release.
                   onMouseDown={(e) => {
                     if (e.button === 1) {
                       e.preventDefault();
+                      e.stopPropagation();
+                      if (shouldCloseTabOnMiddleMouse(e.button, tabs.length)) {
+                        onClose(t.id);
+                      }
                       return;
                     }
                     if (

--- a/src/modules/tabs/lib/middleClickClose.test.ts
+++ b/src/modules/tabs/lib/middleClickClose.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { shouldCloseTabOnMiddleMouse } from "./middleClickClose";
+
+describe("shouldCloseTabOnMiddleMouse", () => {
+  it("closes on middle button when multiple tabs are open", () => {
+    expect(shouldCloseTabOnMiddleMouse(1, 2)).toBe(true);
+    expect(shouldCloseTabOnMiddleMouse(1, 5)).toBe(true);
+  });
+
+  it("does not close the last remaining tab", () => {
+    expect(shouldCloseTabOnMiddleMouse(1, 1)).toBe(false);
+    expect(shouldCloseTabOnMiddleMouse(1, 0)).toBe(false);
+  });
+
+  it("ignores primary and secondary buttons", () => {
+    expect(shouldCloseTabOnMiddleMouse(0, 3)).toBe(false);
+    expect(shouldCloseTabOnMiddleMouse(2, 3)).toBe(false);
+  });
+});

--- a/src/modules/tabs/lib/middleClickClose.ts
+++ b/src/modules/tabs/lib/middleClickClose.ts
@@ -1,0 +1,14 @@
+/**
+ * Middle-click (button === 1) closes a tab when more than one is open.
+ *
+ * Close must run on `mousedown`, not `auxclick`: calling preventDefault() on
+ * the middle-button mousedown (to suppress the browser autoscroll cursor)
+ * cancels the subsequent auxclick per the DOM UI Events spec. That is why the
+ * #484 auxclick handler never fired in practice (#609, #400).
+ */
+export function shouldCloseTabOnMiddleMouse(
+  button: number,
+  tabCount: number,
+): boolean {
+  return button === 1 && tabCount > 1;
+}


### PR DESCRIPTION
## What

Close a tab on middle-mouse **mousedown** (with the existing autoscroll `preventDefault`), instead of on `auxclick`.

## Why

Middle-click on a tab does nothing (#609, #400), even after #484. That PR registered `onAuxClick` **and** called `preventDefault()` on middle-button `mousedown` to suppress the browser autoscroll cursor. Per the DOM UI Events spec, canceling `mousedown` means `auxclick` never fires — so the close handler was unreachable.

## How

- Extract `shouldCloseTabOnMiddleMouse(button, tabCount)` (middle button + more than one tab; same guard as the X button / #484).
- Run close from `onMouseDown` for `button === 1`, still `preventDefault` + `stopPropagation` to block autoscroll.
- Drop the dead `onAuxClick` path.
- Unit tests for the pure helper.

Does **not** auto-close #609 (that issue also covers traffic-light alignment + a feature ask) or #400 (multi-item list). Addresses the middle-click bullet in both.

## Testing

- [x] `pnpm exec vitest run src/modules/tabs/lib/middleClickClose.test.ts` — 3 passed
- [ ] Manual: open 2+ tabs → middle-click closes the targeted tab; last tab is a no-op; no autoscroll cursor

Related: #609 #400 (supersedes the broken #484 wiring)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved middle-click tab closing behavior.
  - Prevented the browser’s autoscroll cursor from appearing when closing tabs with the middle mouse button.
  - Preserved protection against closing the final remaining tab.

- **Tests**
  - Added coverage for middle-, primary-, and secondary-click behavior across different tab counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->