### PR TITLE
fix(pty): emit OSC 7 from cmd.exe so explorer follows cd

### DIFF
--- a/TERAX.md
+++ b/TERAX.md
@@ -61,7 +61,7 @@ A change to a core subsystem (terminal/shell spawn, workspace auth, git, fs, IPC
 PTY shells are bootstrapped via injected init scripts in `src-tauri/src/modules/pty/scripts/`:
 
 - **Unix** (`zshenv.zsh`, `zprofile.zsh`, `zlogin.zsh`, `zshrc.zsh`, `bashrc.bash`) for zsh/bash, plus `init.fish` installed to `~/.config/fish/conf.d/terax.fish` for fish. Emit OSC 7 (cwd) and OSC 133 A/B/C/D (prompt boundaries + exit code) so the host can track cwd and detect command boundaries without re-parsing the prompt. Fish 4.0+ writes its own OSC 133 prompt markers; Terax sets `fish_features=no-mark-prompt` and re-asserts its own prompt via `-C` to avoid doubling.
-- **Windows** (`profile.ps1`) - passed via `pwsh -NoLogo -NoExit -ExecutionPolicy Bypass -File <path>`. Wraps the user's existing `prompt` function (after their `$PROFILE` runs) to emit OSC 7 + OSC 133 A/B/D. Shell priority: `pwsh.exe` (PS 7+) → `powershell.exe` (PS 5.1) → `cmd.exe` (no integration). cwd is normalized to backslashes before being passed to ConPTY (`CreateProcessW` misbehaves with forward-slash cwd).
+- **Windows** (`profile.ps1`) - passed via `pwsh -NoLogo -NoExit -ExecutionPolicy Bypass -File <path>`. Wraps the user's existing `prompt` function (after their `$PROFILE` runs) to emit OSC 7 + OSC 133 A/B/D. Command Prompt loads `profile.cmd` via `cmd /k <path>` and wraps `PROMPT` to emit the same OSC 7 + OSC 133 A/B/D (no C — cmd has no preexec). Shell priority: `pwsh.exe` (PS 7+) → `powershell.exe` (PS 5.1) → `cmd.exe`. cwd is normalized to backslashes before being passed to ConPTY (`CreateProcessW` misbehaves with forward-slash cwd).
 
 `pty/shell_init.rs` is split into `#[cfg(unix)]` / `#[cfg(windows)]` modules - keep new platform-specific code in the right cfg arm.
 

--- a/docs/architecture/pty-shell-integration.md
+++ b/docs/architecture/pty-shell-integration.md
@@ -49,7 +49,7 @@ On Windows the shell priority is:
 
 1. `pwsh.exe` (PowerShell 7+)
 2. `powershell.exe` (Windows PowerShell 5.1)
-3. `cmd.exe` (no integration)
+3. `cmd.exe`
 
 PowerShell loads `profile.ps1` via:
 
@@ -58,6 +58,14 @@ pwsh -NoLogo -NoExit -ExecutionPolicy Bypass -File <profile.ps1>
 ```
 
 The profile wraps the user's existing `prompt` function to emit OSC 7 + OSC 133 A/B/D after `$PROFILE` runs. The cwd is normalized to backslashes before being passed to ConPTY because `CreateProcessW` misbehaves with forward slashes.
+
+Command Prompt loads `profile.cmd` via:
+
+```text
+cmd /k <profile.cmd>
+```
+
+The script wraps the existing `PROMPT` (including AutoRun) to emit OSC 7 + OSC 133 A/B/D. cmd has no preexec hook, so OSC 133 C is omitted.
 
 ### Fish 4.0+
 

--- a/src-tauri/src/modules/pty/scripts/profile.cmd
+++ b/src-tauri/src/modules/pty/scripts/profile.cmd
@@ -1,0 +1,23 @@
+@echo off
+REM terax-shell-integration (cmd.exe)
+REM Emits OSC 7 (cwd) + OSC 133 A/B/D so the host tracks cwd and prompt
+REM boundaries. cmd has no preexec hook, so OSC 133 C is omitted; D/A still
+REM reset in-command state and B marks the prompt as "inside a command"
+REM the same way profile.ps1 does.
+
+if defined __TERAX_HOOKS_LOADED goto :eof
+set "__TERAX_HOOKS_LOADED=1"
+
+if defined TERAX_CLI if exist "%TERAX_CLI%" doskey terax="%TERAX_CLI%" $*
+
+if not defined PROMPT set "PROMPT=$P$G"
+
+echo %PROMPT% | findstr /C:"133;A" >nul
+if not errorlevel 1 goto :eof
+
+if defined TERAX_BLOCKS (
+  prompt $E]133;D$E\$E]133;A$E\$E]7;file://%COMPUTERNAME%/$P$E\$_$E]133;B$E\
+  goto :eof
+)
+
+prompt $E]133;D$E\$E]133;A$E\$E]7;file://%COMPUTERNAME%/$P$E\%PROMPT%$E]133;B$E\

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -498,6 +498,7 @@ mod windows {
     use portable_pty::CommandBuilder;
 
     const PROFILE_PS1: &str = include_str!("scripts/profile.ps1");
+    const PROFILE_CMD: &str = include_str!("scripts/profile.cmd");
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     enum ShellKind {
@@ -560,6 +561,7 @@ mod windows {
             .unwrap_or_default();
         let is_powershell = shell_name == "pwsh.exe" || shell_name == "powershell.exe";
         let is_bash = shell_name == "bash.exe";
+        let is_cmd = shell_name == "cmd.exe";
 
         let mut cmd = CommandBuilder::new(&shell_path);
         super::apply_common(&mut cmd, cwd, blocks, control.as_ref());
@@ -592,6 +594,16 @@ mod windows {
                 }
                 Err(e) => {
                     log::warn!("bash shell integration disabled: {e}");
+                }
+            }
+        } else if is_cmd {
+            match prepare_cmd_profile() {
+                Ok(profile) => {
+                    cmd.arg("/k");
+                    cmd.arg(profile);
+                }
+                Err(e) => {
+                    log::warn!("cmd shell integration disabled: {e}");
                 }
             }
         } else {
@@ -801,6 +813,14 @@ mod windows {
         Ok(root)
     }
 
+    fn prepare_cmd_profile() -> Result<PathBuf, String> {
+        let dir = integration_root()?.join("cmd");
+        fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+        let file = dir.join("profile.cmd");
+        write_if_changed(&file, PROFILE_CMD)?;
+        Ok(file)
+    }
+
     fn prepare_ps_profile() -> Result<PathBuf, String> {
         let dir = integration_root()?.join("powershell");
         fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
@@ -852,7 +872,7 @@ mod windows {
                 .join("powershell.exe"),
             true,
         );
-        add(&mut out, "Command Prompt", system32.join("cmd.exe"), false);
+        add(&mut out, "Command Prompt", system32.join("cmd.exe"), true);
         if let Some(p) = git_bash_path() {
             add(&mut out, "Git Bash", p, true);
         }
@@ -1052,6 +1072,64 @@ mod windows {
                     "--exec".to_string(),
                     "/usr/bin/nu".to_string(),
                 ]
+            );
+        }
+
+        #[test]
+        fn cmd_profile_emits_osc7_and_prompt_markers() {
+            assert!(PROFILE_CMD.contains("]7;file://"));
+            assert!(PROFILE_CMD.contains("]133;A"));
+            assert!(PROFILE_CMD.contains("]133;B"));
+            assert!(PROFILE_CMD.contains("]133;D"));
+            assert!(PROFILE_CMD.contains("__TERAX_HOOKS_LOADED"));
+            assert!(!PROFILE_CMD.contains("setlocal"));
+        }
+
+        #[test]
+        fn command_prompt_is_marked_integrated() {
+            let cmd = list_shells()
+                .into_iter()
+                .find(|s| s.name == "Command Prompt")
+                .expect("cmd.exe should be enumerated on Windows");
+            assert!(cmd.integrated);
+            assert!(cmd.path.to_ascii_lowercase().ends_with("cmd.exe"));
+        }
+
+        #[test]
+        fn cmd_profile_sets_prompt_with_osc7() {
+            let profile = prepare_cmd_profile().unwrap();
+            let script = format!("call {} & echo PROMPT=!PROMPT!", profile.display());
+            let output = std::process::Command::new("cmd.exe")
+                .args(["/d", "/v:on", "/c", &script])
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                stdout.contains("]7;file://"),
+                "expected OSC 7 in PROMPT, got {stdout:?}"
+            );
+            assert!(
+                stdout.contains("]133;A"),
+                "expected OSC 133 A in PROMPT, got {stdout:?}"
+            );
+        }
+
+        #[test]
+        fn cmd_profile_is_idempotent() {
+            let profile = prepare_cmd_profile().unwrap();
+            let script = format!(
+                "call {0} & call {0} & echo PROMPT=!PROMPT!",
+                profile.display()
+            );
+            let output = std::process::Command::new("cmd.exe")
+                .args(["/d", "/v:on", "/c", &script])
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert_eq!(
+                stdout.matches("]133;A").count(),
+                1,
+                "double-sourcing should not wrap PROMPT twice: {stdout:?}"
             );
         }
     }

--- a/src-tauri/src/modules/pty/shell_init.rs
+++ b/src-tauri/src/modules/pty/shell_init.rs
@@ -813,11 +813,16 @@ mod windows {
         Ok(root)
     }
 
+    fn normalize_cmd_script(content: &str) -> String {
+        // cmd.exe can misparse LF-only batch files; always write CRLF.
+        content.replace("\r\n", "\n").replace('\n', "\r\n")
+    }
+
     fn prepare_cmd_profile() -> Result<PathBuf, String> {
         let dir = integration_root()?.join("cmd");
         fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
         let file = dir.join("profile.cmd");
-        write_if_changed(&file, PROFILE_CMD)?;
+        write_if_changed(&file, &normalize_cmd_script(PROFILE_CMD))?;
         Ok(file)
     }
 
@@ -1086,6 +1091,21 @@ mod windows {
         }
 
         #[test]
+        fn cmd_profile_is_written_with_crlf() {
+            let profile = prepare_cmd_profile().unwrap();
+            let bytes = fs::read(&profile).unwrap();
+            assert!(
+                bytes.windows(2).any(|w| w == b"\r\n"),
+                "generated profile.cmd must use CRLF line endings"
+            );
+            let stripped = String::from_utf8_lossy(&bytes).replace("\r\n", "");
+            assert!(
+                !stripped.contains('\n'),
+                "generated profile.cmd must not contain lone LF"
+            );
+        }
+
+        #[test]
         fn command_prompt_is_marked_integrated() {
             let cmd = list_shells()
                 .into_iter()
@@ -1097,10 +1117,17 @@ mod windows {
 
         #[test]
         fn cmd_profile_sets_prompt_with_osc7() {
+            use std::os::windows::process::CommandExt;
             let profile = prepare_cmd_profile().unwrap();
-            let script = format!("call {} & echo PROMPT=!PROMPT!", profile.display());
+            // raw_arg: std Command escapes quotes as \", which cmd.exe rejects.
+            let script = format!(
+                "/c call \"{}\" & echo PROMPT=!PROMPT!",
+                profile.display()
+            );
             let output = std::process::Command::new("cmd.exe")
-                .args(["/d", "/v:on", "/c", &script])
+                .raw_arg("/d")
+                .raw_arg("/v:on")
+                .raw_arg(&script)
                 .output()
                 .unwrap();
             let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1116,13 +1143,16 @@ mod windows {
 
         #[test]
         fn cmd_profile_is_idempotent() {
+            use std::os::windows::process::CommandExt;
             let profile = prepare_cmd_profile().unwrap();
             let script = format!(
-                "call {0} & call {0} & echo PROMPT=!PROMPT!",
+                "/c call \"{0}\" & call \"{0}\" & echo PROMPT=!PROMPT!",
                 profile.display()
             );
             let output = std::process::Command::new("cmd.exe")
-                .args(["/d", "/v:on", "/c", &script])
+                .raw_arg("/d")
+                .raw_arg("/v:on")
+                .raw_arg(&script)
                 .output()
                 .unwrap();
             let stdout = String::from_utf8_lossy(&output.stdout);

--- a/src/modules/terminal/lib/osc-handlers.test.ts
+++ b/src/modules/terminal/lib/osc-handlers.test.ts
@@ -116,6 +116,15 @@ describe("OSC 7 cwd handler — gated by OSC 133 in-command state", () => {
     handlers.get(7)?.("file:///C:/Users/me/project");
     expect(onCwd).toHaveBeenCalledWith("C:/Users/me/project");
   });
+
+  it("normalizes cmd.exe backslash OSC 7 paths", () => {
+    const { term, handlers } = makeFakeTerm();
+    const onCwd = vi.fn();
+    registerCwdHandler(term, onCwd);
+
+    handlers.get(7)?.(String.raw`file://HOST/C:\Users\me\project`);
+    expect(onCwd).toHaveBeenCalledWith("C:/Users/me/project");
+  });
 });
 
 describe("OSC 133 command-state tracking", () => {

--- a/src/modules/terminal/lib/osc-handlers.ts
+++ b/src/modules/terminal/lib/osc-handlers.ts
@@ -116,6 +116,8 @@ function parseOsc7(data: string): string | null {
     const drive = path.match(/^\/([A-Za-z])(\/.*)?$/);
     if (drive) path = `${drive[1].toUpperCase()}:${drive[2] ?? "/"}`;
   }
+  // cmd.exe $P is backslash-separated; match PowerShell's forward-slash form.
+  if (IS_WINDOWS) path = path.replace(/\\/g, "/");
   return path;
 }
 


### PR DESCRIPTION
## What

Inject OSC 7 + OSC 133 A/B/D into Command Prompt so the file tree follows `cd` after the user switches the terminal shell to cmd.exe.

## Why

PowerShell and Git Bash already emit OSC 7 via shell integration. cmd.exe was spawned bare (`integrated: false`), so explorer cwd stayed frozen at the tab's initial directory.

## How

- New `profile.cmd` wraps the existing `PROMPT` (including AutoRun) to emit OSC 7 (`file://$COMPUTERNAME/$P`) plus OSC 133 A/B/D. No C — cmd has no preexec hook.
- Windows spawn path uses `cmd /k <profile.cmd>`.
- `parseOsc7` normalizes cmd `$P` backslashes to the same `C:/...` form PowerShell emits.
- Command Prompt is marked `integrated` in the shell list.

## Testing

- [x] `cargo test --locked cmd_` — 3 passed (`cmd_profile_emits_osc7_and_prompt_markers`, `cmd_profile_sets_prompt_with_osc7`, `cmd_profile_is_idempotent`)
- [x] `cargo test --locked command_prompt_is_marked` — 1 passed
- [x] `pnpm exec vitest run src/modules/terminal/lib/osc-handlers.test.ts` — 15 passed (incl. cmd backslash OSC 7)
- [x] Live Windows: `call profile.cmd` sets `PROMPT` to `$E]133;D...$E]7;file://PC_MATHIS/$P...`; second call does not wrap twice

Fixes #1109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shell integration support for Windows Command Prompt (`cmd.exe`).
  - Command Prompt now reports working-directory changes and prompt boundaries to improve terminal tracking.
  - Added support for Command Prompt terminal aliases when configured.

- **Bug Fixes**
  - Windows working-directory paths are normalized to use forward slashes for consistent terminal handling.

- **Documentation**
  - Updated shell integration documentation to describe Command Prompt support and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->