### PR TITLE
fix(ai): coalesce interleaved reasoning parts for display

### DIFF
--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -36,6 +36,7 @@ import {
   TerminalIcon,
 } from "@hugeicons/core-free-icons";
 import { SLASH_COMMANDS, TERAX_CMD_RE } from "../lib/slashCommands";
+import { coalesceReasoningParts } from "../lib/coalesceReasoning";
 import { Spinner } from "@/components/ui/spinner";
 import { useChatStore } from "../store/chatStore";
 import { sendMessage } from "../store/chatRuntime";
@@ -332,20 +333,26 @@ const RenderedMessage = memo(function RenderedMessage({
   onApproval: (id: string, approved: boolean) => void;
   streaming: boolean;
 }) {
-  // Index of the trailing text part — only that one is "live" mid-stream.
+  // Collapse interleaved / trailing reasoning parts (Minimax + other
+  // OpenAI-compatible streams) into one block before the answer (#1012).
+  // Display-only - message.parts stay untouched for provider history.
+  const displayParts = useMemo(
+    () => coalesceReasoningParts(message.parts as AnyPart[]),
+    [message.parts],
+  );
+
+  // Index of the trailing text part - only that one is "live" mid-stream.
   // Earlier text parts (separated by tool calls) are already finalized.
   let lastTextIdx = -1;
-  for (let i = message.parts.length - 1; i >= 0; i -= 1) {
-    if (message.parts[i]?.type === "text") {
+  for (let i = displayParts.length - 1; i >= 0; i -= 1) {
+    if (displayParts[i]?.type === "text") {
       lastTextIdx = i;
       break;
     }
   }
   // Hooks must run unconditionally (Rules of Hooks) even though user messages
   // render without groups; grouping is cheap so this stays out of the way.
-  const groups = useMemo(() => buildPartGroups(message.parts as AnyPart[]), [
-    message.parts,
-  ]);
+  const groups = useMemo(() => buildPartGroups(displayParts), [displayParts]);
 
   if (message.role === "user") {
     const rawText = message.parts
@@ -403,7 +410,12 @@ const RenderedMessage = memo(function RenderedMessage({
                 <RenderedPart
                   part={g.part}
                   onApproval={onApproval}
-                  streaming={streaming && g.idx === lastTextIdx}
+                  streaming={
+                    streaming &&
+                    (g.part.type === "text"
+                      ? g.idx === lastTextIdx
+                      : g.part.type === "reasoning")
+                  }
                 />
               </PartAppear>
             );
@@ -629,7 +641,7 @@ const RenderedPart = memo(function RenderedPart({
 
   if (part.type === "reasoning") {
     return (
-      <Reasoning>
+      <Reasoning isStreaming={streaming}>
         <ReasoningTrigger />
         <ReasoningContent>
           {(part as unknown as { text: string }).text}

--- a/src/modules/ai/components/AiChat.tsx
+++ b/src/modules/ai/components/AiChat.tsx
@@ -414,7 +414,8 @@ const RenderedMessage = memo(function RenderedMessage({
                     streaming &&
                     (g.part.type === "text"
                       ? g.idx === lastTextIdx
-                      : g.part.type === "reasoning")
+                      : g.part.type === "reasoning" &&
+                        (g.part as { state?: string }).state === "streaming")
                   }
                 />
               </PartAppear>

--- a/src/modules/ai/lib/coalesceReasoning.test.ts
+++ b/src/modules/ai/lib/coalesceReasoning.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { coalesceReasoningParts } from "./coalesceReasoning";
+
+describe("coalesceReasoningParts", () => {
+  it("returns the same parts when there is no reasoning", () => {
+    const parts = [
+      { type: "text", text: "hello" },
+      { type: "tool-read_file", state: "output-available" },
+    ];
+    expect(coalesceReasoningParts(parts)).toBe(parts);
+  });
+
+  it("leaves a single leading reasoning part untouched", () => {
+    const parts = [
+      { type: "reasoning", text: "think", state: "done" },
+      { type: "text", text: "answer" },
+    ];
+    expect(coalesceReasoningParts(parts)).toBe(parts);
+  });
+
+  it("merges interleaved reasoning into one block before content", () => {
+    const parts = [
+      { type: "reasoning", text: "step 1", state: "done" },
+      { type: "text", text: "partial" },
+      { type: "reasoning", text: "step 2", state: "done" },
+      { type: "text", text: " final" },
+      { type: "reasoning", text: "afterthought", state: "done" },
+    ];
+    expect(coalesceReasoningParts(parts)).toEqual([
+      {
+        type: "reasoning",
+        text: "step 1\n\nstep 2\n\nafterthought",
+        state: "done",
+      },
+      { type: "text", text: "partial" },
+      { type: "text", text: " final" },
+    ]);
+  });
+
+  it("hoists trailing-only reasoning before the answer", () => {
+    const parts = [
+      { type: "text", text: "answer first" },
+      { type: "reasoning", text: "leaked think", state: "done" },
+      { type: "reasoning", text: "more leak", state: "done" },
+    ];
+    expect(coalesceReasoningParts(parts)).toEqual([
+      {
+        type: "reasoning",
+        text: "leaked think\n\nmore leak",
+        state: "done",
+      },
+      { type: "text", text: "answer first" },
+    ]);
+  });
+
+  it("marks the merged part streaming if any fragment is streaming", () => {
+    const parts = [
+      { type: "reasoning", text: "a", state: "done" },
+      { type: "text", text: "x" },
+      { type: "reasoning", text: "b", state: "streaming" },
+    ];
+    const out = coalesceReasoningParts(parts);
+    expect(out[0]).toMatchObject({
+      type: "reasoning",
+      text: "a\n\nb",
+      state: "streaming",
+    });
+  });
+
+  it("drops empty reasoning-only noise", () => {
+    const parts = [
+      { type: "reasoning", text: "", state: "done" },
+      { type: "text", text: "only answer" },
+      { type: "reasoning", text: "" },
+    ];
+    expect(coalesceReasoningParts(parts)).toEqual([
+      { type: "text", text: "only answer" },
+    ]);
+  });
+
+  it("preserves non-reasoning parts and tool order", () => {
+    const parts = [
+      { type: "reasoning", text: "r1" },
+      { type: "tool-bash_run", state: "output-available" },
+      { type: "reasoning", text: "r2" },
+      { type: "text", text: "done" },
+    ];
+    expect(coalesceReasoningParts(parts)).toEqual([
+      { type: "reasoning", text: "r1\n\nr2" },
+      { type: "tool-bash_run", state: "output-available" },
+      { type: "text", text: "done" },
+    ]);
+  });
+});

--- a/src/modules/ai/lib/coalesceReasoning.test.ts
+++ b/src/modules/ai/lib/coalesceReasoning.test.ts
@@ -18,6 +18,16 @@ describe("coalesceReasoningParts", () => {
     expect(coalesceReasoningParts(parts)).toBe(parts);
   });
 
+  it("drops a single leading empty non-streaming reasoning part", () => {
+    const parts = [
+      { type: "reasoning", text: "", state: "done" },
+      { type: "text", text: "answer" },
+    ];
+    expect(coalesceReasoningParts(parts)).toEqual([
+      { type: "text", text: "answer" },
+    ]);
+  });
+
   it("merges interleaved reasoning into one block before content", () => {
     const parts = [
       { type: "reasoning", text: "step 1", state: "done" },

--- a/src/modules/ai/lib/coalesceReasoning.ts
+++ b/src/modules/ai/lib/coalesceReasoning.ts
@@ -1,0 +1,71 @@
+/**
+ * Minimax (and other OpenAI-compatible reasoning models) often interleave
+ * `reasoning_content` with `content` in the stream. The AI SDK closes the
+ * current reasoning part on every text delta, so one assistant turn becomes
+ * many `type: "reasoning"` parts  -  some after the answer text (#1012).
+ *
+ * Display-only: merge every reasoning part into a single block and hoist it
+ * before the rest. Stored message history is left intact so providers that
+ * need reasoning in multi-turn context still receive it.
+ */
+export type CoalesceablePart = {
+  type: string;
+  text?: string;
+  state?: string;
+  providerMetadata?: unknown;
+  [key: string]: unknown;
+};
+
+export function coalesceReasoningParts<T extends CoalesceablePart>(
+  parts: readonly T[],
+): T[] {
+  const reasoningIdxs: number[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i]?.type === "reasoning") reasoningIdxs.push(i);
+  }
+  if (reasoningIdxs.length === 0) return parts as T[];
+
+  // Already a single leading reasoning part  -  nothing to fix.
+  if (reasoningIdxs.length === 1 && reasoningIdxs[0] === 0) {
+    return parts as T[];
+  }
+
+  const texts: string[] = [];
+  let state: string | undefined;
+  let providerMetadata: unknown;
+  let sawStreaming = false;
+
+  for (const i of reasoningIdxs) {
+    const p = parts[i]!;
+    const text = typeof p.text === "string" ? p.text : "";
+    if (text.length > 0) texts.push(text);
+    if (p.state === "streaming") sawStreaming = true;
+    else if (state === undefined && typeof p.state === "string") state = p.state;
+    if (providerMetadata === undefined && p.providerMetadata !== undefined) {
+      providerMetadata = p.providerMetadata;
+    }
+  }
+
+  const first = parts[reasoningIdxs[0]!]!;
+  const merged = {
+    ...first,
+    type: "reasoning",
+    text: texts.join("\n\n"),
+    ...(sawStreaming
+      ? { state: "streaming" }
+      : state !== undefined
+        ? { state }
+        : {}),
+    ...(providerMetadata !== undefined ? { providerMetadata } : {}),
+  } as T;
+
+  const rest: T[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i]?.type === "reasoning") continue;
+    rest.push(parts[i]!);
+  }
+
+  // Drop an empty merged reasoning block (all empty texts).
+  if (merged.text === "" && !sawStreaming) return rest;
+  return [merged, ...rest];
+}

--- a/src/modules/ai/lib/coalesceReasoning.ts
+++ b/src/modules/ai/lib/coalesceReasoning.ts
@@ -25,9 +25,15 @@ export function coalesceReasoningParts<T extends CoalesceablePart>(
   }
   if (reasoningIdxs.length === 0) return parts as T[];
 
-  // Already a single leading reasoning part  -  nothing to fix.
+  // Already a single leading non-empty/streaming reasoning part - nothing to fix.
   if (reasoningIdxs.length === 1 && reasoningIdxs[0] === 0) {
-    return parts as T[];
+    const first = parts[0]!;
+    if (
+      first.state === "streaming" ||
+      (typeof first.text === "string" && first.text.length > 0)
+    ) {
+      return parts as T[];
+    }
   }
 
   const texts: string[] = [];


### PR DESCRIPTION
## What
Collapse interleaved / trailing `reasoning` UI parts into a single leading Reasoning block per assistant message.

## Why
Fixes #1012 — Minimax (OpenAI-compatible) streams often alternate `reasoning_content` and `content`. The AI SDK ends the current reasoning part on every text delta, so one turn becomes many Reasoning widgets (including after the answer), and they accumulate as the chat grows.

## How
- Add `coalesceReasoningParts` (display-only) that merges all reasoning texts and hoists one block before the rest of the parts.
- Use it in `AiChat` `RenderedMessage` before `buildPartGroups`.
- Do **not** mutate stored `message.parts` so providers that need reasoning in multi-turn history still receive it (`modelKeepsReasoning` path unchanged).
- Vitest coverage for interleaved, trailing-only, streaming-state, and empty noise cases.

## Testing
- [x] `pnpm exec vitest run src/modules/ai/lib/coalesceReasoning.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [ ] Manual smoke with Minimax custom endpoint (reporter setup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI chat rendering for responses with interleaved or trailing reasoning content.
  * Consolidated reasoning into a single, ordered section before the final answer.
  * Removed empty reasoning-only noise from displayed responses.
  * Improved streaming indicators so active reasoning and trailing text are reflected accurately.
  * Preserved tool activity and provider details while reorganizing displayed reasoning content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->