### PR TITLE
fix(terminal): open OSC 8 file hyperlinks via native opener

### DIFF
--- a/src/lib/external-link.test.ts
+++ b/src/lib/external-link.test.ts
@@ -6,7 +6,12 @@ const opener = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/plugin-opener", () => opener);
 
-import { isExternalUrl, openExternalUrl } from "./external-link";
+import {
+  isExternalUrl,
+  isTerminalOpenableUrl,
+  openExternalUrl,
+  openTerminalUrl,
+} from "./external-link";
 
 describe("isExternalUrl", () => {
   it("accepts web, mail, and phone schemes", () => {
@@ -22,6 +27,21 @@ describe("isExternalUrl", () => {
     expect(isExternalUrl("javascript:void(0)")).toBe(false);
     expect(isExternalUrl("data:text/html,hi")).toBe(false);
     expect(isExternalUrl("file:///etc/passwd")).toBe(false);
+  });
+});
+
+describe("isTerminalOpenableUrl", () => {
+  it("accepts the external schemes plus file", () => {
+    expect(isTerminalOpenableUrl("https://example.com")).toBe(true);
+    expect(isTerminalOpenableUrl("mailto:a@b.c")).toBe(true);
+    expect(isTerminalOpenableUrl("file:///Users/me/readme.md")).toBe(true);
+    expect(isTerminalOpenableUrl("FILE:///C:/Users/me/readme.md")).toBe(true);
+  });
+
+  it("still refuses executable schemes", () => {
+    expect(isTerminalOpenableUrl("javascript:void(0)")).toBe(false);
+    expect(isTerminalOpenableUrl("data:text/html,hi")).toBe(false);
+    expect(isTerminalOpenableUrl("/settings/general")).toBe(false);
   });
 });
 
@@ -48,6 +68,15 @@ describe("openExternalUrl", () => {
     expect(settled).toHaveBeenCalledTimes(1);
   });
 
+  it("does not open file URLs (markdown / shared path)", async () => {
+    const settled = vi.fn();
+
+    await openExternalUrl("file:///Users/me/readme.md", settled);
+
+    expect(opener.openUrl).not.toHaveBeenCalled();
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
   it("still settles when the opener fails", async () => {
     opener.openUrl.mockRejectedValueOnce(new Error("no handler"));
     const settled = vi.fn();
@@ -57,5 +86,32 @@ describe("openExternalUrl", () => {
     ).resolves.toBeUndefined();
 
     expect(settled).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("openTerminalUrl", () => {
+  beforeEach(() => {
+    opener.openUrl.mockClear();
+  });
+
+  it("opens https and file URLs through the opener plugin", async () => {
+    const settled = vi.fn();
+
+    await openTerminalUrl("https://example.com", settled);
+    await openTerminalUrl("file:///Users/me/readme.md", settled);
+
+    expect(opener.openUrl).toHaveBeenCalledWith("https://example.com");
+    expect(opener.openUrl).toHaveBeenCalledWith("file:///Users/me/readme.md");
+    expect(settled).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips javascript and data schemes", async () => {
+    const settled = vi.fn();
+
+    await openTerminalUrl("javascript:alert(1)", settled);
+    await openTerminalUrl("data:text/html,hi", settled);
+
+    expect(opener.openUrl).not.toHaveBeenCalled();
+    expect(settled).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/external-link.ts
+++ b/src/lib/external-link.ts
@@ -4,6 +4,20 @@ export function isExternalUrl(href: string): boolean {
   return /^(?:https?:|mailto:|tel:)/i.test(href);
 }
 
+/** Schemes the terminal OSC 8 / web-links path may open via the native opener.
+ * Includes `file:` so eza/ls --hyperlink works; still rejects javascript:/data:. */
+export function isTerminalOpenableUrl(href: string): boolean {
+  return isExternalUrl(href) || /^file:/i.test(href);
+}
+
+function openViaOpener(href: string, onSettled?: () => void): Promise<void> {
+  return openUrl(href)
+    .catch((error) => {
+      console.error("[terax] failed to open external link:", error);
+    })
+    .finally(() => onSettled?.());
+}
+
 export function openExternalUrl(
   href: string,
   onSettled?: () => void,
@@ -12,10 +26,18 @@ export function openExternalUrl(
     onSettled?.();
     return Promise.resolve();
   }
+  return openViaOpener(href, onSettled);
+}
 
-  return openUrl(href)
-    .catch((error) => {
-      console.error("[terax] failed to open external link:", error);
-    })
-    .finally(() => onSettled?.());
+/** Terminal link activation (OSC 8 + WebLinksAddon). Allows `file:` in addition
+ * to the web/mail/tel schemes used elsewhere. */
+export function openTerminalUrl(
+  href: string,
+  onSettled?: () => void,
+): Promise<void> {
+  if (!isTerminalOpenableUrl(href)) {
+    onSettled?.();
+    return Promise.resolve();
+  }
+  return openViaOpener(href, onSettled);
 }

--- a/src/modules/terminal/lib/terminalLinks.test.ts
+++ b/src/modules/terminal/lib/terminalLinks.test.ts
@@ -11,7 +11,7 @@ describe("createTerminalLinkHandler", () => {
     vi.clearAllMocks();
   });
 
-  it("opens OSC 8 links natively and restores late-bound terminal focus", async () => {
+  it("opens OSC 8 https links natively and restores late-bound terminal focus", async () => {
     openUrl.mockResolvedValue(undefined);
     const initialFocus = vi.fn();
     let focus = initialFocus;
@@ -28,5 +28,29 @@ describe("createTerminalLinkHandler", () => {
     );
     await vi.waitFor(() => expect(focus).toHaveBeenCalledOnce());
     expect(initialFocus).not.toHaveBeenCalled();
+  });
+
+  it("allows non-http OSC 8 protocols and opens file URLs", async () => {
+    openUrl.mockResolvedValue(undefined);
+    const focus = vi.fn();
+    const handler = createTerminalLinkHandler(focus);
+
+    expect(handler.allowNonHttpProtocols).toBe(true);
+
+    handler.activate({} as MouseEvent, "file:///Users/me/project/README.md");
+
+    expect(openUrl).toHaveBeenCalledWith("file:///Users/me/project/README.md");
+    await vi.waitFor(() => expect(focus).toHaveBeenCalledOnce());
+  });
+
+  it("does not open javascript: OSC 8 payloads", async () => {
+    openUrl.mockResolvedValue(undefined);
+    const focus = vi.fn();
+    const handler = createTerminalLinkHandler(focus);
+
+    handler.activate({} as MouseEvent, "javascript:alert(1)");
+
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(focus).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/terminal/lib/terminalLinks.ts
+++ b/src/modules/terminal/lib/terminalLinks.ts
@@ -1,8 +1,11 @@
-import { openExternalUrl } from "@/lib/external-link";
+import { openTerminalUrl } from "@/lib/external-link";
 
 export function createTerminalLinkHandler(focus: () => void) {
   return {
     activate: (_event: MouseEvent, uri: string) =>
-      void openExternalUrl(uri, focus),
+      void openTerminalUrl(uri, focus),
+    // xterm drops non-http OSC 8 URIs unless this is set; activate still
+    // filters schemes via openTerminalUrl (file/http/mailto/tel only).
+    allowNonHttpProtocols: true,
   };
 }


### PR DESCRIPTION
Closes #831. Enable allowNonHttpProtocols on the terminal OSC 8 link handler and open file: URLs via the native opener (eza/ls --hyperlink). Markdown isExternalUrl stays http/mailto/tel only. Tests: vitest external-link + terminalLinks (13 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal links now support opening `file:` URLs in addition to web links.
  * Supported terminal links open through the configured link opener, with terminal focus restored afterward.

* **Bug Fixes**
  * Unsafe `javascript:` and `data:` links are blocked from opening.
  * File links opened externally now complete reliably without using the external opener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->