### PR TITLE
fix(terminal): freeze IME candidate anchor during composition

### DIFF
--- a/src/modules/terminal/lib/imeAnchorFreeze.test.ts
+++ b/src/modules/terminal/lib/imeAnchorFreeze.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyAnchor,
+  attachImeAnchorFreeze,
+  readAnchor,
+  type FrozenAnchor,
+} from "./imeAnchorFreeze";
+
+function styleEl(initial: FrozenAnchor): HTMLElement {
+  const style = { ...initial } as Record<string, string>;
+  return {
+    get style() {
+      return style as unknown as CSSStyleDeclaration;
+    },
+  } as HTMLElement;
+}
+
+describe("readAnchor / applyAnchor", () => {
+  it("reads left/top from style", () => {
+    expect(readAnchor(styleEl({ left: "3px", top: "4px" }))).toEqual({
+      left: "3px",
+      top: "4px",
+    });
+  });
+
+  it("defaults missing style to 0px", () => {
+    expect(readAnchor(styleEl({ left: "", top: "" }))).toEqual({
+      left: "0px",
+      top: "0px",
+    });
+  });
+
+  it("writes when values differ", () => {
+    const el = styleEl({ left: "1px", top: "2px" });
+    applyAnchor(el, { left: "9px", top: "8px" });
+    expect(el.style.left).toBe("9px");
+    expect(el.style.top).toBe("8px");
+    applyAnchor(el, { left: "9px", top: "8px" });
+    expect(el.style.left).toBe("9px");
+  });
+});
+
+describe("attachImeAnchorFreeze", () => {
+  it("captures on first compositionupdate and restores on style mutation", () => {
+    const listeners = new Map<string, Set<EventListener>>();
+    const style = { left: "12px", top: "34px" } as Record<string, string>;
+    let observed: MutationCallback | null = null;
+
+    class FakeMutationObserver {
+      constructor(cb: MutationCallback) {
+        observed = cb;
+      }
+      observe() {}
+      disconnect() {
+        observed = null;
+      }
+    }
+    vi.stubGlobal("MutationObserver", FakeMutationObserver);
+
+    const ta = {
+      style,
+      addEventListener: (type: string, fn: EventListener) => {
+        if (!listeners.has(type)) listeners.set(type, new Set());
+        listeners.get(type)!.add(fn);
+      },
+      removeEventListener: (type: string, fn: EventListener) => {
+        listeners.get(type)?.delete(fn);
+      },
+    } as unknown as HTMLTextAreaElement;
+
+    const handle = attachImeAnchorFreeze(ta);
+    for (const fn of listeners.get("compositionupdate") ?? []) {
+      fn(new Event("compositionupdate"));
+    }
+
+    style.left = "99px";
+    style.top = "88px";
+    (observed as MutationCallback | null)?.([], {} as MutationObserver);
+    expect(style.left).toBe("12px");
+    expect(style.top).toBe("34px");
+
+    for (const fn of listeners.get("compositionend") ?? []) {
+      fn(new Event("compositionend"));
+    }
+    style.left = "50px";
+    expect(observed).toBeNull();
+    expect(style.left).toBe("50px");
+
+    handle.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  it("pins composition view to the same origin", () => {
+    const listeners = new Map<string, Set<EventListener>>();
+    const taStyle = { left: "1px", top: "2px" } as Record<string, string>;
+    const viewStyle = { left: "1px", top: "2px" } as Record<string, string>;
+    let observed: MutationCallback | null = null;
+
+    class FakeMutationObserver {
+      constructor(cb: MutationCallback) {
+        observed = cb;
+      }
+      observe() {}
+      disconnect() {
+        observed = null;
+      }
+    }
+    vi.stubGlobal("MutationObserver", FakeMutationObserver);
+
+    const ta = {
+      style: taStyle,
+      addEventListener: (type: string, fn: EventListener) => {
+        if (!listeners.has(type)) listeners.set(type, new Set());
+        listeners.get(type)!.add(fn);
+      },
+      removeEventListener: (type: string, fn: EventListener) => {
+        listeners.get(type)?.delete(fn);
+      },
+    } as unknown as HTMLTextAreaElement;
+    const view = { style: viewStyle } as unknown as HTMLElement;
+
+    const handle = attachImeAnchorFreeze(ta, { compositionView: view });
+    for (const fn of listeners.get("compositionupdate") ?? []) {
+      fn(new Event("compositionupdate"));
+    }
+    viewStyle.left = "77px";
+    viewStyle.top = "66px";
+    (observed as MutationCallback | null)?.([], {} as MutationObserver);
+    expect(viewStyle.left).toBe("1px");
+    expect(viewStyle.top).toBe("2px");
+    handle.dispose();
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/modules/terminal/lib/imeAnchorFreeze.ts
+++ b/src/modules/terminal/lib/imeAnchorFreeze.ts
@@ -1,0 +1,100 @@
+/**
+ * Freeze the xterm helper textarea (and optional composition view) position
+ * for the duration of an IME composition.
+ *
+ * xterm's CompositionHelper.updateCompositionElements() repositions the
+ * textarea on every render from the buffer cursor. Streaming TUIs move that
+ * cursor constantly, so the native IME candidate window jumps (#1077).
+ *
+ * Capture left/top on the first compositionupdate (after xterm's initial
+ * place), then restore them whenever something moves the elements until
+ * compositionend / blur.
+ */
+
+export type FrozenAnchor = {
+  left: string;
+  top: string;
+};
+
+export function readAnchor(el: HTMLElement): FrozenAnchor {
+  return {
+    left: el.style.left || "0px",
+    top: el.style.top || "0px",
+  };
+}
+
+export function applyAnchor(el: HTMLElement, frozen: FrozenAnchor): void {
+  if (el.style.left !== frozen.left) el.style.left = frozen.left;
+  if (el.style.top !== frozen.top) el.style.top = frozen.top;
+}
+
+export type ImeAnchorFreezeHandle = {
+  dispose: () => void;
+};
+
+/**
+ * Attach freeze listeners to an xterm helper textarea.
+ * Returns a dispose function that removes listeners and stops observing.
+ */
+export function attachImeAnchorFreeze(
+  textarea: HTMLTextAreaElement,
+  options?: { compositionView?: HTMLElement | null },
+): ImeAnchorFreezeHandle {
+  let frozen: FrozenAnchor | null = null;
+  let observer: MutationObserver | null = null;
+
+  const targets = (): HTMLElement[] => {
+    const list: HTMLElement[] = [textarea];
+    const view = options?.compositionView;
+    if (view) list.push(view);
+    return list;
+  };
+
+  const stopObserving = () => {
+    observer?.disconnect();
+    observer = null;
+  };
+
+  const clearFreeze = () => {
+    frozen = null;
+    stopObserving();
+  };
+
+  const reapply = () => {
+    if (!frozen) return;
+    for (const el of targets()) applyAnchor(el, frozen);
+  };
+
+  const startObserving = () => {
+    stopObserving();
+    observer = new MutationObserver(reapply);
+    for (const el of targets()) {
+      observer.observe(el, { attributes: true, attributeFilter: ["style"] });
+    }
+  };
+
+  const onCompositionUpdate = () => {
+    if (frozen) return;
+    frozen = readAnchor(textarea);
+    // Also pin the composition view to the same origin if present.
+    const view = options?.compositionView;
+    if (view) applyAnchor(view, frozen);
+    startObserving();
+  };
+
+  const onCompositionEnd = () => clearFreeze();
+  const onBlur = () => clearFreeze();
+
+  textarea.addEventListener("compositionupdate", onCompositionUpdate);
+  textarea.addEventListener("compositionend", onCompositionEnd);
+  textarea.addEventListener("blur", onBlur);
+
+  return {
+    dispose: () => {
+      clearFreeze();
+      textarea.removeEventListener("compositionupdate", onCompositionUpdate);
+      textarea.removeEventListener("compositionend", onCompositionEnd);
+      textarea.removeEventListener("blur", onBlur);
+    },
+  };
+}

--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -20,6 +20,7 @@ import {
   resetImeBridge,
   transitionImeBridgeOwner,
 } from "./imeBridge";
+import { attachImeAnchorFreeze } from "./imeAnchorFreeze";
 import { terminalReadlineSequence } from "./keymap";
 import {
   readTerminalClipboard,
@@ -80,6 +81,7 @@ export type Slot = {
   lastH: number;
   lastUsedAt: number;
   imeState: ImeBridgeState;
+  imeAnchorDispose: (() => void) | null;
 };
 
 const slots: Slot[] = [];
@@ -265,7 +267,22 @@ function createSlot(): Slot {
     lastH: 0,
     lastUsedAt: 0,
     imeState: createImeBridgeState(),
+    imeAnchorDispose: null,
   };
+
+  // Freeze the helper textarea position for the life of an IME composition so
+  // streaming TUIs cannot yank the native candidate window around (#1077).
+  {
+    const ta = slot.term.textarea;
+    if (ta) {
+      const compositionView =
+        (slot.host.querySelector(".xterm-composition-view") as HTMLElement | null) ??
+        null;
+      slot.imeAnchorDispose = attachImeAnchorFreeze(ta, {
+        compositionView,
+      }).dispose;
+    }
+  }
 
   // Some WKWebView builds bypass xterm's composition events. The pure bridge
   // repairs that path and stands down when native composition is observed.
@@ -808,6 +825,10 @@ function disposeSlot(slot: Slot): void {
   }
   slot.oscDisposers = [];
   disposeSlotWebgl(slot);
+  try {
+    slot.imeAnchorDispose?.();
+  } catch {}
+  slot.imeAnchorDispose = null;
   try {
     slot.term.dispose();
   } catch (e) {


### PR DESCRIPTION
﻿## What
Freeze xterm helper textarea position during IME composition so streaming TUIs cannot yank the native candidate window.

## Why
Fixes #1077

## How
- imeAnchorFreeze helper with MutationObserver
- Wired in rendererPool createSlot; disposed on teardown
- Unit tests included

## Test plan
- [x] vitest imeAnchorFreeze.test.ts 5/5
- [ ] Windows + Microsoft Pinyin + streaming TUI: candidate stays put while composing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IME composition stability by preserving the input anchor position while terminal rendering updates occur.
  - Kept the composition view aligned with the input position during composition.
  - Ensured IME positioning is restored and cleaned up when composition ends, focus is lost, or the terminal is disposed.

- **Tests**
  - Added coverage for anchor positioning, composition updates, style changes, restoration, cleanup, and composition view synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->