### PR TITLE
fix(ai): dismiss connect-provider banner when no keys configured

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1522,6 +1522,7 @@ export default function App() {
                       panelOpen={panelOpen}
                       keysLoaded={keysLoaded}
                       onConnect={() => void openSettingsWindow("models")}
+                      onCloseConnect={() => useChatStore.getState().closePanel()}
                     />
                   </div>
                 </div>

--- a/src/app/components/WorkspaceInputBar.tsx
+++ b/src/app/components/WorkspaceInputBar.tsx
@@ -37,6 +37,7 @@ type Props = {
   panelOpen: boolean;
   keysLoaded: boolean;
   onConnect: () => void;
+  onCloseConnect?: () => void;
 };
 
 export function WorkspaceInputBar({
@@ -49,6 +50,7 @@ export function WorkspaceInputBar({
   panelOpen,
   keysLoaded,
   onConnect,
+  onCloseConnect,
 }: Props) {
   const c = useComposer();
   const { os, shell } = useSystemInfo();
@@ -125,7 +127,7 @@ export function WorkspaceInputBar({
 
   const content =
     !hasComposer && !isBlockTab ? (
-      <AiInputBarConnect onAdd={onConnect} />
+      <AiInputBarConnect onAdd={onConnect} onClose={onCloseConnect} />
     ) : (
       <div className="shrink-0 border-t border-border/60 bg-foreground/[0.02] px-3 py-2">
         <div className="flex flex-col gap-2 rounded-lg px-1 py-1">
@@ -257,3 +259,4 @@ function relPath(p: string, home: string | null): string {
   if (p === h || p.startsWith(`${h}/`)) return `~${p.slice(h.length)}`;
   return p;
 }
+

--- a/src/app/components/WorkspaceInputBar.tsx
+++ b/src/app/components/WorkspaceInputBar.tsx
@@ -127,7 +127,7 @@ export function WorkspaceInputBar({
 
   const content =
     !hasComposer && !isBlockTab ? (
-      <AiInputBarConnect onAdd={onConnect} onClose={onCloseConnect} />
+      <AiInputBarConnect onAdd={onConnect} onClose={onCloseConnect} open={open} />
     ) : (
       <div className="shrink-0 border-t border-border/60 bg-foreground/[0.02] px-3 py-2">
         <div className="flex flex-col gap-2 rounded-lg px-1 py-1">

--- a/src/modules/ai/components/AiInputBar.test.ts
+++ b/src/modules/ai/components/AiInputBar.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source contract for #304: the connect-provider banner must expose a dismiss
+ * path. Without onClose + the dismiss button, panelOpen && !hasComposer left
+ * users stuck - StatusBar only offers panel-close controls when hasComposer
+ * is true.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(here, "AiInputBar.tsx"), "utf8");
+
+describe("AiInputBarConnect dismiss (#304)", () => {
+  it("accepts an onClose prop", () => {
+    expect(src).toMatch(/onClose\?: \(\) => void/);
+  });
+
+  it("renders a Close control wired to onClose", () => {
+    expect(src).toMatch(/aria-label="Close"/);
+    expect(src).toMatch(/onClick=\{onClose\}/);
+    expect(src).toMatch(/Cancel01Icon/);
+  });
+
+  it("dismisses on Escape when onClose is provided", () => {
+    expect(src).toMatch(/e\.key !== "Escape"/);
+    expect(src).toMatch(/window\.addEventListener\("keydown"/);
+  });
+});

--- a/src/modules/ai/components/AiInputBar.test.ts
+++ b/src/modules/ai/components/AiInputBar.test.ts
@@ -28,4 +28,10 @@ describe("AiInputBarConnect dismiss (#304)", () => {
     expect(src).toMatch(/e\.key !== "Escape"/);
     expect(src).toMatch(/window\.addEventListener\("keydown"/);
   });
+
+  it("gates the Escape listener on open so a closed bar does not steal Esc", () => {
+    expect(src).toMatch(/open: boolean/);
+    expect(src).toMatch(/if \(!onClose \|\| !open\) return/);
+    expect(src).toMatch(/\[onClose, open\]/);
+  });
 });

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -1,8 +1,29 @@
 import { Button } from "@/components/ui/button";
-import { Key01Icon } from "@hugeicons/core-free-icons";
+import { Cancel01Icon, Key01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect } from "react";
 
-export function AiInputBarConnect({ onAdd }: { onAdd: () => void }) {
+export function AiInputBarConnect({
+  onAdd,
+  onClose,
+}: {
+  onAdd: () => void;
+  onClose?: () => void;
+}) {
+  // Esc dismisses the stuck connect-provider banner (#304). Without this
+  // (and the dismiss button), panelOpen + !hasComposer left no way to hide it -
+  // StatusBar only shows panel-close controls when hasComposer is true.
+  useEffect(() => {
+    if (!onClose) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
   return (
     <div className="shrink-0 border-t border-border/60 bg-foreground/[0.02] px-3 py-2">
       <div className="flex h-10 items-center justify-between gap-3 rounded-lg px-3 text-xs">
@@ -10,10 +31,25 @@ export function AiInputBarConnect({ onAdd }: { onAdd: () => void }) {
           Connect any AI provider (or use local models) - your key stays in your
           OS keychain.
         </span>
-        <Button size="xs" onClick={onAdd}>
-          <HugeiconsIcon icon={Key01Icon} />
-          Connect provider
-        </Button>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button size="xs" onClick={onAdd}>
+            <HugeiconsIcon icon={Key01Icon} />
+            Connect provider
+          </Button>
+          {onClose ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={onClose}
+              className="size-7"
+              aria-label="Close"
+              title="Close (Esc)"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={2} />
+            </Button>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/src/modules/ai/components/AiInputBar.tsx
+++ b/src/modules/ai/components/AiInputBar.tsx
@@ -6,15 +6,19 @@ import { useEffect } from "react";
 export function AiInputBarConnect({
   onAdd,
   onClose,
+  open,
 }: {
   onAdd: () => void;
   onClose?: () => void;
+  open: boolean;
 }) {
   // Esc dismisses the stuck connect-provider banner (#304). Without this
   // (and the dismiss button), panelOpen + !hasComposer left no way to hide it -
   // StatusBar only shows panel-close controls when hasComposer is true.
+  // Gate on open: the bar stays mounted when closed (keysLoaded), so an ungated
+  // Escape listener would steal Esc from unrelated UI.
   useEffect(() => {
-    if (!onClose) return;
+    if (!onClose || !open) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       e.preventDefault();
@@ -22,7 +26,7 @@ export function AiInputBarConnect({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+  }, [onClose, open]);
 
   return (
     <div className="shrink-0 border-t border-border/60 bg-foreground/[0.02] px-3 py-2">

--- a/src/modules/ai/components/lazy.tsx
+++ b/src/modules/ai/components/lazy.tsx
@@ -35,10 +35,16 @@ export function AiMiniWindow({ state }: { state: PresenceState }) {
   );
 }
 
-export function AiInputBarConnect({ onAdd }: { onAdd: () => void }) {
+export function AiInputBarConnect({
+  onAdd,
+  onClose,
+}: {
+  onAdd: () => void;
+  onClose?: () => void;
+}) {
   return (
     <Suspense fallback={null}>
-      <AiInputBarConnectInner onAdd={onAdd} />
+      <AiInputBarConnectInner onAdd={onAdd} onClose={onClose} />
     </Suspense>
   );
 }
@@ -50,3 +56,4 @@ export function SelectionAskAi(props: SelectionAskAiProps) {
     </Suspense>
   );
 }
+

--- a/src/modules/ai/components/lazy.tsx
+++ b/src/modules/ai/components/lazy.tsx
@@ -38,13 +38,15 @@ export function AiMiniWindow({ state }: { state: PresenceState }) {
 export function AiInputBarConnect({
   onAdd,
   onClose,
+  open,
 }: {
   onAdd: () => void;
   onClose?: () => void;
+  open: boolean;
 }) {
   return (
     <Suspense fallback={null}>
-      <AiInputBarConnectInner onAdd={onAdd} onClose={onClose} />
+      <AiInputBarConnectInner onAdd={onAdd} onClose={onClose} open={open} />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
When the AI panel is open but no providers/keys are configured (`panelOpen && !hasComposer`), the connect-provider banner had **no dismiss path**. StatusBar only renders panel-close controls when `hasComposer` is true, so users who opened the AI entry by mistake were stuck until they quit the app.

## Fix
- Add optional `onClose` to `AiInputBarConnect` with a × button (same pattern as `AiMiniWindow`)
- Esc also dismisses while the banner is mounted
- Wire `onCloseConnect` → `closePanel()` from `App` via `WorkspaceInputBar`

Fixes #304

## Testing
- [x] `vitest run src/modules/ai/components/AiInputBar.test.ts` (3/3)
- [x] `tsc --noEmit` clean
- Manual: open AI with no providers → banner shows → × / Esc hides it; Connect provider still opens Settings → Models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a close button to the AI provider connection prompt.
  * Users can dismiss the prompt by clicking Close or pressing Escape.
  * Closing the prompt hides the AI chat panel when opened from the workspace.
  * Escape-key dismissal applies only while the prompt is open.

* **Tests**
  * Added coverage for close-button behavior, callback handling, and Escape-key dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->