### PR TITLE
fix(terminal): clear WebGL atlas on tab re-show to kill ghost glyphs

### DIFF
--- a/src/modules/terminal/lib/rendererPool.ts
+++ b/src/modules/terminal/lib/rendererPool.ts
@@ -27,6 +27,7 @@ import {
 } from "./terminalClipboard";
 import { createTerminalLinkHandler } from "./terminalLinks";
 import { pasteIntoTerminal } from "./terminalPaste";
+import { repaintTerminalSlot } from "./webglRepaint";
 
 export const POOL_MAX_SIZE = 5;
 const FIT_DEBOUNCE_MS = 8;
@@ -576,9 +577,7 @@ function bindSlot(slot: Slot, p: AcquireParams): void {
   if (fast) {
     if (stale) {
       if (!slot.webglAddon) attachWebgl(slot);
-      try {
-        slot.term.refresh(0, slot.term.rows - 1);
-      } catch {}
+      repaintTerminalSlot(slot);
     }
     if (adapter?.isLeafFocused(p.leafId)) slot.term.focus();
   } else {
@@ -595,9 +594,7 @@ function scheduleUnhide(slot: Slot, stale: boolean): void {
       slot.host.style.visibility = "";
       if (stale) {
         if (!slot.webglAddon) attachWebgl(slot);
-        try {
-          slot.term.refresh(0, slot.term.rows - 1);
-        } catch {}
+        repaintTerminalSlot(slot);
       }
       const leafId = slot.currentLeafId;
       if (leafId !== null && adapter?.isLeafFocused(leafId)) {
@@ -853,9 +850,7 @@ function attachWebgl(slot: Slot): void {
         if (!usePreferencesStore.getState().terminalWebglEnabled) return;
         attachWebgl(slot);
         if (slot.webglAddon) {
-          try {
-            slot.term.refresh(0, slot.term.rows - 1);
-          } catch {}
+          repaintTerminalSlot(slot);
         }
       }, WEBGL_RECOVERY_DELAY_MS);
     });
@@ -928,9 +923,7 @@ export function applyWebglPreference(enabled: boolean): void {
       if (slot.currentLeafId !== null && !slot.parked && !slot.webglAddon) {
         attachWebgl(slot);
         if (slot.webglAddon) {
-          try {
-            slot.term.refresh(0, slot.term.rows - 1);
-          } catch {}
+          repaintTerminalSlot(slot);
         }
       }
     } else if (slot.webglAddon) {
@@ -1076,9 +1069,7 @@ export function refreshLeafSlot(leafId: number): void {
       adapter?.resolveLeaf(leafId)?.resizePty(slot.lastCols, slot.lastRows);
     }
   }
-  try {
-    slot.term.refresh(0, slot.term.rows - 1);
-  } catch {}
+  repaintTerminalSlot(slot);
 }
 
 export function disposeLeafSlot(leafId: number): void {

--- a/src/modules/terminal/lib/webglRepaint.test.ts
+++ b/src/modules/terminal/lib/webglRepaint.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { repaintTerminalSlot } from "./webglRepaint";
+
+describe("repaintTerminalSlot", () => {
+  it("clears the WebGL texture atlas before refreshing", () => {
+    const clearTextureAtlas = vi.fn();
+    const refresh = vi.fn();
+    repaintTerminalSlot({
+      webglAddon: { clearTextureAtlas },
+      term: { rows: 24, refresh },
+    });
+    expect(clearTextureAtlas).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledWith(0, 23);
+    expect(clearTextureAtlas.mock.invocationCallOrder[0]).toBeLessThan(
+      refresh.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("still refreshes when WebGL is not attached", () => {
+    const refresh = vi.fn();
+    repaintTerminalSlot({
+      webglAddon: null,
+      term: { rows: 10, refresh },
+    });
+    expect(refresh).toHaveBeenCalledWith(0, 9);
+  });
+
+  it("tolerates clearTextureAtlas throwing during dispose", () => {
+    const refresh = vi.fn();
+    expect(() =>
+      repaintTerminalSlot({
+        webglAddon: {
+          clearTextureAtlas: () => {
+            throw new Error("disposed");
+          },
+        },
+        term: { rows: 5, refresh },
+      }),
+    ).not.toThrow();
+    expect(refresh).toHaveBeenCalledWith(0, 4);
+  });
+});

--- a/src/modules/terminal/lib/webglRepaint.ts
+++ b/src/modules/terminal/lib/webglRepaint.ts
@@ -1,0 +1,23 @@
+/**
+ * Drop stale WebGL glyphs then redraw the visible buffer.
+ *
+ * Terminal.refresh alone can leave atlas ghosts after a slot was parked or
+ * hidden behind another tab - the WebGL atlas still holds cells from the prior
+ * frame. Clearing it before refresh is the xterm.js-recommended path for that
+ * class of baked-in / ghost text (#604).
+ */
+export function repaintTerminalSlot(slot: {
+  webglAddon: { clearTextureAtlas(): void } | null;
+  term: { rows: number; refresh(start: number, end: number): void };
+}): void {
+  try {
+    slot.webglAddon?.clearTextureAtlas();
+  } catch {
+    // Addon may already be disposed during context-loss recovery.
+  }
+  try {
+    slot.term.refresh(0, Math.max(0, slot.term.rows - 1));
+  } catch {
+    // Terminal may be mid-dispose while a rAF unhide still fires.
+  }
+}


### PR DESCRIPTION
## Summary
When switching away from a terminal tab and back, unsubmitted prompt text (and sometimes alt-screen TUI cells) could stay visually baked into the WebGL grid even though backspace could no longer erase them. `Terminal.refresh` alone does not drop the WebGL texture atlas, so stale glyphs survived the unhide/rebind path.

## Fix
Add `repaintTerminalSlot` which calls `WebglAddon.clearTextureAtlas()` before `term.refresh`, and use it on:
- stale fast-rebind / `scheduleUnhide`
- WebGL context-loss recovery
- `applyWebglPreference(true)`
- `refreshLeafSlot` (tab re-show)

## Why
Fixes #604. Matches the xterm.js-recommended atlas clear for ghost/baked glyphs after a renderer was parked or hidden.

## Test plan
- [x] `pnpm exec vitest run src/modules/terminal/lib/webglRepaint.test.ts` (3 passed)
- [x] `pnpm exec tsc --noEmit` clean
- [ ] Manual: WebGL on, type in Tab A without submitting, switch to Tab B, switch back — prompt text should not be a dead ghost; backspace should work on live text
- [ ] Manual: resize still forces a clean redraw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal repainting during reuse, delayed display, WebGL recovery, preference changes, and manual refreshes.
  * Ensured terminal content refreshes reliably even when WebGL resources are unavailable or being disposed.
* **Tests**
  * Added coverage for WebGL texture cleanup and terminal refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->