### PR TITLE
fix(terminal): canvas-probe Nerd Font auto-detect on WKWebView

### DIFF
--- a/src/lib/fonts.test.ts
+++ b/src/lib/fonts.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { resolveFontFamily } from "./fonts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  detectMonoFontFamily,
+  resetDetectedMonoFontFamily,
+  resolveFontFamily,
+} from "./fonts";
 
 const FALLBACK = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
 
 describe("resolveFontFamily", () => {
+  beforeEach(() => {
+    resetDetectedMonoFontFamily();
+  });
+
   it("quotes a bare family and appends the mono fallback", () => {
     expect(resolveFontFamily("JetBrainsMono Nerd Font")).toBe(
       `"JetBrainsMono Nerd Font", ${FALLBACK}`,
@@ -31,5 +39,93 @@ describe("resolveFontFamily", () => {
   it("falls back to the mono chain for empty input", () => {
     expect(resolveFontFamily("")).toBe(FALLBACK);
     expect(resolveFontFamily("   ")).toBe(FALLBACK);
+  });
+});
+
+describe("detectMonoFontFamily", () => {
+  beforeEach(() => {
+    resetDetectedMonoFontFamily();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetDetectedMonoFontFamily();
+  });
+
+  it("uses document.fonts.check when it reports a Nerd Font", () => {
+    vi.stubGlobal("document", {
+      fonts: {
+        check: (spec: string) => spec.includes("MesloLGS NF"),
+      },
+      createElement: () => {
+        throw new Error("canvas should not be needed when check hits");
+      },
+    });
+
+    expect(detectMonoFontFamily()).toBe(`"MesloLGS NF", ${FALLBACK}`);
+  });
+
+  it("falls back to canvas measureText when fonts.check is false (WKWebView)", () => {
+    let currentFont = "";
+    const measureText = vi.fn(() => ({
+      width: currentFont.includes("MesloLGS NF") ? 120 : 100,
+    }));
+    vi.stubGlobal("document", {
+      fonts: {
+        check: () => false,
+      },
+      createElement: (tag: string) => {
+        if (tag !== "canvas") throw new Error(`unexpected ${tag}`);
+        return {
+          getContext: () => ({
+            set font(value: string) {
+              currentFont = value;
+            },
+            get font() {
+              return currentFont;
+            },
+            measureText,
+          }),
+        };
+      },
+    });
+
+    expect(detectMonoFontFamily()).toBe(`"MesloLGS NF", ${FALLBACK}`);
+    expect(measureText).toHaveBeenCalled();
+  });
+
+  it("returns the mono fallback when neither check nor canvas finds a font", () => {
+    vi.stubGlobal("document", {
+      fonts: {
+        check: () => false,
+      },
+      createElement: () => ({
+        getContext: () => ({
+          font: "",
+          measureText: () => ({ width: 42 }),
+        }),
+      }),
+    });
+
+    expect(detectMonoFontFamily()).toBe(FALLBACK);
+  });
+
+  it("memoizes the first detection result", () => {
+    const check = vi.fn(() => false);
+    vi.stubGlobal("document", {
+      fonts: { check },
+      createElement: () => ({
+        getContext: () => ({
+          font: "",
+          measureText: () => ({ width: 42 }),
+        }),
+      }),
+    });
+
+    expect(detectMonoFontFamily()).toBe(FALLBACK);
+    const firstPass = check.mock.calls.length;
+    expect(firstPass).toBeGreaterThan(0);
+    expect(detectMonoFontFamily()).toBe(FALLBACK);
+    expect(check.mock.calls.length).toBe(firstPass);
   });
 });

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -18,6 +18,9 @@ const NERD_FONT_CANDIDATES = [
 
 const FALLBACK_CHAIN = '"JetBrains Mono", SFMono-Regular, Menlo, monospace';
 
+/** Probe text whose width differs across most mono families vs generic monospace. */
+const CANVAS_PROBE = "mmmmmmmmmmlliABCDEF@#$%Ww";
+
 let detected: string | null = null;
 let monoReady: Promise<void> | null = null;
 
@@ -45,22 +48,59 @@ export function resolveFontFamily(userInput: string): string {
   return `${head}, ${FALLBACK_CHAIN}`;
 }
 
+/**
+ * WKWebView's `document.fonts.check()` returns false for OS-installed fonts that
+ * are not `@font-face`-registered (#820). Canvas `measureText` still sees them:
+ * compare `"Family", monospace` vs bare `monospace` — a real install shifts width.
+ */
+function canvasFontInstalled(family: string): boolean {
+  if (typeof document === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return false;
+    ctx.font = `72px monospace`;
+    const baseline = ctx.measureText(CANVAS_PROBE).width;
+    ctx.font = `72px "${family}", monospace`;
+    const withFamily = ctx.measureText(CANVAS_PROBE).width;
+    return withFamily !== baseline;
+  } catch {
+    return false;
+  }
+}
+
+function fontsCheckInstalled(family: string): boolean {
+  if (typeof document === "undefined" || !document.fonts?.check) return false;
+  try {
+    return document.fonts.check(`12px "${family}"`);
+  } catch {
+    return false;
+  }
+}
+
+/** True when the family is available to the renderer (FontFaceSet or canvas). */
+export function isMonoFontInstalled(family: string): boolean {
+  if (fontsCheckInstalled(family)) return true;
+  return canvasFontInstalled(family);
+}
+
 export function detectMonoFontFamily(): string {
   if (detected) return detected;
-  if (typeof document === "undefined" || !document.fonts) {
+  if (typeof document === "undefined") {
     detected = FALLBACK_CHAIN;
     return detected;
   }
   for (const f of NERD_FONT_CANDIDATES) {
-    try {
-      if (document.fonts.check(`12px "${f}"`)) {
-        detected = `"${f}", ${FALLBACK_CHAIN}`;
-        return detected;
-      }
-    } catch {
-      // Some browsers throw on invalid font shorthand; ignore.
+    if (isMonoFontInstalled(f)) {
+      detected = `"${f}", ${FALLBACK_CHAIN}`;
+      return detected;
     }
   }
   detected = FALLBACK_CHAIN;
   return detected;
+}
+
+/** Test-only: clear the memoized auto-detect result. */
+export function resetDetectedMonoFontFamily(): void {
+  detected = null;
 }

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -51,7 +51,7 @@ export function resolveFontFamily(userInput: string): string {
 /**
  * WKWebView's `document.fonts.check()` returns false for OS-installed fonts that
  * are not `@font-face`-registered (#820). Canvas `measureText` still sees them:
- * compare `"Family", monospace` vs bare `monospace` — a real install shifts width.
+ * compare `"Family", monospace` vs bare `monospace` ;  a real install shifts width.
  */
 function canvasFontInstalled(family: string): boolean {
   if (typeof document === "undefined") return false;

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -51,7 +51,7 @@ export function resolveFontFamily(userInput: string): string {
 /**
  * WKWebView's `document.fonts.check()` returns false for OS-installed fonts that
  * are not `@font-face`-registered (#820). Canvas `measureText` still sees them:
- * compare `"Family", monospace` vs bare `monospace` ;  a real install shifts width.
+ * compare `"Family", monospace` vs bare `monospace`; a real install shifts width.
  */
 function canvasFontInstalled(family: string): boolean {
   if (typeof document === "undefined") return false;


### PR DESCRIPTION
## Summary
- Blank **Font family** auto-detect used only `document.fonts.check()`, which returns `false` for OS-installed Nerd Fonts inside macOS WKWebView (not `@font-face`-registered).
- That skipped every `NERD_FONT_CANDIDATES` entry and fell through to JetBrains Mono → powerline/Nerd glyphs as tofu.
- Keep `fonts.check` as the fast path; on miss, probe with canvas `measureText` (Family, monospace` vs bare `monospace`).

## Test plan
- [x] `npx vitest run src/lib/fonts.test.ts` (10/10)
- [ ] macOS: blank Font family + installed MesloLGS NF + powerlevel10k/Starship → icons render (manual)
- [ ] Explicit Font family still wins over auto-detect

Fixes #820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved monospace font detection in environments where standard font checks are unavailable or incomplete.
  - Added a fallback that verifies font availability through text measurement, improving font selection in embedded web views.
  - Ensured font detection results remain consistent after the initial check.
  - Improved fallback behavior when no supported monospace font can be detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->