### PR TITLE
fix(markdown): inherit inline code font size from text context

### DIFF
--- a/src/components/ai-elements/markdown-code.tsx
+++ b/src/components/ai-elements/markdown-code.tsx
@@ -35,7 +35,7 @@ export function MarkdownCode({
   if (!match) {
     return (
       <code
-        className="rounded bg-muted/70 px-1.5 py-0.5 font-mono text-[11px] text-foreground"
+        className="rounded bg-muted/70 px-1.5 py-0.5 font-mono text-[0.875em] text-foreground"
         {...rest}
       >
         {children}


### PR DESCRIPTION
## What
Changes the Markdown-renderer inline code font size to be relative instead of absolute.

## Why
Inline code previews would not grow/shrink with Markdown headings, resulting in altering font sizes within a singular sentence/heading.

## How
Change the hardcoded `11px` to `0.875em` to maintain consistency across normal test, but grow/shrink with Markdown-headings.

## Testing
I went into `pnpm tauri dev` and verified that inline code now grows/shrinks on various H1 through Hn Markdown headings.

- [X] `pnpm lint` clean
- [X] `pnpm check-types` clean
- [X] `pnpm test` clean
- [X] Manual smoke-test of the affected feature
- [ ] ~~(If you touched `src-tauri/`) `cargo clippy --all-targets --locked -- -D warnings` clean~~
- [ ] ~~(If you touched `src-tauri/`) `cargo nextest run --locked` clean (or `cargo test --locked`)~~
- [ ] ~~(If you changed a `#[tauri::command]` signature) called out below so the FE caller can be updated in lockstep~~
- [X] (If UI) tested in `pnpm tauri dev`
- [X] Platforms tested: MacOS
- [ ] ~~Shells tested (if relevant): <!-- bash / zsh / fish / pwsh / cmd -->~~

## Notes for reviewer
Nothing risky - minor change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted inline code text sizing to better match the surrounding text and improve readability across display contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->